### PR TITLE
feat: Łukasiewicz's  3-Axioms System

### DIFF
--- a/Logic/Logic/Axioms.lean
+++ b/Logic/Logic/Axioms.lean
@@ -20,6 +20,9 @@ protected abbrev Imply₂ := (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r
 abbrev Imply₂.set : Set F := { Axioms.Imply₂ p q r | (p) (q) (r) }
 notation "⟶₂" => Imply₂.set
 
+protected abbrev ElimContra := (~q ⟶ ~p) ⟶ (p ⟶ q)
+abbrev ElimContra.set : Set F := { Axioms.ElimContra p q | (p) (q) }
+
 protected abbrev AndElim₁ := p ⋏ q ⟶ p
 abbrev AndElim₁.set : Set F := { Axioms.AndElim₁ p q | (p) (q) }
 notation "⋏E₁" => AndElim₁.set

--- a/Logic/Logic/Axioms.lean
+++ b/Logic/Logic/Axioms.lean
@@ -20,7 +20,7 @@ protected abbrev Imply₂ := (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r
 abbrev Imply₂.set : Set F := { Axioms.Imply₂ p q r | (p) (q) (r) }
 notation "⟶₂" => Imply₂.set
 
-protected abbrev ElimContra := (~q ⟶ ~p) ⟶ (p ⟶ q)
+protected abbrev ElimContra := ((q ⟶ ⊥) ⟶ (p ⟶ ⊥)) ⟶ (p ⟶ q)
 abbrev ElimContra.set : Set F := { Axioms.ElimContra p q | (p) (q) }
 
 protected abbrev AndElim₁ := p ⋏ q ⟶ p

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -28,6 +28,9 @@ class HasAxiomImply₁ (𝓢 : S)  where
 class HasAxiomImply₂ (𝓢 : S)  where
   imply₂ (p q r : F) : 𝓢 ⊢ Axioms.Imply₂ p q r
 
+class HasAxiomElimContra (𝓢 : S)  where
+  elim_contra (p q : F) : 𝓢 ⊢ Axioms.ElimContra p q
+
 class HasAxiomAndElim₁ (𝓢 : S)  where
   and₁ (p q : F) : 𝓢 ⊢ Axioms.AndElim₁ p q
 
@@ -88,35 +91,45 @@ lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ⟶ q → 𝓢 ⊢! p → 𝓢 ⊢! 
 infixl:90 "⨀" => mdp!
 
 
-variable [System.Minimal 𝓢]
+variable
+  [System.ModusPonens 𝓢]
+  [System.HasAxiomVerum 𝓢]
+  [System.HasAxiomImply₁ 𝓢]
+  [System.HasAxiomImply₂ 𝓢]
+  [System.HasAxiomAndElim₁ 𝓢]
+  [System.HasAxiomAndElim₂ 𝓢]
+  [System.HasAxiomAndInst 𝓢]
+  [System.HasAxiomOrInst₁ 𝓢]
+  [System.HasAxiomOrInst₂ 𝓢]
+  [System.HasAxiomOrElim 𝓢]
 
 def cast {p q : F} (e : p = q) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q := e ▸ b
 
-def verum [HasAxiomVerum 𝓢] : 𝓢 ⊢ ⊤ := HasAxiomVerum.verum
-@[simp] lemma verum! : 𝓢 ⊢! ⊤ := ⟨verum⟩
+def verum : 𝓢 ⊢ ⊤ := HasAxiomVerum.verum
+@[simp] lemma verum! [HasAxiomVerum 𝓢] : 𝓢 ⊢! ⊤ := ⟨verum⟩
 
-def imply₁ [HasAxiomImply₁ 𝓢] : 𝓢 ⊢ p ⟶ q ⟶ p := HasAxiomImply₁.imply₁ _ _
+def imply₁ : 𝓢 ⊢ p ⟶ q ⟶ p := HasAxiomImply₁.imply₁ _ _
 @[simp] lemma imply₁! : 𝓢 ⊢! p ⟶ q ⟶ p := ⟨imply₁⟩
 
-def imply₂ [HasAxiomImply₂ 𝓢] : 𝓢 ⊢ (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r := HasAxiomImply₂.imply₂ _ _ _
+def imply₂ : 𝓢 ⊢ (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r := HasAxiomImply₂.imply₂ _ _ _
 @[simp] lemma imply₂! : 𝓢 ⊢! (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r := ⟨imply₂⟩
 
-def and₁ [HasAxiomAndElim₁ 𝓢] : 𝓢 ⊢ p ⋏ q ⟶ p := HasAxiomAndElim₁.and₁ _ _
+def and₁ : 𝓢 ⊢ p ⋏ q ⟶ p := HasAxiomAndElim₁.and₁ _ _
 @[simp] lemma and₁! : 𝓢 ⊢! p ⋏ q ⟶ p := ⟨and₁⟩
 
-def and₂ [HasAxiomAndElim₂ 𝓢] : 𝓢 ⊢ p ⋏ q ⟶ q := HasAxiomAndElim₂.and₂ _ _
+def and₂ : 𝓢 ⊢ p ⋏ q ⟶ q := HasAxiomAndElim₂.and₂ _ _
 @[simp] lemma and₂! : 𝓢 ⊢! p ⋏ q ⟶ q := ⟨and₂⟩
 
-def and₃ [HasAxiomAndInst 𝓢] : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := HasAxiomAndInst.and₃ _ _
+def and₃ : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := HasAxiomAndInst.and₃ _ _
 @[simp] lemma and₃! : 𝓢 ⊢! p ⟶ q ⟶ p ⋏ q := ⟨and₃⟩
 
-def or₁ [HasAxiomOrInst₁ 𝓢] : 𝓢 ⊢ p ⟶ p ⋎ q := HasAxiomOrInst₁.or₁ _ _
+def or₁ : 𝓢 ⊢ p ⟶ p ⋎ q := HasAxiomOrInst₁.or₁ _ _
 @[simp] lemma or₁! : 𝓢 ⊢! p ⟶ p ⋎ q := ⟨or₁⟩
 
-def or₂ [HasAxiomOrInst₂ 𝓢] : 𝓢 ⊢ q ⟶ p ⋎ q := HasAxiomOrInst₂.or₂ _ _
+def or₂ : 𝓢 ⊢ q ⟶ p ⋎ q := HasAxiomOrInst₂.or₂ _ _
 @[simp] lemma or₂! : 𝓢 ⊢! q ⟶ p ⋎ q := ⟨or₂⟩
 
-def or₃ [HasAxiomOrElim 𝓢] : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q) ⟶ r := HasAxiomOrElim.or₃ _ _ _
+def or₃ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q) ⟶ r := HasAxiomOrElim.or₃ _ _ _
 @[simp] lemma or₃! : 𝓢 ⊢! (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q) ⟶ r := ⟨or₃⟩
 
 def efq [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ⊥ ⟶ p := HasAxiomEFQ.efq _
@@ -142,6 +155,9 @@ def dummett [HasAxiomDummett 𝓢] : 𝓢 ⊢ (p ⟶ q) ⋎ (q ⟶ p) := HasAxio
 
 def peirce [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((p ⟶ q) ⟶ p) ⟶ p := HasAxiomPeirce.peirce _ _
 @[simp] lemma peirce! [HasAxiomPeirce 𝓢] : 𝓢 ⊢! ((p ⟶ q) ⟶ p) ⟶ p := ⟨peirce⟩
+
+def elim_contra [HasAxiomElimContra 𝓢] : 𝓢 ⊢ (~q ⟶ ~p) ⟶ (p ⟶ q) := HasAxiomElimContra.elim_contra _ _
+@[simp] lemma elim_contra! [HasAxiomElimContra 𝓢] : 𝓢 ⊢! (~q ⟶ ~p) ⟶ (p ⟶ q) := ⟨elim_contra⟩
 
 def imply₁' (h : 𝓢 ⊢ p) : 𝓢 ⊢ q ⟶ p := imply₁ ⨀ h
 lemma imply₁'! (d : 𝓢 ⊢! p) : 𝓢 ⊢! q ⟶ p := ⟨imply₁' d.some⟩

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -241,6 +241,11 @@ lemma mdp₃! (hqr : 𝓢 ⊢! p ⟶ q ⟶ r ⟶ s ⟶ t) (hq : 𝓢 ⊢! p ⟶ 
 infixl:90 "⨀₃" => mdp₃
 infixl:90 "⨀₃" => mdp₃!
 
+def mdp₄ (bqr : 𝓢 ⊢ p ⟶ q ⟶ r ⟶ s ⟶ t ⟶ u) (bq : 𝓢 ⊢ p ⟶ q ⟶ r ⟶ s ⟶ t) : 𝓢 ⊢ p ⟶ q ⟶ r ⟶ s ⟶ u := (dhyp p <| dhyp q <| dhyp r <| imply₂) ⨀₃ bqr ⨀₃ bq
+lemma mdp₄! (hqr : 𝓢 ⊢! p ⟶ q ⟶ r ⟶ s ⟶ t ⟶ u) (hq : 𝓢 ⊢! p ⟶ q ⟶ r ⟶ s ⟶ t) : 𝓢 ⊢! p ⟶ q ⟶ r ⟶ s ⟶ u := ⟨mdp₄ hqr.some hq.some⟩
+infixl:90 "⨀₄" => mdp₄
+infixl:90 "⨀₄" => mdp₄!
+
 def impTrans'' (bpq : 𝓢 ⊢ p ⟶ q) (bqr : 𝓢 ⊢ q ⟶ r) : 𝓢 ⊢ p ⟶ r := imply₂ ⨀ dhyp p bqr ⨀ bpq
 lemma imp_trans''! (hpq : 𝓢 ⊢! p ⟶ q) (hqr : 𝓢 ⊢! q ⟶ r) : 𝓢 ⊢! p ⟶ r := ⟨impTrans'' hpq.some hqr.some⟩
 

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -156,8 +156,8 @@ def dummett [HasAxiomDummett 𝓢] : 𝓢 ⊢ (p ⟶ q) ⋎ (q ⟶ p) := HasAxio
 def peirce [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((p ⟶ q) ⟶ p) ⟶ p := HasAxiomPeirce.peirce _ _
 @[simp] lemma peirce! [HasAxiomPeirce 𝓢] : 𝓢 ⊢! ((p ⟶ q) ⟶ p) ⟶ p := ⟨peirce⟩
 
-def elim_contra [HasAxiomElimContra 𝓢] : 𝓢 ⊢ (~q ⟶ ~p) ⟶ (p ⟶ q) := HasAxiomElimContra.elim_contra _ _
-@[simp] lemma elim_contra! [HasAxiomElimContra 𝓢] : 𝓢 ⊢! (~q ⟶ ~p) ⟶ (p ⟶ q) := ⟨elim_contra⟩
+def elim_contra [HasAxiomElimContra 𝓢] : 𝓢 ⊢ ((q ⟶ ⊥) ⟶ (p ⟶ ⊥)) ⟶ (p ⟶ q) := HasAxiomElimContra.elim_contra _ _
+@[simp] lemma elim_contra! [HasAxiomElimContra 𝓢] : 𝓢 ⊢! ((q ⟶ ⊥) ⟶ (p ⟶ ⊥)) ⟶ (p ⟶ q) := ⟨elim_contra⟩
 
 def imply₁' (h : 𝓢 ⊢ p) : 𝓢 ⊢ q ⟶ p := imply₁ ⨀ h
 lemma imply₁'! (d : 𝓢 ⊢! p) : 𝓢 ⊢! q ⟶ p := ⟨imply₁' d.some⟩

--- a/Logic/Logic/HilbertStyle/Context.lean
+++ b/Logic/Logic/HilbertStyle/Context.lean
@@ -77,8 +77,18 @@ lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := iff_of
 
 section minimal
 
-variable [System.Minimal 𝓢] {Γ Δ E : List F}
+variable {Γ Δ E : List F}
 
+variable
+  [System.ModusPonens 𝓢]
+  [System.HasAxiomVerum 𝓢]
+  [System.HasAxiomImply₁ 𝓢]
+  [System.HasAxiomImply₂ 𝓢]
+  [System.HasAxiomAndElim₁ 𝓢]
+  [System.HasAxiomAndElim₂ 𝓢]
+  [System.HasAxiomAndInst 𝓢]
+  [System.HasAxiomOrInst₁ 𝓢]
+  [System.HasAxiomOrInst₂ 𝓢]
 instance : Axiomatized (FiniteContext F 𝓢) where
   prfAxm := fun hp ↦ generalConj' hp
   weakening := fun H b ↦ impTrans'' (conjImplyConj' H) b
@@ -110,18 +120,27 @@ def id : [p] ⊢[𝓢] p := byAxm
 
 @[simp] lemma id! : [p] ⊢[𝓢]! p := by_axm!
 
-instance minimal (Γ : FiniteContext F 𝓢) : System.Minimal Γ where
-  mdp := mdp₁
-  verum := of verum
-  imply₁ := fun _ _ ↦ of imply₁
-  imply₂ := fun _ _ _ ↦ of imply₂
-  and₁ := fun _ _ ↦ of and₁
-  and₂ := fun _ _ ↦ of and₂
-  and₃ := fun _ _ ↦ of and₃
-  or₁ := fun _ _ ↦ of or₁
-  or₂ := fun _ _ ↦ of or₂
-  or₃ := fun _ _ _ ↦ of or₃
-  neg_equiv := fun _ ↦ of neg_equiv
+instance (Γ : FiniteContext F 𝓢) : System.ModusPonens Γ := ⟨mdp₁⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomVerum Γ := ⟨of verum⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomImply₁ Γ := ⟨fun _ _ ↦ of imply₁⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomImply₂ Γ := ⟨fun _ _ _ ↦ of imply₂⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndElim₁ Γ := ⟨fun _ _ ↦ of and₁⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndElim₂ Γ := ⟨fun _ _ ↦ of and₂⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndInst Γ := ⟨fun _ _ ↦ of and₃⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrInst₁ Γ := ⟨fun _ _ ↦ of or₁⟩
+
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrInst₂ Γ := ⟨fun _ _ ↦ of or₂⟩
+
+instance [HasAxiomOrElim 𝓢] (Γ : FiniteContext F 𝓢) : System.HasAxiomOrElim Γ := ⟨fun _ _ _ ↦ of or₃⟩
+
+instance [NegationEquiv 𝓢] (Γ : FiniteContext F 𝓢) : System.NegationEquiv Γ := ⟨fun _ ↦ of neg_equiv⟩
 
 def mdp' (bΓ : Γ ⊢[𝓢] p ⟶ q) (bΔ : Δ ⊢[𝓢] p) : (Γ ++ Δ) ⊢[𝓢] q := wk (by simp) bΓ ⨀ wk (by simp) bΔ
 

--- a/Logic/Logic/HilbertStyle/Context.lean
+++ b/Logic/Logic/HilbertStyle/Context.lean
@@ -75,8 +75,6 @@ lemma toₛ! (b : Γ ⊢[𝓢]! p) : 𝓢 ⊢! ⋀Γ ⟶ p := b
 
 lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := iff_of_eq rfl
 
-section minimal
-
 variable {Γ Δ E : List F}
 
 variable
@@ -89,6 +87,7 @@ variable
   [System.HasAxiomAndInst 𝓢]
   [System.HasAxiomOrInst₁ 𝓢]
   [System.HasAxiomOrInst₂ 𝓢]
+
 instance : Axiomatized (FiniteContext F 𝓢) where
   prfAxm := fun hp ↦ generalConj' hp
   weakening := fun H b ↦ impTrans'' (conjImplyConj' H) b
@@ -184,7 +183,7 @@ instance [HasAxiomEFQ 𝓢] : DeductiveExplosion (FiniteContext F 𝓢) := infer
 
 instance [HasAxiomDNE 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomDNE Γ := ⟨fun p ↦ of (HasAxiomDNE.dne p)⟩
 
-end minimal
+instance [System.Minimal 𝓢] (Γ : FiniteContext F 𝓢) : System.Minimal Γ where
 
 instance [System.Intuitionistic 𝓢] (Γ : FiniteContext F 𝓢) : System.Intuitionistic Γ where
 

--- a/Logic/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Logic/Logic/HilbertStyle/Lukasiewicz.lean
@@ -35,53 +35,140 @@ protected class Lukasiewicz [LukasiewiczAbbrev F]
 
 namespace Lukasiewicz
 
+variable {𝓢 : S} {p p₁ p₂ q q₁ q₂ r s t : F}
+
 variable [System.Lukasiewicz 𝓢]
 
 def verum : 𝓢 ⊢ ⊤ := by simp [LukasiewiczAbbrev.top]; exact impId ⊥;
-instance : HasAxiomVerum 𝓢 := ⟨Lukasiewicz.verum (𝓢 := 𝓢)⟩
+instance : HasAxiomVerum 𝓢 := ⟨Lukasiewicz.verum⟩
 
-variable {p q r : F}
+private def elim_contra₂ : 𝓢 ⊢ (~q ⟶ ~p) ⟶ (p ⟶ q) := by
+  have : 𝓢 ⊢ ((q ⟶ ⊥) ⟶ (p ⟶ ⊥)) ⟶ (p ⟶ q) := elim_contra
+  repeat rw [LukasiewiczAbbrev.neg];
+  exact this;
 
-attribute [local simp]
-  HasAxiomImply₁.imply₁
-  HasAxiomImply₂.imply₂
+def dne : 𝓢 ⊢ ~~p ⟶ p := by
+  have d₁ : 𝓢 ⊢ ~~p ⟶ (~~(~~p) ⟶ ~~p) ⟶ ~p ⟶ ~(~~p) := dhyp _ $ elim_contra₂;
+  have d₂ : 𝓢 ⊢ ~~p ⟶ ~~(~~p) ⟶ ~~p := imply₁;
+  have d₃ : 𝓢 ⊢ ~~p ⟶ (~p ⟶ ~(~~p)) ⟶ ~~p ⟶ p := dhyp _ $ elim_contra₂;
+  have d₄ : 𝓢 ⊢ ~~p ⟶ ~p ⟶ ~(~~p) := d₁ ⨀₁ d₂;
+  have d₅ : 𝓢 ⊢ ~~p ⟶ ~~p ⟶ p := d₃ ⨀₁ d₄;
+  have d₆ : 𝓢 ⊢ ~~p ⟶ ~~p := impId _;
+  exact d₅ ⨀₁ d₆;
+instance : HasAxiomDNE 𝓢 := ⟨λ p => Lukasiewicz.dne (p := p)⟩
 
-def orInst₁ : 𝓢 ⊢ p ⟶ p ⋎ q := by
-  simp [LukasiewiczAbbrev.or];
+def dni : 𝓢 ⊢ p ⟶ ~~p := by
+  have d₁ : 𝓢 ⊢ (~(~~p) ⟶ ~p) ⟶ p ⟶ ~~p := elim_contra₂;
+  have d₂ : 𝓢 ⊢ ~(~~p) ⟶ ~p := dne (p := ~p);
+  exact d₁ ⨀ d₂;
+
+def explode (h₁ : 𝓢 ⊢ p) (h₂ : 𝓢 ⊢ ~p) : 𝓢 ⊢ q := by
+  have d₁ := imply₁ (𝓢 := 𝓢) (p := ~p) (q := ~q);
+  have := d₁ ⨀ h₂;
+  exact elim_contra₂ ⨀ this ⨀ h₁;
+
+def explodeHyp (h₁ : 𝓢 ⊢ p ⟶ q) (h₂ : 𝓢 ⊢ p ⟶ ~q) : 𝓢 ⊢ p ⟶ r := by
+  have : 𝓢 ⊢ p ⟶ ~q ⟶ ~(r) ⟶ ~q := dhyp imply₁ (q := p)
+  have : 𝓢 ⊢ p ⟶ ~(r) ⟶ ~q := this ⨀₁ h₂;
+  have : 𝓢 ⊢ p ⟶ q ⟶ r := (dhyp elim_contra₂ (q := p)) ⨀₁ this;
+  exact this ⨀₁ h₁;
+
+def explodeHyp₂ (h₁ : 𝓢 ⊢ p ⟶ q ⟶ r) (h₂ : 𝓢 ⊢ p ⟶ q ⟶ ~(r)) : 𝓢 ⊢ p ⟶ q ⟶ s := by
+  have : 𝓢 ⊢ p ⟶ q ⟶ ~(r) ⟶ ~s ⟶ ~(r) := dhyp (dhyp imply₁ (q := q)) (q := p)
+  have : 𝓢 ⊢ p ⟶ q ⟶ ~(s) ⟶ ~(r) := this ⨀₂ h₂;
+  have : 𝓢 ⊢ p ⟶ q ⟶ r ⟶ s := (dhyp (dhyp elim_contra₂ (q := q)) (q := p)) ⨀₂ this;
+  exact this ⨀₂ h₁;
+
+def efq : 𝓢 ⊢ ⊥ ⟶ p := by
+  have := explodeHyp (𝓢 := 𝓢) (p := ⊥) (q := ⊤) (r := p);
+  exact this (by simp; exact imply₁) (by simp; exact imply₁);
+instance : HasAxiomEFQ 𝓢 := ⟨λ p => Lukasiewicz.efq (p := p)⟩
+
+def impSwap (h : 𝓢 ⊢ p ⟶ q ⟶ r) : 𝓢 ⊢ q ⟶ p ⟶ r := by
+  refine mdp₂ (r := q) ?_ ?_;
+  . exact dhyp q h;
+  . exact imply₁;
+
+def mdpIn₁ : 𝓢 ⊢ (p ⟶ q) ⟶ p ⟶ q := impId _
+
+def mdpIn₂ : 𝓢 ⊢ p ⟶ (p ⟶ q) ⟶ q := impSwap mdpIn₁
+
+def mdp₂In₁ : 𝓢 ⊢ (p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ (p ⟶ r) := imply₂
+
+def mdp₂In₂ : 𝓢 ⊢ (p ⟶ q) ⟶ (p ⟶ q ⟶ r) ⟶ (p ⟶ r) := impSwap mdp₂In₁
+
+def impTrans'₁ (bpq : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ (q ⟶ r) ⟶ (p ⟶ r) := by
+  apply impSwap;
+  exact impTrans'' bpq mdpIn₂;
+
+def impTrans'₂ (bqr: 𝓢 ⊢ q ⟶ r) : 𝓢 ⊢ (p ⟶ q) ⟶ (p ⟶ r) := imply₂ ⨀ (dhyp p bqr)
+
+def impTrans₂ : 𝓢 ⊢ (q ⟶ r) ⟶ (p ⟶ q) ⟶ (p ⟶ r) := impTrans'' (impSwap (dhyp p (impId (q ⟶ r)))) mdp₂In₁
+
+def impTrans₁ : 𝓢 ⊢ (p ⟶ q) ⟶ (q ⟶ r) ⟶ (p ⟶ r) := impSwap impTrans₂
+
+def dhypBoth (h : 𝓢 ⊢ q ⟶ r) : 𝓢 ⊢ (p ⟶ q) ⟶ (p ⟶ r) := imply₂ ⨀ (dhyp _ $ h)
+
+def explode₂₁ : 𝓢 ⊢ ~p ⟶ p ⟶ q := by
+  simp;
+  exact dhypBoth efq;
+
+def explode₁₂ : 𝓢 ⊢ p ⟶ ~p ⟶ q := impSwap explode₂₁
+
+def contraIntro : 𝓢 ⊢ (p ⟶ q) ⟶ (~q ⟶ ~p):= by simpa using impTrans₁;
+
+def contraIntro' : 𝓢 ⊢ (p ⟶ q) → 𝓢 ⊢ (~q ⟶ ~p) := λ h => contraIntro ⨀ h
+
+def andElim₁ : 𝓢 ⊢ p ⋏ q ⟶ p := by
+  simp only [LukasiewiczAbbrev.and];
+  have : 𝓢 ⊢ ~p ⟶ p ⟶ ~q := explodeHyp₂ explode₂₁ imply₁;
+  have : 𝓢 ⊢ ~(p ⟶ ~q) ⟶ ~~p := contraIntro' explode₂₁
+  exact impTrans'' this dne;
+instance : HasAxiomAndElim₁ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (p := p) (q := q)⟩
+
+def andElim₂ : 𝓢 ⊢ p ⋏ q ⟶ q := by
+  simp only [LukasiewiczAbbrev.and];
+  have := imply₁ (𝓢 := 𝓢) (p := ~q) (q := p);
+  have := contraIntro' this;
+  exact impTrans'' this dne;
+instance : HasAxiomAndElim₂ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₂ (p := p) (q := q)⟩
+
+def andImplyLeft : 𝓢 ⊢ (p₁ ⟶ q) ⟶ p₁ ⋏ p₂ ⟶ q := (impSwap $ dhyp _ (impId _)) ⨀₂ (dhyp _ andElim₁)
+def andImplyLeft' (h : 𝓢 ⊢ (p₁ ⟶ q)) : 𝓢 ⊢ p₁ ⋏ p₂ ⟶ q := andImplyLeft ⨀ h
+
+def andImplyRight : 𝓢 ⊢ (p₂ ⟶ q) ⟶ p₁ ⋏ p₂ ⟶ q := (impSwap $ dhyp _ (impId _)) ⨀₂ (dhyp _ andElim₂)
+def andImplyRight' (h : 𝓢 ⊢ (p₂ ⟶ q)) : 𝓢 ⊢ p₁ ⋏ p₂ ⟶ q := andImplyRight ⨀ h
+
+def andInst'' (hp : 𝓢 ⊢ p) (hq : 𝓢 ⊢ q) : 𝓢 ⊢ p ⋏ q := by
+  simp only [LukasiewiczAbbrev.and];
+  have : 𝓢 ⊢ (p ⟶ ~q) ⟶ p ⟶ ~q := impId _
+  have : 𝓢 ⊢ (p ⟶ ~q) ⟶ ~q := this ⨀₁ dhyp _ hp;
+  have : 𝓢 ⊢ q ⟶ ~(p ⟶ ~q) := impTrans'' dni $ contraIntro' this;
+  exact this ⨀ hq;
+
+-- and_destruct
+def andInst : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := by
   sorry;
 
-instance : HasAxiomOrInst₁ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₁ (𝓢 := 𝓢) (p := p) (q := q)⟩
+instance : HasAxiomAndInst 𝓢 := ⟨λ p q => Lukasiewicz.andInst (p := p) (q := q)⟩
+
+def orInst₁ : 𝓢 ⊢ p ⟶ p ⋎ q := by
+  simp only [LukasiewiczAbbrev.or];
+  exact explode₁₂;
+
+instance : HasAxiomOrInst₁ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₁ (p := p) (q := q)⟩
 
 def orInst₂ : 𝓢 ⊢ q ⟶ p ⋎ q := by
   simp [LukasiewiczAbbrev.or];
   exact imply₁;
-instance : HasAxiomOrInst₂ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₂ (𝓢 := 𝓢) (p := p) (q := q)⟩
+instance : HasAxiomOrInst₂ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₂ (p := p) (q := q)⟩
 
+-- or_imply
 def orElim : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r) := by
   simp only [LukasiewiczAbbrev.or];
   sorry;
-instance : HasAxiomOrElim 𝓢 := ⟨λ p q r => Lukasiewicz.orElim (𝓢 := 𝓢) (p := p) (q := q) (r := r)⟩
 
-def andInst : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := by
-  simp only [LukasiewiczAbbrev.and];
-  sorry;
-instance : HasAxiomAndInst 𝓢 := ⟨λ p q => Lukasiewicz.andInst (𝓢 := 𝓢) (p := p) (q := q)⟩
-
-def andElim₁ : 𝓢 ⊢ p ⋏ q ⟶ p := by
-  simp only [LukasiewiczAbbrev.and];
-  refine imply₂ (𝓢 := 𝓢) (p := ~(p ⟶ ~q)) (q := p) (r := p) ⨀ ?_ ⨀ ?_;
-  . sorry;
-  . sorry;
-instance : HasAxiomAndElim₁ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (𝓢 := 𝓢) (p := p) (q := q)⟩
-
-def andElim₂ : 𝓢 ⊢ p ⋏ q ⟶ q := by
-  simp only [LukasiewiczAbbrev.and];
-  sorry;
-instance : HasAxiomAndElim₂ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₂ (𝓢 := 𝓢) (p := p) (q := q)⟩
-
-def dne : 𝓢 ⊢ ~(~p) ⟶ p := by
-  sorry;
-instance : HasAxiomDNE 𝓢 := ⟨λ p => Lukasiewicz.dne (𝓢 := 𝓢) (p := p)⟩
+instance : HasAxiomOrElim 𝓢 := ⟨λ p q r => Lukasiewicz.orElim (p := p) (q := q) (r := r)⟩
 
 instance : System.Classical 𝓢 where
 

--- a/Logic/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Logic/Logic/HilbertStyle/Lukasiewicz.lean
@@ -1,0 +1,92 @@
+import Logic.Logic.HilbertStyle.Basic
+
+namespace LO
+
+section
+
+class LukasiewiczAbbrev (F : Type*) [LogicalConnective F] where
+  top : ⊤ = ~(⊥ : F)
+  neg {p : F} : ~p = p ⟶ ⊥
+  or {p q : F} : p ⋎ q = ~p ⟶ q
+  and {p q : F} : p ⋏ q = ~(p ⟶ ~q)
+
+attribute [simp]
+  LukasiewiczAbbrev.top
+  LukasiewiczAbbrev.neg
+  LukasiewiczAbbrev.or
+  LukasiewiczAbbrev.and
+
+instance [LogicalConnective F] [LukasiewiczAbbrev F] : NegAbbrev F := ⟨LukasiewiczAbbrev.neg⟩
+
+end
+
+
+namespace System
+
+variable {S F : Type*} [LogicalConnective F] [LukasiewiczAbbrev F] [System F S]
+
+variable (𝓢 : S)
+
+protected class Lukasiewicz [LukasiewiczAbbrev F]
+  extends ModusPonens 𝓢,
+          HasAxiomImply₁ 𝓢,
+          HasAxiomImply₂ 𝓢,
+          HasAxiomElimContra 𝓢
+
+namespace Lukasiewicz
+
+variable [System.Lukasiewicz 𝓢]
+
+def verum : 𝓢 ⊢ ⊤ := by simp [LukasiewiczAbbrev.top]; exact impId ⊥;
+instance : HasAxiomVerum 𝓢 := ⟨Lukasiewicz.verum (𝓢 := 𝓢)⟩
+
+variable {p q r : F}
+
+attribute [local simp]
+  HasAxiomImply₁.imply₁
+  HasAxiomImply₂.imply₂
+
+def orInst₁ : 𝓢 ⊢ p ⟶ p ⋎ q := by
+  simp [LukasiewiczAbbrev.or];
+  sorry;
+
+instance : HasAxiomOrInst₁ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₁ (𝓢 := 𝓢) (p := p) (q := q)⟩
+
+def orInst₂ : 𝓢 ⊢ q ⟶ p ⋎ q := by
+  simp [LukasiewiczAbbrev.or];
+  exact imply₁;
+instance : HasAxiomOrInst₂ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₂ (𝓢 := 𝓢) (p := p) (q := q)⟩
+
+def orElim : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r) := by
+  simp only [LukasiewiczAbbrev.or];
+  sorry;
+instance : HasAxiomOrElim 𝓢 := ⟨λ p q r => Lukasiewicz.orElim (𝓢 := 𝓢) (p := p) (q := q) (r := r)⟩
+
+def andInst : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := by
+  simp only [LukasiewiczAbbrev.and];
+  sorry;
+instance : HasAxiomAndInst 𝓢 := ⟨λ p q => Lukasiewicz.andInst (𝓢 := 𝓢) (p := p) (q := q)⟩
+
+def andElim₁ : 𝓢 ⊢ p ⋏ q ⟶ p := by
+  simp only [LukasiewiczAbbrev.and];
+  refine imply₂ (𝓢 := 𝓢) (p := ~(p ⟶ ~q)) (q := p) (r := p) ⨀ ?_ ⨀ ?_;
+  . sorry;
+  . sorry;
+instance : HasAxiomAndElim₁ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (𝓢 := 𝓢) (p := p) (q := q)⟩
+
+def andElim₂ : 𝓢 ⊢ p ⋏ q ⟶ q := by
+  simp only [LukasiewiczAbbrev.and];
+  sorry;
+instance : HasAxiomAndElim₂ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₂ (𝓢 := 𝓢) (p := p) (q := q)⟩
+
+def dne : 𝓢 ⊢ ~(~p) ⟶ p := by
+  sorry;
+instance : HasAxiomDNE 𝓢 := ⟨λ p => Lukasiewicz.dne (𝓢 := 𝓢) (p := p)⟩
+
+instance : System.Classical 𝓢 where
+
+end Lukasiewicz
+
+end System
+
+end LO

--- a/Logic/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Logic/Logic/HilbertStyle/Lukasiewicz.lean
@@ -128,8 +128,8 @@ instance : HasAxiomAndElim₁ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (p := 
 
 def andElim₂ : 𝓢 ⊢ p ⋏ q ⟶ q := by
   simp only [LukasiewiczAbbrev.and];
-  have := imply₁ (𝓢 := 𝓢) (p := ~q) (q := p);
-  have := contraIntro' this;
+  have : 𝓢 ⊢ ~q ⟶ p ⟶ ~q := imply₁ (p := ~q) (q := p);
+  have : 𝓢 ⊢ ~(p ⟶ ~q) ⟶ ~~q := contraIntro' this;
   exact impTrans'' this dne;
 instance : HasAxiomAndElim₂ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₂ (p := p) (q := q)⟩
 
@@ -170,7 +170,21 @@ instance : HasAxiomOrInst₂ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₂ (p := p)
 -- or_imply
 def orElim : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r) := by
   simp only [LukasiewiczAbbrev.or];
-  sorry;
+  have d₁ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ (p ⟶ r) ⟶ ~(r) ⟶ ~p
+    := (dhyp (p ⟶ r) <| dhyp (q ⟶ r) <| dhyp (~p ⟶ q) <| contraIntro (p := p) (q := r));
+  have d₂ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~(r) ⟶ ~p
+    := d₁ ⨀₃ (imply₁₁ (p ⟶ r) (q ⟶ r) (~p ⟶ q));
+  have d₃ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~(r) ⟶ q
+    := (dhyp (p ⟶ r) <| dhyp (q ⟶ r) <| imply₁ (p := ~p ⟶ q) (q := ~(r))) ⨀₄ d₂;
+  have d₄ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~(r) ⟶ r
+    := (dhyp (p ⟶ r) <| imply₁₁ (p := q ⟶ r) (q := ~p ⟶ q) (r := ~(r))) ⨀₄ d₃;
+  have d₅ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~(r) ⟶ r ⟶ ⊥
+    := by simpa using dhyp (p ⟶ r) <| dhyp (q ⟶ r) <| dhyp (~p ⟶ q) <| impId (p := ~(r));
+  have d₆ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~~(r)
+    := by simpa using d₅ ⨀₄ d₄;
+  have d₇ : 𝓢 ⊢ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (~p ⟶ q) ⟶ ~~(r) ⟶ r
+    := dhyp (p ⟶ r) <| dhyp (q ⟶ r) <| dhyp (~p ⟶ q) <| dne (p := r);
+  exact d₇ ⨀₃ d₆;
 
 instance : HasAxiomOrElim 𝓢 := ⟨λ p q r => Lukasiewicz.orElim (p := p) (q := q) (r := r)⟩
 

--- a/Logic/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Logic/Logic/HilbertStyle/Lukasiewicz.lean
@@ -146,9 +146,13 @@ def andInst'' (hp : 𝓢 ⊢ p) (hq : 𝓢 ⊢ q) : 𝓢 ⊢ p ⋏ q := by
   have : 𝓢 ⊢ q ⟶ ~(p ⟶ ~q) := impTrans'' dni $ contraIntro' this;
   exact this ⨀ hq;
 
--- and_destruct
 def andInst : 𝓢 ⊢ p ⟶ q ⟶ p ⋏ q := by
-  sorry;
+  have d₁ : 𝓢 ⊢ p ⟶ q ⟶ (p ⟶ ~q) ⟶ p ⟶ ~q := dhyp p <| dhyp q <| impId (p ⟶ ~q);
+  have d₂ : 𝓢 ⊢ p ⟶ q ⟶ (p ⟶ ~q) ⟶ p := imply₁₁ (p := p) (q := q) (r := (p ⟶ ~q));
+  have d₃ : 𝓢 ⊢ p ⟶ q ⟶ (p ⟶ ~q) ⟶ q := dhyp p <| imply₁;
+  have d₄ : 𝓢 ⊢ p ⟶ q ⟶ (p ⟶ ~q) ⟶ ~q := d₁ ⨀₃ d₂;
+  have d₄ : 𝓢 ⊢ p ⟶ q ⟶ (p ⟶ ~q) ⟶ q ⟶ ⊥ := by simpa using d₄;
+  simpa using d₄ ⨀₃ d₃;
 
 instance : HasAxiomAndInst 𝓢 := ⟨λ p q => Lukasiewicz.andInst (p := p) (q := q)⟩
 

--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -1,5 +1,6 @@
 import Logic.Modal.Standard.Formula
 import Logic.Modal.Standard.System
+import Logic.Logic.HilbertStyle.Lukasiewicz
 
 namespace LO.Modal.Standard
 


### PR DESCRIPTION
#124 で様相論理の記号を`⟶`と`⊥`だけに制限することにした（すなわち古典的なものだけを考えることにした）ため，演繹体系もそれに伴って命題論理の部分はŁukasiewiczの3公理体系で十分なように削除した．

演繹体系が「`⟶`と`⊥`から他の論理記号が略記として定義可能かつŁukasiewiczの3公理を持っている」ことに対応するclass`System.Lukasiewicz`を定め，これを満たしている場合`System.Classical`になる．

ただしこれは`andInst`や`dne`などが証明可能なことを`System.Lukasiewicz`だけでやる必要があり（おそらく演繹定理も微妙に使えないかもしれない）難解なパズルで面倒，なにかよい文献があれば教えてほしい．一応[lean-logic](https://github.com/iehality/lean-logic/blob/main/src/provability.lean)なども参考にしてみているが．