### PR TITLE
fix(Modal): Fix StrictlyWeakerThan relations

### DIFF
--- a/Logic/Logic/System.lean
+++ b/Logic/Logic/System.lean
@@ -101,6 +101,19 @@ lemma strictlyWeakerThan_iff : 𝓢 <ₛ 𝓣 ↔ (∀ {f}, 𝓢 ⊢! f → 𝓣
   simp [StrictlyWeakerThan, weakerThan_iff]; intro _
   exact exists_congr (fun _ ↦ by simp [and_comm])
 
+@[trans]
+lemma strictlyWeakerThan.trans : 𝓢 <ₛ 𝓣 → 𝓣 <ₛ 𝓤 → 𝓢 <ₛ 𝓤 := by
+  rintro ⟨h₁, nh₁⟩ ⟨h₂, _⟩;
+  constructor;
+  . exact WeakerThan.trans h₁ h₂;
+  . apply not_weakerThan_iff.mpr;
+    obtain ⟨f, hf₁, hf₂⟩ := not_weakerThan_iff.mp nh₁;
+    use f;
+    constructor;
+    . apply weakerThan_iff.mp h₂;
+      assumption;
+    . assumption;
+
 lemma weakening (h : 𝓢 ≤ₛ 𝓣) {f} : 𝓢 ⊢! f → 𝓣 ⊢! f := weakerThan_iff.mp h
 
 lemma Equiv.iff : 𝓢 =ₛ 𝓣 ↔ (∀ f, 𝓢 ⊢! f ↔ 𝓣 ⊢! f) := by simp [Equiv, Set.ext_iff, theory]

--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -233,6 +233,8 @@ end Normal
 protected abbrev KT : DeductionParameter α := 𝝂𝗧
 notation "𝐊𝐓" => DeductionParameter.KT
 
+protected abbrev KB : DeductionParameter α := 𝝂𝗕
+notation "𝐊𝐁" => DeductionParameter.KB
 
 protected abbrev KD : DeductionParameter α := 𝝂𝗗
 notation "𝐊𝐃" => DeductionParameter.KD
@@ -388,6 +390,12 @@ lemma normal_reducible_subset {𝓓₁ 𝓓₂ : DeductionParameter α} [𝓓₁
 lemma reducible_K_KT : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐓 := normal_reducible_subset
 
 lemma reducible_K_KD : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐃 := normal_reducible_subset
+
+lemma reducible_K_KB : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐁 := normal_reducible_subset
+
+lemma reducible_K_K4 : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝟒 := normal_reducible_subset
+
+lemma reducible_K_K5 : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝟓 := normal_reducible_subset
 
 lemma reducible_KT_S4 : (𝐊𝐓 : DeductionParameter α) ≤ₛ 𝐒𝟒 := normal_reducible_subset
 

--- a/Logic/Modal/Standard/Geach.lean
+++ b/Logic/Modal/Standard/Geach.lean
@@ -151,6 +151,8 @@ instance : 𝐊𝐓.IsGeach (α := α) where taples := [⟨0, 0, 1, 0⟩]
 
 instance : 𝐊𝐓𝐁.IsGeach (α := α) where taples := [⟨0, 0, 1, 0⟩, ⟨0, 1, 0, 1⟩]
 
+instance : 𝐊𝟒.IsGeach (α := α) where taples := [⟨0, 2, 1, 0⟩]
+
 instance : 𝐒𝟒.IsGeach (α := α) where taples := [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩]
 
 instance : 𝐒𝟒.𝟐.IsGeach (α := α) where taples := [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩, ⟨1, 1, 1, 1⟩]

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -116,6 +116,8 @@ abbrev ReflexiveFrameClass : FrameClass := { F | Reflexive F }
 
 abbrev SerialFrameClass : FrameClass := { F | Serial F }
 
+abbrev TransitiveFrameClass : FrameClass := { F | Transitive F }
+
 abbrev ReflexiveEuclideanFrameClass : FrameClass := { F | Reflexive F ∧ Euclidean F }
 
 abbrev EquivalenceFrameClass : FrameClass := { F | Reflexive F ∧ Transitive F ∧ Symmetric F }
@@ -229,6 +231,8 @@ instance sound_KT : Sound (𝐊𝐓 : DeductionParameter α) ReflexiveFrameClass
 
 instance sound_KTB : Sound (𝐊𝐓𝐁 : DeductionParameter α) ReflexiveSymmetricFrameClass# := instGeachLogicSoundAux
 
+instance sound_K4 : Sound (𝐊𝟒 : DeductionParameter α) TransitiveFrameClass# := instGeachLogicSoundAux
+
 instance sound_S4 : Sound (𝐒𝟒 : DeductionParameter α) PreorderFrameClass# := instGeachLogicSoundAux
 
 instance sound_S5 : Sound (𝐒𝟓 : DeductionParameter α) ReflexiveEuclideanFrameClass# := instGeachLogicSoundAux
@@ -304,6 +308,8 @@ private def instGeachLogicCompleteAux {Λ : DeductionParameter α} [geach : Λ.I
 
 instance : Complete (𝐊𝐓 : DeductionParameter α) ReflexiveFrameClass.{u}# := instGeachLogicCompleteAux
 
+instance KT_complete : Complete (𝐊𝐓 : DeductionParameter α) ReflexiveFrameClass.{u}# := instGeachLogicCompleteAux
+
 instance KTB_complete : Complete (𝐊𝐓𝐁 : DeductionParameter α) ReflexiveSymmetricFrameClass.{u}# := instGeachLogicCompleteAux
 
 instance S4_complete : Complete (𝐒𝟒 : DeductionParameter α) PreorderFrameClass.{u}# := instGeachLogicCompleteAux
@@ -314,18 +320,87 @@ instance KT4B_complete : Complete (𝐊𝐓𝟒𝐁 : DeductionParameter α) Equ
 
 end Completeness
 
+end Kripke
+
 
 section Reducible
 
+variable [Inhabited α] [DecidableEq α]
 
-theorem reducible_KD_KT : (𝐊𝐃 : DeductionParameter α) ≤ₛ 𝐊𝐓 := by
+open Kripke
+open Formula (atom)
+open Formula.Kripke
+
+
+theorem KD_weakerThan_KT : (𝐊𝐃 : DeductionParameter α) ≤ₛ 𝐊𝐓 := by
   apply reducible_of_subset_FrameClass (α := α) SerialFrameClass ReflexiveFrameClass;
   simp_all [serial_of_refl];
 
+theorem KD_strictlyWeakerThan_KT : (𝐊𝐃 : DeductionParameter α) <ₛ 𝐊𝐓 := by
+  constructor;
+  . apply KD_weakerThan_KT;
+  . simp [weakerThan_iff];
+    use (□(atom default) ⟶ (atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply sound_KD.not_provable_of_countermodel;
+      simp [FrameClass];
+      use { World := Fin 2, Rel := λ _ y => y = 1 };
+      constructor;
+      . simp [Serial];
+      . simp [ValidOnFrame, ValidOnModel];
+        use (λ w _ => w = 1), 0;
+        simp [Satisfies];
 
-theorem reducible_S4_S5 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟓 := by
+
+example : (𝐊 : DeductionParameter α) <ₛ 𝐊𝐓 := strictlyWeakerThan.trans K_strictlyWeakerThan_KD KD_strictlyWeakerThan_KT
+
+
+theorem K4_weakerThan_S4 : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒 := by
+  apply reducible_of_subset_FrameClass (α := α) TransitiveFrameClass PreorderFrameClass;
+  simp;
+
+theorem K4_strictlyWeakerThan_S4 : (𝐊𝟒 : DeductionParameter α) <ₛ 𝐒𝟒 := by
+  constructor;
+  . apply K4_weakerThan_S4;
+  . simp [weakerThan_iff]
+    use (□(atom default) ⟶ (atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp)
+    . apply sound_K4.not_provable_of_countermodel;
+      simp [FrameClass];
+      use { World := Fin 3, Rel := λ _ y => y = 1 };
+      constructor;
+      . simp [Transitive];
+      . simp [ValidOnFrame, ValidOnModel];
+        use (λ w _ => w = 1), 0;
+        simp [Satisfies];
+
+
+theorem S4_weakerThan_S5 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟓 := by
   apply reducible_of_subset_FrameClass PreorderFrameClass ReflexiveEuclideanFrameClass;
   simp_all [trans_of_refl_eucl];
+
+theorem S4_strictlyWeakerThan_S5 : (𝐒𝟒 : DeductionParameter α) <ₛ 𝐒𝟓 := by
+  constructor;
+  . apply S4_weakerThan_S5;
+  . simp [weakerThan_iff];
+    use (◇(atom default) ⟶  □◇(atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply sound_S4.not_provable_of_countermodel;
+      simp [FrameClass];
+      use { World := Fin 3, Rel := λ x y => (x = y) ∨ (x = 0 ∧ y = 1) ∨ (x = 0 ∧ y = 2) };
+      refine ⟨?_, ?_, ?_⟩;
+      . simp [Reflexive];
+      . simp [Transitive]; aesop;
+      . simp [ValidOnFrame, ValidOnModel];
+        use (λ w _ => w = 2), 0;
+        simp [Satisfies];
+        constructor;
+        . omega;
+        . use 1; omega;
+
 
 theorem equiv_S5_KT4B : (𝐒𝟓 : DeductionParameter α) =ₛ 𝐊𝐓𝟒𝐁 := by
   apply equiv_of_eq_FrameClass ReflexiveEuclideanFrameClass EquivalenceFrameClass;
@@ -333,68 +408,6 @@ theorem equiv_S5_KT4B : (𝐒𝟓 : DeductionParameter α) =ₛ 𝐊𝐓𝟒𝐁
   . simp_all [symm_of_refl_eucl, trans_of_refl_eucl];
   . simp_all [eucl_of_symm_trans];
 
-
-/- TODO: strict reducible
-theorem LogicalStrictStrong.KD_KT [hα : Nontrivial α] : (𝐊𝐃 : AxiomSet α) <ᴸ 𝐊𝐓 := by
-  constructor;
-  . simp;
-  . obtain ⟨x, y, hxy⟩ := hα.exists_pair_ne
-    simp only [LogicalStrong, not_forall];
-    use (□(Formula.atom default) ⟶ (Formula.atom default));
-    use ⟨Deduction.maxm (by simp)⟩
-    apply not_imp_not.mpr $ AxiomSet.sounds;
-    simp [Formula.FrameClassConsequence];
-    existsi (λ _ w₂ => w₂ = y);
-    constructor;
-    . simp only [AxiomSetFrameClass.geach];
-      apply GeachLogic.frameClassDefinability_aux.mp;
-      simp [Serial];
-    . simp [Formula.FrameConsequence];
-      use (λ w _ => w = y);
-      simp;
-      use x;
-
-theorem LogicalStrictStrong.K4_S4 [hα : Nontrivial α] : (𝐊𝟒 : AxiomSet α) <ᴸ 𝐒𝟒 := by
-  constructor;
-  . apply LogicalStrong.of_subset; simp;
-  . obtain ⟨x, y, hxy⟩ := hα.exists_pair_ne;
-    simp only [LogicalStrong, not_forall];
-    use (□(Formula.atom default) ⟶ (Formula.atom default));
-    use ⟨Deduction.maxm (by simp)⟩
-    apply not_imp_not.mpr $ AxiomSet.sounds;
-    simp [Formula.FrameClassConsequence];
-    existsi (λ _ w₂ => w₂ = y);
-    constructor;
-    . simp only [AxiomSetFrameClass.geach];
-      apply GeachLogic.frameClassDefinability_aux.mp;
-      simp [Transitive];
-    . simp [Formula.FrameConsequence];
-      use (λ w _ => w = y);
-      simp;
-      use x;
-
-theorem LogicalStrictStrong.S4_S5 : (𝐒𝟒 : AxiomSet (Fin 3)) <ᴸ 𝐒𝟓 := by
-  constructor;
-  . simp;
-  . simp only [LogicalStrong, not_forall];
-    existsi (◇(Formula.atom default) ⟶ □◇(Formula.atom default));
-    use ⟨Deduction.maxm (by simp)⟩;
-    apply not_imp_not.mpr $ AxiomSet.sounds;
-    simp [Formula.FrameClassConsequence];
-    existsi (λ w₁ w₂ => (w₁ = w₂) ∨ (w₁ = 0 ∧ w₂ = 1) ∨ (w₁ = 0 ∧ w₂ = 2));
-    constructor;
-    . simp only [AxiomSetFrameClass.geach];
-      apply GeachLogic.frameClassDefinability_aux.mp;
-      simp [Reflexive, Transitive];
-      aesop;
-    . simp [Formula.FrameConsequence];
-      use (λ w₁ w₂ => (w₁ = w₂) ∨ (w₁ = 0 ∧ w₂ = 1) ∨ (w₁ = 0 ∧ w₂ = 2));
-      aesop;
--/
-
 end Reducible
-
-
-end Kripke
 
 end LO.Modal.Standard

--- a/Logic/Modal/Standard/Kripke/Reducible.lean
+++ b/Logic/Modal/Standard/Kripke/Reducible.lean
@@ -20,25 +20,6 @@ lemma reducible_of_subset_FrameClass (h𝔽 : 𝔽₂ ⊆ 𝔽₁) : 𝝂Ax₁ �
   intro F hF;
   exact sound₁.sound hp $ h𝔽 hF;
 
-/-
-lemma strictreducible_of_ssubset_FrameClass (hne : Ax₂.Nonempty) (h𝔽 : 𝔽₂ ⊂ 𝔽₁) : Ax₁ᴺ <ₛ Ax₂ᴺ := by
-  rw [Set.ssubset_def] at h𝔽;
-  constructor;
-  . apply reducible_of_subset_FrameClass sound₁ complete₂; exact h𝔽.1;
-  . apply System.not_weakerThan_iff.mpr;
-    obtain ⟨p, hp⟩ := hne;
-    use p;
-    constructor;
-    . exact ⟨Deduction.maxm (by simp_all)⟩;
-    . apply (not_imp_not.mpr $ sound₁.sound);
-      simp [Kripke.ValidOnFrameClass];
-      obtain ⟨F, hF₁, hF₂⟩ := by simpa [Set.not_subset] using h𝔽.2;
-      use F;
-      constructor;
-      . exact hF₁;
-      . sorry;
--/
-
 lemma equiv_of_eq_FrameClass (h𝔽 : 𝔽₁ = 𝔽₂) : 𝝂Ax₁ =ₛ 𝝂Ax₂ := by
   apply System.Equiv.antisymm_iff.mpr;
   constructor;

--- a/Logic/Modal/Standard/Kripke/Soundness.lean
+++ b/Logic/Modal/Standard/Kripke/Soundness.lean
@@ -107,4 +107,77 @@ instance K_fin_sound : Sound (𝐊 : DeductionParameter α) AllFrameClassꟳ# :=
 
 end
 
-end LO.Modal.Standard.Kripke
+end Kripke
+
+section Reducible
+
+variable [Inhabited α] [DecidableEq α]
+
+open System (weakerThan_iff)
+open Kripke
+open Formula (atom)
+open Formula.Kripke
+
+theorem K_strictlyWeakerThan_KD : (𝐊 : DeductionParameter α) <ₛ 𝐊𝐃 := by
+  constructor;
+  . apply reducible_K_KD;
+  . simp [weakerThan_iff];
+    use (□(atom default) ⟶ ◇(atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply K_sound.not_provable_of_countermodel;
+      simp [FrameClass, ValidOnFrame, ValidOnModel];
+      use { World := Fin 1, Rel := λ _ _ => False }, (λ w _ => w = 0), 0;
+      simp [Satisfies];
+
+theorem K_strictlyWeakerThan_K4 : (𝐊 : DeductionParameter α) <ₛ 𝐊𝟒 := by
+  constructor;
+  . apply reducible_K_K4;
+  . simp [weakerThan_iff];
+    use (□(atom default) ⟶ □□(atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply K_sound.not_provable_of_countermodel;
+      simp [FrameClass, ValidOnFrame, ValidOnModel];
+      use { World := Fin 2, Rel := λ x y => x ≠ y }, (λ w _ => w = 1), 0;
+      simp [Satisfies];
+      constructor;
+      . intro y;
+        match y with
+        | 0 => simp [Frame.Rel]; aesop;
+        | 1 => simp;
+      . use 1;
+        constructor;
+        . simp [Frame.Rel]; aesop;
+        . use 0; simp [Frame.Rel]; aesop;
+
+theorem K_strictlyWeakerThan_KB : (𝐊 : DeductionParameter α) <ₛ 𝐊𝐁 := by
+  constructor;
+  . apply reducible_K_KB;
+  . simp [weakerThan_iff];
+    use ((atom default) ⟶ □◇(atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply K_sound.not_provable_of_countermodel;
+      simp [FrameClass, ValidOnFrame, ValidOnModel];
+      use { World := Fin 2, Rel := λ x y => x = 0 ∧ y = 1 }, (λ w _ => w = 0), 0;
+      simp [Satisfies];
+      use 1;
+
+theorem K_strictlyWeakerThan_K5 : (𝐊 : DeductionParameter α) <ₛ 𝐊𝟓 := by
+  constructor;
+  . apply reducible_K_K5;
+  . simp [weakerThan_iff];
+    use (◇(atom default) ⟶ □◇(atom default));
+    constructor;
+    . exact Deduction.maxm! (by simp);
+    . apply K_sound.not_provable_of_countermodel;
+      simp [FrameClass, ValidOnFrame, ValidOnModel];
+      use { World := Fin 2, Rel := λ x _ => x = 0 }, (λ w _ => w = 0), 0;
+      simp [Satisfies];
+      use 1;
+      simp;
+
+end Reducible
+
+end LO.Modal.Standard


### PR DESCRIPTION
様相論理の`StrictlyWeakerThan`を示すには一つ一つフレームを構成するしかなさそう（一般化された方法はない）ということがわかったのでそれに関しての修正．フレームの構成としては例えば下記のgeneratorを使えば出してくれる．

https://www.umsu.de/trees/#p~5~8~9p

ただしそれを踏まえても $\bf K,T,B,D,4,5$ で残り10個ほどある．