### PR TITLE
feat(Modal): Boxdot Translation between `𝐆𝐋` and `𝐆𝐫𝐳` Part.1

### DIFF
--- a/Logic/Logic/HilbertStyle/Supplemental.lean
+++ b/Logic/Logic/HilbertStyle/Supplemental.lean
@@ -447,6 +447,12 @@ noncomputable def NotOrOfImply' [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ p ⟶ q) : 𝓢
   exact d₂ ⨀ d₃;
 lemma not_or_of_imply'! [HasAxiomDNE 𝓢] (d : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! ~p ⋎ q := ⟨NotOrOfImply' d.some⟩
 
+noncomputable def NotOrOfImply [HasAxiomDNE 𝓢]  : 𝓢 ⊢ (p ⟶ q) ⟶ (~p ⋎ q) := by
+  apply deduct';
+  apply NotOrOfImply';
+  exact FiniteContext.byAxm;
+lemma not_or_of_imply! [HasAxiomDNE 𝓢] : 𝓢 ⊢! (p ⟶ q) ⟶ ~p ⋎ q := ⟨NotOrOfImply⟩
+
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def dnCollectImply [HasAxiomEFQ 𝓢] : 𝓢 ⊢ (~~p ⟶ ~~q) ⟶ ~~(p ⟶ q) := by
   apply deduct';

--- a/Logic/Modal/Standard/Boxdot.lean
+++ b/Logic/Modal/Standard/Boxdot.lean
@@ -52,4 +52,19 @@ theorem iff_S4_boxdotTranslatedK4 : 𝐒𝟒 ⊢! p ↔ 𝐊𝟒 ⊢! pᵇ := by
   . apply boxdotTranslatedK4_of_S4;
   . apply S4_of_boxdotTranslatedK4;
 
+lemma boxdotTranslatedGL_of_Grz : 𝐆𝐫𝐳 ⊢! p → 𝐆𝐋 ⊢! pᵇ := by
+  intro h;
+  induction h using Deduction.inducition_with_necOnly! with
+  | hMaxm a =>
+    rcases a with (⟨_, _, rfl⟩ | ⟨_, rfl⟩);
+    . exact boxdot_axiomK!;
+    . exact boxdot_Grz_of_L!;
+  | hNec ihp =>
+    dsimp [BoxdotTranslation];
+    exact boxdot_nec! $ ihp;
+  | hMdp ihpq ihp =>
+    dsimp [BoxdotTranslation] at ihpq ihp;
+    exact ihpq ⨀ ihp;
+  | _ => dsimp [BoxdotTranslation]; trivial;
+
 end LO.Modal.Standard

--- a/Logic/Modal/Standard/System.lean
+++ b/Logic/Modal/Standard/System.lean
@@ -502,6 +502,9 @@ def imply_Box_BoxBoxdot : 𝓢 ⊢ □p ⟶ □⊡p := by
   exact impTrans'' (implyRightAnd (impId _) axiomFour) collect_box_and
 @[simp] lemma imply_box_boxboxdot! : 𝓢 ⊢! □p ⟶ □⊡p := ⟨imply_Box_BoxBoxdot⟩
 
+def imply_Box_BoxBoxdot' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ □⊡p := imply_Box_BoxBoxdot ⨀ h
+def imply_Box_BoxBoxdot'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! □⊡p := ⟨imply_Box_BoxBoxdot' h.some⟩
+
 def iff_Box_BoxBoxdot [HasAxiomFour 𝓢] : 𝓢 ⊢ □p ⟷ □⊡p := by
   apply iffIntro;
   . exact imply_Box_BoxBoxdot
@@ -731,6 +734,38 @@ private noncomputable def T_of_Grz : 𝓢 ⊢ □p ⟶ p := impTrans'' lemma_Grz
 noncomputable instance : HasAxiomT 𝓢 := ⟨fun _ ↦ T_of_Grz⟩
 
 end Grz
+
+
+section GL_Grz
+
+variable [System.K 𝓢] [HasAxiomL 𝓢]
+
+private noncomputable def boxdot_Grz_of_L1 : 𝓢 ⊢ (⊡(⊡(p ⟶ ⊡p) ⟶ p)) ⟶ (□(p ⟶ ⊡p) ⟶ p) := by
+  have : 𝓢 ⊢ (□(p ⟶ ⊡p) ⋏ ~p) ⟶ ⊡(p ⟶ ⊡p) := by
+    apply deduct';
+    apply and₃';
+    . exact (of efq_imply_not₁) ⨀ and₂;
+    . exact (of (impId _)) ⨀ and₁;
+  have : 𝓢 ⊢ ~⊡(p ⟶ ⊡p) ⟶ (~□(p ⟶ ⊡p) ⋎ p) := impTrans'' (contra₀' this) $ impTrans'' demorgan₄ (orReplaceRight dne);
+  have : 𝓢 ⊢ (~⊡(p ⟶ ⊡p) ⋎ p) ⟶ (~□(p ⟶ ⊡p) ⋎ p) := or₃'' this or₂;
+  have : 𝓢 ⊢ ~⊡(p ⟶ ⊡p) ⋎ p ⟶ □(p ⟶ ⊡p) ⟶ p := impTrans'' this implyOfNotOr;
+  have : 𝓢 ⊢ (⊡(p ⟶ ⊡p) ⟶ p) ⟶ (□(p ⟶ ⊡p) ⟶ p) := impTrans'' NotOrOfImply this;
+  exact impTrans'' boxdotAxiomT this;
+
+noncomputable def boxdot_Grz_of_L : 𝓢 ⊢ ⊡(⊡(p ⟶ ⊡p) ⟶ p) ⟶ p := by
+  have : 𝓢 ⊢ □(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □⊡(p ⟶ ⊡p) ⟶ □p := axiomK;
+  have : 𝓢 ⊢ □(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(p ⟶ ⊡p) ⟶ □p := impTrans'' this $ implyLeftReplace $ imply_Box_BoxBoxdot;
+  have : 𝓢 ⊢ □(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(p ⟶ ⊡p) ⟶ (p ⟶ ⊡p) := by
+    apply deduct'; apply deduct; apply deduct;
+    exact and₃' FiniteContext.byAxm $ (of this) ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm);
+  have : 𝓢 ⊢ □□(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(□(p ⟶ ⊡p) ⟶ (p ⟶ ⊡p)) := implyBoxDistribute' this;
+  have : 𝓢 ⊢ □(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(□(p ⟶ ⊡p) ⟶ (p ⟶ ⊡p)) := impTrans'' axiomFour this;
+  have : 𝓢 ⊢ □(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(p ⟶ ⊡p) := impTrans'' this axiomL;
+  have : 𝓢 ⊢ ⊡(⊡(p ⟶ ⊡p) ⟶ p) ⟶ □(p ⟶ ⊡p) := impTrans'' boxdotBox this;
+  exact mdp₁ boxdot_Grz_of_L1 this;
+lemma boxdot_Grz_of_L! : 𝓢 ⊢! ⊡(⊡(p ⟶ ⊡p) ⟶ p) ⟶ p := ⟨boxdot_Grz_of_L⟩
+
+end GL_Grz
 
 
 end


### PR DESCRIPTION
`𝐆𝐋`は`𝐆𝐫𝐳`を介してboxdot変換で埋め込める．逆を証明するには意味論的な分析がいる（はず）

```lean
lemma boxdotTranslatedGL_of_Grz : 𝐆𝐫𝐳 ⊢! p → 𝐆𝐋 ⊢! pᵇ
```

