### PR TITLE
Update to 4.13 for Modal

### DIFF
--- a/Foundation/IntProp/ConsistentTableau.lean
+++ b/Foundation/IntProp/ConsistentTableau.lean
@@ -425,7 +425,7 @@ lemma mem₂_neg_of_mem₁ : p ∈ t.tableau.1 → ∼p ∈ t.tableau.2 := by
 
 lemma mem₁_of_provable : Λ ⊢! p → p ∈ t.tableau.1 := by
   intro h;
-  exact mdp₁ mem₁_verum $ dhyp! h;
+  exact mdp₁ mem₁_verum $ imply₁'! h;
 
 lemma mdp₁_mem (hp : p ∈ t.tableau.1) (h : p ➝ q ∈ t.tableau.1) : q ∈ t.tableau.1 := by
   apply not_mem₂_iff_mem₁.mp;

--- a/Foundation/Logic/HilbertStyle/Basic.lean
+++ b/Foundation/Logic/HilbertStyle/Basic.lean
@@ -4,11 +4,169 @@ import Foundation.Logic.Axioms
 namespace LO.System
 
 variable {S F : Type*} [LogicalConnective F] [System F S]
+variable {𝓢 : S} {p q r : F}
 
-variable (𝓢 : S)
 
-class ModusPonens where
+def cast (e : p = q) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q := e ▸ b
+def cast! (e : p = q) (b : 𝓢 ⊢! p) : 𝓢 ⊢! q := ⟨cast e b.some⟩
+
+
+class ModusPonens (𝓢 : S) where
   mdp {p q : F} : 𝓢 ⊢ p ➝ q → 𝓢 ⊢ p → 𝓢 ⊢ q
+
+alias mdp := ModusPonens.mdp
+infixl:90 "⨀" => mdp
+
+lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ➝ q → 𝓢 ⊢! p → 𝓢 ⊢! q := by
+  rintro ⟨hpq⟩ ⟨hp⟩;
+  exact ⟨hpq ⨀ hp⟩
+infixl:90 "⨀" => mdp!
+
+class HasAxiomVerum (𝓢 : S) where
+  verum : 𝓢 ⊢ Axioms.Verum
+
+def verum [HasAxiomVerum 𝓢] : 𝓢 ⊢ ⊤ := HasAxiomVerum.verum
+@[simp] lemma verum! [HasAxiomVerum 𝓢] : 𝓢 ⊢! ⊤ := ⟨verum⟩
+
+
+class HasAxiomImply₁ (𝓢 : S)  where
+  imply₁ (p q : F) : 𝓢 ⊢ Axioms.Imply₁ p q
+
+def imply₁ [HasAxiomImply₁ 𝓢] : 𝓢 ⊢ p ➝ q ➝ p := HasAxiomImply₁.imply₁ _ _
+@[simp] lemma imply₁! [HasAxiomImply₁ 𝓢] : 𝓢 ⊢! p ➝ q ➝ p := ⟨imply₁⟩
+
+def imply₁' [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (h : 𝓢 ⊢ p) : 𝓢 ⊢ q ➝ p := imply₁ ⨀ h
+lemma imply₁'! [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (d : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨imply₁' d.some⟩
+
+@[deprecated imply₁'] def dhyp [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (q : F) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q ➝ p := imply₁' b
+@[deprecated imply₁'!] lemma dhyp! [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (b : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨dhyp _ b.some⟩
+
+
+class HasAxiomImply₂ (𝓢 : S)  where
+  imply₂ (p q r : F) : 𝓢 ⊢ Axioms.Imply₂ p q r
+
+def imply₂ [HasAxiomImply₂ 𝓢] : 𝓢 ⊢ (p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r := HasAxiomImply₂.imply₂ _ _ _
+@[simp] lemma imply₂! [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! (p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r := ⟨imply₂⟩
+
+def imply₂' [ModusPonens 𝓢] [HasAxiomImply₂ 𝓢] (d₁ : 𝓢 ⊢ p ➝ q ➝ r) (d₂ : 𝓢 ⊢ p ➝ q) (d₃ : 𝓢 ⊢ p) : 𝓢 ⊢ r := imply₂ ⨀ d₁ ⨀ d₂ ⨀ d₃
+lemma imply₂'! [ModusPonens 𝓢] [HasAxiomImply₂ 𝓢] (d₁ : 𝓢 ⊢! p ➝ q ➝ r) (d₂ : 𝓢 ⊢! p ➝ q) (d₃ : 𝓢 ⊢! p) : 𝓢 ⊢! r := ⟨imply₂' d₁.some d₂.some d₃.some⟩
+
+
+class HasAxiomAndElim (𝓢 : S)  where
+  and₁ (p q : F) : 𝓢 ⊢ Axioms.AndElim₁ p q
+  and₂ (p q : F) : 𝓢 ⊢ Axioms.AndElim₂ p q
+
+def and₁ [HasAxiomAndElim 𝓢] : 𝓢 ⊢ p ⋏ q ➝ p := HasAxiomAndElim.and₁ _ _
+@[simp] lemma and₁! [HasAxiomAndElim 𝓢] : 𝓢 ⊢! p ⋏ q ➝ p := ⟨and₁⟩
+
+def and₁' [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ p := and₁ ⨀ d
+alias andLeft := and₁'
+
+lemma and₁'! [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! (p ⋏ q)) : 𝓢 ⊢! p := ⟨and₁' d.some⟩
+alias and_left! := and₁'!
+
+def and₂ [HasAxiomAndElim 𝓢] : 𝓢 ⊢ p ⋏ q ➝ q := HasAxiomAndElim.and₂ _ _
+@[simp] lemma and₂! [HasAxiomAndElim 𝓢] : 𝓢 ⊢! p ⋏ q ➝ q := ⟨and₂⟩
+
+def and₂' [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ q := and₂ ⨀ d
+alias andRight := and₂'
+
+lemma and₂'!  [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! (p ⋏ q)) : 𝓢 ⊢! q := ⟨and₂' d.some⟩
+alias and_right! := and₂'!
+
+
+class HasAxiomAndInst (𝓢 : S) where
+  and₃ (p q : F) : 𝓢 ⊢ Axioms.AndInst p q
+
+def and₃ [HasAxiomAndInst 𝓢] : 𝓢 ⊢ p ➝ q ➝ p ⋏ q := HasAxiomAndInst.and₃ _ _
+@[simp] lemma and₃! [HasAxiomAndInst 𝓢] : 𝓢 ⊢! p ➝ q ➝ p ⋏ q := ⟨and₃⟩
+
+def and₃' [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢ p) (d₂: 𝓢 ⊢ q) : 𝓢 ⊢ p ⋏ q := and₃ ⨀ d₁ ⨀ d₂
+alias andIntro := and₃'
+
+lemma and₃'!  [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢! p) (d₂: 𝓢 ⊢! q) : 𝓢 ⊢! p ⋏ q := ⟨and₃' d₁.some d₂.some⟩
+alias and_intro! := and₃'!
+
+
+class HasAxiomOrInst (𝓢 : S) where
+  or₁ (p q : F) : 𝓢 ⊢ Axioms.OrInst₁ p q
+  or₂ (p q : F) : 𝓢 ⊢ Axioms.OrInst₂ p q
+
+def or₁  [HasAxiomOrInst 𝓢] : 𝓢 ⊢ p ➝ p ⋎ q := HasAxiomOrInst.or₁ _ _
+@[simp] lemma or₁! [HasAxiomOrInst 𝓢] : 𝓢 ⊢! p ➝ p ⋎ q := ⟨or₁⟩
+
+def or₁' [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ p) : 𝓢 ⊢ p ⋎ q := or₁ ⨀ d
+lemma or₁'! [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! p) : 𝓢 ⊢! p ⋎ q := ⟨or₁' d.some⟩
+
+def or₂ [HasAxiomOrInst 𝓢] : 𝓢 ⊢ q ➝ p ⋎ q := HasAxiomOrInst.or₂ _ _
+@[simp] lemma or₂! [HasAxiomOrInst 𝓢] : 𝓢 ⊢! q ➝ p ⋎ q := ⟨or₂⟩
+
+def or₂' [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ q) : 𝓢 ⊢ p ⋎ q := or₂ ⨀ d
+lemma or₂'! [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! q) : 𝓢 ⊢! p ⋎ q := ⟨or₂' d.some⟩
+
+
+class HasAxiomOrElim (𝓢 : S) where
+  or₃ (p q r : F) : 𝓢 ⊢ Axioms.OrElim p q r
+
+def or₃ [HasAxiomOrElim 𝓢] : 𝓢 ⊢ (p ➝ r) ➝ (q ➝ r) ➝ (p ⋎ q) ➝ r := HasAxiomOrElim.or₃ _ _ _
+@[simp] lemma or₃! [HasAxiomOrElim 𝓢] : 𝓢 ⊢! (p ➝ r) ➝ (q ➝ r) ➝ (p ⋎ q) ➝ r := ⟨or₃⟩
+
+def or₃'' [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ p ➝ r) (d₂ : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋎ q ➝ r := or₃ ⨀ d₁ ⨀ d₂
+lemma or₃''! [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! p ➝ r) (d₂ : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋎ q ➝ r := ⟨or₃'' d₁.some d₂.some⟩
+
+def or₃''' [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ p ➝ r) (d₂ : 𝓢 ⊢ q ➝ r) (d₃ : 𝓢 ⊢ p ⋎ q) : 𝓢 ⊢ r := or₃ ⨀ d₁ ⨀ d₂ ⨀ d₃
+alias orCases := or₃'''
+
+lemma or₃'''! [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! p ➝ r) (d₂ : 𝓢 ⊢! q ➝ r) (d₃ : 𝓢 ⊢! p ⋎ q) : 𝓢 ⊢! r := ⟨or₃''' d₁.some d₂.some d₃.some⟩
+alias or_cases! := or₃'''!
+
+
+class HasAxiomEFQ (𝓢 : S) where
+  efq (p : F) : 𝓢 ⊢ Axioms.EFQ p
+
+def efq [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ⊥ ➝ p := HasAxiomEFQ.efq _
+@[simp] lemma efq! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⊥ ➝ p := ⟨efq⟩
+
+def efq' [ModusPonens 𝓢] [HasAxiomEFQ 𝓢] (b : 𝓢 ⊢ ⊥) : 𝓢 ⊢ p := efq ⨀ b
+lemma efq'! [ModusPonens 𝓢] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! ⊥) : 𝓢 ⊢! p := ⟨efq' h.some⟩
+
+
+class HasAxiomLEM (𝓢 : S) where
+  lem (p : F) : 𝓢 ⊢ Axioms.LEM p
+
+def lem [HasAxiomLEM 𝓢] : 𝓢 ⊢ p ⋎ ∼p := HasAxiomLEM.lem p
+@[simp] lemma lem! [HasAxiomLEM 𝓢] : 𝓢 ⊢! p ⋎ ∼p := ⟨lem⟩
+
+
+class HasAxiomDNE (𝓢 : S) where
+  dne (p : F) : 𝓢 ⊢ Axioms.DNE p
+
+def dne [HasAxiomDNE 𝓢] : 𝓢 ⊢ ∼∼p ➝ p := HasAxiomDNE.dne _
+@[simp] lemma dne! [HasAxiomDNE 𝓢] : 𝓢 ⊢! ∼∼p ➝ p := ⟨dne⟩
+
+def dne' [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢ ∼∼p) : 𝓢 ⊢ p := dne ⨀ b
+lemma dne'! [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢! ∼∼p) : 𝓢 ⊢! p := ⟨dne' h.some⟩
+
+
+class HasAxiomWeakLEM (𝓢 : S) where
+  wlem (p : F) : 𝓢 ⊢ Axioms.WeakLEM p
+
+def wlem [HasAxiomWeakLEM 𝓢] : 𝓢 ⊢ ∼p ⋎ ∼∼p := HasAxiomWeakLEM.wlem p
+@[simp] lemma wlem! [HasAxiomWeakLEM 𝓢] : 𝓢 ⊢! ∼p ⋎ ∼∼p := ⟨wlem⟩
+
+
+class HasAxiomDummett (𝓢 : S) where
+  dummett (p q : F) : 𝓢 ⊢ Axioms.GD p q
+
+def dummett [HasAxiomDummett 𝓢] : 𝓢 ⊢ (p ➝ q) ⋎ (q ➝ p) := HasAxiomDummett.dummett p q
+@[simp] lemma dummett! [HasAxiomDummett 𝓢] : 𝓢 ⊢! Axioms.GD p q := ⟨dummett⟩
+
+
+class HasAxiomPeirce (𝓢 : S) where
+  peirce (p q : F) : 𝓢 ⊢ Axioms.Peirce p q
+
+def peirce [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((p ➝ q) ➝ p) ➝ p := HasAxiomPeirce.peirce _ _
+@[simp] lemma peirce! [HasAxiomPeirce 𝓢] : 𝓢 ⊢! ((p ➝ q) ➝ p) ➝ p := ⟨peirce⟩
 
 
 /--
@@ -19,264 +177,154 @@ class ModusPonens where
 class NegationEquiv (𝓢 : S) where
   neg_equiv (p) : 𝓢 ⊢ Axioms.NegEquiv p
 
-class HasAxiomVerum (𝓢 : S) where
-  verum : 𝓢 ⊢ Axioms.Verum
-
-class HasAxiomImply₁ (𝓢 : S)  where
-  imply₁ (p q : F) : 𝓢 ⊢ Axioms.Imply₁ p q
-
-class HasAxiomImply₂ (𝓢 : S)  where
-  imply₂ (p q r : F) : 𝓢 ⊢ Axioms.Imply₂ p q r
+def neg_equiv [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p ⭤ (p ➝ ⊥) := NegationEquiv.neg_equiv _
+@[simp] lemma neg_equiv! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼p ⭤ (p ➝ ⊥) := ⟨neg_equiv⟩
 
 class HasAxiomElimContra (𝓢 : S)  where
   elim_contra (p q : F) : 𝓢 ⊢ Axioms.ElimContra p q
 
-class HasAxiomAndElim₁ (𝓢 : S)  where
-  and₁ (p q : F) : 𝓢 ⊢ Axioms.AndElim₁ p q
-
-class HasAxiomAndElim₂ (𝓢 : S)  where
-  and₂ (p q : F) : 𝓢 ⊢ Axioms.AndElim₂ p q
-
-class HasAxiomAndInst (𝓢 : S)  where
-  and₃ (p q : F) : 𝓢 ⊢ Axioms.AndInst p q
-
-class HasAxiomOrInst₁ (𝓢 : S)  where
-  or₁ (p q : F) : 𝓢 ⊢ Axioms.OrInst₁ p q
-
-class HasAxiomOrInst₂ (𝓢 : S)  where
-  or₂ (p q : F) : 𝓢 ⊢ Axioms.OrInst₂ p q
-
-class HasAxiomOrElim (𝓢 : S)  where
-  or₃ (p q r : F) : 𝓢 ⊢ Axioms.OrElim p q r
-
-class HasAxiomEFQ where
-  efq (p : F) : 𝓢 ⊢ Axioms.EFQ p
-
-class HasAxiomLEM where
-  lem (p : F) : 𝓢 ⊢ Axioms.LEM p
-
-class HasAxiomDNE where
-  dne (p : F) : 𝓢 ⊢ Axioms.DNE p
-
-class HasAxiomWeakLEM where
-  wlem (p : F) : 𝓢 ⊢ Axioms.WeakLEM p
-
-class HasAxiomDummett where
-  dummett (p q : F) : 𝓢 ⊢ Axioms.GD p q
-
-class HasAxiomPeirce where
-  peirce (p q : F) : 𝓢 ⊢ Axioms.Peirce p q
-
-protected class Minimal extends
-              NegationEquiv 𝓢,
-              ModusPonens 𝓢,
-              HasAxiomVerum 𝓢,
-              HasAxiomImply₁ 𝓢, HasAxiomImply₂ 𝓢,
-              HasAxiomAndElim₁ 𝓢, HasAxiomAndElim₂ 𝓢, HasAxiomAndInst 𝓢,
-              HasAxiomOrInst₁ 𝓢, HasAxiomOrInst₂ 𝓢, HasAxiomOrElim 𝓢
-
-protected class Intuitionistic extends System.Minimal 𝓢, HasAxiomEFQ 𝓢
-
-protected class Classical extends System.Minimal 𝓢, HasAxiomDNE 𝓢
-
-variable {𝓢}
-
-
-alias mdp := ModusPonens.mdp
-infixl:90 "⨀" => mdp
-
-
-lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ➝ q → 𝓢 ⊢! p → 𝓢 ⊢! q := by
-  rintro ⟨hpq⟩ ⟨hp⟩;
-  exact ⟨hpq ⨀ hp⟩
-infixl:90 "⨀" => mdp!
-
--- TODO: remove this option later
-set_option linter.unusedSectionVars false
-variable
-  [System.ModusPonens 𝓢]
-  [System.HasAxiomVerum 𝓢]
-  [System.HasAxiomImply₁ 𝓢]
-  [System.HasAxiomImply₂ 𝓢]
-  [System.HasAxiomAndElim₁ 𝓢]
-  [System.HasAxiomAndElim₂ 𝓢]
-  [System.HasAxiomAndInst 𝓢]
-  [System.HasAxiomOrInst₁ 𝓢]
-  [System.HasAxiomOrInst₂ 𝓢]
-  [System.HasAxiomOrElim 𝓢]
-
-def cast {p q : F} (e : p = q) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q := e ▸ b
-
-def verum : 𝓢 ⊢ ⊤ := HasAxiomVerum.verum
-@[simp] lemma verum! [HasAxiomVerum 𝓢] : 𝓢 ⊢! ⊤ := ⟨verum⟩
-
-def imply₁ : 𝓢 ⊢ p ➝ q ➝ p := HasAxiomImply₁.imply₁ _ _
-@[simp] lemma imply₁! : 𝓢 ⊢! p ➝ q ➝ p := ⟨imply₁⟩
-
-def imply₂ : 𝓢 ⊢ (p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r := HasAxiomImply₂.imply₂ _ _ _
-@[simp] lemma imply₂! : 𝓢 ⊢! (p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r := ⟨imply₂⟩
-
-def and₁ : 𝓢 ⊢ p ⋏ q ➝ p := HasAxiomAndElim₁.and₁ _ _
-@[simp] lemma and₁! : 𝓢 ⊢! p ⋏ q ➝ p := ⟨and₁⟩
-
-def and₂ : 𝓢 ⊢ p ⋏ q ➝ q := HasAxiomAndElim₂.and₂ _ _
-@[simp] lemma and₂! : 𝓢 ⊢! p ⋏ q ➝ q := ⟨and₂⟩
-
-def and₃ : 𝓢 ⊢ p ➝ q ➝ p ⋏ q := HasAxiomAndInst.and₃ _ _
-@[simp] lemma and₃! : 𝓢 ⊢! p ➝ q ➝ p ⋏ q := ⟨and₃⟩
-
-def or₁ : 𝓢 ⊢ p ➝ p ⋎ q := HasAxiomOrInst₁.or₁ _ _
-@[simp] lemma or₁! : 𝓢 ⊢! p ➝ p ⋎ q := ⟨or₁⟩
-
-def or₂ : 𝓢 ⊢ q ➝ p ⋎ q := HasAxiomOrInst₂.or₂ _ _
-@[simp] lemma or₂! : 𝓢 ⊢! q ➝ p ⋎ q := ⟨or₂⟩
-
-def or₃ : 𝓢 ⊢ (p ➝ r) ➝ (q ➝ r) ➝ (p ⋎ q) ➝ r := HasAxiomOrElim.or₃ _ _ _
-@[simp] lemma or₃! : 𝓢 ⊢! (p ➝ r) ➝ (q ➝ r) ➝ (p ⋎ q) ➝ r := ⟨or₃⟩
-
-def efq [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ⊥ ➝ p := HasAxiomEFQ.efq _
-@[simp] lemma efq! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⊥ ➝ p := ⟨efq⟩
-
-def efq' [HasAxiomEFQ 𝓢] (b : 𝓢 ⊢ ⊥) : 𝓢 ⊢ p := efq ⨀ b
-@[simp] lemma efq'! [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! ⊥) : 𝓢 ⊢! p := ⟨efq' h.some⟩
-
-def lem [HasAxiomLEM 𝓢] : 𝓢 ⊢ p ⋎ ∼p := HasAxiomLEM.lem p
-@[simp] lemma lem! [HasAxiomLEM 𝓢] : 𝓢 ⊢! p ⋎ ∼p := ⟨lem⟩
-
-def dne [HasAxiomDNE 𝓢] : 𝓢 ⊢ ∼∼p ➝ p := HasAxiomDNE.dne _
-@[simp] lemma dne! [HasAxiomDNE 𝓢] : 𝓢 ⊢! ∼∼p ➝ p := ⟨dne⟩
-
-def dne' [HasAxiomDNE 𝓢] (b : 𝓢 ⊢ ∼∼p) : 𝓢 ⊢ p := dne ⨀ b
-@[simp] lemma dne'! [HasAxiomDNE 𝓢] (h : 𝓢 ⊢! ∼∼p) : 𝓢 ⊢! p := ⟨dne' h.some⟩
-
-def wlem [HasAxiomWeakLEM 𝓢] : 𝓢 ⊢ ∼p ⋎ ∼∼p := HasAxiomWeakLEM.wlem p
-@[simp] lemma wlem! [HasAxiomWeakLEM 𝓢] : 𝓢 ⊢! ∼p ⋎ ∼∼p := ⟨wlem⟩
-
-def dummett [HasAxiomDummett 𝓢] : 𝓢 ⊢ (p ➝ q) ⋎ (q ➝ p) := HasAxiomDummett.dummett p q
-@[simp] lemma dummett! [HasAxiomDummett 𝓢] : 𝓢 ⊢! Axioms.GD p q := ⟨dummett⟩
-
-def peirce [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((p ➝ q) ➝ p) ➝ p := HasAxiomPeirce.peirce _ _
-@[simp] lemma peirce! [HasAxiomPeirce 𝓢] : 𝓢 ⊢! ((p ➝ q) ➝ p) ➝ p := ⟨peirce⟩
-
 def elim_contra [HasAxiomElimContra 𝓢] : 𝓢 ⊢ ((∼q) ➝ (∼p)) ➝ (p ➝ q) := HasAxiomElimContra.elim_contra _ _
 @[simp] lemma elim_contra! [HasAxiomElimContra 𝓢] : 𝓢 ⊢! (∼q ➝ ∼p) ➝ (p ➝ q)  := ⟨elim_contra⟩
 
-def imply₁' (h : 𝓢 ⊢ p) : 𝓢 ⊢ q ➝ p := imply₁ ⨀ h
-lemma imply₁'! (d : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨imply₁' d.some⟩
 
-def dhyp (q : F) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q ➝ p := imply₁' b
-lemma dhyp! (b : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨dhyp _ b.some⟩
+protected class Minimal (𝓢 : S) extends
+              ModusPonens 𝓢,
+              NegationEquiv 𝓢,
+              HasAxiomVerum 𝓢,
+              HasAxiomImply₁ 𝓢, HasAxiomImply₂ 𝓢,
+              HasAxiomAndElim 𝓢, HasAxiomAndInst 𝓢,
+              HasAxiomOrInst 𝓢, HasAxiomOrElim 𝓢
 
-def imply₂' (d₁ : 𝓢 ⊢ p ➝ q ➝ r) (d₂ : 𝓢 ⊢ p ➝ q) (d₃ : 𝓢 ⊢ p) : 𝓢 ⊢ r := imply₂ ⨀ d₁ ⨀ d₂ ⨀ d₃
-lemma imply₂'! (d₁ : 𝓢 ⊢! p ➝ q ➝ r) (d₂ : 𝓢 ⊢! p ➝ q) (d₃ : 𝓢 ⊢! p) : 𝓢 ⊢! r := ⟨imply₂' d₁.some d₂.some d₃.some⟩
+protected class Intuitionistic (𝓢 : S) extends System.Minimal 𝓢, HasAxiomEFQ 𝓢
 
-def and₁' (d : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ p := and₁ ⨀ d
-lemma and₁'! (d : 𝓢 ⊢! (p ⋏ q)) : 𝓢 ⊢! p := ⟨and₁' d.some⟩
-
-alias andLeft := and₁'
-alias and_left! := and₁'!
-
-def and₂' (d : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ q := and₂ ⨀ d
-lemma and₂'! (d : 𝓢 ⊢! (p ⋏ q)) : 𝓢 ⊢! q := ⟨and₂' d.some⟩
-
-alias andRight := and₂'
-alias and_right! := and₂'!
-
-def and₃' (d₁ : 𝓢 ⊢ p) (d₂: 𝓢 ⊢ q) : 𝓢 ⊢ p ⋏ q := and₃ ⨀ d₁ ⨀ d₂
-lemma and₃'! (d₁ : 𝓢 ⊢! p) (d₂: 𝓢 ⊢! q) : 𝓢 ⊢! p ⋏ q := ⟨and₃' d₁.some d₂.some⟩
-
-alias andIntro := and₃'
-alias and_intro! := and₃'!
-
-def iffIntro (b₁ : 𝓢 ⊢ p ➝ q) (b₂ : 𝓢 ⊢ q ➝ p) : 𝓢 ⊢ p ⭤ q := andIntro b₁ b₂
-def iff_intro! (h₁ : 𝓢 ⊢! p ➝ q) (h₂ : 𝓢 ⊢! q ➝ p) : 𝓢 ⊢! p ⭤ q := ⟨andIntro h₁.some h₂.some⟩
-
-lemma and_intro_iff : 𝓢 ⊢! p ⋏ q ↔ 𝓢 ⊢! p ∧ 𝓢 ⊢! q := ⟨fun h ↦ ⟨and_left! h, and_right! h⟩, fun h ↦ and_intro! h.1 h.2⟩
-
-lemma iff_intro_iff : 𝓢 ⊢! p ⭤ q ↔ 𝓢 ⊢! p ➝ q ∧ 𝓢 ⊢! q ➝ p := ⟨fun h ↦ ⟨and_left! h, and_right! h⟩, fun h ↦ and_intro! h.1 h.2⟩
-
-lemma provable_iff_of_iff (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! p ↔ 𝓢 ⊢! q := ⟨fun hp ↦ and_left! h ⨀ hp, fun hq ↦ and_right! h ⨀ hq⟩
-
-def or₁' (d : 𝓢 ⊢ p) : 𝓢 ⊢ p ⋎ q := or₁ ⨀ d
-lemma or₁'! (d : 𝓢 ⊢! p) : 𝓢 ⊢! p ⋎ q := ⟨or₁' d.some⟩
-
-def or₂' (d : 𝓢 ⊢ q) : 𝓢 ⊢ p ⋎ q := or₂ ⨀ d
-lemma or₂'! (d : 𝓢 ⊢! q) : 𝓢 ⊢! p ⋎ q := ⟨or₂' d.some⟩
-
-def or₃'' (d₁ : 𝓢 ⊢ p ➝ r) (d₂ : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋎ q ➝ r := or₃ ⨀ d₁ ⨀ d₂
-lemma or₃''! (d₁ : 𝓢 ⊢! p ➝ r) (d₂ : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋎ q ➝ r := ⟨or₃'' d₁.some d₂.some⟩
-
-def or₃''' (d₁ : 𝓢 ⊢ p ➝ r) (d₂ : 𝓢 ⊢ q ➝ r) (d₃ : 𝓢 ⊢ p ⋎ q) : 𝓢 ⊢ r := or₃ ⨀ d₁ ⨀ d₂ ⨀ d₃
-lemma or₃'''! (d₁ : 𝓢 ⊢! p ➝ r) (d₂ : 𝓢 ⊢! q ➝ r) (d₃ : 𝓢 ⊢! p ⋎ q) : 𝓢 ⊢! r := ⟨or₃''' d₁.some d₂.some d₃.some⟩
-
-alias orCases := or₃'''
-alias or_cases! := or₃'''!
-
-def impId (p : F) : 𝓢 ⊢ p ➝ p := imply₂ (p := p) (q := (p ➝ p)) (r := p) ⨀ imply₁ ⨀ imply₁
-@[simp] def imp_id! : 𝓢 ⊢! p ➝ p := ⟨impId p⟩
-
-def iffId (p : F) : 𝓢 ⊢ p ⭤ p := and₃' (impId p) (impId p)
-@[simp] def iff_id! : 𝓢 ⊢! p ⭤ p := ⟨iffId p⟩
+protected class Classical (𝓢 : S) extends System.Minimal 𝓢, HasAxiomDNE 𝓢
 
 
-def neg_equiv [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p ⭤ (p ➝ ⊥) := NegationEquiv.neg_equiv _
-@[simp] lemma neg_equiv! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼p ⭤ (p ➝ ⊥) := ⟨neg_equiv⟩
+section
 
-def neg_equiv'.mp [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p → 𝓢 ⊢ p ➝ ⊥ := λ h => (and₁' neg_equiv) ⨀ h
-def neg_equiv'.mpr [NegationEquiv 𝓢] : 𝓢 ⊢ p ➝ ⊥ → 𝓢 ⊢ ∼p := λ h => (and₂' neg_equiv) ⨀ h
-lemma neg_equiv'! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼p ↔ 𝓢 ⊢! p ➝ ⊥ := ⟨λ ⟨h⟩ => ⟨neg_equiv'.mp h⟩, λ ⟨h⟩ => ⟨neg_equiv'.mpr h⟩⟩
+variable [ModusPonens 𝓢]
 
-def notbot [NegationEquiv 𝓢] : 𝓢 ⊢ ∼⊥ := neg_equiv'.mpr (impId ⊥)
-@[simp] lemma notbot! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼⊥ := ⟨notbot⟩
+def neg_equiv'.mp [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p → 𝓢 ⊢ p ➝ ⊥ := λ h => (and₁' neg_equiv) ⨀ h
+def neg_equiv'.mpr [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢ p ➝ ⊥ → 𝓢 ⊢ ∼p := λ h => (and₂' neg_equiv) ⨀ h
+lemma neg_equiv'! [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢! ∼p ↔ 𝓢 ⊢! p ➝ ⊥ := ⟨λ ⟨h⟩ => ⟨neg_equiv'.mp h⟩, λ ⟨h⟩ => ⟨neg_equiv'.mpr h⟩⟩
 
-instance [NegAbbrev F] : System.NegationEquiv 𝓢 where
+def iffIntro [HasAxiomAndInst 𝓢] (b₁ : 𝓢 ⊢ p ➝ q) (b₂ : 𝓢 ⊢ q ➝ p) : 𝓢 ⊢ p ⭤ q := andIntro b₁ b₂
+def iff_intro! [HasAxiomAndInst 𝓢] (h₁ : 𝓢 ⊢! p ➝ q) (h₂ : 𝓢 ⊢! q ➝ p) : 𝓢 ⊢! p ⭤ q := ⟨andIntro h₁.some h₂.some⟩
+
+lemma and_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! p ⋏ q ↔ 𝓢 ⊢! p ∧ 𝓢 ⊢! q := ⟨fun h ↦ ⟨and_left! h, and_right! h⟩, fun h ↦ and_intro! h.1 h.2⟩
+
+lemma iff_intro_iff  [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! p ⭤ q ↔ 𝓢 ⊢! p ➝ q ∧ 𝓢 ⊢! q ➝ p := ⟨fun h ↦ ⟨and_left! h, and_right! h⟩, fun h ↦ and_intro! h.1 h.2⟩
+
+lemma provable_iff_of_iff  [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! p ↔ 𝓢 ⊢! q := ⟨fun hp ↦ and_left! h ⨀ hp, fun hq ↦ and_right! h ⨀ hq⟩
+
+def impId [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p : F) : 𝓢 ⊢ p ➝ p := imply₂ (p := p) (q := (p ➝ p)) (r := p) ⨀ imply₁ ⨀ imply₁
+@[simp] def imp_id! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! p ➝ p := ⟨impId p⟩
+
+def iffId [HasAxiomAndInst 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p : F) : 𝓢 ⊢ p ⭤ p := and₃' (impId p) (impId p)
+@[simp] def iff_id! [HasAxiomAndInst 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! p ⭤ p := ⟨iffId p⟩
+
+instance [NegAbbrev F] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] [HasAxiomAndInst 𝓢] : System.NegationEquiv 𝓢 where
   neg_equiv := by intro p; simp [Axioms.NegEquiv, NegAbbrev.neg]; apply iffId;
 
-def mdp₁ (bqr : 𝓢 ⊢ p ➝ q ➝ r) (bq : 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ r := imply₂ ⨀ bqr ⨀ bq
-lemma mdp₁! (hqr : 𝓢 ⊢! p ➝ q ➝ r) (hq : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! p ➝ r := ⟨mdp₁ hqr.some hq.some⟩
+
+def notbot [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ ∼⊥ := neg_equiv'.mpr (impId ⊥)
+@[simp] lemma notbot! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! ∼⊥ := ⟨notbot⟩
+
+def mdp₁ [HasAxiomImply₂ 𝓢] (bqr : 𝓢 ⊢ p ➝ q ➝ r) (bq : 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ r := imply₂ ⨀ bqr ⨀ bq
+lemma mdp₁! [HasAxiomImply₂ 𝓢] (hqr : 𝓢 ⊢! p ➝ q ➝ r) (hq : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! p ➝ r := ⟨mdp₁ hqr.some hq.some⟩
 
 infixl:90 "⨀₁" => mdp₁
 infixl:90 "⨀₁" => mdp₁!
 
-def mdp₂ (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s) (bq : 𝓢 ⊢ p ➝ q ➝ r) : 𝓢 ⊢ p ➝ q ➝ s := dhyp p (imply₂) ⨀₁ bqr ⨀₁ bq
-lemma mdp₂! (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s) (hq : 𝓢 ⊢! p ➝ q ➝ r) : 𝓢 ⊢! p ➝ q ➝ s := ⟨mdp₂ hqr.some hq.some⟩
+def mdp₂ [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s) (bq : 𝓢 ⊢ p ➝ q ➝ r) : 𝓢 ⊢ p ➝ q ➝ s := dhyp p (imply₂) ⨀₁ bqr ⨀₁ bq
+lemma mdp₂! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s) (hq : 𝓢 ⊢! p ➝ q ➝ r) : 𝓢 ⊢! p ➝ q ➝ s := ⟨mdp₂ hqr.some hq.some⟩
 
 infixl:90 "⨀₂" => mdp₂
 infixl:90 "⨀₂" => mdp₂!
 
-def mdp₃ (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t) (bq : 𝓢 ⊢ p ➝ q ➝ r ➝ s) : 𝓢 ⊢ p ➝ q ➝ r ➝ t := (dhyp p <| dhyp q <| imply₂) ⨀₂ bqr ⨀₂ bq
-lemma mdp₃! (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t) (hq : 𝓢 ⊢! p ➝ q ➝ r ➝ s) : 𝓢 ⊢! p ➝ q ➝ r ➝ t := ⟨mdp₃ hqr.some hq.some⟩
+def mdp₃ [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t) (bq : 𝓢 ⊢ p ➝ q ➝ r ➝ s) : 𝓢 ⊢ p ➝ q ➝ r ➝ t := (dhyp p <| dhyp q <| imply₂) ⨀₂ bqr ⨀₂ bq
+lemma mdp₃! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t) (hq : 𝓢 ⊢! p ➝ q ➝ r ➝ s) : 𝓢 ⊢! p ➝ q ➝ r ➝ t := ⟨mdp₃ hqr.some hq.some⟩
 
 infixl:90 "⨀₃" => mdp₃
 infixl:90 "⨀₃" => mdp₃!
 
-def mdp₄ (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t ➝ u) (bq : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t) : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ u := (dhyp p <| dhyp q <| dhyp r <| imply₂) ⨀₃ bqr ⨀₃ bq
-lemma mdp₄! (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t ➝ u) (hq : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t) : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ u := ⟨mdp₄ hqr.some hq.some⟩
+def mdp₄ [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (bqr : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t ➝ u) (bq : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ t) : 𝓢 ⊢ p ➝ q ➝ r ➝ s ➝ u := (dhyp p <| dhyp q <| dhyp r <| imply₂) ⨀₃ bqr ⨀₃ bq
+lemma mdp₄! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hqr : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t ➝ u) (hq : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ t) : 𝓢 ⊢! p ➝ q ➝ r ➝ s ➝ u := ⟨mdp₄ hqr.some hq.some⟩
 infixl:90 "⨀₄" => mdp₄
 infixl:90 "⨀₄" => mdp₄!
 
-def impTrans'' (bpq : 𝓢 ⊢ p ➝ q) (bqr : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ➝ r := imply₂ ⨀ dhyp p bqr ⨀ bpq
-lemma imp_trans''! (hpq : 𝓢 ⊢! p ➝ q) (hqr : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ➝ r := ⟨impTrans'' hpq.some hqr.some⟩
+def impTrans'' [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (bpq : 𝓢 ⊢ p ➝ q) (bqr : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ➝ r := imply₂ ⨀ dhyp p bqr ⨀ bpq
+lemma imp_trans''! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hpq : 𝓢 ⊢! p ➝ q) (hqr : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ➝ r := ⟨impTrans'' hpq.some hqr.some⟩
 
-lemma unprovable_imp_trans''! (hpq : 𝓢 ⊢! p ➝ q) : 𝓢 ⊬ p ➝ r → 𝓢 ⊬ q ➝ r := by
+lemma unprovable_imp_trans''! [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hpq : 𝓢 ⊢! p ➝ q) : 𝓢 ⊬ p ➝ r → 𝓢 ⊬ q ➝ r := by
   contrapose; simp [neg_neg];
   exact imp_trans''! hpq;
 
-def iffTrans'' (h₁ : 𝓢 ⊢ p ⭤ q) (h₂ : 𝓢 ⊢ q ⭤ r) : 𝓢 ⊢ p ⭤ r := by
+def iffTrans'' [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h₁ : 𝓢 ⊢ p ⭤ q) (h₂ : 𝓢 ⊢ q ⭤ r) : 𝓢 ⊢ p ⭤ r := by
   apply iffIntro;
   . exact impTrans'' (and₁' h₁) (and₁' h₂);
   . exact impTrans'' (and₂' h₂) (and₂' h₁);
-lemma iff_trans''! (h₁ : 𝓢 ⊢! p ⭤ q) (h₂ : 𝓢 ⊢! q ⭤ r) : 𝓢 ⊢! p ⭤ r := ⟨iffTrans'' h₁.some h₂.some⟩
+lemma iff_trans''! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢]  (h₁ : 𝓢 ⊢! p ⭤ q) (h₂ : 𝓢 ⊢! q ⭤ r) : 𝓢 ⊢! p ⭤ r := ⟨iffTrans'' h₁.some h₂.some⟩
 
-lemma unprovable_iff! (H : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊬ p ↔ 𝓢 ⊬ q := by
+lemma unprovable_iff! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (H : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊬ p ↔ 𝓢 ⊬ q := by
   constructor;
   . intro hp hq; have := and₂'! H ⨀ hq; contradiction;
   . intro hq hp; have := and₁'! H ⨀ hp; contradiction;
 
-def imply₁₁ (p q r : F) : 𝓢 ⊢ p ➝ q ➝ r ➝ p := impTrans'' imply₁ imply₁
-@[simp] lemma imply₁₁! (p q r : F) : 𝓢 ⊢! p ➝ q ➝ r ➝ p := ⟨imply₁₁ p q r⟩
+def imply₁₁ [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p q r : F) : 𝓢 ⊢ p ➝ q ➝ r ➝ p := impTrans'' imply₁ imply₁
+@[simp] lemma imply₁₁! [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p q r : F) : 𝓢 ⊢! p ➝ q ➝ r ➝ p := ⟨imply₁₁ p q r⟩
 
-def generalConj [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ Γ.conj ➝ p :=
+-- lemma generalConjFinset! [DecidableEq F] {Γ : Finset F} (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ➝ p := by simp [Finset.conj, (generalConj! (Finset.mem_toList.mpr h))];
+
+def implyAnd [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (bq : 𝓢 ⊢ p ➝ q) (br : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ➝ q ⋏ r := dhyp p and₃ ⨀₁ bq ⨀₁ br
+lemma imply_and! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hq : 𝓢 ⊢! p ➝ q) (hr : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ➝ q ⋏ r := ⟨implyAnd hq.some hr.some⟩
+
+
+def andComm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p q : F) : 𝓢 ⊢ p ⋏ q ➝ q ⋏ p := implyAnd and₂ and₁
+lemma and_comm! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! p ⋏ q ➝ q ⋏ p := ⟨andComm p q⟩
+
+def andComm' [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ q ⋏ p := andComm _ _ ⨀ h
+lemma and_comm'! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h : 𝓢 ⊢! p ⋏ q) : 𝓢 ⊢! q ⋏ p := ⟨andComm' h.some⟩
+
+
+def iffComm  [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p q : F) : 𝓢 ⊢ (p ⭤ q) ➝ (q ⭤ p) := andComm _ _
+lemma iff_comm!  [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! (p ⭤ q) ➝ (q ⭤ p) := ⟨iffComm p q⟩
+
+def iffComm' [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ q ⭤ p := iffComm _ _ ⨀ h
+lemma iff_comm'! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! q ⭤ p := ⟨iffComm' h.some⟩
+
+
+def andImplyIffImplyImply [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (p q r : F) : 𝓢 ⊢ (p ⋏ q ➝ r) ⭤ (p ➝ q ➝ r) := by
+  let b₁ : 𝓢 ⊢ (p ⋏ q ➝ r) ➝ p ➝ q ➝ r :=
+    imply₁₁ (p ⋏ q ➝ r) p q ⨀₃ dhyp (p ⋏ q ➝ r) and₃
+  let b₂ : 𝓢 ⊢ (p ➝ q ➝ r) ➝ p ⋏ q ➝ r :=
+    imply₁ ⨀₂ (dhyp (p ➝ q ➝ r) and₁) ⨀₂ (dhyp (p ➝ q ➝ r) and₂);
+  exact iffIntro b₁ b₂
+lemma and_imply_iff_imply_imply! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! (p ⋏ q ➝ r) ⭤ (p ➝ q ➝ r) := ⟨andImplyIffImplyImply p q r⟩
+
+def andImplyIffImplyImply'.mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (d : 𝓢 ⊢ p ⋏ q ➝ r) : 𝓢 ⊢ p ➝ q ➝ r := (and₁' $ andImplyIffImplyImply p q r) ⨀ d
+def andImplyIffImplyImply'.mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (d : 𝓢 ⊢ p ➝ q ➝ r) : 𝓢 ⊢ p ⋏ q ➝ r := (and₂' $ andImplyIffImplyImply p q r) ⨀ d
+
+lemma and_imply_iff_imply_imply'! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢]: (𝓢 ⊢! p ⋏ q ➝ r) ↔ (𝓢 ⊢! p ➝ q ➝ r) := by
+  apply Iff.intro;
+  . intro ⟨h⟩; exact ⟨andImplyIffImplyImply'.mp h⟩
+  . intro ⟨h⟩; exact ⟨andImplyIffImplyImply'.mpr h⟩
+
+def imply_left_verum [HasAxiomVerum 𝓢] [HasAxiomImply₁ 𝓢] : 𝓢 ⊢ p ➝ ⊤ := dhyp p verum
+@[simp] lemma imply_left_verum! [HasAxiomImply₁ 𝓢] [HasAxiomVerum 𝓢] : 𝓢 ⊢! p ➝ ⊤ := ⟨imply_left_verum⟩
+
+
+
+instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq ⨀ b⟩
+
+
+section Conjunction
+
+variable [System.Minimal 𝓢]
+variable [DecidableEq F]
+variable {Γ Δ : List F}
+
+def generalConj {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ Γ.conj ➝ p :=
   match Γ with
   | []     => by simp at h
   | q :: Γ =>
@@ -285,63 +333,21 @@ def generalConj [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ 
     else
       have : p ∈ Γ := by simpa [e] using h
       impTrans'' and₂ (generalConj this)
+lemma generalConj! (h : p ∈ Γ) : 𝓢 ⊢! Γ.conj ➝ p := ⟨generalConj h⟩
 
-lemma generalConj! [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢! Γ.conj ➝ p := ⟨generalConj h⟩
-
--- lemma generalConjFinset! [DecidableEq F] {Γ : Finset F} (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ➝ p := by simp [Finset.conj, (generalConj! (Finset.mem_toList.mpr h))];
-
-def implyAnd (bq : 𝓢 ⊢ p ➝ q) (br : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ➝ q ⋏ r :=
-  dhyp p and₃ ⨀₁ bq ⨀₁ br
-
-
-def andComm (p q : F) : 𝓢 ⊢ p ⋏ q ➝ q ⋏ p := implyAnd and₂ and₁
-lemma and_comm! : 𝓢 ⊢! p ⋏ q ➝ q ⋏ p := ⟨andComm p q⟩
-
-def andComm' (h : 𝓢 ⊢ p ⋏ q) : 𝓢 ⊢ q ⋏ p := andComm _ _ ⨀ h
-lemma and_comm'! (h : 𝓢 ⊢! p ⋏ q) : 𝓢 ⊢! q ⋏ p := ⟨andComm' h.some⟩
-
-
-def iffComm (p q : F) : 𝓢 ⊢ (p ⭤ q) ➝ (q ⭤ p) := andComm _ _
-lemma iff_comm! : 𝓢 ⊢! (p ⭤ q) ➝ (q ⭤ p) := ⟨iffComm p q⟩
-
-def iffComm' (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ q ⭤ p := iffComm _ _ ⨀ h
-lemma iff_comm'! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! q ⭤ p := ⟨iffComm' h.some⟩
-
-
-def andImplyIffImplyImply (p q r : F) : 𝓢 ⊢ (p ⋏ q ➝ r) ⭤ (p ➝ q ➝ r) := by
-  let b₁ : 𝓢 ⊢ (p ⋏ q ➝ r) ➝ p ➝ q ➝ r :=
-    imply₁₁ (p ⋏ q ➝ r) p q ⨀₃ dhyp (p ⋏ q ➝ r) and₃
-  let b₂ : 𝓢 ⊢ (p ➝ q ➝ r) ➝ p ⋏ q ➝ r :=
-    imply₁ ⨀₂ (dhyp (p ➝ q ➝ r) and₁) ⨀₂ (dhyp (p ➝ q ➝ r) and₂);
-  exact iffIntro b₁ b₂
-
-lemma and_imply_iff_imply_imply! : 𝓢 ⊢! (p ⋏ q ➝ r) ⭤ (p ➝ q ➝ r) := ⟨andImplyIffImplyImply p q r⟩
-
-def andImplyIffImplyImply'.mp (d : 𝓢 ⊢ p ⋏ q ➝ r) : 𝓢 ⊢ p ➝ q ➝ r := (and₁' $ andImplyIffImplyImply p q r) ⨀ d
-def andImplyIffImplyImply'.mpr (d : 𝓢 ⊢ p ➝ q ➝ r) : 𝓢 ⊢ p ⋏ q ➝ r := (and₂' $ andImplyIffImplyImply p q r) ⨀ d
-
-lemma and_imply_iff_imply_imply'! : (𝓢 ⊢! p ⋏ q ➝ r) ↔ (𝓢 ⊢! p ➝ q ➝ r) := by
-  apply Iff.intro;
-  . intro ⟨h⟩; exact ⟨andImplyIffImplyImply'.mp h⟩
-  . intro ⟨h⟩; exact ⟨andImplyIffImplyImply'.mpr h⟩
-
-def conjIntro [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ Γ.conj :=
+def conjIntro (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ Γ.conj :=
   match Γ with
   | []     => verum
   | q :: Γ => andIntro (b q (by simp)) (conjIntro Γ (fun q hq ↦ b q (by simp [hq])))
 
-def implyConj [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ Γ.conj :=
+def implyConj (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ Γ.conj :=
   match Γ with
   | []     => dhyp p verum
   | q :: Γ => implyAnd (b q (by simp)) (implyConj p Γ (fun q hq ↦ b q (by simp [hq])))
 
-def conjImplyConj [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj ➝ Δ.conj :=
-  implyConj _ _ (fun _ hq ↦ generalConj (h hq))
+def conjImplyConj (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj ➝ Δ.conj := implyConj _ _ (fun _ hq ↦ generalConj (h hq))
 
-instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq ⨀ b⟩
-
-
-def generalConj' [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ ⋀Γ ➝ p :=
+def generalConj' {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ ⋀Γ ➝ p :=
   match Γ with
   | []     => by simp at h
   | [q]    => by simp_all; exact impId q;
@@ -351,28 +357,33 @@ def generalConj' [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢
     . rw [←e]; exact and₁;
     . have : p ∈ (r :: Γ) := by simpa [e] using h;
       exact impTrans'' and₂ (generalConj' this);
-lemma generate_conj'! [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ➝ p := ⟨generalConj' h⟩
+lemma generate_conj'! (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ➝ p := ⟨generalConj' h⟩
 
-def conjIntro' [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ ⋀Γ :=
+def conjIntro' (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ ⋀Γ :=
   match Γ with
   | []     => verum
   | [q]    => by apply b; simp;
   | q :: r :: Γ => by
     simp;
     exact andIntro (b q (by simp)) (conjIntro' _ (by aesop))
-lemma conj_intro'! [DecidableEq F] {Γ : List F} (b : (p : F) → p ∈ Γ → 𝓢 ⊢! p) : 𝓢 ⊢! ⋀Γ := ⟨conjIntro' Γ (λ p hp => (b p hp).some)⟩
+lemma conj_intro'! (b : (p : F) → p ∈ Γ → 𝓢 ⊢! p) : 𝓢 ⊢! ⋀Γ := ⟨conjIntro' Γ (λ p hp => (b p hp).some)⟩
 
-def implyConj' [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ ⋀Γ :=
+def implyConj' (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ p ➝ ⋀Γ :=
   match Γ with
   | []     => dhyp p verum
   | [q]    => by apply b; simp;
   | q :: r :: Γ => by
     simp;
     apply implyAnd (b q (by simp)) (implyConj' p _ (fun q hq ↦ b q (by simp [hq])));
-lemma imply_conj'! [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! p ➝ ⋀Γ := ⟨implyConj' p Γ (λ q hq => (b q hq).some)⟩
+lemma imply_conj'! (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! p ➝ ⋀Γ := ⟨implyConj' p Γ (λ q hq => (b q hq).some)⟩
 
-def conjImplyConj' [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ ➝ ⋀Δ :=
+def conjImplyConj' {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ ➝ ⋀Δ :=
   implyConj' _ _ (fun _ hq ↦ generalConj' (h hq))
+
+end Conjunction
+
+end
+
 
 section
 

--- a/Foundation/Logic/HilbertStyle/Basic.lean
+++ b/Foundation/Logic/HilbertStyle/Basic.lean
@@ -91,7 +91,8 @@ lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ➝ q → 𝓢 ⊢! p → 𝓢 ⊢! 
   exact ⟨hpq ⨀ hp⟩
 infixl:90 "⨀" => mdp!
 
-
+-- TODO: remove this option later
+set_option linter.unusedSectionVars false
 variable
   [System.ModusPonens 𝓢]
   [System.HasAxiomVerum 𝓢]
@@ -224,6 +225,9 @@ def neg_equiv [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p ⭤ (p ➝ ⊥) := NegationEq
 def neg_equiv'.mp [NegationEquiv 𝓢] : 𝓢 ⊢ ∼p → 𝓢 ⊢ p ➝ ⊥ := λ h => (and₁' neg_equiv) ⨀ h
 def neg_equiv'.mpr [NegationEquiv 𝓢] : 𝓢 ⊢ p ➝ ⊥ → 𝓢 ⊢ ∼p := λ h => (and₂' neg_equiv) ⨀ h
 lemma neg_equiv'! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼p ↔ 𝓢 ⊢! p ➝ ⊥ := ⟨λ ⟨h⟩ => ⟨neg_equiv'.mp h⟩, λ ⟨h⟩ => ⟨neg_equiv'.mpr h⟩⟩
+
+def notbot [NegationEquiv 𝓢] : 𝓢 ⊢ ∼⊥ := neg_equiv'.mpr (impId ⊥)
+@[simp] lemma notbot! [NegationEquiv 𝓢] : 𝓢 ⊢! ∼⊥ := ⟨notbot⟩
 
 instance [NegAbbrev F] : System.NegationEquiv 𝓢 where
   neg_equiv := by intro p; simp [Axioms.NegEquiv, NegAbbrev.neg]; apply iffId;

--- a/Foundation/Logic/HilbertStyle/Basic.lean
+++ b/Foundation/Logic/HilbertStyle/Basic.lean
@@ -39,7 +39,6 @@ def imply₁' [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (h : 𝓢 ⊢ p) : 𝓢
 lemma imply₁'! [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (d : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨imply₁' d.some⟩
 
 @[deprecated imply₁'] def dhyp [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (q : F) (b : 𝓢 ⊢ p) : 𝓢 ⊢ q ➝ p := imply₁' b
-@[deprecated imply₁'!] lemma dhyp! [ModusPonens 𝓢] [HasAxiomImply₁ 𝓢] (b : 𝓢 ⊢! p) : 𝓢 ⊢! q ➝ p := ⟨dhyp _ b.some⟩
 
 
 class HasAxiomImply₂ (𝓢 : S)  where

--- a/Foundation/Logic/HilbertStyle/Context.lean
+++ b/Foundation/Logic/HilbertStyle/Context.lean
@@ -5,7 +5,7 @@ namespace LO
 
 namespace System
 
-variable (F : Type*) [LogicalConnective F] [DecidableEq F] {S : Type*} [System F S]
+variable (F : Type*) {S : Type*}
 
 structure FiniteContext (𝓢 : S) where
   ctx : List F
@@ -18,9 +18,9 @@ variable {𝓢 : S}
 
 instance : Coe (List F) (FiniteContext F 𝓢) := ⟨mk⟩
 
-abbrev conj (Γ : FiniteContext F 𝓢) : F := ⋀Γ.ctx
+abbrev conj [LogicalConnective F] (Γ : FiniteContext F 𝓢) : F := ⋀Γ.ctx
 
-abbrev disj (Γ : FiniteContext F 𝓢) : F := ⋁Γ.ctx
+abbrev disj [LogicalConnective F] (Γ : FiniteContext F 𝓢) : F := ⋁Γ.ctx
 
 instance : EmptyCollection (FiniteContext F 𝓢) := ⟨⟨[]⟩⟩
 
@@ -42,6 +42,8 @@ instance : Collection F (FiniteContext F 𝓢) where
   subset_iff := List.subset_def
   not_mem_empty := by simp
   mem_cons_iff := by simp [Cons.cons, mem_def]
+
+variable [System F S] [LogicalConnective F]
 
 instance (𝓢 : S) : System F (FiniteContext F 𝓢) := ⟨(𝓢 ⊢ ·.conj ➝ ·)⟩
 
@@ -75,8 +77,12 @@ lemma toₛ! (b : Γ ⊢[𝓢]! p) : 𝓢 ⊢! ⋀Γ ➝ p := b
 
 lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! ⋀Γ ➝ p := iff_of_eq rfl
 
-variable {Γ Δ E : List F}
 
+set_option deprecated.oldSectionVars true in -- TODO: remove this option
+section
+
+variable [DecidableEq F]
+variable {Γ Δ E : List F}
 variable
   [System.ModusPonens 𝓢]
   [System.HasAxiomVerum 𝓢]
@@ -201,7 +207,10 @@ instance [System.Intuitionistic 𝓢] (Γ : FiniteContext F 𝓢) : System.Intui
 
 instance [System.Classical 𝓢] (Γ : FiniteContext F 𝓢) : System.Classical Γ where
 
+end
+
 end FiniteContext
+
 
 variable (F)
 
@@ -209,6 +218,7 @@ structure Context (𝓢 : S) where
   ctx : Set F
 
 variable {F}
+
 
 namespace Context
 
@@ -236,6 +246,8 @@ instance : Collection F (Context F 𝓢) where
   subset_iff := by rintro ⟨s⟩ ⟨u⟩; simp [Set.subset_def]
   not_mem_empty := by simp
   mem_cons_iff := by simp [Cons.cons, mem_def]
+
+variable [LogicalConnective F] [System F S]
 
 structure Proof (Γ : Context F 𝓢) (p : F) where
   ctx : List F
@@ -266,7 +278,10 @@ notation Γ:45 " *⊢[" 𝓢 "]* " s:46 => PrfSet 𝓢 Γ s
 
 notation Γ:45 " *⊢[" 𝓢 "]*! " s:46 => ProvableSet 𝓢 Γ s
 
+set_option deprecated.oldSectionVars true in -- TODO: remove this option
+section
 
+variable [DecidableEq F]
 variable {𝓢}
 
 lemma provable_iff {p : F} : Γ *⊢[𝓢]! p ↔ ∃ Δ : List F, (∀ q ∈ Δ, q ∈ Γ) ∧ Δ ⊢[𝓢]! p :=
@@ -355,6 +370,8 @@ end minimal
 instance [System.Intuitionistic 𝓢] (Γ : Context F 𝓢) : System.Intuitionistic Γ where
 
 instance [System.Classical 𝓢] (Γ : Context F 𝓢) : System.Classical Γ where
+
+end
 
 end Context
 

--- a/Foundation/Logic/HilbertStyle/Context.lean
+++ b/Foundation/Logic/HilbertStyle/Context.lean
@@ -24,7 +24,7 @@ abbrev disj (Γ : FiniteContext F 𝓢) : F := ⋁Γ.ctx
 
 instance : EmptyCollection (FiniteContext F 𝓢) := ⟨⟨[]⟩⟩
 
-instance : Membership F (FiniteContext F 𝓢) := ⟨(· ∈ ·.ctx)⟩
+instance : Membership F (FiniteContext F 𝓢) := ⟨λ Γ x => (x ∈ Γ.ctx)⟩
 
 instance : HasSubset (FiniteContext F 𝓢) := ⟨(·.ctx ⊆ ·.ctx)⟩
 
@@ -218,7 +218,7 @@ instance : Coe (Set F) (Context F 𝓢) := ⟨mk⟩
 
 instance : EmptyCollection (Context F 𝓢) := ⟨⟨∅⟩⟩
 
-instance : Membership F (Context F 𝓢) := ⟨(· ∈ ·.ctx)⟩
+instance : Membership F (Context F 𝓢) := ⟨λ Γ x => (x ∈ Γ.ctx)⟩
 
 instance : HasSubset (Context F 𝓢) := ⟨(·.ctx ⊆ ·.ctx)⟩
 

--- a/Foundation/Logic/HilbertStyle/Context.lean
+++ b/Foundation/Logic/HilbertStyle/Context.lean
@@ -78,23 +78,12 @@ lemma toₛ! (b : Γ ⊢[𝓢]! p) : 𝓢 ⊢! ⋀Γ ➝ p := b
 lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! ⋀Γ ➝ p := iff_of_eq rfl
 
 
-set_option deprecated.oldSectionVars true in -- TODO: remove this option
 section
 
-variable [DecidableEq F]
 variable {Γ Δ E : List F}
-variable
-  [System.ModusPonens 𝓢]
-  [System.HasAxiomVerum 𝓢]
-  [System.HasAxiomImply₁ 𝓢]
-  [System.HasAxiomImply₂ 𝓢]
-  [System.HasAxiomAndElim₁ 𝓢]
-  [System.HasAxiomAndElim₂ 𝓢]
-  [System.HasAxiomAndInst 𝓢]
-  [System.HasAxiomOrInst₁ 𝓢]
-  [System.HasAxiomOrInst₂ 𝓢]
+variable [System.Minimal 𝓢]
 
-instance : Axiomatized (FiniteContext F 𝓢) where
+instance [DecidableEq F] : Axiomatized (FiniteContext F 𝓢) where
   prfAxm := fun hp ↦ generalConj' hp
   weakening := fun H b ↦ impTrans'' (conjImplyConj' H) b
 
@@ -104,13 +93,13 @@ instance : Compact (FiniteContext F 𝓢) where
   φ_subset := by simp
   φ_finite := by rintro ⟨Γ⟩; simp [Collection.Finite, Collection.set]
 
-def byAxm {p} (h : p ∈ Γ := by simp) : Γ ⊢[𝓢] p := Axiomatized.prfAxm (by simpa)
+def byAxm [DecidableEq F] {p} (h : p ∈ Γ := by simp) : Γ ⊢[𝓢] p := Axiomatized.prfAxm (by simpa)
 
-lemma by_axm! {p} (h : p ∈ Γ := by simp) : Γ ⊢[𝓢]! p := Axiomatized.provable_axm _ (by simpa)
+lemma by_axm! [DecidableEq F] {p} (h : p ∈ Γ := by simp) : Γ ⊢[𝓢]! p := Axiomatized.provable_axm _ (by simpa)
 
-def weakening (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢] p → Δ ⊢[𝓢] p := Axiomatized.weakening (by simpa)
+def weakening [DecidableEq F] (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢] p → Δ ⊢[𝓢] p := Axiomatized.weakening (by simpa)
 
-lemma weakening! (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢]! p → Δ ⊢[𝓢]! p := fun h ↦ Axiomatized.le_of_subset (by simpa) h
+lemma weakening! [DecidableEq F] (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢]! p → Δ ⊢[𝓢]! p := fun h ↦ Axiomatized.le_of_subset (by simpa) h
 
 def of {p : F} (b : 𝓢 ⊢ p) : Γ ⊢[𝓢] p := dhyp (⋀Γ) b
 
@@ -119,23 +108,19 @@ def emptyPrf {p : F} : [] ⊢[𝓢] p → 𝓢 ⊢ p := fun b ↦ b ⨀ verum
 def provable_iff_provable {p : F} : 𝓢 ⊢! p ↔ [] ⊢[𝓢]! p :=
   ⟨fun b ↦ ⟨of b.some⟩, fun b ↦ ⟨emptyPrf b.some⟩⟩
 
-lemma of'! (h : 𝓢 ⊢! p) : Γ ⊢[𝓢]! p := weakening! (by simp) $ provable_iff_provable.mp h
+lemma of'! [DecidableEq F] (h : 𝓢 ⊢! p) : Γ ⊢[𝓢]! p := weakening! (by simp) $ provable_iff_provable.mp h
 
-def id : [p] ⊢[𝓢] p := byAxm
+def id [DecidableEq F] : [p] ⊢[𝓢] p := byAxm
+@[simp] lemma id! [DecidableEq F] : [p] ⊢[𝓢]! p := by_axm!
 
-def byAxm₀ : (p :: Γ) ⊢[𝓢] p := byAxm
+def byAxm₀ [DecidableEq F] : (p :: Γ) ⊢[𝓢] p := byAxm
+lemma by_axm₀! [DecidableEq F] : (p :: Γ) ⊢[𝓢]! p := by_axm!
 
-def byAxm₁ : (p :: q :: Γ) ⊢[𝓢] q := byAxm
+def byAxm₁ [DecidableEq F] : (p :: q :: Γ) ⊢[𝓢] q := byAxm
+lemma by_axm₁! [DecidableEq F] : (p :: q :: Γ) ⊢[𝓢]! q := by_axm!
 
-def byAxm₂ : (p :: q :: r :: Γ) ⊢[𝓢] r := byAxm
-
-lemma by_axm₀! : (p :: Γ) ⊢[𝓢]! p := by_axm!
-
-lemma by_axm₁! : (p :: q :: Γ) ⊢[𝓢]! q := by_axm!
-
-lemma by_axm₂! : (p :: q :: r :: Γ) ⊢[𝓢]! r := by_axm!
-
-@[simp] lemma id! : [p] ⊢[𝓢]! p := by_axm!
+def byAxm₂ [DecidableEq F] : (p :: q :: r :: Γ) ⊢[𝓢] r := byAxm
+lemma by_axm₂! [DecidableEq F] : (p :: q :: r :: Γ) ⊢[𝓢]! r := by_axm!
 
 instance (Γ : FiniteContext F 𝓢) : System.ModusPonens Γ := ⟨mdp₁⟩
 
@@ -145,21 +130,20 @@ instance (Γ : FiniteContext F 𝓢) : System.HasAxiomImply₁ Γ := ⟨fun _ _ 
 
 instance (Γ : FiniteContext F 𝓢) : System.HasAxiomImply₂ Γ := ⟨fun _ _ _ ↦ of imply₂⟩
 
-instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndElim₁ Γ := ⟨fun _ _ ↦ of and₁⟩
-
-instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndElim₂ Γ := ⟨fun _ _ ↦ of and₂⟩
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndElim Γ := ⟨fun _ _ ↦ of and₁, fun _ _ ↦ of and₂⟩
 
 instance (Γ : FiniteContext F 𝓢) : System.HasAxiomAndInst Γ := ⟨fun _ _ ↦ of and₃⟩
 
-instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrInst₁ Γ := ⟨fun _ _ ↦ of or₁⟩
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrInst Γ := ⟨fun _ _ ↦ of or₁, fun _ _ ↦ of or₂⟩
 
-instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrInst₂ Γ := ⟨fun _ _ ↦ of or₂⟩
+instance (Γ : FiniteContext F 𝓢) : System.HasAxiomOrElim Γ := ⟨fun _ _ _ ↦ of or₃⟩
 
-instance [HasAxiomOrElim 𝓢] (Γ : FiniteContext F 𝓢) : System.HasAxiomOrElim Γ := ⟨fun _ _ _ ↦ of or₃⟩
+instance (Γ : FiniteContext F 𝓢) : System.NegationEquiv Γ := ⟨fun _ ↦ of neg_equiv⟩
 
-instance [NegationEquiv 𝓢] (Γ : FiniteContext F 𝓢) : System.NegationEquiv Γ := ⟨fun _ ↦ of neg_equiv⟩
+instance [System.Minimal 𝓢] (Γ : FiniteContext F 𝓢) : System.Minimal Γ where
 
-def mdp' (bΓ : Γ ⊢[𝓢] p ➝ q) (bΔ : Δ ⊢[𝓢] p) : (Γ ++ Δ) ⊢[𝓢] q := wk (by simp) bΓ ⨀ wk (by simp) bΔ
+
+def mdp' [DecidableEq F] (bΓ : Γ ⊢[𝓢] p ➝ q) (bΔ : Δ ⊢[𝓢] p) : (Γ ++ Δ) ⊢[𝓢] q := wk (by simp) bΓ ⨀ wk (by simp) bΔ
 
 def deduct {p q : F} : {Γ : List F} → (p :: Γ) ⊢[𝓢] q → Γ ⊢[𝓢] p ➝ q
   | .nil => fun b ↦ ofDef <| dhyp _ (toDef b)
@@ -190,7 +174,7 @@ instance deduction : Deduction (FiniteContext F 𝓢) where
   ofInsert := deduct
   inv := deductInv
 
-instance : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
+instance [DecidableEq F] : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
   ⟨fun {Γ Δ _} bΓ bΔ ↦
     have : Γ ⊢ Δ.conj := conjIntro' _ (fun _ hp ↦ bΓ hp)
     ofDef <| impTrans'' (toDef this) (toDef bΔ)⟩
@@ -198,13 +182,9 @@ instance : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
 instance [HasAxiomEFQ 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomEFQ Γ := ⟨fun _ ↦ of efq⟩
 
 instance [HasAxiomEFQ 𝓢] : DeductiveExplosion (FiniteContext F 𝓢) := inferInstance
-
-instance [HasAxiomDNE 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomDNE Γ := ⟨fun p ↦ of (HasAxiomDNE.dne p)⟩
-
-instance [System.Minimal 𝓢] (Γ : FiniteContext F 𝓢) : System.Minimal Γ where
-
 instance [System.Intuitionistic 𝓢] (Γ : FiniteContext F 𝓢) : System.Intuitionistic Γ where
 
+instance [HasAxiomDNE 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomDNE Γ := ⟨fun p ↦ of (HasAxiomDNE.dne p)⟩
 instance [System.Classical 𝓢] (Γ : FiniteContext F 𝓢) : System.Classical Γ where
 
 end
@@ -278,10 +258,8 @@ notation Γ:45 " *⊢[" 𝓢 "]* " s:46 => PrfSet 𝓢 Γ s
 
 notation Γ:45 " *⊢[" 𝓢 "]*! " s:46 => ProvableSet 𝓢 Γ s
 
-set_option deprecated.oldSectionVars true in -- TODO: remove this option
 section
 
-variable [DecidableEq F]
 variable {𝓢}
 
 lemma provable_iff {p : F} : Γ *⊢[𝓢]! p ↔ ∃ Δ : List F, (∀ q ∈ Δ, q ∈ Γ) ∧ Δ ⊢[𝓢]! p :=
@@ -291,7 +269,7 @@ section minimal
 
 variable [System.Minimal 𝓢]
 
-instance : Axiomatized (Context F 𝓢) where
+instance [DecidableEq F] : Axiomatized (Context F 𝓢) where
   prfAxm := fun {Γ p} hp ↦ ⟨[p], by simpa using hp, byAxm (by simp [Collection.set])⟩
   weakening := fun h b ↦ ⟨b.ctx, fun p hp ↦ Collection.subset_iff.mp h p (b.subset p hp), b.prf⟩
 
@@ -319,7 +297,7 @@ def deduct [DecidableEq F] {p q : F} {Γ : Set F} : (insert p Γ) *⊢[𝓢] q �
 def deductInv {p q : F} {Γ : Set F} : Γ *⊢[𝓢] p ➝ q → (insert p Γ) *⊢[𝓢] q
   | ⟨Δ, h, b⟩ => ⟨p :: Δ, by simp; intro r hr; exact Or.inr (h r hr), FiniteContext.deductInv b⟩
 
-instance deduction : Deduction (Context F 𝓢) where
+instance deduction [DecidableEq F] : Deduction (Context F 𝓢) where
   ofInsert := deduct
   inv := deductInv
 
@@ -327,14 +305,14 @@ def of {p : F} (b : 𝓢 ⊢ p) : Γ *⊢[𝓢] p := ⟨[], by simp, FiniteConte
 
 lemma of! (b : 𝓢 ⊢! p) : Γ *⊢[𝓢]! p := ⟨Context.of b.some⟩
 
-def mdp {Γ : Set F} (bpq : Γ *⊢[𝓢] p ➝ q) (bp : Γ *⊢[𝓢] p) : Γ *⊢[𝓢] q :=
+def mdp [DecidableEq F] {Γ : Set F} (bpq : Γ *⊢[𝓢] p ➝ q) (bp : Γ *⊢[𝓢] p) : Γ *⊢[𝓢] q :=
   ⟨ bpq.ctx ++ bp.ctx, by
     simp; rintro r (hr | hr)
     · exact bpq.subset r hr
     · exact bp.subset r hr,
     FiniteContext.mdp' bpq.prf bp.prf ⟩
 
-lemma by_axm! (h : p ∈ Γ) : Γ *⊢[𝓢]! p := System.by_axm _ (by simpa)
+lemma by_axm! [DecidableEq F] (h : p ∈ Γ) : Γ *⊢[𝓢]! p := System.by_axm _ (by simpa)
 
 def emptyPrf {p : F} : ∅ *⊢[𝓢] p → 𝓢 ⊢ p := by
   rintro ⟨Γ, hΓ, h⟩;
@@ -346,7 +324,7 @@ lemma emptyPrf! {p : F} : ∅ *⊢[𝓢]! p → 𝓢 ⊢! p := fun h ↦ ⟨empt
 
 lemma provable_iff_provable {p : F} : 𝓢 ⊢! p ↔ ∅ *⊢[𝓢]! p := ⟨of!, emptyPrf!⟩
 
-instance minimal (Γ : Context F 𝓢) : System.Minimal Γ where
+instance minimal [DecidableEq F] (Γ : Context F 𝓢) : System.Minimal Γ where
   mdp := mdp
   verum := of verum
   imply₁ := fun _ _ ↦ of imply₁
@@ -367,9 +345,9 @@ instance [HasAxiomEFQ 𝓢] : DeductiveExplosion (FiniteContext F 𝓢) := infer
 
 end minimal
 
-instance [System.Intuitionistic 𝓢] (Γ : Context F 𝓢) : System.Intuitionistic Γ where
+instance [DecidableEq F] [System.Intuitionistic 𝓢] (Γ : Context F 𝓢) : System.Intuitionistic Γ where
 
-instance [System.Classical 𝓢] (Γ : Context F 𝓢) : System.Classical Γ where
+instance [DecidableEq F] [System.Classical 𝓢] (Γ : Context F 𝓢) : System.Classical Γ where
 
 end
 

--- a/Foundation/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Foundation/Logic/HilbertStyle/Lukasiewicz.lean
@@ -119,14 +119,13 @@ def andElim₁ : 𝓢 ⊢ p ⋏ q ➝ p := by
   have : 𝓢 ⊢ ∼p ➝ p ➝ ∼q := explodeHyp₂ explode₂₁ imply₁;
   have : 𝓢 ⊢ ∼(p ➝ ∼q) ➝ ∼∼p := contraIntro' explode₂₁
   exact impTrans'' this dne;
-instance : HasAxiomAndElim₁ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (p := p) (q := q)⟩
 
 def andElim₂ : 𝓢 ⊢ p ⋏ q ➝ q := by
   simp only [LukasiewiczAbbrev.and];
   have : 𝓢 ⊢ ∼q ➝ p ➝ ∼q := imply₁ (p := ∼q) (q := p);
   have : 𝓢 ⊢ ∼(p ➝ ∼q) ➝ ∼∼q := contraIntro' this;
   exact impTrans'' this dne;
-instance : HasAxiomAndElim₂ 𝓢 := ⟨λ p q => Lukasiewicz.andElim₂ (p := p) (q := q)⟩
+instance : HasAxiomAndElim 𝓢 := ⟨λ p q => Lukasiewicz.andElim₁ (p := p) (q := q), λ p q => Lukasiewicz.andElim₂ (p := p) (q := q)⟩
 
 def andImplyLeft : 𝓢 ⊢ (p₁ ➝ q) ➝ p₁ ⋏ p₂ ➝ q := (impSwap $ dhyp _ (impId _)) ⨀₂ (dhyp _ andElim₁)
 def andImplyLeft' (h : 𝓢 ⊢ (p₁ ➝ q)) : 𝓢 ⊢ p₁ ⋏ p₂ ➝ q := andImplyLeft ⨀ h
@@ -151,16 +150,16 @@ def andInst : 𝓢 ⊢ p ➝ q ➝ p ⋏ q := by
 
 instance : HasAxiomAndInst 𝓢 := ⟨λ p q => Lukasiewicz.andInst (p := p) (q := q)⟩
 
+
 def orInst₁ : 𝓢 ⊢ p ➝ p ⋎ q := by
   simp only [LukasiewiczAbbrev.or];
   exact explode₁₂;
 
-instance : HasAxiomOrInst₁ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₁ (p := p) (q := q)⟩
-
 def orInst₂ : 𝓢 ⊢ q ➝ p ⋎ q := by
   simp [LukasiewiczAbbrev.or];
   exact imply₁;
-instance : HasAxiomOrInst₂ 𝓢 := ⟨λ p q => Lukasiewicz.orInst₂ (p := p) (q := q)⟩
+
+instance : HasAxiomOrInst 𝓢 := ⟨λ p q => Lukasiewicz.orInst₁ (p := p) (q := q), λ p q => Lukasiewicz.orInst₂ (p := p) (q := q)⟩
 
 -- or_imply
 def orElim : 𝓢 ⊢ (p ➝ r) ➝ (q ➝ r) ➝ (p ⋎ q ➝ r) := by

--- a/Foundation/Logic/HilbertStyle/Supplemental.lean
+++ b/Foundation/Logic/HilbertStyle/Supplemental.lean
@@ -597,7 +597,7 @@ lemma conjconj_subset! (h : ∀ p, p ∈ Γ → p ∈ Δ) : 𝓢 ⊢! ⋀Δ ➝ 
 
 lemma conjconj_provable! (h : ∀ p, p ∈ Γ → Δ ⊢[𝓢]! p) : 𝓢 ⊢! ⋀Δ ➝ ⋀Γ :=
   by induction Γ using List.induction_with_singleton with
-  | hnil => exact dhyp! verum!;
+  | hnil => exact imply₁'! verum!;
   | hsingle => simp_all; exact provable_iff.mp h;
   | hcons p Γ hne ih => simp_all; exact imply_right_and! (provable_iff.mp h.1) ih;
 
@@ -618,7 +618,7 @@ lemma iff_imply_left_cons_conj'! : 𝓢 ⊢! ⋀(p :: Γ) ➝ q ↔ 𝓢 ⊢! p 
   | nil =>
     simp [and_imply_iff_imply_imply'!];
     constructor;
-    . intro h; apply imp_swap'!; exact dhyp! h;
+    . intro h; apply imp_swap'!; exact imply₁'! h;
     . intro h; exact imp_swap'! h ⨀ verum!;
   | cons q ih => simp;
 

--- a/Foundation/Logic/HilbertStyle/Supplemental.lean
+++ b/Foundation/Logic/HilbertStyle/Supplemental.lean
@@ -1,6 +1,8 @@
 import Foundation.Logic.System
 import Foundation.Logic.HilbertStyle.Context
 
+set_option deprecated.oldSectionVars true
+
 namespace LO.System
 
 variable {F : Type*} [LogicalConnective F] [DecidableEq F]

--- a/Foundation/Logic/HilbertStyle/Supplemental.lean
+++ b/Foundation/Logic/HilbertStyle/Supplemental.lean
@@ -1,8 +1,6 @@
 import Foundation.Logic.System
 import Foundation.Logic.HilbertStyle.Context
 
-set_option deprecated.oldSectionVars true
-
 namespace LO.System
 
 variable {F : Type*} [LogicalConnective F] [DecidableEq F]
@@ -22,41 +20,41 @@ def mdp_in : 𝓢 ⊢ p ⋏ (p ➝ q) ➝ q := by
   exact hpq ⨀ hp;
 lemma mdp_in! : 𝓢 ⊢! p ⋏ (p ➝ q) ➝ q := ⟨mdp_in⟩
 
-def bot_of_mem_either [System.NegationEquiv 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
+def bot_of_mem_either (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
   have hp : Γ ⊢[𝓢] p := FiniteContext.byAxm h₁;
   have hnp : Γ ⊢[𝓢] p ➝ ⊥ := neg_equiv'.mp $ FiniteContext.byAxm h₂;
   exact hnp ⨀ hp
 
-@[simp] lemma bot_of_mem_either! [System.NegationEquiv 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢]! ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
+@[simp] lemma bot_of_mem_either! (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢]! ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
 
 
-def efq_of_mem_either [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢] q := efq' $ bot_of_mem_either h₁ h₂
-@[simp] lemma efq_of_mem_either! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢]! q := ⟨efq_of_mem_either h₁ h₂⟩
+def efq_of_mem_either [HasAxiomEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢] q := efq' $ bot_of_mem_either h₁ h₂
+@[simp] lemma efq_of_mem_either! [HasAxiomEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ∼p ∈ Γ) : Γ ⊢[𝓢]! q := ⟨efq_of_mem_either h₁ h₂⟩
 
-def efq_imply_not₁ [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ∼p ➝ p ➝ q := by
+def efq_imply_not₁ [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ∼p ➝ p ➝ q := by
   apply deduct';
   apply deduct;
   apply efq_of_mem_either (p := p) (by simp) (by simp);
-@[simp] lemma efq_imply_not₁! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ∼p ➝ p ➝ q := ⟨efq_imply_not₁⟩
+@[simp] lemma efq_imply_not₁! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ∼p ➝ p ➝ q := ⟨efq_imply_not₁⟩
 
-def efq_imply_not₂ [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ p ➝ ∼p ➝ q := by
+def efq_imply_not₂ [HasAxiomEFQ 𝓢] : 𝓢 ⊢ p ➝ ∼p ➝ q := by
   apply deduct';
   apply deduct;
   apply efq_of_mem_either (p := p) (by simp) (by simp);
-@[simp] lemma efq_imply_not₂! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ➝ ∼p ➝ q := ⟨efq_imply_not₂⟩
+@[simp] lemma efq_imply_not₂! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ➝ ∼p ➝ q := ⟨efq_imply_not₂⟩
 
-lemma efq_of_neg! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! ∼p) : 𝓢 ⊢! p ➝ q := by
+lemma efq_of_neg! [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! ∼p) : 𝓢 ⊢! p ➝ q := by
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
   have dnp : [p] ⊢[𝓢]! p ➝ ⊥ := of'! $ neg_equiv'!.mp h;
   exact efq'! (dnp ⨀ FiniteContext.id!);
 
-lemma efq_of_neg₂! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! p) : 𝓢 ⊢! ∼p ➝ q := efq_imply_not₂! ⨀ h
+lemma efq_of_neg₂! [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! p) : 𝓢 ⊢! ∼p ➝ q := efq_imply_not₂! ⨀ h
 
-def neg_mdp [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢ ∼p) (hn : 𝓢 ⊢ p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp hnp) ⨀ hn
+def neg_mdp (hnp : 𝓢 ⊢ ∼p) (hn : 𝓢 ⊢ p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp hnp) ⨀ hn
 -- infixl:90 "⨀" => neg_mdp
 
-lemma neg_mdp! [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢! ∼p) (hn : 𝓢 ⊢! p) : 𝓢 ⊢! ⊥ := ⟨neg_mdp hnp.some hn.some⟩
+omit [DecidableEq F] in lemma neg_mdp! (hnp : 𝓢 ⊢! ∼p) (hn : 𝓢 ⊢! p) : 𝓢 ⊢! ⊥ := ⟨neg_mdp hnp.some hn.some⟩
 -- infixl:90 "⨀" => neg_mdp!
 
 def dneOr [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ ∼∼p ⋎ ∼∼q) : 𝓢 ⊢ p ⋎ q := or₃''' (impTrans'' dne or₁) (impTrans'' dne or₂) d
@@ -66,14 +64,14 @@ def implyLeftOr' (h : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ➝ (r ⋎ q) := by
   apply or₁';
   apply deductInv;
   exact of h;
-lemma imply_left_or'! (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ➝ (r ⋎ q) := ⟨implyLeftOr' h.some⟩
+omit [DecidableEq F] in lemma imply_left_or'! (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ➝ (r ⋎ q) := ⟨implyLeftOr' h.some⟩
 
 def implyRightOr' (h : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ q ➝ (p ⋎ r) := by
   apply deduct';
   apply or₂';
   apply deductInv;
   exact of h;
-lemma imply_right_or'! (h : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! q ➝ (p ⋎ r) := ⟨implyRightOr' h.some⟩
+omit [DecidableEq F] in lemma imply_right_or'! (h : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! q ➝ (p ⋎ r) := ⟨implyRightOr' h.some⟩
 
 
 def implyRightAnd (hq : 𝓢 ⊢ p ➝ q) (hr : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ➝ q ⋏ r := by
@@ -83,7 +81,7 @@ def implyRightAnd (hq : 𝓢 ⊢ p ➝ q) (hr : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p �
   exact and₃' (mdp' hq FiniteContext.id) (mdp' hr FiniteContext.id)
 lemma imply_right_and! (hq : 𝓢 ⊢! p ➝ q) (hr : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ➝ q ⋏ r := ⟨implyRightAnd hq.some hr.some⟩
 
-lemma imply_left_and_comm'! (d : 𝓢 ⊢! p ⋏ q ➝ r) : 𝓢 ⊢! q ⋏ p ➝ r := imp_trans''! and_comm! d
+omit [DecidableEq F] in lemma imply_left_and_comm'! (d : 𝓢 ⊢! p ⋏ q ➝ r) : 𝓢 ⊢! q ⋏ p ➝ r := imp_trans''! and_comm! d
 
 lemma dhyp_and_left! (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! (q ⋏ p) ➝ r := by
   apply and_imply_iff_imply_imply'!.mpr;
@@ -96,7 +94,6 @@ lemma cut! (d₁ : 𝓢 ⊢! p₁ ⋏ c ➝ q₁) (d₂ : 𝓢 ⊢! p₂ ➝ c �
   apply deduct'!;
   exact or₃'''! (imply_left_or'! $ of'! (and_imply_iff_imply_imply'!.mp d₁) ⨀ (and₁'! id!)) or₂! (of'! d₂ ⨀ and₂'! id!);
 
-@[simp] lemma imply_left_verum : 𝓢 ⊢! p ➝ ⊤ := dhyp! $ verum!
 
 def orComm : 𝓢 ⊢ p ⋎ q ➝ q ⋎ p := by
   apply deduct';
@@ -145,7 +142,7 @@ lemma and_assoc! : 𝓢 ⊢! (p ⋏ q) ⋏ r ⭤ p ⋏ (q ⋏ r) := by
     . exact hr;
 
 def andReplaceLeft' (hc : 𝓢 ⊢ p ⋏ q) (h : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ r ⋏ q := and₃' (h ⨀ and₁' hc) (and₂' hc)
-lemma and_replace_left'! (hc : 𝓢 ⊢! p ⋏ q) (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! r ⋏ q := ⟨andReplaceLeft' hc.some h.some⟩
+omit [DecidableEq F] in lemma and_replace_left'! (hc : 𝓢 ⊢! p ⋏ q) (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! r ⋏ q := ⟨andReplaceLeft' hc.some h.some⟩
 
 def andReplaceLeft (h : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ⋏ q ➝ r ⋏ q := by
   apply deduct';
@@ -154,7 +151,7 @@ lemma and_replace_left! (h : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ⋏ q ➝ r ⋏ q 
 
 
 def andReplaceRight' (hc : 𝓢 ⊢ p ⋏ q) (h : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋏ r := and₃' (and₁' hc) (h ⨀ and₂' hc)
-lemma andReplaceRight'! (hc : 𝓢 ⊢! p ⋏ q) (h : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋏ r := ⟨andReplaceRight' hc.some h.some⟩
+omit [DecidableEq F] in lemma andReplaceRight'! (hc : 𝓢 ⊢! p ⋏ q) (h : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋏ r := ⟨andReplaceRight' hc.some h.some⟩
 
 def andReplaceRight (h : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋏ q ➝ p ⋏ r := by
   apply deduct';
@@ -163,7 +160,7 @@ lemma and_replace_right! (h : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋏ q ➝ p ⋏ r
 
 
 def andReplace' (hc : 𝓢 ⊢ p ⋏ q) (h₁ : 𝓢 ⊢ p ➝ r) (h₂ : 𝓢 ⊢ q ➝ s) : 𝓢 ⊢ r ⋏ s := andReplaceRight' (andReplaceLeft' hc h₁) h₂
-lemma and_replace'! (hc : 𝓢 ⊢! p ⋏ q) (h₁ : 𝓢 ⊢! p ➝ r) (h₂ : 𝓢 ⊢! q ➝ s) : 𝓢 ⊢! r ⋏ s := ⟨andReplace' hc.some h₁.some h₂.some⟩
+omit [DecidableEq F] in lemma and_replace'! (hc : 𝓢 ⊢! p ⋏ q) (h₁ : 𝓢 ⊢! p ➝ r) (h₂ : 𝓢 ⊢! q ➝ s) : 𝓢 ⊢! r ⋏ s := ⟨andReplace' hc.some h₁.some h₂.some⟩
 
 def andReplace (h₁ : 𝓢 ⊢ p ➝ r) (h₂ : 𝓢 ⊢ q ➝ s) : 𝓢 ⊢ p ⋏ q ➝ r ⋏ s := by
   apply deduct';
@@ -172,7 +169,7 @@ lemma and_replace! (h₁ : 𝓢 ⊢! p ➝ r) (h₂ : 𝓢 ⊢! q ➝ s) : 𝓢 
 
 
 def orReplaceLeft' (hc : 𝓢 ⊢ p ⋎ q) (hp : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ r ⋎ q := or₃''' (impTrans'' hp or₁) (or₂) hc
-lemma or_replace_left'! (hc : 𝓢 ⊢! p ⋎ q) (hp : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! r ⋎ q := ⟨orReplaceLeft' hc.some hp.some⟩
+omit [DecidableEq F] in lemma or_replace_left'! (hc : 𝓢 ⊢! p ⋎ q) (hp : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! r ⋎ q := ⟨orReplaceLeft' hc.some hp.some⟩
 
 def orReplaceLeft (hp : 𝓢 ⊢ p ➝ r) : 𝓢 ⊢ p ⋎ q ➝ r ⋎ q := by
   apply deduct';
@@ -181,7 +178,7 @@ lemma or_replace_left! (hp : 𝓢 ⊢! p ➝ r) : 𝓢 ⊢! p ⋎ q ➝ r ⋎ q 
 
 
 def orReplaceRight' (hc : 𝓢 ⊢ p ⋎ q) (hq : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋎ r := or₃''' (or₁) (impTrans'' hq or₂) hc
-lemma or_replace_right'! (hc : 𝓢 ⊢! p ⋎ q) (hq : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋎ r := ⟨orReplaceRight' hc.some hq.some⟩
+omit [DecidableEq F] in lemma or_replace_right'! (hc : 𝓢 ⊢! p ⋎ q) (hq : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋎ r := ⟨orReplaceRight' hc.some hq.some⟩
 
 def orReplaceRight (hq : 𝓢 ⊢ q ➝ r) : 𝓢 ⊢ p ⋎ q ➝ p ⋎ r := by
   apply deduct';
@@ -190,7 +187,8 @@ lemma or_replace_right! (hq : 𝓢 ⊢! q ➝ r) : 𝓢 ⊢! p ⋎ q ➝ p ⋎ r
 
 
 def orReplace' (h : 𝓢 ⊢ p₁ ⋎ q₁) (hp : 𝓢 ⊢ p₁ ➝ p₂) (hq : 𝓢 ⊢ q₁ ➝ q₂) : 𝓢 ⊢ p₂ ⋎ q₂ := orReplaceRight' (orReplaceLeft' h hp) hq
-lemma or_replace'! (h : 𝓢 ⊢! p₁ ⋎ q₁) (hp : 𝓢 ⊢! p₁ ➝ p₂) (hq : 𝓢 ⊢! q₁ ➝ q₂) : 𝓢 ⊢! p₂ ⋎ q₂ := ⟨orReplace' h.some hp.some hq.some⟩
+
+omit [DecidableEq F] in lemma or_replace'! (h : 𝓢 ⊢! p₁ ⋎ q₁) (hp : 𝓢 ⊢! p₁ ➝ p₂) (hq : 𝓢 ⊢! q₁ ➝ q₂) : 𝓢 ⊢! p₂ ⋎ q₂ := ⟨orReplace' h.some hp.some hq.some⟩
 
 def orReplace (hp : 𝓢 ⊢ p₁ ➝ p₂) (hq : 𝓢 ⊢ q₁ ➝ q₂) : 𝓢 ⊢ p₁ ⋎ q₁ ➝ p₂ ⋎ q₂ := by
   apply deduct';
@@ -234,8 +232,6 @@ lemma imp_replace_iff! (hp : 𝓢 ⊢! p₁ ⭤ p₂) (hq : 𝓢 ⊢! q₁ ⭤ q
 
 lemma imp_replace_iff!' (hp : 𝓢 ⊢! p₁ ⭤ p₂) (hq : 𝓢 ⊢! q₁ ⭤ q₂) : 𝓢 ⊢! p₁ ➝ q₁ ↔ 𝓢 ⊢! p₂ ➝ q₂ :=
   provable_iff_of_iff (imp_replace_iff! hp hq)
-
-variable [System.NegationEquiv 𝓢]
 
 def dni : 𝓢 ⊢ p ➝ ∼∼p := by
   apply deduct';
@@ -331,11 +327,11 @@ lemma negneg_equiv_dne! [HasAxiomDNE 𝓢] : 𝓢 ⊢! p ⭤ ((p ➝ ⊥) ➝ �
 
 end NegationEquiv
 
-def elim_contra_neg [NegationEquiv 𝓢] [HasAxiomElimContra 𝓢] : 𝓢 ⊢ ((q ➝ ⊥) ➝ (p ➝ ⊥)) ➝ (p ➝ q) := by
+def elim_contra_neg [HasAxiomElimContra 𝓢] : 𝓢 ⊢ ((q ➝ ⊥) ➝ (p ➝ ⊥)) ➝ (p ➝ q) := by
   refine impTrans'' ?_ elim_contra;
   apply deduct';
   exact impTrans'' (impTrans'' (and₁' neg_equiv) FiniteContext.byAxm) (and₂' neg_equiv);
-lemma elim_contra_neg! [NegationEquiv 𝓢] [HasAxiomElimContra 𝓢] : 𝓢 ⊢! ((q ➝ ⊥) ➝ (p ➝ ⊥)) ➝ (p ➝ q) := ⟨elim_contra_neg⟩
+lemma elim_contra_neg! [HasAxiomElimContra 𝓢] : 𝓢 ⊢! ((q ➝ ⊥) ➝ (p ➝ ⊥)) ➝ (p ➝ q) := ⟨elim_contra_neg⟩
 
 
 def tne : 𝓢 ⊢ ∼(∼∼p) ➝ ∼p := contra₀' dni
@@ -349,13 +345,13 @@ def implyLeftReplace (h : 𝓢 ⊢ q ➝ p) : 𝓢 ⊢ (p ➝ r) ➝ (q ➝ r) :
   exact impTrans'' (of h) id;
 lemma replace_imply_left! (h : 𝓢 ⊢! q ➝ p) : 𝓢 ⊢! (p ➝ r) ➝ (q ➝ r) := ⟨implyLeftReplace h.some⟩
 
-
+omit [DecidableEq F] in
 lemma replace_imply_left_by_iff'! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! p ➝ r ↔ 𝓢 ⊢! q ➝ r := by
   constructor;
   . exact imp_trans''! $ and₂'! h;
   . exact imp_trans''! $ and₁'! h;
 
-
+omit [DecidableEq F] in
 lemma replace_imply_right_by_iff'! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! r ➝ p ↔ 𝓢 ⊢! r ➝ q := by
   constructor;
   . intro hrp; exact imp_trans''! hrp $ and₁'! h;
@@ -381,7 +377,7 @@ def p_pq_q : 𝓢 ⊢ p ➝ (p ➝ q) ➝ q := impSwap' $ impId _
 lemma p_pq_q! : 𝓢 ⊢! p ➝ (p ➝ q) ➝ q := ⟨p_pq_q⟩
 
 def dhyp_imp' (h : 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ (r ➝ p) ➝ (r ➝ q) := imply₂ ⨀ (dhyp r h)
-lemma dhyp_imp'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! (r ➝ p) ➝ (r ➝ q) := ⟨dhyp_imp' h.some⟩
+omit [DecidableEq F] in lemma dhyp_imp'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! (r ➝ p) ➝ (r ➝ q) := ⟨dhyp_imp' h.some⟩
 
 def rev_dhyp_imp' (h : 𝓢 ⊢ q ➝ p) : 𝓢 ⊢ (p ➝ r) ➝ (q ➝ r) := impSwap' $ impTrans'' h p_pq_q
 lemma rev_dhyp_imp'! (h : 𝓢 ⊢! q ➝ p) : 𝓢 ⊢! (p ➝ r) ➝ (q ➝ r) := ⟨rev_dhyp_imp' h.some⟩
@@ -398,7 +394,7 @@ lemma dn_distribute_imply'! (b : 𝓢 ⊢! ∼∼(p ➝ q)) : 𝓢 ⊢! ∼∼p 
 
 
 def introFalsumOfAnd' (h : 𝓢 ⊢ p ⋏ ∼p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp $ and₂' h) ⨀ (and₁' h)
-lemma intro_falsum_of_and'! (h : 𝓢 ⊢! p ⋏ ∼p) : 𝓢 ⊢! ⊥ := ⟨introFalsumOfAnd' h.some⟩
+omit [DecidableEq F] in lemma intro_falsum_of_and'! (h : 𝓢 ⊢! p ⋏ ∼p) : 𝓢 ⊢! ⊥ := ⟨introFalsumOfAnd' h.some⟩
 /-- Law of contradiction -/
 alias lac'! := intro_falsum_of_and'!
 
@@ -578,6 +574,7 @@ lemma generalConj'₂! (h : p ∈ Γ) (d : 𝓢 ⊢! ⋀Γ) : 𝓢 ⊢! p := (ge
 
 section Conjunction
 
+omit [DecidableEq F] in
 lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! ⋀Γ) ↔ (∀ p ∈ Γ, 𝓢 ⊢! p) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
@@ -647,9 +644,9 @@ lemma forthback_conj_remove! : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ➝ ⋀Γ := by
   . subst e; exact and₂'! id!;
   . exact iff_provable_list_conj.mp (and₁'! id!) q (by apply List.mem_remove_iff.mpr; simp_all);
 
--- TODO: make `p` explicit
 lemma imply_left_remove_conj! (b : 𝓢 ⊢! ⋀Γ ➝ q) : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ➝ q := imp_trans''! forthback_conj_remove! b
 
+omit [DecidableEq F] in
 lemma iff_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ↔ 𝓢 ⊢! ⋀Γ ⋏ ⋀Δ := by
   constructor;
   . intro h;
@@ -732,6 +729,7 @@ lemma iff_concact_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ↔ 𝓢 �
   . intro h; exact (and₁'! iff_concact_disj!) ⨀ h;
   . intro h; exact (and₂'! iff_concact_disj!) ⨀ h;
 
+omit [DecidableEq F] in
 lemma implyRight_cons_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ➝ ⋁(q :: Γ) ↔ 𝓢 ⊢! p ➝ q ⋎ ⋁Γ := by
   induction Γ with
   | nil =>
@@ -779,6 +777,7 @@ section consistency
 
 variable [HasAxiomEFQ 𝓢]
 
+omit [DecidableEq F] in
 lemma inconsistent_of_provable_of_unprovable {p : F}
     (hp : 𝓢 ⊢! p) (hn : 𝓢 ⊢! ∼p) : Inconsistent 𝓢 := by
   have : 𝓢 ⊢! p ➝ ⊥ := neg_equiv'!.mp hn

--- a/Foundation/Logic/LindenbaumAlgebra.lean
+++ b/Foundation/Logic/LindenbaumAlgebra.lean
@@ -21,7 +21,7 @@ protected lemma ProvablyEquivalent.symm [System.Minimal 𝓢] {p q : F} : p ≡ 
 protected lemma ProvablyEquivalent.trans [System.Minimal 𝓢] {p q r : F} : p ≡ q → q ≡ r → p ≡ r := iff_trans''!
 
 lemma provable_iff_provablyEquivalent_verum [System.Minimal 𝓢] {p : F} : 𝓢 ⊢! p ↔ p ≡ ⊤ :=
-  ⟨fun h ↦ iff_intro! imply_left_verum! (dhyp! h), fun h ↦ (and_right! h) ⨀ verum!⟩
+  ⟨fun h ↦ iff_intro! imply_left_verum! (imply₁'! h), fun h ↦ (and_right! h) ⨀ verum!⟩
 
 variable (𝓢)
 
@@ -183,7 +183,7 @@ instance LindenbaumAlgebra.boolean : BooleanAlgebra (LindenbaumAlgebra 𝓢) whe
   top_le_sup_compl p := by
     induction' p using Quotient.ind with p
     simp [compl_def, sup_def, top_def, le_def]
-    apply dhyp! lem!
+    apply imply₁'! lem!
   le_top p := by
     induction' p using Quotient.ind with p
     simp only [top_def, le_def]

--- a/Foundation/Logic/LindenbaumAlgebra.lean
+++ b/Foundation/Logic/LindenbaumAlgebra.lean
@@ -21,7 +21,7 @@ protected lemma ProvablyEquivalent.symm [System.Minimal 𝓢] {p q : F} : p ≡ 
 protected lemma ProvablyEquivalent.trans [System.Minimal 𝓢] {p q r : F} : p ≡ q → q ≡ r → p ≡ r := iff_trans''!
 
 lemma provable_iff_provablyEquivalent_verum [System.Minimal 𝓢] {p : F} : 𝓢 ⊢! p ↔ p ≡ ⊤ :=
-  ⟨fun h ↦ iff_intro! imply_left_verum (dhyp! h), fun h ↦ (and_right! h) ⨀ verum!⟩
+  ⟨fun h ↦ iff_intro! imply_left_verum! (dhyp! h), fun h ↦ (and_right! h) ⨀ verum!⟩
 
 variable (𝓢)
 
@@ -120,7 +120,7 @@ instance : GeneralizedHeytingAlgebra (LindenbaumAlgebra 𝓢) where
   le_top p := by
     induction' p using Quotient.ind with p
     simp only [top_def, le_def]
-    exact imply_left_verum
+    exact imply_left_verum!
   le_himp_iff p q r := by
     induction' p using Quotient.ind with p
     induction' q using Quotient.ind with q
@@ -187,7 +187,7 @@ instance LindenbaumAlgebra.boolean : BooleanAlgebra (LindenbaumAlgebra 𝓢) whe
   le_top p := by
     induction' p using Quotient.ind with p
     simp only [top_def, le_def]
-    exact imply_left_verum
+    exact imply_left_verum!
   bot_le p := by
     induction' p using Quotient.ind with p
     simp only [bot_def, le_def]

--- a/Foundation/Modal/Boxdot/Basic.lean
+++ b/Foundation/Modal/Boxdot/Basic.lean
@@ -23,7 +23,7 @@ variable {p : Formula α}
 
 theorem boxdotTranslated
   {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
-  (h : ∀ p ∈ Ax(Λ₁), Λ₂ ⊢! pᵇ) : Λ₁ ⊢! p → Λ₂ ⊢! pᵇ := by
+  (h : ∀ p ∈ Λ₁.axioms, Λ₂ ⊢! pᵇ) : Λ₁ ⊢! p → Λ₂ ⊢! pᵇ := by
   intro d;
   induction d using Deduction.inducition_with_necOnly! with
   | hMaxm hs => exact h _ hs;

--- a/Foundation/Modal/Complemental.lean
+++ b/Foundation/Modal/Complemental.lean
@@ -2,7 +2,6 @@ import Foundation.Modal.ConsistentTheory
 
 namespace LO.Modal
 
-variable [DecidableEq α]
 variable {Λ : Hilbert α}
 
 namespace Formula
@@ -39,7 +38,7 @@ lemma resort_box (h : -p = □q) : p = ∼□q := by
   . subst_vars; rfl;
   . contradiction;
 
-lemma or (p : Formula α) : -p = ∼p ∨ ∃ q, ∼q = p := by
+lemma or [DecidableEq α] (p : Formula α) : -p = ∼p ∨ ∃ q, ∼q = p := by
   induction p using Formula.cases_neg with
   | himp _ _ hn => simp [imp_def₁ hn];
   | hfalsum => simp;
@@ -57,7 +56,7 @@ variable [System (Formula α) S] {𝓢 : S}
 variable [System.ModusPonens 𝓢]
 variable {p q : Formula α}
 
-lemma complement_derive_bot (hp : 𝓢 ⊢! p) (hcp : 𝓢 ⊢! -p) : 𝓢 ⊢! ⊥ := by
+lemma complement_derive_bot [DecidableEq α] (hp : 𝓢 ⊢! p) (hcp : 𝓢 ⊢! -p) : 𝓢 ⊢! ⊥ := by
   induction p using Formula.cases_neg with
   | hfalsum => assumption;
   | hatom a =>
@@ -73,7 +72,7 @@ lemma complement_derive_bot (hp : 𝓢 ⊢! p) (hcp : 𝓢 ⊢! -p) : 𝓢 ⊢! 
     simp [Formula.complement] at hcp;
     exact hcp ⨀ hp;
 
-lemma neg_complement_derive_bot (hp : 𝓢 ⊢! ∼p) (hcp : 𝓢 ⊢! ∼(-p)) : 𝓢 ⊢! ⊥ := by
+lemma neg_complement_derive_bot [DecidableEq α] (hp : 𝓢 ⊢! ∼p) (hcp : 𝓢 ⊢! ∼(-p)) : 𝓢 ⊢! ⊥ := by
   induction p using Formula.cases_neg with
   | hfalsum =>
     simp [Formula.complement] at hcp;
@@ -95,6 +94,8 @@ end
 
 
 namespace Formulae
+
+variable [DecidableEq α]
 
 def complementary (P : Formulae α) : Formulae α := P ∪ (P.image (Formula.complement))
 postfix:80 "⁻" => Formulae.complementary
@@ -126,13 +127,22 @@ def SubformulaeComplementaryClosed (P : Formulae α) (p : Formula α) : Prop := 
 
 section Consistent
 
-def Consistent (Λ : Hilbert α) (P : Formulae α) : Prop :=  P *⊬[Λ] ⊥
+def Consistent (Λ : Hilbert α) (P : Formulae α) : Prop := P *⊬[Λ] ⊥
 
 open Theory
 
+omit [DecidableEq α] in
 @[simp]
-lemma iff_theory_consistent_formulae_consistent {P : Formulae α}
-  : Theory.Consistent Λ P ↔ Formulae.Consistent Λ P := by simp [Consistent, Theory.Consistent]
+lemma iff_theory_consistent_formulae_consistent {P : Formulae α} : Theory.Consistent Λ P ↔ Formulae.Consistent Λ P := by
+  simp [Consistent, Theory.Consistent]
+
+omit [DecidableEq α] in
+@[simp]
+lemma empty_conisistent [System.Consistent Λ] : Formulae.Consistent Λ ∅ := by
+  rw [←iff_theory_consistent_formulae_consistent];
+  convert Theory.emptyset_consistent (α := α);
+  . simp;
+  . assumption;
 
 lemma provable_iff_insert_neg_not_consistent : ↑P *⊢[Λ]! p ↔ ¬(Formulae.Consistent Λ (insert (∼p) P)) := by
   rw [←iff_theory_consistent_formulae_consistent];
@@ -183,13 +193,6 @@ lemma intro_triunion_consistent
     . left; left; assumption;
     . left; right; assumption;
     . right; assumption;
-
-@[simp]
-lemma empty_conisistent [System.Consistent Λ] : Formulae.Consistent Λ ∅ := by
-  rw [←iff_theory_consistent_formulae_consistent];
-  convert Theory.emptyset_consistent (α := α);
-  . simp;
-  . assumption;
 
 
 namespace exists_consistent_complementary_closed
@@ -302,6 +305,7 @@ end Consistent
 end Formulae
 
 
+variable [DecidableEq α]
 
 structure ComplementaryClosedConsistentFormulae (Λ) (S : Formulae α) where
   formulae : Formulae α
@@ -410,7 +414,7 @@ lemma iff_mem_imp
         simp only [Formula.complement.imp_def₁ h] at hq;
         exact efq_of_neg! $ Context.by_axm! (by simpa using hq);
     . apply membership_iff (by assumption) |>.mpr;
-      exact dhyp! $ membership_iff (by assumption) |>.mp $ iff_mem_compl (by assumption) |>.mpr hr;
+      exact imply₁'! $ membership_iff (by assumption) |>.mp $ iff_mem_compl (by assumption) |>.mpr hr;
 
 lemma iff_not_mem_imp
   (hsub_qr : (q ➝ r) ∈ S) (hsub_q : q ∈ S := by trivial)  (hsub_r : r ∈ S := by trivial)

--- a/Foundation/Modal/ConsistentTheory.lean
+++ b/Foundation/Modal/ConsistentTheory.lean
@@ -1,5 +1,8 @@
 import Foundation.Modal.Hilbert
 
+-- TODO: remove
+set_option deprecated.oldSectionVars true
+
 namespace LO.Modal
 
 variable {α : Type*} [DecidableEq α] [Inhabited α]
@@ -188,8 +191,8 @@ lemma either_consistent (p) : Theory.Consistent Λ (insert p T) ∨ Theory.Consi
   contradiction;
 
 lemma exists_maximal_consistent_theory
-  : ∃ Z, Theory.Consistent Λ Z ∧ T ⊆ Z ∧ ∀ U, Theory.Consistent Λ U → Z ⊆ U → U = Z
-  := zorn_subset_nonempty { T : Theory α | T.Consistent Λ } (by
+  : ∃ Z, Theory.Consistent Λ Z ∧ T ⊆ Z ∧ ∀ U, Theory.Consistent Λ U → Z ⊆ U → U = Z := by
+  obtain ⟨Z, h₁, ⟨h₂, h₃⟩⟩ := zorn_subset_nonempty { T : Theory α | T.Consistent Λ } (by
     intro c hc chain hnc;
     existsi (⋃₀ c);
     simp only [Set.mem_setOf_eq, Set.mem_sUnion];
@@ -211,7 +214,15 @@ lemma exists_maximal_consistent_theory
       contradiction;
     . intro s a;
       exact Set.subset_sUnion_of_mem a;
-  ) T T_consis
+  ) T T_consis;
+  use Z;
+  simp_all only [Set.mem_setOf_eq, Set.le_eq_subset, true_and];
+  constructor;
+  . assumption;
+  . intro U hU hZU;
+    apply Set.eq_of_subset_of_subset;
+    . exact h₃ hU hZU;
+    . assumption;
 protected alias lindenbaum := exists_maximal_consistent_theory
 
 open Classical in
@@ -247,8 +258,8 @@ lemma intro_triunion_consistent
       apply conjconj_subset!;
       intro p hp; simp [Γ₁, Γ₂];
       rcases h₁₂ p hp with (h₁ | h₂);
-      . left; apply List.mem_filter_of_mem <;> simpa;
-      . right; apply List.mem_filter_of_mem <;> simpa;
+      . left; exact ⟨hp, h₁⟩;
+      . right; exact ⟨hp, h₂⟩;
   . apply h;
     refine ⟨?_, ?_, h₃⟩;
     . intro p hp;

--- a/Foundation/Modal/ConsistentTheory.lean
+++ b/Foundation/Modal/ConsistentTheory.lean
@@ -1,12 +1,9 @@
 import Foundation.Modal.Hilbert
 
--- TODO: remove
-set_option deprecated.oldSectionVars true
-
 namespace LO.Modal
 
-variable {α : Type*} [DecidableEq α] [Inhabited α]
-variable {Λ : Hilbert α} [Λ_consis : System.Consistent Λ]
+variable {α : Type*}
+variable {Λ : Hilbert α}
 
 open System
 
@@ -16,7 +13,7 @@ abbrev Theory.Inconsistent (Λ : Hilbert α) (T : Theory α) := ¬(T.Consistent 
 
 namespace Theory
 
-variable {T : Theory α}
+variable {T : Theory α} (T_consis : T.Consistent Λ)
 
 lemma def_consistent : T.Consistent Λ ↔ ∀ (Γ : List (Formula α)), (∀ q ∈ Γ, q ∈ T) → Γ ⊬[Λ] ⊥ := by
   constructor;
@@ -30,20 +27,12 @@ lemma def_inconsistent : ¬T.Consistent Λ ↔ ∃ (Γ : List (Formula α)), (�
   simp only [def_consistent]; push_neg; tauto;
 
 @[simp]
-lemma self_consistent : Ax(Λ).Consistent Λ := by
+lemma self_consistent [Λ_consis : System.Consistent Λ] : Λ.axioms.Consistent Λ := by
   obtain ⟨q, hq⟩ := Λ_consis.exists_unprovable;
   apply def_consistent.mpr;
   intro Γ hΓ;
   by_contra hC;
   have : Λ ⊢! q := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => Deduction.maxm! $ hΓ _ h);
-  contradiction;
-
-lemma emptyset_consistent : Theory.Consistent Λ ∅ := by
-  obtain ⟨f, hf⟩ := Λ_consis.exists_unprovable;
-  apply def_consistent.mpr;
-  intro Γ hΓ; by_contra hC;
-  replace hΓ := List.nil_iff.mpr hΓ; subst hΓ;
-  have : Λ ⊢! f := efq'! $ hC ⨀ verum!;
   contradiction;
 
 lemma union_consistent : Theory.Consistent Λ (T₁ ∪ T₂) → T₁.Consistent Λ ∧ T₂.Consistent Λ := by
@@ -54,6 +43,16 @@ lemma union_consistent : Theory.Consistent Λ (T₁ ∪ T₂) → T₁.Consisten
 lemma union_not_consistent : ¬T₁.Consistent Λ ∨ ¬T₂.Consistent Λ → ¬(Theory.Consistent Λ (T₁ ∪ T₂)) := by
   contrapose; push_neg;
   exact union_consistent;
+
+lemma emptyset_consistent [Λ_consis : System.Consistent Λ] : Theory.Consistent Λ ∅ := by
+  obtain ⟨f, hf⟩ := Λ_consis.exists_unprovable;
+  apply def_consistent.mpr;
+  intro Γ hΓ; by_contra hC;
+  replace hΓ := List.nil_iff.mpr hΓ; subst hΓ;
+  have : Λ ⊢! f := efq'! $ hC ⨀ verum!;
+  contradiction;
+
+variable [DecidableEq α]
 
 lemma iff_insert_consistent : Theory.Consistent Λ (insert p T) ↔ ∀ {Γ : List (Formula α)}, (∀ q ∈ Γ, q ∈ T) → Λ ⊬ p ⋏ ⋀Γ ➝ ⊥ := by
   constructor;
@@ -145,28 +144,27 @@ lemma unprovable_iff_singleton_consistent : Λ ⊬ ∼p ↔ Theory.Consistent Λ
   rw [e] at H;
   exact Iff.trans Context.provable_iff_provable.not H;
 
-variable (T_consis : T.Consistent Λ)
-
-lemma unprovable_falsum : T *⊬[Λ] ⊥ := by
+omit [DecidableEq α] in
+lemma unprovable_falsum (T_consis : T.Consistent Λ) : T *⊬[Λ] ⊥ := by
   by_contra hC;
   obtain ⟨Γ, hΓ₁, _⟩ := Context.provable_iff.mp $ hC;
   have : Γ ⊬[Λ] ⊥ := (def_consistent.mp T_consis) _ hΓ₁;
   contradiction;
 
-lemma unprovable_either : ¬(T *⊢[Λ]! p ∧ T *⊢[Λ]! ∼p) := by
+lemma unprovable_either (T_consis : T.Consistent Λ) : ¬(T *⊢[Λ]! p ∧ T *⊢[Λ]! ∼p) := by
   by_contra hC;
   have ⟨hC₁, hC₂⟩ := hC;
   have : T *⊢[Λ]! ⊥ := neg_mdp! hC₂ hC₁;
   have : T *⊬[Λ] ⊥ := unprovable_falsum T_consis;
   contradiction;
 
-lemma not_mem_falsum_of_consistent : ⊥ ∉ T := by
+lemma not_mem_falsum_of_consistent (T_consis : T.Consistent Λ) : ⊥ ∉ T := by
   by_contra hC;
   have : Λ ⊬ ⊥ ➝ ⊥ := (def_consistent.mp T_consis) [⊥] (by simpa);
   have : Λ ⊢! ⊥ ➝ ⊥ := efq!;
   contradiction;
 
-lemma not_singleton_consistent [Λ.HasNecessitation] (h : ∼(□p) ∈ T) : Theory.Consistent Λ {∼p} := by
+lemma not_singleton_consistent [Λ.HasNecessitation] (T_consis : T.Consistent Λ) (h : ∼□p ∈ T) : Theory.Consistent Λ {∼p} := by
   apply def_consistent.mpr;
   intro Γ hΓ;
   simp only [Set.mem_singleton_iff] at hΓ;
@@ -175,7 +173,7 @@ lemma not_singleton_consistent [Λ.HasNecessitation] (h : ∼(□p) ∈ T) : The
   have : Λ ⊬ ∼(□p) ➝ ⊥ := def_consistent.mp T_consis (Γ := [∼(□p)]) (by aesop)
   contradiction;
 
-lemma either_consistent (p) : Theory.Consistent Λ (insert p T) ∨ Theory.Consistent Λ (insert (∼p) T) := by
+lemma either_consistent (T_consis : T.Consistent Λ) (p) : Theory.Consistent Λ (insert p T) ∨ Theory.Consistent Λ (insert (∼p) T) := by
   by_contra hC; push_neg at hC;
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp hC.1;
   obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_inconsistent.mp hC.2;
@@ -191,6 +189,7 @@ lemma either_consistent (p) : Theory.Consistent Λ (insert p T) ∨ Theory.Consi
   contradiction;
 
 lemma exists_maximal_consistent_theory
+  (T_consis : T.Consistent Λ)
   : ∃ Z, Theory.Consistent Λ Z ∧ T ⊆ Z ∧ ∀ U, Theory.Consistent Λ U → Z ⊆ U → U = Z := by
   obtain ⟨Z, h₁, ⟨h₂, h₃⟩⟩ := zorn_subset_nonempty { T : Theory α | T.Consistent Λ } (by
     intro c hc chain hnc;
@@ -272,13 +271,13 @@ lemma intro_triunion_consistent
         simpa using List.of_mem_filter hp;
       . assumption;
 
-lemma not_mem_of_mem_neg (h : ∼p ∈ T) : p ∉ T := by
+lemma not_mem_of_mem_neg (T_consis : T.Consistent Λ) (h : ∼p ∈ T) : p ∉ T := by
   by_contra hC;
   have : [p, ∼p] ⊬[Λ] ⊥ := (Theory.def_consistent.mp T_consis) [p, ∼p] (by simp_all);
   have : [p, ∼p] ⊢[Λ]! ⊥ := System.bot_of_mem_either! (p := p) (Γ := [p, ∼p]) (by simp) (by simp);
   contradiction;
 
-lemma not_mem_neg_of_mem (h : p ∈ T) : ∼p ∉ T := by
+lemma not_mem_neg_of_mem (T_consis : T.Consistent Λ) (h : p ∈ T) : ∼p ∉ T := by
   by_contra hC;
   have : [p, ∼p] ⊬[Λ] ⊥ := (Theory.def_consistent.mp T_consis) [p, ∼p] (by simp_all);
   have : [p, ∼p] ⊢[Λ]! ⊥ := System.bot_of_mem_either! (p := p) (Γ := [p, ∼p]) (by simp) (by simp);
@@ -295,6 +294,7 @@ namespace MaximalConsistentTheory
 
 open Theory
 
+variable [DecidableEq α]
 variable {Λ : Hilbert α}
 variable {Ω Ω₁ Ω₂ : MCT Λ}
 variable {p : Formula α}
@@ -322,6 +322,7 @@ lemma either_mem (Ω : MCT Λ) (p) : p ∈ Ω.theory ∨ ∼p ∈ Ω.theory := b
   | inl h => have := Ω.maximal (Set.ssubset_insert hC.1); contradiction;
   | inr h => have := Ω.maximal (Set.ssubset_insert hC.2); contradiction;
 
+omit [DecidableEq α] in
 lemma maximal' {p : Formula α} (hp : p ∉ Ω.theory) : ¬Theory.Consistent Λ (insert p Ω.theory) := Ω.maximal (Set.ssubset_insert hp)
 
 lemma membership_iff : (p ∈ Ω.theory) ↔ (Ω.theory *⊢[Λ]! p) := by
@@ -335,7 +336,7 @@ lemma membership_iff : (p ∈ Ω.theory) ↔ (Ω.theory *⊢[Λ]! p) := by
     have := Ω.consistent;
     contradiction;
 
-lemma subset_axiomset : Ax(Λ) ⊆ Ω.theory := by
+lemma subset_axiomset : Λ.axioms ⊆ Ω.theory := by
   intro p hp;
   apply membership_iff.mpr;
   apply Context.of!;
@@ -427,6 +428,7 @@ lemma iff_congr : (Ω.theory *⊢[Λ]! (p ⭤ q)) → ((p ∈ Ω.theory) ↔ (q 
 
 lemma mem_dn_iff : (p ∈ Ω.theory) ↔ (∼∼p ∈ Ω.theory) := iff_congr $ dn!
 
+omit [DecidableEq α] in
 lemma equality_def : Ω₁ = Ω₂ ↔ Ω₁.theory = Ω₂.theory := by
   constructor;
   . intro h; cases h; rfl;
@@ -586,6 +588,7 @@ lemma multibox_multidia : (∀ {p : Formula α}, (□^[n]p ∈ Ω₁.theory → 
 
 variable {Γ : List (Formula α)}
 
+omit [Λ.IsNormal] in
 lemma iff_mem_conj : (⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, p ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
 
 lemma iff_mem_multibox_conj : (□^[n]⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □^[n]p ∈ Ω.theory) := by

--- a/Foundation/Modal/Formula.lean
+++ b/Foundation/Modal/Formula.lean
@@ -216,9 +216,7 @@ instance : Collection (Formula α) (Theory α) := inferInstance
 
 section Subformula
 
-variable [DecidableEq α]
-
-def Formula.Subformulas: Formula α → Formulae α
+def Formula.Subformulas [DecidableEq α] : Formula α → Formulae α
   | atom a => {(atom a)}
   | ⊥      => {⊥}
   | p ➝ q  => insert (p ➝ q) (p.Subformulas ∪ q.Subformulas)
@@ -227,6 +225,8 @@ def Formula.Subformulas: Formula α → Formulae α
 prefix:70 "𝒮 " => Formula.Subformulas
 
 namespace Formula.Subformulas
+
+variable [DecidableEq α]
 
 @[simp] lemma mem_self (p : Formula α) : p ∈ 𝒮 p := by induction p <;> { simp [Subformulas]; try tauto; }
 
@@ -304,7 +304,7 @@ class Formulae.SubformulaClosed (X : Formulae α) where
 
 namespace SubformulaClosed
 
-instance {p : Formula α} : Formulae.SubformulaClosed (𝒮 p) where
+instance [DecidableEq α] {p : Formula α} : Formulae.SubformulaClosed (𝒮 p) where
   box_closed   := by aesop;
   imp_closed   := by aesop;
 
@@ -331,7 +331,7 @@ class Theory.SubformulaClosed (T : Theory α) where
 
 namespace Theory.SubformulaClosed
 
-instance {p : Formula α} : Theory.SubformulaClosed (𝒮 p).toSet where
+instance {p : Formula α} [DecidableEq α] : Theory.SubformulaClosed (𝒮 p).toSet where
   box_closed   := by aesop;
   imp_closed   := by aesop;
 
@@ -384,11 +384,10 @@ end Atoms
 
 namespace Formula
 
-variable [DecidableEq α]
 variable {p q r : Formula α}
 
 @[elab_as_elim]
-def cases_neg {C : Formula α → Sort w}
+def cases_neg [DecidableEq α] {C : Formula α → Sort w}
     (hfalsum : C ⊥)
     (hatom   : ∀ a : α, C (atom a))
     (hneg    : ∀ p : Formula α, C (∼p))
@@ -402,7 +401,7 @@ def cases_neg {C : Formula α → Sort w}
   | p ➝ q  => if e : q = ⊥ then e ▸ hneg p else himp p q e
 
 @[elab_as_elim]
-def rec_neg {C : Formula α → Sort w}
+def rec_neg [DecidableEq α] {C : Formula α → Sort w}
     (hfalsum : C ⊥)
     (hatom   : ∀ a : α, C (atom a))
     (hneg    : ∀ p : Formula α, C (p) → C (∼p))
@@ -434,18 +433,18 @@ lemma negated_imp : (p ➝ q).negated ↔ (q = ⊥) := by
   . simp_all [Formula.imp_eq]; rfl;
   . simp_all [Formula.imp_eq]; simpa;
 
-lemma negated_iff : p.negated ↔ ∃ q, p = ∼q := by
+lemma negated_iff [DecidableEq α] : p.negated ↔ ∃ q, p = ∼q := by
   induction p using Formula.cases_neg with
   | himp => simp [negated_imp, NegAbbrev.neg];
   | _ => simp [negated]
 
-lemma not_negated_iff : ¬p.negated ↔ ∀ q, p ≠ ∼q := by
+lemma not_negated_iff [DecidableEq α] : ¬p.negated ↔ ∀ q, p ≠ ∼q := by
   induction p using Formula.cases_neg with
   | himp => simp [negated_imp, NegAbbrev.neg];
   | _ => simp [negated]
 
 @[elab_as_elim]
-def rec_negated {C : Formula α → Sort w}
+def rec_negated [DecidableEq α] {C : Formula α → Sort w}
     (hfalsum : C ⊥)
     (hatom   : ∀ a : α, C (atom a))
     (hneg    : ∀ p : Formula α, C (p) → C (∼p))

--- a/Foundation/Modal/Geach.lean
+++ b/Foundation/Modal/Geach.lean
@@ -158,7 +158,7 @@ attribute [simp] Hilbert.IsGeach.char
 
 namespace IsGeach
 
-lemma ax {Λ : Hilbert α} [geach : Λ.IsGeach ts] : Ax(Λ) = (𝗞 ∪ 𝗚𝗲(ts)) := by
+lemma ax {Λ : Hilbert α} [geach : Λ.IsGeach ts] : Λ.axioms = (𝗞 ∪ 𝗚𝗲(ts)) := by
   have e := geach.char;
   simp [Modal.Geach] at e;
   simp_all;

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -32,12 +32,9 @@ structure Hilbert (α : Type*) where
   axioms : Theory α
   rules : InferenceRules α
 
-notation "Ax(" Λ ")" => Hilbert.axioms Λ
-notation "Rl(" Λ ")" => Hilbert.rules Λ
-
 inductive Deduction (Λ : Hilbert α) : (Formula α) → Type _
-  | maxm {p}     : p ∈ Ax(Λ) → Deduction Λ p
-  | rule {rl}    : rl ∈ Rl(Λ) → (∀ {p}, p ∈ rl.antecedents → Deduction Λ p) → Deduction Λ rl.consequence
+  | maxm {p}     : p ∈ Λ.axioms → Deduction Λ p
+  | rule {rl}    : rl ∈ Λ.rules → (∀ {p}, p ∈ rl.antecedents → Deduction Λ p) → Deduction Λ rl.consequence
   | mdp {p q}    : Deduction Λ (p ➝ q) → Deduction Λ p → Deduction Λ q
   | imply₁ p q   : Deduction Λ $ Axioms.Imply₁ p q
   | imply₂ p q r : Deduction Λ $ Axioms.Imply₂ p q r
@@ -69,34 +66,34 @@ namespace Hilbert
 open Deduction
 
 class HasNecessitation (Λ : Hilbert α) where
-  has_necessitation : ⟮Nec⟯ ⊆ Rl(Λ) := by aesop
+  has_necessitation : ⟮Nec⟯ ⊆ Λ.rules := by aesop
 
 instance [HasNecessitation Λ] : System.Necessitation Λ where
-  nec := @λ p d => rule (show { antecedents := [p], consequence := □p } ∈ Rl(Λ) by apply HasNecessitation.has_necessitation; simp_all) (by aesop);
+  nec := @λ p d => rule (show { antecedents := [p], consequence := □p } ∈ Λ.rules by apply HasNecessitation.has_necessitation; simp_all) (by aesop);
 
 
 class HasLoebRule (Λ : Hilbert α) where
-  has_loeb : ⟮Loeb⟯ ⊆ Rl(Λ) := by aesop
+  has_loeb : ⟮Loeb⟯ ⊆ Λ.rules := by aesop
 
 instance [HasLoebRule Λ] : System.LoebRule Λ where
-  loeb := @λ p d => rule (show { antecedents := [□p ➝ p], consequence := p } ∈ Rl(Λ) by apply HasLoebRule.has_loeb; simp_all) (by aesop);
+  loeb := @λ p d => rule (show { antecedents := [□p ➝ p], consequence := p } ∈ Λ.rules by apply HasLoebRule.has_loeb; simp_all) (by aesop);
 
 
 class HasHenkinRule (Λ : Hilbert α) where
-  has_henkin : ⟮Henkin⟯ ⊆ Rl(Λ) := by aesop
+  has_henkin : ⟮Henkin⟯ ⊆ Λ.rules := by aesop
 
 instance [HasHenkinRule Λ] : System.HenkinRule Λ where
-  henkin := @λ p d => rule (show { antecedents := [□p ⭤ p], consequence := p } ∈ Rl(Λ) by apply HasHenkinRule.has_henkin; simp_all) (by aesop);
+  henkin := @λ p d => rule (show { antecedents := [□p ⭤ p], consequence := p } ∈ Λ.rules by apply HasHenkinRule.has_henkin; simp_all) (by aesop);
 
 
 class HasNecOnly (Λ : Hilbert α) where
-  has_necessitation_only : Rl(Λ) = ⟮Nec⟯ := by rfl
+  has_necessitation_only : Λ.rules = ⟮Nec⟯ := by rfl
 
 instance [h : HasNecOnly Λ] : Λ.HasNecessitation where
   has_necessitation := by rw [h.has_necessitation_only]
 
 class HasAxiomK (Λ : Hilbert α) where
-  has_axiomK : 𝗞 ⊆ Ax(Λ) := by aesop
+  has_axiomK : 𝗞 ⊆ Λ.axioms := by aesop
 
 instance [HasAxiomK Λ] : System.HasAxiomK Λ where
   K _ _ := maxm (by apply HasAxiomK.has_axiomK; simp_all)
@@ -114,11 +111,11 @@ variable {Λ : Hilbert α}
 
 noncomputable def inducition!
   {motive  : (p : Formula α) → Λ ⊢! p → Sort*}
-  (hRules  : (r : InferenceRule α) → (hr : r ∈ Rl(Λ)) →
+  (hRules  : (r : InferenceRule α) → (hr : r ∈ Λ.rules) →
              (hant : ∀ {p}, p ∈ r.antecedents → Λ ⊢! p) →
              (ih : ∀ {p}, (hp : p ∈ r.antecedents) →
              motive p (hant hp)) → motive r.consequence ⟨rule hr (λ hp => (hant hp).some)⟩)
-  (hMaxm     : ∀ {p}, (h : p ∈ Ax(Λ)) → motive p ⟨maxm h⟩)
+  (hMaxm     : ∀ {p}, (h : p ∈ Λ.axioms) → motive p ⟨maxm h⟩)
   (hMdp      : ∀ {p q}, {hpq : Λ ⊢! p ➝ q} → {hp : Λ ⊢! p} → motive (p ➝ q) hpq → motive p hp → motive q ⟨mdp hpq.some hp.some⟩)
   (hImply₁     : ∀ {p q}, motive (p ➝ q ➝ p) $ ⟨imply₁ p q⟩)
   (hImply₂     : ∀ {p q r}, motive ((p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r) $ ⟨imply₂ p q r⟩)
@@ -136,7 +133,7 @@ noncomputable def inducition!
 /-- Useful induction for normal modal logic. -/
 noncomputable def inducition_with_necOnly! [Λ.HasNecOnly]
   {motive  : (p : Formula α) → Λ ⊢! p → Prop}
-  (hMaxm   : ∀ {p}, (h : p ∈ Ax(Λ)) → motive p ⟨maxm h⟩)
+  (hMaxm   : ∀ {p}, (h : p ∈ Λ.axioms) → motive p ⟨maxm h⟩)
   (hMdp    : ∀ {p q}, {hpq : Λ ⊢! p ➝ q} → {hp : Λ ⊢! p} → motive (p ➝ q) hpq → motive p hp → motive q (hpq ⨀ hp))
   (hNec    : ∀ {p}, {hp : Λ ⊢! p} → (ihp : motive p hp) → motive (□p) (System.nec! hp))
   (hImply₁   : ∀ {p q}, motive (p ➝ q ➝ p) $ ⟨imply₁ p q⟩)
@@ -177,8 +174,8 @@ notation "𝐊" => Modal.K
 instance : 𝐊.IsNormal (α := α) where
 
 abbrev ExtK (Ax : Theory α) : Hilbert α := ⟨𝗞 ∪ Ax, ⟮Nec⟯⟩
-instance : Hilbert.IsNormal (α := α) (ExtK Ax) where
 prefix:max "𝜿" => ExtK
+instance : (𝜿Ax).IsNormal (α := α) where
 
 lemma K_is_extK_of_empty : (𝐊 : Hilbert α) = 𝜿∅ := by aesop;
 
@@ -190,7 +187,7 @@ open System
 
 variable {Ax : Theory α}
 
-lemma def_ax : Ax(𝜿Ax) = (𝗞 ∪ Ax) := by simp;
+lemma def_ax : (𝜿Ax).axioms = (𝗞 ∪ Ax) := by simp;
 
 lemma maxm! (h : p ∈ Ax) : 𝜿Ax ⊢! p := ⟨Deduction.maxm (by simp [def_ax]; right; assumption)⟩
 
@@ -206,16 +203,20 @@ instance : System.S4 (𝝈Ax) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-@[simp] lemma ExtS4.def_ax : Ax(𝝈Ax) = (𝗞 ∪ 𝗧 ∪ 𝟰 ∪ Ax) := by aesop;
+@[simp] lemma ExtS4.def_ax : (𝝈Ax).axioms = (𝗞 ∪ 𝗧 ∪ 𝟰 ∪ Ax) := by aesop;
 
 end
 
 
 protected abbrev KT : Hilbert α := 𝜿(𝗧)
 notation "𝐊𝐓" => Modal.KT
+instance : System.KT (𝐊𝐓 : Hilbert α) where
+  T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev KB : Hilbert α := 𝜿(𝗕)
 notation "𝐊𝐁" => Modal.KB
+instance : System.KB (𝐊𝐁 : Hilbert α) where
+  B _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev KD : Hilbert α := 𝜿(𝗗)
 notation "𝐊𝐃" => Modal.KD
@@ -224,7 +225,7 @@ instance : System.KD (𝐊𝐃 : Hilbert α) where
 
 protected abbrev KP : Hilbert α := 𝜿(𝗣)
 notation "𝐊𝐏" => Modal.KP
-instance : System.HasAxiomP (𝐊𝐏 : Hilbert α) where
+instance : System.KP (𝐊𝐏 : Hilbert α) where
   P := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev KTB : Hilbert α := 𝜿(𝗧 ∪ 𝗕)
@@ -237,6 +238,8 @@ instance : System.K4 (𝐊𝟒 : Hilbert α) where
 
 protected abbrev K5 : Hilbert α := 𝜿(𝟱)
 notation "𝐊𝟓" => Modal.K5
+instance : System.K5 (𝐊𝟓 : Hilbert α) where
+  Five _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev S4 : Hilbert α := 𝝈(∅)
 notation "𝐒𝟒" => Modal.S4
@@ -264,10 +267,9 @@ instance : System.S5 (𝐒𝟓 : Hilbert α) where
 
 protected abbrev S5Grz : Hilbert α := 𝜿(𝗧 ∪ 𝟱 ∪ 𝗚𝗿𝘇) -- 𝐒𝟓 + 𝗚𝗿𝘇
 notation "𝐒𝟓𝐆𝐫𝐳" => Modal.S5Grz
-instance : System.S5 (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) where
+instance : System.S5Grz (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Five _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
-instance : System.Grz (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) where
   Grz _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev Triv : Hilbert α := 𝜿(𝗧 ∪ 𝗧𝗰)
@@ -341,7 +343,7 @@ open System
 open Formula (atom)
 
 lemma normal_weakerThan_of_maxm {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
-  (hMaxm : ∀ {p : Formula α}, p ∈ Ax(Λ₁) → Λ₂ ⊢! p)
+  (hMaxm : ∀ {p : Formula α}, p ∈ Λ₁.axioms → Λ₂ ⊢! p)
   : Λ₁ ≤ₛ Λ₂ := by
   apply System.weakerThan_iff.mpr;
   intro p h;
@@ -351,34 +353,33 @@ lemma normal_weakerThan_of_maxm {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ�
   | hNec ihp => exact nec! ihp;
   | _ => trivial;
 
-lemma normal_weakerThan_of_subset {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
-  (hSubset : Ax(Λ₁) ⊆ Ax(Λ₂) := by intro; aesop;)
+lemma normal_weakerThan_of_subset {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal] (hSubset : Λ₁.axioms ⊆ Λ₂.axioms)
   : Λ₁ ≤ₛ Λ₂ := by
   apply normal_weakerThan_of_maxm;
   intro p hp;
   exact ⟨Deduction.maxm $ hSubset hp⟩;
 
-lemma K_weakerThan_KD : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐃 := normal_weakerThan_of_subset
+lemma K_weakerThan_KD : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐃 := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_KB : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐁 := normal_weakerThan_of_subset
+lemma K_weakerThan_KB : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐁 := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_KT : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐓 := normal_weakerThan_of_subset
+lemma K_weakerThan_KT : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐓 := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_K4 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟒 := normal_weakerThan_of_subset
+lemma K_weakerThan_K4 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟒 := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_K5 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟓 := normal_weakerThan_of_subset
+lemma K_weakerThan_K5 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟓 := normal_weakerThan_of_subset $ by aesop;
 
-lemma KT_weakerThan_S4 : (𝐊𝐓 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset
+lemma KT_weakerThan_S4 : (𝐊𝐓 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma K4_weakerThan_S4 : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset
+lemma K4_weakerThan_S4 : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Dot2 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟐 := normal_weakerThan_of_subset
+lemma S4_weakerThan_S4Dot2 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟐 := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Dot3 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟑 := normal_weakerThan_of_subset
+lemma S4_weakerThan_S4Dot3 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟑 := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Grz : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒𝐆𝐫𝐳 := normal_weakerThan_of_subset
+lemma S4_weakerThan_S4Grz : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒𝐆𝐫𝐳 := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma K_weakerThan_GL : (𝐊 : Hilbert α) ≤ₛ 𝐆𝐋 := normal_weakerThan_of_subset
+lemma K_weakerThan_GL : (𝐊 : Hilbert α) ≤ₛ 𝐆𝐋 := normal_weakerThan_of_subset $ by intro; aesop;
 
 lemma K4_weakerThan_Triv : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐓𝐫𝐢𝐯 := by
   apply normal_weakerThan_of_maxm;

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -6,31 +6,36 @@ namespace LO.Modal
 
 variable {α : Type*}
 
+section
+
 /-- instance of inference rule -/
 structure InferenceRule (α : Type*) where
   antecedents : List (Formula α)
+  consequence : Formula α
   /--
   Empty antecedent rule can be simply regarded as axiom rule.
   However, union of all these rules including to `Hilbert.rules` would be too complex for implementation and induction,
   so more than one antecedent is required.
   -/
   antecedents_nonempty : antecedents ≠ [] := by simp
-  consequence : Formula α
 
-abbrev InferenceRules (α : Type*) := Set (InferenceRule α)
+abbrev Necessitation (p : Formula α) : InferenceRule α := ⟨[p], □p, by simp⟩
+abbrev Necessitation.set : Set (InferenceRule α) := { Necessitation p | p }
+notation "⟮Nec⟯" => Necessitation.set
 
-abbrev Necessitation {α} : InferenceRules α := { { antecedents := [p], consequence := □p} | (p) }
-notation "⟮Nec⟯" => Necessitation
+abbrev LoebRule (p : Formula α) : InferenceRule α := ⟨[□p ➝ p], p, by simp⟩
+abbrev LoebRule.set : Set (InferenceRule α) := { LoebRule p | p }
+notation "⟮Loeb⟯" => LoebRule.set
 
-abbrev LoebRule {α} : InferenceRules α := { { antecedents := [□p ➝ p], consequence := p} | (p) }
-notation "⟮Loeb⟯" => LoebRule
+abbrev HenkinRule (p : Formula α) : InferenceRule α := ⟨[□p ⭤ p], p, by simp⟩
+abbrev HenkinRule.set : Set (InferenceRule α) := { HenkinRule p | p }
+notation "⟮Henkin⟯" => HenkinRule.set
 
-abbrev HenkinRule {α} : InferenceRules α := { { antecedents := [□p ⭤ p], consequence := p }| (p) }
-notation "⟮Henkin⟯" => HenkinRule
+end
 
 structure Hilbert (α : Type*) where
   axioms : Theory α
-  rules : InferenceRules α
+  rules : Set (InferenceRule α)
 
 inductive Deduction (Λ : Hilbert α) : (Formula α) → Type _
   | maxm {p}     : p ∈ Λ.axioms → Deduction Λ p
@@ -99,6 +104,8 @@ instance [HasAxiomK Λ] : System.HasAxiomK Λ where
   K _ _ := maxm (by apply HasAxiomK.has_axiomK; simp_all)
 
 class IsNormal (Λ : Hilbert α) extends Λ.HasNecOnly, Λ.HasAxiomK where
+
+instance [IsNormal Λ] : System.K Λ where
 
 end Hilbert
 

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -4,7 +4,7 @@ import Foundation.Logic.HilbertStyle.Lukasiewicz
 
 namespace LO.Modal
 
-variable {α : Type*} [DecidableEq α]
+variable {α : Type*}
 
 /-- instance of inference rule -/
 structure InferenceRule (α : Type*) where
@@ -336,6 +336,7 @@ instance : 𝐍.HasNecOnly (α := α) where
 
 section
 
+variable [DecidableEq α]
 open System
 open Formula (atom)
 
@@ -477,6 +478,7 @@ lemma GL_equiv_K4Loeb : (𝐆𝐋 : Hilbert α) =ₛ 𝐊𝟒(𝐋) := by
   . exact GL_weakerThan_K4Loeb;
   . exact WeakerThan.trans (K4Loeb_weakerThan_K4Henkin) $ WeakerThan.trans K4Henkin_weakerThan_K4H K4Henkin_weakerThan_GL
 
+set_option linter.unusedSectionVars false in -- TODO: remove
 lemma GL_weakerThan_GLS : (𝐆𝐋 : Hilbert α) ≤ₛ 𝐆𝐋𝐒 := by
   apply System.weakerThan_iff.mpr;
   intro p h;

--- a/Foundation/Modal/Kripke/Completeness.lean
+++ b/Foundation/Modal/Kripke/Completeness.lean
@@ -8,7 +8,7 @@ open System
 open Formula
 open MaximalConsistentTheory
 
-variable {α : Type u} [DecidableEq α] [Inhabited α]
+variable {α : Type u} [DecidableEq α]
 variable {Λ : Hilbert α} [Λ.IsNormal]
 
 namespace Kripke
@@ -22,8 +22,8 @@ namespace CanonicalFrame
 variable [Nonempty (MCT Λ)]
 variable {Ω₁ Ω₂ : (CanonicalFrame Λ).World}
 
-@[simp]
-lemma rel_def_box: Ω₁ ≺ Ω₂ ↔ ∀ {p}, □p ∈ Ω₁.theory → p ∈ Ω₂.theory := by simp [Frame.Rel']; aesop;
+omit [DecidableEq α] [Λ.IsNormal] in
+@[simp] lemma rel_def_box: Ω₁ ≺ Ω₂ ↔ ∀ {p}, □p ∈ Ω₁.theory → p ∈ Ω₂.theory := by simp [Frame.Rel']; aesop;
 
 lemma multirel_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω₁.theory → p ∈ Ω₂.theory := by
   induction n generalizing Ω₁ Ω₂ with
@@ -165,7 +165,7 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Λ) ⊧ p ↔ Λ �
     have : Γ ⊬[Λ] ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
     contradiction;
 
-lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Λ) ⊧* Ax(Λ) := by
+lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Λ) ⊧* Λ.axioms := by
   apply Semantics.realizeSet_iff.mpr;
   intro p hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;

--- a/Foundation/Modal/Kripke/Dot3.lean
+++ b/Foundation/Modal/Kripke/Dot3.lean
@@ -13,10 +13,10 @@ open System
 open Kripke
 open Formula
 
-variable {α : Type u} [Inhabited α] [DecidableEq α] [atleast : Atleast 2 α]
+variable {α : Type u}
 variable {F : Kripke.Frame}
 
-private lemma connected_of_dot3 : F#α ⊧* .𝟯 → Connected F := by
+private lemma connected_of_dot3 (atleast : Atleast 2 α) : F#α ⊧* .𝟯 → Connected F := by
   contrapose;
   intro hCon; simp [Connected] at hCon;
   obtain ⟨x, y, rxy, z, ryz, nryz, nrzy⟩ := hCon;
@@ -51,34 +51,37 @@ private lemma dot3_of_connected : Connected F → F#α ⊧* .𝟯 := by
   | inl ryz => have := hp z ryz; contradiction;
   | inr rzy => have := hq y rzy; contradiction;
 
-instance axiomDot3_Definability : 𝔽((.𝟯 : Theory α)).DefinedBy ConnectedFrameClass where
+instance axiomDot3_Definability [Atleast 2 α] : 𝔽((.𝟯 : Theory α)).DefinedBy ConnectedFrameClass where
   define := by
     intro F;
     constructor;
-    . exact connected_of_dot3;
+    . exact connected_of_dot3 (by assumption);
     . exact dot3_of_connected;
   nonempty := by
     use ⟨PUnit, λ _ _ => True⟩;
     tauto;
 
-instance axiomS4Dot3_defines : 𝔽(((𝗧 ∪ 𝟰 ∪ .𝟯) : Theory α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := by
+instance axiomS4Dot3_defines [Atleast 2 α] [Inhabited α] [DecidableEq α] : 𝔽(((𝗧 ∪ 𝟰 ∪ .𝟯) : Theory α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := by
   rw [(show ReflexiveTransitiveConnectedFrameClass = ({ F | (Reflexive F ∧ Transitive F) ∧ Connected F } : FrameClass) by aesop)];
   apply definability_union_frameclass_of_theory;
   . convert axiomMultiGeach_definability (ts := [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩]);
     . aesop;
     . simp [GeachConfluent.reflexive_def, GeachConfluent.transitive_def]; rfl;
     . assumption;
+    . assumption;
   . exact axiomDot3_Definability;
   . use ⟨PUnit, λ _ _ => True⟩;
     simp [Reflexive, Transitive, Connected];
     refine ⟨⟨?_, ?_⟩, ?_⟩ <;> tauto;
 
-instance S4Dot3_defines : 𝔽((𝐒𝟒.𝟑 : Hilbert α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := inferInstance
+instance S4Dot3_defines [Inhabited α] [DecidableEq α] [Atleast 2 α] : 𝔽((𝐒𝟒.𝟑 : Hilbert α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := inferInstance
 
-instance : System.Consistent (𝐒𝟒.𝟑 : Hilbert α) := inferInstance
+instance  [Inhabited α] [DecidableEq α] [Atleast 2 α] : System.Consistent (𝐒𝟒.𝟑 : Hilbert α) := inferInstance
 
 open MaximalConsistentTheory in
-lemma connected_CanonicalFrame {Ax : Theory α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (𝜿Ax)] : Connected (CanonicalFrame 𝜿Ax) := by
+lemma connected_CanonicalFrame
+  [Inhabited α] [DecidableEq α] [Atleast 2 α]
+  {Ax : Theory α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (𝜿Ax)] : Connected (CanonicalFrame 𝜿Ax) := by
   dsimp only [Connected];
   intro X Y Z ⟨hXY, hXZ⟩;
   by_contra hC; push_neg at hC;
@@ -104,7 +107,9 @@ lemma connected_CanonicalFrame {Ax : Theory α} (hAx : .𝟯 ⊆ Ax) [System.Con
   have : □(□p ➝ q) ⋎ □(□q ➝ p) ∈ X.theory := by apply subset_axiomset _; aesop;
   contradiction;
 
-instance : Complete (𝐒𝟒.𝟑 : Hilbert α) (ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame ReflexiveTransitiveConnectedFrameClass $ by
+instance
+  [Inhabited α] [DecidableEq α] [Atleast 2 α]
+  : Complete (𝐒𝟒.𝟑 : Hilbert α) (ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame ReflexiveTransitiveConnectedFrameClass $ by
   refine ⟨?reflexive, ?transitive, ?connective⟩;
   . simp [GeachConfluent.reflexive_def];
     apply geachConfluent_CanonicalFrame;

--- a/Foundation/Modal/Kripke/Filteration.lean
+++ b/Foundation/Modal/Kripke/Filteration.lean
@@ -6,7 +6,7 @@ universe u v
 
 namespace LO.Modal
 
-variable {α : Type u} [DecidableEq α] [Inhabited α]
+variable {α : Type u} -- [DecidableEq α] [Inhabited α]
 
 namespace Kripke
 
@@ -125,14 +125,14 @@ instance CoarsestFilterationModel.filterOf {M} {T : Theory α} [T.SubformulaClos
 
 section
 
-variable {M} {T : Theory α} [T.SubformulaClosed] {FM : Kripke.Model α} (h_filter : FilterOf FM M T)
+variable {M} {T : Theory α} [T.SubformulaClosed] {FM : Kripke.Model α}
 
-lemma reflexive_filteration_model (hRefl : Reflexive M.Frame) : Reflexive FM.Frame := by
+lemma reflexive_filteration_model (h_filter : FilterOf FM M T) (hRefl : Reflexive M.Frame) : Reflexive FM.Frame := by
   intro Qx;
   obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (h_filter.def_world) Qx);
   convert h_filter.def_rel₁ $ hRefl x <;> simp_all;
 
-lemma serial_filteration_model (hSerial : Serial M.Frame) : Serial FM.Frame := by
+lemma serial_filteration_model (h_filter : FilterOf FM M T) (hSerial : Serial M.Frame) : Serial FM.Frame := by
   intro Qx;
   obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (h_filter.def_world) Qx);
   obtain ⟨y, Rxy⟩ := hSerial x;
@@ -180,7 +180,7 @@ theorem filteration {x : M.World} {p : Formula α} (hs : p ∈ T := by trivial) 
 
 end
 
-instance K_finite_complete : Complete 𝐊 (AllFrameClass.{u}ꟳ#α) := ⟨by
+instance K_finite_complete [DecidableEq α] : Complete 𝐊 (AllFrameClass.{u}ꟳ#α) := ⟨by
   intro p hp;
   apply K_complete.complete;
   intro F _ V x;
@@ -195,10 +195,10 @@ instance K_finite_complete : Complete 𝐊 (AllFrameClass.{u}ꟳ#α) := ⟨by
   ) FM.Valuation
 ⟩
 
-instance : FiniteFrameProperty (α := α) 𝐊 AllFrameClass where
+instance  [DecidableEq α] : FiniteFrameProperty (α := α) 𝐊 AllFrameClass where
 
 
-instance KTB_finite_complete : Complete 𝐊𝐓𝐁 (ReflexiveSymmetricFrameClass.{u}ꟳ#α) := ⟨by
+instance KTB_finite_complete [DecidableEq α] [Inhabited α] : Complete 𝐊𝐓𝐁 (ReflexiveSymmetricFrameClass.{u}ꟳ#α) := ⟨by
   intro p hp;
   apply KTB_complete.complete;
   intro F ⟨F_refl, F_symm⟩ V x;
@@ -219,13 +219,13 @@ instance KTB_finite_complete : Complete 𝐊𝐓𝐁 (ReflexiveSymmetricFrameCla
   ) FM.Valuation
 ⟩
 
-instance : FiniteFrameProperty (α := α) 𝐊𝐓𝐁 ReflexiveSymmetricFrameClass where
+instance [DecidableEq α] [Inhabited α] : FiniteFrameProperty (α := α) 𝐊𝐓𝐁 ReflexiveSymmetricFrameClass where
 
 section
 
 open Kripke.Frame (TransitiveClosure)
 
-variable {M : Model α} (M_trans : Transitive M.Frame) {T : Theory α} [T.SubformulaClosed]
+variable {M : Model α} {T : Theory α} [T.SubformulaClosed]
 
 abbrev FinestFilterationTransitiveClosureModel (M : Model α) (T : Theory α) [T.SubformulaClosed] : Kripke.Model α where
   Frame := (FinestFilterationFrame M T)^+
@@ -233,7 +233,7 @@ abbrev FinestFilterationTransitiveClosureModel (M : Model α) (T : Theory α) [T
 
 namespace FinestFilterationTransitiveClosureModel
 
-instance filterOf : FilterOf (FinestFilterationTransitiveClosureModel M T) M T where
+instance filterOf (M_trans : Transitive M.Frame) : FilterOf (FinestFilterationTransitiveClosureModel M T) M T where
   def_rel₁ := by
     intro x y hxy;
     apply TransitiveClosure.single;
@@ -264,7 +264,7 @@ lemma rel_transitive : Transitive (FinestFilterationTransitiveClosureModel M T).
 lemma rel_symmetric (M_symm : Symmetric M.Frame) : Symmetric (FinestFilterationTransitiveClosureModel M T).Frame :=
   Frame.TransitiveClosure.rel_symmetric $ symmetric_finest_filteration_model M_symm
 
-lemma rel_reflexive (M_refl : Reflexive M.Frame) : Reflexive (FinestFilterationTransitiveClosureModel M T).Frame := by
+lemma rel_reflexive (M_trans : Transitive M.Frame) (M_refl : Reflexive M.Frame) : Reflexive (FinestFilterationTransitiveClosureModel M T).Frame := by
   exact reflexive_filteration_model (filterOf M_trans) M_refl;
 
 end FinestFilterationTransitiveClosureModel
@@ -272,7 +272,7 @@ end FinestFilterationTransitiveClosureModel
 end
 
 open FinestFilterationTransitiveClosureModel in
-instance S4_finite_complete : Complete 𝐒𝟒 (PreorderFrameClass.{u}ꟳ#α) := ⟨by
+instance S4_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐒𝟒 (PreorderFrameClass.{u}ꟳ#α) := ⟨by
   intro p hp;
   apply S4_complete.complete;
   intro F ⟨F_refl, F_trans⟩ V x;
@@ -291,11 +291,11 @@ instance S4_finite_complete : Complete 𝐒𝟒 (PreorderFrameClass.{u}ꟳ#α) :
     exact F_trans;
 ⟩
 
-instance : FiniteFrameProperty (α := α) 𝐒𝟒 PreorderFrameClass where
+instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (α := α) 𝐒𝟒 PreorderFrameClass where
 
 
 open FinestFilterationTransitiveClosureModel in
-instance KT4B_finite_complete : Complete 𝐊𝐓𝟒𝐁 (EquivalenceFrameClass.{u}ꟳ#α) := ⟨by
+instance KT4B_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐊𝐓𝟒𝐁 (EquivalenceFrameClass.{u}ꟳ#α) := ⟨by
   intro p hp;
   apply KT4B_complete.complete;
   intro F ⟨F_refl, F_trans, F_symm⟩ V x;
@@ -315,7 +315,7 @@ instance KT4B_finite_complete : Complete 𝐊𝐓𝟒𝐁 (EquivalenceFrameClass
     exact F_trans;
 ⟩
 
-instance : FiniteFrameProperty (α := α) 𝐊𝐓𝟒𝐁 EquivalenceFrameClass where
+instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (α := α) 𝐊𝐓𝟒𝐁 EquivalenceFrameClass where
 -- MEMO: `𝐒𝟓 =ₛ 𝐊𝐓𝟒𝐁`だから決定可能性という面では`𝐒𝟓`も決定可能．
 
 end Kripke

--- a/Foundation/Modal/Kripke/GL/Completeness.lean
+++ b/Foundation/Modal/Kripke/GL/Completeness.lean
@@ -43,6 +43,7 @@ open System System.FiniteContext
 open Formula.Kripke
 open ComplementaryClosedConsistentFormulae
 
+omit [Inhabited α] in
 private lemma GL_truthlemma.lemma1
   {X : CCF 𝐆𝐋 (𝒮 p)} (hq : □q ∈ 𝒮 p)
   : ((X.formulae.prebox ∪ X.formulae.prebox.box) ∪ {□q, -q}) ⊆ (𝒮 p)⁻ := by
@@ -53,17 +54,19 @@ private lemma GL_truthlemma.lemma1
   . apply Finset.mem_union.mpr;
     tauto;
   . have := X.closed.subset hp;
-    have := Formulae.complementary_mem_box (by apply Formula.Subformulas.mem_imp₁) this;
+    have := Formulae.complementary_mem_box (by apply Subformulas.mem_imp₁) this;
     apply Finset.mem_union.mpr;
-    left; trivial;
+    left;
+    exact Subformulas.mem_box this;
   . exact X.closed.subset hr;
   . apply Finset.mem_union.mpr;
     right; simp;
     use q;
     constructor;
-    . trivial;
+    . exact Subformulas.mem_box hq;
     . rfl;
 
+omit [Inhabited α] in
 private lemma GL_truthlemma.lemma2
   {X : CCF 𝐆𝐋 (𝒮 p)} (hq₁ : □q ∈ 𝒮 p) (hq₂ : □q ∉ X.formulae)
   : Formulae.Consistent 𝐆𝐋 ((X.formulae.prebox ∪ X.formulae.prebox.box) ∪ {□q, -q}) := by
@@ -128,20 +131,20 @@ lemma GL_truthlemma {X : (GLCompleteModel p)} (q_sub : q ∈ 𝒮 p) :
       intro h;
       simp [Satisfies];
       constructor;
-      . apply ihq (by trivial) |>.mpr;
-        exact iff_not_mem_imp q_sub |>.mp h |>.1;
-      . apply ihr (by trivial) |>.not.mpr;
-        have := iff_not_mem_imp q_sub |>.mp h |>.2;
-        exact iff_mem_compl (by trivial) |>.not.mpr (by simpa using this);
+      . apply ihq (Subformulas.mem_imp₁ q_sub) |>.mpr;
+        exact iff_not_mem_imp q_sub (Subformulas.mem_imp₁ q_sub) (Subformulas.mem_imp₂ q_sub) |>.mp h |>.1;
+      . apply ihr (Subformulas.mem_imp₂ q_sub) |>.not.mpr;
+        have := iff_not_mem_imp q_sub (Subformulas.mem_imp₁ q_sub) (Subformulas.mem_imp₂ q_sub) |>.mp h |>.2;
+        exact iff_mem_compl (Subformulas.mem_imp₂ q_sub) |>.not.mpr (by simpa using this);
     . contrapose;
       intro h; simp [Satisfies] at h;
       obtain ⟨hq, hr⟩ := h;
-      replace hq := ihq (by trivial) |>.mp hq;
-      replace hr := ihr (by trivial) |>.not.mp hr;
-      apply iff_not_mem_imp q_sub |>.mpr;
+      replace hq := ihq (Subformulas.mem_imp₁ q_sub) |>.mp hq;
+      replace hr := ihr (Subformulas.mem_imp₂ q_sub) |>.not.mp hr;
+      apply iff_not_mem_imp q_sub (Subformulas.mem_imp₁ q_sub) (Subformulas.mem_imp₂ q_sub) |>.mpr;
       constructor;
       . assumption;
-      . simpa using iff_mem_compl (by trivial) |>.not.mp (by simpa using hr);
+      . simpa using iff_mem_compl (Subformulas.mem_imp₂ q_sub) |>.not.mp (by simpa using hr);
   | hbox q ih =>
     constructor;
     . contrapose;
@@ -158,10 +161,10 @@ lemma GL_truthlemma {X : (GLCompleteModel p)} (q_sub : q ∈ 𝒮 p) :
       . use q;
         refine ⟨q_sub, h, ?_, ?_⟩;
         . apply hY₁.2; simp;
-        . apply ih (by trivial) |>.not.mpr;
-          exact iff_mem_compl (by trivial) |>.not.mpr $ by simp; apply hY₁.2; simp;
+        . apply ih (Subformulas.mem_box q_sub) |>.not.mpr;
+          exact iff_mem_compl (Subformulas.mem_box q_sub) |>.not.mpr $ by simp; apply hY₁.2; simp;
     . intro h Y RXY;
-      apply ih (by trivial) |>.mpr;
+      apply ih (Subformulas.mem_box q_sub) |>.mpr;
       simp at RXY;
       refine RXY.1 q ?_ h |>.1;
       assumption;

--- a/Foundation/Modal/Kripke/GL/Tree.lean
+++ b/Foundation/Modal/Kripke/GL/Tree.lean
@@ -21,7 +21,7 @@ lemma modal_equivalence_at_root_on_treeUnravelling (M : Kripke.Model α) (M_tran
 
 section
 
-variable [Inhabited α] [DecidableEq α]
+
 variable {p : Formula α}
 
 open Classical
@@ -46,6 +46,7 @@ lemma valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTra
   apply modal_equivalence_at_root_on_treeUnravelling (M↾r) (Frame.PointGenerated.rel_transitive F_trans) ⟨r, by tauto⟩ |>.mp;
   exact H ⟨(F.FiniteTransitiveTreeUnravelling F_trans F_irrefl r), (M.FiniteTransitiveTreeUnravelling r).Valuation⟩;
 
+variable [Inhabited α] [DecidableEq α]
 theorem iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree : 𝐆𝐋 ⊢! p ↔ (∀ M : FiniteTransitiveTreeModel.{u, u} α, M.root ⊧ p) := by
   constructor;
   . intro h M;
@@ -198,7 +199,7 @@ lemma GL_imply_boxdot_plain_of_imply_box_box : 𝐆𝐋 ⊢! □p ➝ □q → �
 
 theorem GL_unnecessitation! : 𝐆𝐋 ⊢! □p → 𝐆𝐋 ⊢! p := by
   intro h;
-  have : 𝐆𝐋 ⊢! □⊤ ➝ □p := dhyp! (q := □⊤) h;
+  have : 𝐆𝐋 ⊢! □⊤ ➝ □p := imply₁'! (q := □⊤) h;
   have : 𝐆𝐋 ⊢! ⊡⊤ ➝ p := GL_imply_boxdot_plain_of_imply_box_box this;
   exact this ⨀ boxdotverum!;
 

--- a/Foundation/Modal/Kripke/Semantics.lean
+++ b/Foundation/Modal/Kripke/Semantics.lean
@@ -506,9 +506,8 @@ open Formula (atom)
 open Formula.Kripke
 open Kripke (K_sound)
 
-variable [DecidableEq α] [Inhabited α]
 
-theorem K_strictlyWeakerThan_KD : (𝐊 : Hilbert α) <ₛ 𝐊𝐃 := by
+theorem K_strictlyWeakerThan_KD [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝐃 := by
   constructor;
   . apply K_weakerThan_KD;
   . simp [weakerThan_iff];
@@ -520,7 +519,7 @@ theorem K_strictlyWeakerThan_KD : (𝐊 : Hilbert α) <ₛ 𝐊𝐃 := by
       use ⟨Fin 1, λ _ _ => False⟩, (λ w _ => w = 0), 0;
       simp [Satisfies];
 
-theorem K_strictlyWeakerThan_KB : (𝐊 : Hilbert α) <ₛ 𝐊𝐁 := by
+theorem K_strictlyWeakerThan_KB [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝐁 := by
   constructor;
   . apply K_weakerThan_KB;
   . simp [weakerThan_iff];
@@ -533,7 +532,7 @@ theorem K_strictlyWeakerThan_KB : (𝐊 : Hilbert α) <ₛ 𝐊𝐁 := by
       simp [Satisfies];
       use 1;
 
-theorem K_strictlyWeakerThan_K4 : (𝐊 : Hilbert α) <ₛ 𝐊𝟒 := by
+theorem K_strictlyWeakerThan_K4 [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝟒 := by
   constructor;
   . apply K_weakerThan_K4;
   . simp [weakerThan_iff];
@@ -554,7 +553,7 @@ theorem K_strictlyWeakerThan_K4 : (𝐊 : Hilbert α) <ₛ 𝐊𝟒 := by
         . aesop;
         . use 0; aesop;
 
-theorem K_strictlyWeakerThan_K5 : (𝐊 : Hilbert α) <ₛ 𝐊𝟓 := by
+theorem K_strictlyWeakerThan_K5 [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝟓 := by
   constructor;
   . apply K_weakerThan_K5;
   . simp [weakerThan_iff];
@@ -572,17 +571,20 @@ theorem K_strictlyWeakerThan_K5 : (𝐊 : Hilbert α) <ₛ 𝐊𝟓 := by
 section
 
 variable {Ax₁ Ax₂ : Theory α} (𝔽₁ 𝔽₂ : FrameClass)
-  [sound₁ : Sound 𝜿Ax₁ (𝔽₁#α)] [sound₂ : Sound 𝜿Ax₂ (𝔽₂#α)]
-  [complete₁ : Complete 𝜿Ax₁ (𝔽₁#α)] [complete₂ : Complete 𝜿Ax₂ (𝔽₂#α)]
 
-lemma weakerThan_of_subset_FrameClass (h𝔽 : 𝔽₂ ⊆ 𝔽₁) : 𝜿Ax₁ ≤ₛ 𝜿Ax₂ := by
+lemma weakerThan_of_subset_FrameClass
+  [sound₁ : Sound 𝜿Ax₁ 𝔽₁#α] [complete₂ : Complete 𝜿Ax₂ 𝔽₂#α]
+  (h𝔽 : 𝔽₂ ⊆ 𝔽₁) : 𝜿Ax₁ ≤ₛ 𝜿Ax₂ := by
   apply System.weakerThan_iff.mpr;
   intro p hp;
   apply complete₂.complete;
   intro F hF;
   exact sound₁.sound hp $ h𝔽 hF;
 
-lemma equiv_of_eq_FrameClass (h𝔽 : 𝔽₁ = 𝔽₂) : 𝜿Ax₁ =ₛ 𝜿Ax₂ := by
+lemma equiv_of_eq_FrameClass
+  [sound₁ : Sound 𝜿Ax₁ 𝔽₁#α] [sound₂ : Sound 𝜿Ax₂ 𝔽₂#α]
+  [complete₁ : Complete 𝜿Ax₁ 𝔽₁#α] [complete₂ : Complete 𝜿Ax₂ 𝔽₂#α]
+  (h𝔽 : 𝔽₁ = 𝔽₂) : 𝜿Ax₁ =ₛ 𝜿Ax₂ := by
   apply System.Equiv.antisymm_iff.mpr;
   constructor;
   . apply weakerThan_of_subset_FrameClass 𝔽₁ 𝔽₂; subst_vars; rfl;

--- a/Foundation/Modal/LogicSymbol.lean
+++ b/Foundation/Modal/LogicSymbol.lean
@@ -120,7 +120,7 @@ end LO
 section
 
 open LO (Box Dia)
-variable {F : Type*} [DecidableEq F]
+variable {F : Type*}
 
 protected abbrev Set.multibox [Box F] (n : ℕ) : Set F → Set F := Set.image (□·)^[n]
 notation:80 "□''^[" n:90 "]" s:80 => Set.multibox n s
@@ -151,30 +151,30 @@ prefix:80 "◇''⁻¹" => Set.predia
 namespace Set
 
 variable {s t : Set F}
-variable [Box F] [Dia F]
+
+section
+
+variable [Box F]
 
 @[simp] lemma eq_box_multibox_one : □''s = □''^[1]s := by rfl
-@[simp] lemma eq_dia_multidia_one : ◇''s = ◇''^[1]s := by rfl
+
 @[simp] lemma eq_prebox_premultibox_one : □''⁻¹s = □''⁻¹^[1]s := by rfl
-@[simp] lemma eq_predia_premultidia_one : ◇''⁻¹s = ◇''⁻¹^[1]s := by rfl
+
 
 @[simp] lemma multibox_subset_mono (h : s ⊆ t) : □''^[n]s ⊆ □''^[n]t := by simp_all [Set.subset_def];
+
 @[simp] lemma box_subset_mono (h : s ⊆ t) : □''s ⊆ □''t := by simpa using multibox_subset_mono (n := 1) h;
 
-@[simp] lemma multidia_subset_mono (h : s ⊆ t) : ◇''^[n]s ⊆ ◇''^[n]t := by simp_all [Set.subset_def];
-@[simp] lemma dia_subset_mono (h : s ⊆ t) : ◇''s ⊆ ◇''t := by simpa using multidia_subset_mono (n := 1) h;
 
 @[simp] lemma premultibox_subset_mono (h : s ⊆ t) : □''⁻¹^[n]s ⊆ □''⁻¹^[n]t := by simp_all [Set.subset_def];
+
 @[simp] lemma prebox_subset_mono (h : s ⊆ t) : □''⁻¹s ⊆  □''⁻¹t := by simpa using premultibox_subset_mono (n := 1) h;
 
-@[simp] lemma premultidia_subset_mono (h : s ⊆ t) : ◇''⁻¹^[n]s ⊆ ◇''⁻¹^[n]t := by simp_all [Set.subset_def];
-@[simp] lemma predia_subset_mono (h : s ⊆ t) : ◇''⁻¹s ⊆ ◇''⁻¹t := by simpa using premultidia_subset_mono (n := 1) h;
 
 @[simp] lemma iff_mem_premultibox : p ∈ □''⁻¹^[n]s ↔ □^[n]p ∈ s := by simp;
+
 @[simp] lemma iff_mem_multibox : □^[n]p ∈ □''^[n]s ↔ p ∈ s := by simp;
 
-@[simp] lemma iff_mem_premultidia : p ∈ ◇''⁻¹^[n]s ↔ ◇^[n]p ∈ s := by simp;
-@[simp] lemma iff_mem_multidia : ◇^[n]p ∈ ◇''^[n]s ↔ p ∈ s := by simp;
 
 lemma subset_premulitibox_iff_multibox_subset (h : s ⊆ □''⁻¹^[n]t) :  □''^[n]s ⊆ t := by
   intro p hp;
@@ -183,41 +183,17 @@ lemma subset_premulitibox_iff_multibox_subset (h : s ⊆ □''⁻¹^[n]t) :  □
 
 lemma subset_prebox_iff_box_subset (h : s ⊆ □''⁻¹t) : □''s ⊆ t := by simpa using subset_premulitibox_iff_multibox_subset (n := 1) h
 
-
-lemma subset_premultidia_iff_multidia_subset (h : s ⊆ ◇''⁻¹^[n]t) :  ◇''^[n]s ⊆ t := by
-  intro p hp;
-  obtain ⟨_, _, rfl⟩ := multidia_subset_mono h hp;
-  assumption;
-
-lemma subset_predia_iff_dia_subset (h : s ⊆ ◇''⁻¹t) : ◇''s ⊆ t := by simpa using subset_premultidia_iff_multidia_subset (n := 1) h
-
-
 lemma subset_multibox_iff_premulitibox_subset (h : s ⊆ □''^[n]t) : □''⁻¹^[n]s ⊆ t := by
   intro p hp;
   have := premultibox_subset_mono h hp;
   simp_all;
 lemma subset_box_iff_prebox_subset (h : s ⊆ □''t) : □''⁻¹s ⊆ t := by simpa using subset_multibox_iff_premulitibox_subset (n := 1) h
 
-lemma subset_multidia_iff_premultidia_subset (h : s ⊆ ◇''^[n]t) : ◇''⁻¹^[n]s ⊆ t := by
-  intro p hp;
-  have := premultidia_subset_mono h hp;
-  simp_all;
-
-lemma subset_dia_iff_predia_subset (h : s ⊆ ◇''t) : ◇''⁻¹s ⊆ t := by simpa using subset_multidia_iff_premultidia_subset (n := 1) h
-
-
 lemma forall_multibox_of_subset_multibox (h : s ⊆ □''^[n]t) : ∀ p ∈ s, ∃ q ∈ t, p = □^[n]q := by
   intro p hp;
   obtain ⟨q, _, rfl⟩ := h hp;
   use q;
 lemma forall_box_of_subset_box (h : s ⊆ □''t) : ∀ p ∈ s, ∃ q ∈ t, p = □q := by simpa using forall_multibox_of_subset_multibox (n := 1) h
-
-lemma forall_multidia_of_subset_multidia (h : s ⊆ ◇''^[n]t) : ∀ p ∈ s, ∃ q ∈ t, p = ◇^[n]q := by
-  intro p hp;
-  obtain ⟨q, _, rfl⟩ := h hp;
-  use q;
-lemma forall_dia_of_subset_dia (h : s ⊆ ◇''t) : ∀ p ∈ s, ∃ q ∈ t, p = ◇q := by simpa using forall_multidia_of_subset_multidia (n := 1) h
-
 
 lemma eq_premultibox_multibox_of_subset_premultibox (h : s ⊆ □''^[n]t) :  □''^[n]□''⁻¹^[n]s = s := by
   apply Set.eq_of_subset_of_subset;
@@ -229,6 +205,52 @@ lemma eq_premultibox_multibox_of_subset_premultibox (h : s ⊆ □''^[n]t) :  �
     simp_all [Set.premultibox];
 lemma eq_prebox_box_of_subset_prebox (h : s ⊆ □''t) : □''□''⁻¹s = s := by simpa using eq_premultibox_multibox_of_subset_premultibox (n := 1) h
 
+end
+
+
+section
+
+variable [Dia F]
+
+@[simp] lemma eq_dia_multidia_one : ◇''s = ◇''^[1]s := by rfl
+
+@[simp] lemma eq_predia_premultidia_one : ◇''⁻¹s = ◇''⁻¹^[1]s := by rfl
+
+
+@[simp] lemma multidia_subset_mono (h : s ⊆ t) : ◇''^[n]s ⊆ ◇''^[n]t := by simp_all [Set.subset_def];
+
+@[simp] lemma dia_subset_mono (h : s ⊆ t) : ◇''s ⊆ ◇''t := by simpa using multidia_subset_mono (n := 1) h;
+
+
+@[simp] lemma premultidia_subset_mono (h : s ⊆ t) : ◇''⁻¹^[n]s ⊆ ◇''⁻¹^[n]t := by simp_all [Set.subset_def];
+
+@[simp] lemma predia_subset_mono (h : s ⊆ t) : ◇''⁻¹s ⊆ ◇''⁻¹t := by simpa using premultidia_subset_mono (n := 1) h;
+
+
+@[simp] lemma iff_mem_premultidia : p ∈ ◇''⁻¹^[n]s ↔ ◇^[n]p ∈ s := by simp;
+
+@[simp] lemma iff_mem_multidia : ◇^[n]p ∈ ◇''^[n]s ↔ p ∈ s := by simp;
+
+lemma subset_premultidia_iff_multidia_subset (h : s ⊆ ◇''⁻¹^[n]t) :  ◇''^[n]s ⊆ t := by
+  intro p hp;
+  obtain ⟨_, _, rfl⟩ := multidia_subset_mono h hp;
+  assumption;
+
+lemma subset_predia_iff_dia_subset (h : s ⊆ ◇''⁻¹t) : ◇''s ⊆ t := by simpa using subset_premultidia_iff_multidia_subset (n := 1) h
+
+lemma subset_multidia_iff_premultidia_subset (h : s ⊆ ◇''^[n]t) : ◇''⁻¹^[n]s ⊆ t := by
+  intro p hp;
+  have := premultidia_subset_mono h hp;
+  simp_all;
+
+lemma subset_dia_iff_predia_subset (h : s ⊆ ◇''t) : ◇''⁻¹s ⊆ t := by simpa using subset_multidia_iff_premultidia_subset (n := 1) h
+
+lemma forall_multidia_of_subset_multidia (h : s ⊆ ◇''^[n]t) : ∀ p ∈ s, ∃ q ∈ t, p = ◇^[n]q := by
+  intro p hp;
+  obtain ⟨q, _, rfl⟩ := h hp;
+  use q;
+lemma forall_dia_of_subset_dia (h : s ⊆ ◇''t) : ∀ p ∈ s, ∃ q ∈ t, p = ◇q := by simpa using forall_multidia_of_subset_multidia (n := 1) h
+
 lemma eq_premultidia_multidia_of_subset_premultidia (h : s ⊆ ◇''^[n]t) :  ◇''^[n]◇''⁻¹^[n]s = s := by
   apply Set.eq_of_subset_of_subset;
   . intro p hp;
@@ -239,8 +261,14 @@ lemma eq_premultidia_multidia_of_subset_premultidia (h : s ⊆ ◇''^[n]t) :  �
     simp_all [Set.premultidia];
 lemma eq_predia_dia_of_subset_predia (h : s ⊆ ◇''t) : ◇''◇''⁻¹s = s := by simpa using eq_premultidia_multidia_of_subset_premultidia (n := 1) h
 
+end
+
 end Set
 
+
+section
+
+variable [DecidableEq F]
 
 protected abbrev Finset.multibox [Box F] (n : ℕ) : Finset F → Finset F := Finset.image (□·)^[n]
 
@@ -259,54 +287,84 @@ protected noncomputable abbrev Finset.prebox [Box F] : Finset F → Finset F := 
 
 protected noncomputable abbrev Finset.predia [Dia F] : Finset F → Finset F := Finset.premultidia (n := 1)
 
+end
 
 namespace Finset
 
-variable [Box F] [Dia F]
-         {s t : Finset F} {n : ℕ}
+variable {s t : Finset F} {n : ℕ}
 
-@[simp] lemma eq_box_multibox_one : s.box = s.multibox 1 := by rfl
-@[simp] lemma eq_dia_multidia_one : s.dia = s.multidia 1 := by rfl
+section
+
+variable [Box F]
+
+@[simp] lemma eq_box_multibox_one [DecidableEq F] : s.box = s.multibox 1 := by rfl
+
 @[simp] lemma eq_prebox_premultibox_one : s.prebox = s.premultibox 1 := by rfl
-@[simp] lemma eq_predia_premultidia_one : s.predia = s.premultidia 1 := by rfl
 
-lemma multibox_coe : (s.multibox n) = □''^[n](s : Set F) := by simp_all
-lemma box_coe : s.box = □''(s : Set F) := by simpa using multibox_coe (n := 1)
+lemma multibox_coe [DecidableEq F] : (s.multibox n) = □''^[n](s : Set F) := by simp_all
 
-lemma multidia_coe : (s.multidia n) = ◇''^[n](s : Set F) := by simp_all
-lemma dia_coe : s.dia = ◇''(s : Set F) := by simpa using multidia_coe (n := 1)
+lemma box_coe [DecidableEq F] : s.box = □''(s : Set F) := by simpa using multibox_coe (n := 1)
 
-lemma multibox_mem_coe : p ∈ s.multibox n ↔ p ∈ □''^[n](↑s : Set F) := by constructor <;> simp_all
-lemma box_mem_coe : p ∈ s.box ↔ p ∈ □''(↑s : Set F) := by simp;
+lemma multibox_mem_coe [DecidableEq F] : p ∈ s.multibox n ↔ p ∈ □''^[n](↑s : Set F) := by constructor <;> simp_all
 
-lemma multidia_mem_coe : p ∈ s.multidia n ↔ p ∈ ◇''^[n](↑s : Set F) := by constructor <;> simp_all
-lemma dia_mem_coe : p ∈ s.dia ↔ p ∈ ◇''(↑s : Set F) := by simp;
-
+lemma box_mem_coe [DecidableEq F] : p ∈ s.box ↔ p ∈ □''(↑s : Set F) := by simp;
 
 lemma premultibox_coe : (s.premultibox n) = □''⁻¹^[n](s : Set F) := by simp_all
+
 lemma prebox_coe : s.prebox = □''⁻¹(↑s : Set F) := by simpa using premultibox_coe (n := 1)
 
-lemma premultidia_coe : (s.premultidia n) = ◇''⁻¹^[n](s : Set F) := by simp_all
-lemma predia_coe : s.predia = ◇''⁻¹(↑s : Set F) := by simpa using premultidia_coe (n := 1)
-
-
 lemma premultibox_multibox_eq_of_subset_multibox
+  [DecidableEq F]
   {s : Finset F} {t : Set F} (hs : ↑s ⊆ □''^[n]t) : (s.premultibox n).multibox n = s := by
   have := Set.eq_premultibox_multibox_of_subset_premultibox hs;
   rw [←premultibox_coe, ←multibox_coe] at this;
   exact Finset.coe_inj.mp this;
-lemma prebox_box_eq_of_subset_box {s : Finset F} {t : Set F} (hs : ↑s ⊆ □''t) : s.prebox.box = s := by simpa using premultibox_multibox_eq_of_subset_multibox (n := 1) hs
+
+lemma prebox_box_eq_of_subset_box [DecidableEq F] {s : Finset F} {t : Set F} (hs : ↑s ⊆ □''t) : s.prebox.box = s
+  := by simpa using premultibox_multibox_eq_of_subset_multibox (n := 1) hs
+
+end
+
+
+section
+
+variable [Dia F]
+
+@[simp] lemma eq_dia_multidia_one [DecidableEq F] : s.dia = s.multidia 1 := by rfl
+
+@[simp] lemma eq_predia_premultidia_one : s.predia = s.premultidia 1 := by rfl
+
+lemma multidia_coe [DecidableEq F] : (s.multidia n) = ◇''^[n](s : Set F) := by simp_all
+
+lemma dia_coe [DecidableEq F] : s.dia = ◇''(s : Set F) := by simpa using multidia_coe (n := 1)
+
+lemma multidia_mem_coe [DecidableEq F] : p ∈ s.multidia n ↔ p ∈ ◇''^[n](↑s : Set F) := by constructor <;> simp_all
+
+lemma dia_mem_coe [DecidableEq F] : p ∈ s.dia ↔ p ∈ ◇''(↑s : Set F) := by simp;
+
+lemma premultidia_coe : (s.premultidia n) = ◇''⁻¹^[n](s : Set F) := by simp_all
+
+lemma predia_coe : s.predia = ◇''⁻¹(↑s : Set F) := by simpa using premultidia_coe (n := 1)
 
 lemma premultidia_multidia_eq_of_subset_multidia
+  [DecidableEq F]
   {s : Finset F} {t : Set F} (hs : ↑s ⊆ ◇''^[n]t) : (s.premultidia n).multidia n = s := by
   have := Set.eq_premultidia_multidia_of_subset_premultidia hs;
   rw [←premultidia_coe, ←multidia_coe] at this;
   exact Finset.coe_inj.mp this;
-lemma predia_dia_eq_of_subset_dia {s : Finset F} {t : Set F} (hs : ↑s ⊆ ◇''t) : s.predia.dia = s := by simpa using premultidia_multidia_eq_of_subset_multidia (n := 1) hs
+
+lemma predia_dia_eq_of_subset_dia [DecidableEq F] {s : Finset F} {t : Set F} (hs : ↑s ⊆ ◇''t) : s.predia.dia = s
+  := by simpa using premultidia_multidia_eq_of_subset_multidia (n := 1) hs
+
+end
 
 end Finset
 
 
+
+section
+
+variable [DecidableEq F]
 
 protected noncomputable abbrev List.multibox [Box F] (n : ℕ) : List F → List F := λ l => Finset.multibox n l.toFinset |>.toList
 notation "□'^[" n:90 "]" l:80 => List.multibox n l
@@ -333,35 +391,55 @@ prefix:80 "□'⁻¹" => List.prebox
 protected noncomputable abbrev List.predia [Dia F] : List F → List F := List.premultidia (n := 1)
 prefix:80 "◇'⁻¹" => List.predia
 
+end
+
 namespace List
 
-variable [Box F] [Dia F]
-         {l : List F} {s : Set F} {p : F}
+variable {l : List F} {s : Set F} {p : F}
+
+
+lemma forall_multibox_of_subset_multibox [Box F] (h : ∀ p ∈ l, p ∈ □''^[n]s) : ∀ p ∈ l, ∃ q ∈ s, p = □^[n]q := by
+  intro p hp;
+  obtain ⟨q, _, rfl⟩ := h p hp;
+  use q;
+
+lemma forall_box_of_subset_box [Box F] (h : ∀ p ∈ l, p ∈ □''s) : ∀ p ∈ l, ∃ q ∈ s, p = □q := by
+  simpa using forall_multibox_of_subset_multibox (n := 1) h
+
+
+lemma forall_multidia_of_subset_multidia [Dia F] (h : ∀ p ∈ l, p ∈ ◇''^[n]s) : ∀ p ∈ l, ∃ q ∈ s, p = ◇^[n]q := by
+  intro p hp;
+  obtain ⟨q, _, rfl⟩ := h p hp;
+  use q;
+
+lemma forall_dia_of_subset_dia [Dia F] (h : ∀ p ∈ l, p ∈ ◇''s) : ∀ p ∈ l, ∃ q ∈ s, p = ◇q := by
+  simpa using forall_multidia_of_subset_multidia (n := 1) h
+
+
+variable [DecidableEq F]
+
+section
+
+variable [Box F]
 
 @[simp] lemma eq_box_multibox_one : □'l = □'^[1]l := by rfl
-@[simp] lemma eq_dia_multidia_one : ◇'l = ◇'^[1]l := by rfl
+
 @[simp] lemma eq_prebox_premultibox_one : □'⁻¹l = □'⁻¹^[1]l := by rfl
-@[simp] lemma eq_predia_premultidia_one : ◇'⁻¹l = ◇'⁻¹^[1]l := by rfl
 
 
 @[simp] lemma multibox_nil : (□'^[n]([] :List F)) = [] := by simp;
+
 @[simp] lemma box_nil : (□'([] : List F)) = [] := by simp;
 
-@[simp] lemma multidia_nil : (◇'^[n]([] :List F)) = [] := by simp;
-@[simp] lemma dia_nil : (◇'([] : List F)) = [] := by simp;
 
 @[simp] lemma premultibox_nil : (□'⁻¹^[n]([] :List F)) = [] := by simp;
-@[simp] lemma prebox_nil : (□'⁻¹([] : List F)) = [] := by simp;
 
-@[simp] lemma premultidia_nil : (◇'⁻¹^[n]([] :List F)) = [] := by simp;
-@[simp] lemma predia_nil : (◇'⁻¹([] : List F)) = [] := by simp;
+@[simp] lemma prebox_nil : (□'⁻¹([] : List F)) = [] := by simp;
 
 
 @[simp] lemma multibox_single : (□'^[n][p]) = [□^[n]p] := by simp;
-@[simp] lemma box_single : (□'[p]) = [□p] := by simp;
 
-@[simp] lemma multidia_single : (◇'^[n][p]) = [◇^[n]p] := by simp;
-@[simp] lemma dia_single : (◇'[p]) = [◇p] := by simp;
+@[simp] lemma box_single : (□'[p]) = [□p] := by simp;
 
 
 lemma multibox_cons (hl : p ∉ l) : □'^[n](p :: l) ~ □^[n]p :: □'^[n]l := by
@@ -370,26 +448,40 @@ lemma multibox_cons (hl : p ∉ l) : □'^[n](p :: l) ~ □^[n]p :: □'^[n]l :=
   simp_all;
 lemma box_cons (hl : p ∉ l) : □'(p :: l) ~ □p :: □'l := by simpa using multibox_cons hl
 
+
+end
+
+section
+
+variable [Dia F]
+
+@[simp] lemma eq_dia_multidia_one : ◇'l = ◇'^[1]l := by rfl
+
+@[simp] lemma eq_predia_premultidia_one : ◇'⁻¹l = ◇'⁻¹^[1]l := by rfl
+
+
+@[simp] lemma multidia_nil : (◇'^[n]([] :List F)) = [] := by simp;
+
+@[simp] lemma dia_nil : (◇'([] : List F)) = [] := by simp;
+
+
+@[simp] lemma premultidia_nil : (◇'⁻¹^[n]([] :List F)) = [] := by simp;
+
+@[simp] lemma predia_nil : (◇'⁻¹([] : List F)) = [] := by simp;
+
+
+@[simp] lemma multidia_single : (◇'^[n][p]) = [◇^[n]p] := by simp;
+
+@[simp] lemma dia_single : (◇'[p]) = [◇p] := by simp;
+
 lemma multidia_cons (hl : p ∉ l) : ◇'^[n](p :: l) ~ ◇^[n]p :: ◇'^[n]l := by
   simp [List.multidia];
   apply Finset.toList_insert;
   simp_all;
+
 lemma dia_cons (hl : p ∉ l) : ◇'(p :: l) ~ ◇p :: ◇'l := by simpa using multidia_cons hl
 
-
-lemma forall_multibox_of_subset_multibox (h : ∀ p ∈ l, p ∈ □''^[n]s) : ∀ p ∈ l, ∃ q ∈ s, p = □^[n]q := by
-  intro p hp;
-  obtain ⟨q, _, rfl⟩ := h p hp;
-  use q;
-lemma forall_box_of_subset_box (h : ∀ p ∈ l, p ∈ □''s) : ∀ p ∈ l, ∃ q ∈ s, p = □q := by
-  simpa using forall_multibox_of_subset_multibox (n := 1) h
-
-lemma forall_multidia_of_subset_multidia (h : ∀ p ∈ l, p ∈ ◇''^[n]s) : ∀ p ∈ l, ∃ q ∈ s, p = ◇^[n]q := by
-  intro p hp;
-  obtain ⟨q, _, rfl⟩ := h p hp;
-  use q;
-lemma forall_dia_of_subset_dia (h : ∀ p ∈ l, p ∈ ◇''s) : ∀ p ∈ l, ∃ q ∈ s, p = ◇q := by
-  simpa using forall_multidia_of_subset_multidia (n := 1) h
+end
 
 end List
 

--- a/Foundation/Modal/LogicSymbol.lean
+++ b/Foundation/Modal/LogicSymbol.lean
@@ -150,7 +150,8 @@ prefix:80 "◇''⁻¹" => Set.predia
 
 namespace Set
 
-variable [Box F] [Dia F] {s t : Set F}
+variable {s t : Set F}
+variable [Box F] [Dia F]
 
 @[simp] lemma eq_box_multibox_one : □''s = □''^[1]s := by rfl
 @[simp] lemma eq_dia_multidia_one : ◇''s = ◇''^[1]s := by rfl

--- a/Foundation/Modal/Maximal.lean
+++ b/Foundation/Modal/Maximal.lean
@@ -119,7 +119,7 @@ lemma deducible_iff_verTranslation : 𝐕𝐞𝐫 ⊢! p ⭤ pⱽ := by
   | hbox =>
     apply iff_intro!;
     . exact imply₁'! verum!
-    . exact dhyp! (by simp)
+    . exact imply₁'! (by simp)
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | _ => apply iff_id!
 

--- a/Foundation/Modal/ModalCompanion/Basic.lean
+++ b/Foundation/Modal/ModalCompanion/Basic.lean
@@ -23,13 +23,13 @@ postfix:90 "ᵍ" => GoedelTranslation
 class ModalCompanion (iΛ : IntProp.Hilbert α) (mΛ : Modal.Hilbert α) where
   companion : ∀ {p : IntProp.Formula α}, iΛ ⊢! p ↔ mΛ ⊢! pᵍ
 
-variable {α : Type u} [DecidableEq α] [Inhabited α] [Encodable α]
+variable {α : Type u}
 variable {iΛ : IntProp.Hilbert α} {mΛ : Hilbert α}
 variable {p q r : IntProp.Formula α}
 
-lemma axiomTc_GTranslate! [System.K4 mΛ] : mΛ ⊢! pᵍ ➝ □pᵍ := by
+lemma axiomTc_GTranslate! [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! pᵍ ➝ □pᵍ := by
   induction p using IntProp.Formula.rec' with
-  | hverum => exact dhyp! (nec! verum!);
+  | hverum => exact imply₁'! (nec! verum!);
   | hfalsum => simp only [GoedelTranslation, efq!];
   | hand p q ihp ihq =>
     simp only [GoedelTranslation];
@@ -42,11 +42,11 @@ lemma axiomTc_GTranslate! [System.K4 mΛ] : mΛ ⊢! pᵍ ➝ □pᵍ := by
 
 section
 
-private lemma provable_efq_of_provable_S4.case_imply₁ [System.K4 mΛ] : mΛ ⊢! (p ➝ q ➝ p)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_imply₁ [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! (p ➝ q ➝ p)ᵍ := by
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomTc_GTranslate! $ axiomK'! $ nec! $ imply₁!;
 
-private lemma provable_efq_of_provable_S4.case_imply₂ [System.S4 mΛ] : mΛ ⊢! ((p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_imply₂ [DecidableEq α] [System.S4 mΛ] : mΛ ⊢! ((p ➝ q ➝ r) ➝ (p ➝ q) ➝ p ➝ r)ᵍ := by
   simp only [GoedelTranslation];
   apply nec! $ imp_trans''! (imp_trans''! (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! imply₂!) axiomK!;
   apply provable_iff_provable.mpr;
@@ -56,7 +56,7 @@ private lemma provable_efq_of_provable_S4.case_imply₂ [System.S4 mΛ] : mΛ �
   have : [pᵍ, pᵍ ➝ □(qᵍ ➝ rᵍ)] ⊢[mΛ]! (pᵍ ➝ □(qᵍ ➝ rᵍ)) := by_axm!;
   have : [pᵍ, pᵍ ➝ □(qᵍ ➝ rᵍ)] ⊢[mΛ]! □(qᵍ ➝ rᵍ) := (by assumption) ⨀ (by assumption);
   exact axiomT'! this;
-private lemma provable_efq_of_provable_S4.case_and₃ [System.K4 mΛ] : mΛ ⊢! (p ➝ q ➝ p ⋏ q)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_and₃ [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! (p ➝ q ➝ p ⋏ q)ᵍ := by
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomTc_GTranslate! $ axiomK'! $ nec! $ and₃!
 
@@ -73,7 +73,7 @@ private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 mΛ] : mΛ �
 instance [System.S4 mΛ] : System.K4 mΛ where
 
 open provable_efq_of_provable_S4 in
-lemma provable_efq_of_provable_S4 (h : 𝐈𝐧𝐭 ⊢! p) : 𝐒𝟒 ⊢! pᵍ := by
+lemma provable_efq_of_provable_S4 [DecidableEq α] (h : 𝐈𝐧𝐭 ⊢! p) : 𝐒𝟒 ⊢! pᵍ := by
   induction h.some with
   | eaxm ih =>
     simp_all only [Set.mem_setOf_eq];
@@ -95,13 +95,13 @@ lemma provable_efq_of_provable_S4 (h : 𝐈𝐧𝐭 ⊢! p) : 𝐒𝟒 ⊢! pᵍ
 end
 
 
-lemma dp_of_mdp [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : iΛ ⊢! p ⋎ q → iΛ ⊢! p ∨ iΛ ⊢! q := by
+lemma dp_of_mdp [DecidableEq α] [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : iΛ ⊢! p ⋎ q → iΛ ⊢! p ∨ iΛ ⊢! q := by
     intro hpq;
     have : mΛ ⊢! □pᵍ ⋎ □qᵍ := or₃'''! (imply_left_or'! axiomTc_GTranslate!) (imply_right_or'! axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
     cases ModalDisjunctive.modal_disjunctive this with
     | inl h => left; exact ModalCompanion.companion.mpr h;
     | inr h => right; exact ModalCompanion.companion.mpr h;
 
-theorem disjunctive_of_modalDisjunctive [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : Disjunctive iΛ := ⟨dp_of_mdp (iΛ := iΛ) (mΛ := mΛ)⟩
+theorem disjunctive_of_modalDisjunctive [DecidableEq α] [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : Disjunctive iΛ := ⟨dp_of_mdp (iΛ := iΛ) (mΛ := mΛ)⟩
 
 end LO.Modal

--- a/Foundation/Modal/System.lean
+++ b/Foundation/Modal/System.lean
@@ -897,7 +897,6 @@ section Unnecessitation
 variable [Unnecessitation 𝓢]
 
 alias unnec := Unnecessitation.unnec
-
 lemma unnec! : 𝓢 ⊢! □p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨unnec hp⟩
 
 def multiunnec : 𝓢 ⊢ □^[n]p → 𝓢 ⊢ p := by

--- a/Foundation/Modal/System.lean
+++ b/Foundation/Modal/System.lean
@@ -655,7 +655,7 @@ lemma multibox_cons_conj! :  𝓢 ⊢! ⋀(□'^[n](p :: Γ)) ➝ ⋀□'^[n]Γ 
 @[simp]
 lemma collect_multibox_conj! : 𝓢 ⊢! ⋀□'^[n]Γ ➝ □^[n]⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simpa using dhyp! multiboxverum!;
+  | hnil => simpa using imply₁'! multiboxverum!;
   | hsingle => simp;
   | hcons p Γ h ih =>
     simp_all;

--- a/Foundation/Modal/System.lean
+++ b/Foundation/Modal/System.lean
@@ -1,6 +1,8 @@
 import Foundation.Logic.HilbertStyle.Supplemental
 import Foundation.Modal.Axioms
 
+set_option deprecated.oldSectionVars true
+
 namespace LO.System
 
 section Systems
@@ -112,6 +114,9 @@ variable [System.Classical 𝓢] [System.NegationEquiv 𝓢]
 open FiniteContext
 open Necessitation
 
+
+section Necessitation
+
 variable [Necessitation 𝓢]
 
 alias nec := Necessitation.nec
@@ -125,6 +130,10 @@ def multinec : 𝓢 ⊢ p → 𝓢 ⊢ □^[n]p := by
   | succ n ih => simpa using nec ih;
 lemma multinec! : 𝓢 ⊢! p → 𝓢 ⊢! □^[n]p := by rintro ⟨hp⟩; exact ⟨multinec hp⟩
 
+end Necessitation
+
+
+section AxiomK
 
 variable [HasAxiomK 𝓢]
 
@@ -141,6 +150,9 @@ def axiomK' (h : 𝓢 ⊢ □(p ➝ q)) : 𝓢 ⊢ □p ➝ □q := axiomK ⨀ h
 
 def axiomK'' (h₁ : 𝓢 ⊢ □(p ➝ q)) (h₂ : 𝓢 ⊢ □p) : 𝓢 ⊢ □q := axiomK' h₁ ⨀ h₂
 @[simp] lemma axiomK''! (h₁ : 𝓢 ⊢! □(p ➝ q)) (h₂ : 𝓢 ⊢! □p) : 𝓢 ⊢! □q := ⟨axiomK'' h₁.some h₂.some⟩
+
+
+variable [Necessitation 𝓢]
 
 def multibox_axiomK : 𝓢 ⊢ □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := by
   induction n with
@@ -168,6 +180,9 @@ def multiboxIff' (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ □^[n]p ⭤ □^[n]q := by
   | succ n ih => simpa using boxIff' ih;
 @[simp] lemma multibox_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □^[n]p ⭤ □^[n]q := ⟨multiboxIff' h.some⟩
 
+end AxiomK
+
+
 instance [ModalDeMorgan F] [HasAxiomDNE 𝓢] : HasDiaDuality 𝓢 := ⟨by
   intro p;
   simp only [Axioms.DiaDuality, ModalDeMorgan.box, DeMorgan.neg];
@@ -183,7 +198,7 @@ instance [DiaAbbrev F] : HasDiaDuality 𝓢 := ⟨by
 
 section Duality
 
-variable [HasDiaDuality 𝓢]
+variable [HasDiaDuality 𝓢] [Necessitation 𝓢] [HasAxiomK 𝓢]
 
 def diaDuality : 𝓢 ⊢ ◇p ⭤ ∼(□(∼p)) := HasDiaDuality.dia_dual _
 @[simp] lemma dia_duality! : 𝓢 ⊢! ◇p ⭤ ∼(□(∼p)) := ⟨diaDuality⟩
@@ -273,6 +288,10 @@ lemma box_duality'! : 𝓢 ⊢! □p ↔ 𝓢 ⊢! ∼(◇(∼p)) := multibox_du
 
 end Duality
 
+
+section
+
+variable [Necessitation 𝓢] [HasAxiomK 𝓢]
 
 def box_dne : 𝓢 ⊢ □(∼∼p) ➝ □p := axiomK' $ nec dne
 @[simp] lemma box_dne! : 𝓢 ⊢! □(∼∼p) ➝ □p := ⟨box_dne⟩
@@ -417,7 +436,12 @@ lemma collect_multibox_or'! (h : 𝓢 ⊢! □^[n]p ⋎ □^[n]q) : 𝓢 ⊢! �
 def collect_box_or' (h : 𝓢 ⊢ □p ⋎ □q) : 𝓢 ⊢ □(p ⋎ q) := collect_multibox_or' (n := 1) h
 lemma collect_box_or'! (h : 𝓢 ⊢! □p ⋎ □q) : 𝓢 ⊢! □(p ⋎ q) := ⟨collect_box_or' h.some⟩
 
-variable [HasDiaDuality 𝓢]
+end
+
+
+section DiaDuality
+
+variable [Necessitation 𝓢] [HasAxiomK 𝓢] [HasDiaDuality 𝓢]
 
 def diaOrInst₁ : 𝓢 ⊢ ◇p ➝ ◇(p ⋎ q) := by
   apply impTrans'' (and₁' diaDuality);
@@ -477,8 +501,6 @@ def collect_dia_or' (h : 𝓢 ⊢ ◇p ⋎ ◇q) : 𝓢 ⊢ ◇(p ⋎ q) := coll
 -- def distributeDiaAnd' (h : 𝓢 ⊢ ◇(p ⋏ q)) : 𝓢 ⊢ ◇p ⋏ ◇q := distributeDiaAnd ⨀ h
 lemma distribute_dia_and'! (h : 𝓢 ⊢! ◇(p ⋏ q)) : 𝓢 ⊢! ◇p ⋏ ◇q := distribute_dia_and! ⨀ h
 
--- open BasicModalLogicalConnective (boxdot)
-
 def boxdotAxiomK : 𝓢 ⊢ ⊡(p ➝ q) ➝ (⊡p ➝ ⊡q) := by
   apply deduct';
   apply deduct;
@@ -499,33 +521,49 @@ lemma boxdot_box! : 𝓢 ⊢! ⊡p ➝ □p := ⟨boxdotBox⟩
 def BoxBoxdot_BoxDotbox : 𝓢 ⊢ □⊡p ➝ ⊡□p := impTrans'' distribute_box_and (impId _)
 lemma boxboxdot_boxdotbox : 𝓢 ⊢! □⊡p ➝ ⊡□p := ⟨BoxBoxdot_BoxDotbox⟩
 
-def axiomT [HasAxiomT 𝓢] : 𝓢 ⊢ □p ➝ p := HasAxiomT.T _
-@[simp] lemma axiomT! [HasAxiomT 𝓢] : 𝓢 ⊢! □p ➝ p := ⟨axiomT⟩
+end DiaDuality
 
-instance [HasAxiomT 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ FiniteContext.of axiomT⟩
-instance [HasAxiomT 𝓢] (Γ : Context F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ Context.of axiomT⟩
 
-def axiomT' [HasAxiomT 𝓢] (h : 𝓢 ⊢ □p) : 𝓢 ⊢ p := axiomT ⨀ h
-@[simp] lemma axiomT'! [HasAxiomT 𝓢] (h : 𝓢 ⊢! □p) : 𝓢 ⊢! p := ⟨axiomT' h.some⟩
+section AxiomT
 
-def diaTc [HasDiaDuality 𝓢] [HasAxiomT 𝓢] : 𝓢 ⊢ p ➝ ◇p := by
+variable [HasAxiomT 𝓢]
+
+def axiomT : 𝓢 ⊢ □p ➝ p := HasAxiomT.T _
+@[simp] lemma axiomT! : 𝓢 ⊢! □p ➝ p := ⟨axiomT⟩
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ FiniteContext.of axiomT⟩
+instance (Γ : Context F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ Context.of axiomT⟩
+
+def axiomT' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ p := axiomT ⨀ h
+@[simp] lemma axiomT'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! p := ⟨axiomT' h.some⟩
+
+def diaTc [HasDiaDuality 𝓢] : 𝓢 ⊢ p ➝ ◇p := by
   apply impTrans'' ?_ (and₂' diaDuality);
   exact impTrans'' dni $ contra₀' axiomT;
-@[simp] lemma diaTc! [HasDiaDuality 𝓢] [HasAxiomT 𝓢] : 𝓢 ⊢! p ➝ ◇p := ⟨diaTc⟩
+@[simp] lemma diaTc! [HasDiaDuality 𝓢] : 𝓢 ⊢! p ➝ ◇p := ⟨diaTc⟩
 
-def diaTc' [HasDiaDuality 𝓢] [HasAxiomT 𝓢] (h : 𝓢 ⊢ p) : 𝓢 ⊢ ◇p := diaTc ⨀ h
-lemma diaTc'! [HasDiaDuality 𝓢] [HasAxiomT 𝓢] (h : 𝓢 ⊢! p) : 𝓢 ⊢! ◇p := ⟨diaTc' h.some⟩
+def diaTc' [HasDiaDuality 𝓢] (h : 𝓢 ⊢ p) : 𝓢 ⊢ ◇p := diaTc ⨀ h
+lemma diaTc'! [HasDiaDuality 𝓢] (h : 𝓢 ⊢! p) : 𝓢 ⊢! ◇p := ⟨diaTc' h.some⟩
 
-def axiomB [HasAxiomB 𝓢] : 𝓢 ⊢ p ➝ □◇p := HasAxiomB.B _
-@[simp] lemma axiomB! [HasAxiomB 𝓢] : 𝓢 ⊢! p ➝ □◇p := ⟨axiomB⟩
+end AxiomT
 
-instance [HasAxiomB 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ FiniteContext.of axiomB⟩
-instance [HasAxiomB 𝓢] (Γ : Context F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ Context.of axiomB⟩
+
+section AxiomB
+
+variable [HasAxiomB 𝓢]
+
+def axiomB : 𝓢 ⊢ p ➝ □◇p := HasAxiomB.B _
+@[simp] lemma axiomB! : 𝓢 ⊢! p ➝ □◇p := ⟨axiomB⟩
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ FiniteContext.of axiomB⟩
+instance (Γ : Context F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ Context.of axiomB⟩
+
+end AxiomB
 
 
 section AxiomD
 
-variable [HasAxiomD 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomD 𝓢]
 
 def axiomD : 𝓢 ⊢ □p ➝ ◇p := HasAxiomD.D _
 @[simp] lemma axiomD! : 𝓢 ⊢! □p ➝ ◇p := ⟨axiomD⟩
@@ -533,21 +571,18 @@ def axiomD : 𝓢 ⊢ □p ➝ ◇p := HasAxiomD.D _
 instance (Γ : FiniteContext F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ FiniteContext.of axiomD⟩
 instance (Γ : Context F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ Context.of axiomD⟩
 
--- TODO: move
-def notbot : 𝓢 ⊢ ∼⊥ := neg_equiv'.mpr (impId ⊥)
-
-private def P_of_D : 𝓢 ⊢ Axioms.P := by
+private def P_of_D [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.P := by
   have : 𝓢 ⊢ ∼∼□(∼⊥) := dni' $ nec notbot;
   have : 𝓢 ⊢ ∼◇⊥ := (contra₀' $ and₁' diaDuality) ⨀ this;
   exact (contra₀' axiomD) ⨀ this;
-instance : HasAxiomP 𝓢 := ⟨P_of_D⟩
+instance [HasDiaDuality 𝓢] : HasAxiomP 𝓢 := ⟨P_of_D⟩
 
 end AxiomD
 
 
 section AxiomP
 
-variable [HasAxiomP 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomP 𝓢]
 
 def axiomP : 𝓢 ⊢ ∼□⊥  := HasAxiomP.P
 @[simp] lemma axiomP! : 𝓢 ⊢! ∼□⊥ := ⟨axiomP⟩
@@ -555,25 +590,27 @@ def axiomP : 𝓢 ⊢ ∼□⊥  := HasAxiomP.P
 instance (Γ : FiniteContext F 𝓢) : HasAxiomP Γ := ⟨FiniteContext.of axiomP⟩
 instance (Γ : Context F 𝓢) : HasAxiomP Γ := ⟨Context.of axiomP⟩
 
-private def D_of_P : 𝓢 ⊢ Axioms.D p := by
+private def D_of_P [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.D p := by
   have : 𝓢 ⊢ p ➝ (∼p ➝ ⊥) := impTrans'' dni (and₁' neg_equiv);
   have : 𝓢 ⊢ □p ➝ □(∼p ➝ ⊥) := implyBoxDistribute' this;
   have : 𝓢 ⊢ □p ➝ (□(∼p) ➝ □⊥) := impTrans'' this axiomK;
   have : 𝓢 ⊢ □p ➝ (∼□⊥ ➝ ∼□(∼p)) := impTrans'' this contra₀;
   have : 𝓢 ⊢ □p ➝ ∼□(∼p) := impSwap' this ⨀ axiomP;
   exact impTrans'' this (and₂' diaDuality);
-instance : HasAxiomD 𝓢 := ⟨fun _ ↦ D_of_P⟩
+instance [HasDiaDuality 𝓢] : HasAxiomD 𝓢 := ⟨fun _ ↦ D_of_P⟩
 
 end AxiomP
 
 
-def axiomFour [HasAxiomFour 𝓢] : 𝓢 ⊢ □p ➝ □□p := HasAxiomFour.Four _
-@[simp] lemma axiomFour! [HasAxiomFour 𝓢] : 𝓢 ⊢! □p ➝ □□p := ⟨axiomFour⟩
+section AxiomFour
 
-instance [HasAxiomFour 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ FiniteContext.of axiomFour⟩
-instance [HasAxiomFour 𝓢] (Γ : Context F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ Context.of axiomFour⟩
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomFour 𝓢]
 
-variable [HasAxiomFour 𝓢]
+def axiomFour : 𝓢 ⊢ □p ➝ □□p := HasAxiomFour.Four _
+@[simp] lemma axiomFour! : 𝓢 ⊢! □p ➝ □□p := ⟨axiomFour⟩
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ FiniteContext.of axiomFour⟩
+instance (Γ : Context F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ Context.of axiomFour⟩
 
 def axiomFour' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ □□p := axiomFour ⨀ h
 def axiomFour'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! □□p := ⟨axiomFour' h.some⟩
@@ -617,11 +654,13 @@ def iff_box_boxdot [HasAxiomT 𝓢] : 𝓢 ⊢ □p ⭤ ⊡p := by
   . exact and₂;
 @[simp] lemma iff_box_boxdot! [HasAxiomT 𝓢] : 𝓢 ⊢! □p ⭤ ⊡p := ⟨iff_box_boxdot⟩
 
-def iff_dia_diadot [HasAxiomT 𝓢] [HasAxiomFour 𝓢] : 𝓢 ⊢ ◇p ⭤ ⟐p := by
+def iff_dia_diadot [HasAxiomT 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢ ◇p ⭤ ⟐p := by
   apply iffIntro;
   . exact or₂;
   . exact or₃'' (diaTc) (impId _)
-@[simp] lemma iff_dia_diadot! [HasAxiomT 𝓢] [HasAxiomFour 𝓢] : 𝓢 ⊢! ◇p ⭤ ⟐p := ⟨iff_dia_diadot⟩
+@[simp] lemma iff_dia_diadot! [HasAxiomT 𝓢] [HasAxiomFour 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢! ◇p ⭤ ⟐p := ⟨iff_dia_diadot⟩
+
+end AxiomFour
 
 
 section AxiomFive
@@ -639,7 +678,7 @@ end AxiomFive
 
 section S5
 
-variable [HasAxiomFive 𝓢] [HasAxiomT 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomT 𝓢] [HasAxiomFive 𝓢]
 
 -- MEMO: need more simple proof
 def diabox_box : 𝓢 ⊢ ◇□p ➝ □p := by
@@ -671,7 +710,7 @@ end S5
 
 section AxiomTc
 
-variable [HasAxiomTc 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomTc 𝓢]
 
 def axiomTc : 𝓢 ⊢ p ➝ □p := HasAxiomTc.Tc _
 @[simp] lemma axiomTc! : 𝓢 ⊢! p ➝ □p := ⟨axiomTc⟩
@@ -738,7 +777,7 @@ end AxiomVer
 
 section AxiomL
 
-variable [HasAxiomL 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomL 𝓢]
 
 def axiomL : 𝓢 ⊢ □(□p ➝ p) ➝ □p := HasAxiomL.L _
 @[simp] lemma axiomL! : 𝓢 ⊢! □(□p ➝ p) ➝ □p := ⟨axiomL⟩
@@ -817,6 +856,8 @@ end AxiomH
 
 section LoebRule
 
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢]
+
 alias loeb := LoebRule.loeb
 lemma loeb! [LoebRule 𝓢] : 𝓢 ⊢! □p ➝ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨loeb hp⟩
 
@@ -836,6 +877,8 @@ end LoebRule
 
 
 section HenkinRule
+
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢]
 
 alias henkin := HenkinRule.henkin
 lemma henkin! [HenkinRule 𝓢] : 𝓢 ⊢! □p ⭤ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨henkin hp⟩
@@ -905,7 +948,7 @@ end
 
 section Grz
 
-variable [HasAxiomGrz 𝓢]
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomGrz 𝓢]
 
 def axiomGrz : 𝓢 ⊢ □(□(p ➝ □p) ➝ p) ➝ p := HasAxiomGrz.Grz _
 @[simp] lemma axiomGrz! : 𝓢 ⊢! □(□(p ➝ □p) ➝ p) ➝ p := ⟨axiomGrz⟩
@@ -950,13 +993,15 @@ end Grz
 
 section Tc_of_S5Grz
 
-private def lem₁_diaT_of_S5Grz [HasDiaDuality 𝓢] : 𝓢 ⊢ (∼□(∼p) ➝ ∼□(∼□p)) ➝ (◇p ➝ ◇□p)
+variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomT 𝓢] [HasAxiomFive 𝓢] [HasAxiomGrz 𝓢]
+
+private def lem₁_diaT_of_S5Grz : 𝓢 ⊢ (∼□(∼p) ➝ ∼□(∼□p)) ➝ (◇p ➝ ◇□p)
   := impTrans'' (rev_dhyp_imp' diaDuality_mp) (dhyp_imp' diaDuality_mpr)
 
-private def lem₂_diaT_of_S5Grz [HasAxiomT 𝓢] [HasAxiomFive 𝓢] : 𝓢 ⊢ (◇p ➝ ◇□p) ➝ (◇p ➝ p)
+private def lem₂_diaT_of_S5Grz : 𝓢 ⊢ (◇p ➝ ◇□p) ➝ (◇p ➝ p)
   := dhyp_imp' rm_diabox
 
-private def diaT_of_S5Grz [HasAxiomT 𝓢] [HasAxiomFive 𝓢] [HasAxiomGrz 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢ ◇p ➝ p := by
+private def diaT_of_S5Grz : 𝓢 ⊢ ◇p ➝ p := by
   have : 𝓢 ⊢ (p ➝ □p) ➝ (∼□p ➝ ∼p) := contra₀;
   have : 𝓢 ⊢ □(p ➝ □p) ➝ □(∼□p ➝ ∼p) := implyBoxDistribute' this;
   have : 𝓢 ⊢ □(p ➝ □p) ➝ (□(∼□p) ➝ □(∼p)) := impTrans'' this axiomK;
@@ -969,15 +1014,15 @@ private def diaT_of_S5Grz [HasAxiomT 𝓢] [HasAxiomFive 𝓢] [HasAxiomGrz 𝓢
   have : 𝓢 ⊢ □◇p ➝ p := impTrans'' this axiomGrz;
   exact impTrans'' axiomFive this;
 
-private def Tc_of_S5Grz [HasAxiomFive 𝓢] [HasAxiomT 𝓢] [HasAxiomGrz 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢ p ➝ □p :=
+private def Tc_of_S5Grz : 𝓢 ⊢ p ➝ □p :=
   impTrans'' (contra₃' (impTrans'' (and₂' diaDuality) diaT_of_S5Grz)) box_dne
 
-instance [HasAxiomT 𝓢] [HasAxiomFive 𝓢] [HasAxiomGrz 𝓢] [HasDiaDuality 𝓢] : HasAxiomTc 𝓢 := ⟨fun _ ↦ Tc_of_S5Grz⟩
+instance : HasAxiomTc 𝓢 := ⟨fun _ ↦ Tc_of_S5Grz⟩
 
 end Tc_of_S5Grz
 
 
-lemma contextual_nec! (h : Γ ⊢[𝓢]! p) : (□'Γ) ⊢[𝓢]! □p
+lemma contextual_nec! [Necessitation 𝓢] [HasAxiomK 𝓢] (h : Γ ⊢[𝓢]! p) : (□'Γ) ⊢[𝓢]! □p
   := provable_iff.mpr $ imp_trans''! collect_box_conj! $ imply_box_distribute'! $ provable_iff.mp h
 
 end

--- a/Foundation/Modal/System.lean
+++ b/Foundation/Modal/System.lean
@@ -428,10 +428,10 @@ def multibox_axiomK : 𝓢 ⊢ □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := by
   induction n with
   | zero => simp; apply impId;
   | succ n ih => simpa using impTrans'' (axiomK' $ nec ih) (by apply axiomK);
-@[simp] lemma multibox_axiomK! : 𝓢 ⊢! □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := ⟨multibox_axiomK⟩
+omit [DecidableEq F] in @[simp] lemma multibox_axiomK! : 𝓢 ⊢! □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := ⟨multibox_axiomK⟩
 
 def multibox_axiomK' (h : 𝓢 ⊢ □^[n](p ➝ q)) : 𝓢 ⊢ □^[n]p ➝ □^[n]q := multibox_axiomK ⨀ h
-@[simp] lemma multibox_axiomK'! (h : 𝓢 ⊢! □^[n](p ➝ q)) : 𝓢 ⊢! □^[n]p ➝ □^[n]q := ⟨multibox_axiomK' h.some⟩
+omit [DecidableEq F] in @[simp] lemma multibox_axiomK'! (h : 𝓢 ⊢! □^[n](p ➝ q)) : 𝓢 ⊢! □^[n]p ➝ □^[n]q := ⟨multibox_axiomK' h.some⟩
 
 alias multiboxedImplyDistribute := multibox_axiomK'
 alias multiboxed_imply_distribute! := multibox_axiomK'!
@@ -441,24 +441,25 @@ def boxIff' (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ (□p ⭤ □q) := by
   apply iffIntro;
   . exact axiomK' $ nec $ and₁' h;
   . exact axiomK' $ nec $ and₂' h;
-@[simp] lemma box_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □p ⭤ □q := ⟨boxIff' h.some⟩
+omit [DecidableEq F] in @[simp] lemma box_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □p ⭤ □q := ⟨boxIff' h.some⟩
 
 def multiboxIff' (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ □^[n]p ⭤ □^[n]q := by
   induction n with
   | zero => simpa;
   | succ n ih => simpa using boxIff' ih;
-@[simp] lemma multibox_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □^[n]p ⭤ □^[n]q := ⟨multiboxIff' h.some⟩
+omit [DecidableEq F] in @[simp] lemma multibox_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □^[n]p ⭤ □^[n]q := ⟨multiboxIff' h.some⟩
 
 
 def diaDuality_mp : 𝓢 ⊢ ◇p ➝ ∼(□(∼p)) := and₁' diaDuality
-@[simp] lemma diaDuality_mp! : 𝓢 ⊢! ◇p ➝ ∼(□(∼p)) := ⟨diaDuality_mp⟩
+omit [DecidableEq F] in @[simp] lemma diaDuality_mp! : 𝓢 ⊢! ◇p ➝ ∼(□(∼p)) := ⟨diaDuality_mp⟩
 
 def diaDuality_mpr : 𝓢 ⊢ ∼(□(∼p)) ➝ ◇p := and₂' diaDuality
-@[simp] lemma diaDuality_mpr! : 𝓢 ⊢! ∼(□(∼p)) ➝ ◇p := ⟨diaDuality_mpr⟩
+omit [DecidableEq F] in @[simp] lemma diaDuality_mpr! : 𝓢 ⊢! ∼(□(∼p)) ➝ ◇p := ⟨diaDuality_mpr⟩
 
 def diaDuality'.mp (h : 𝓢 ⊢ ◇p) : 𝓢 ⊢ ∼(□(∼p)) := (and₁' diaDuality) ⨀ h
 def diaDuality'.mpr (h : 𝓢 ⊢ ∼(□(∼p))) : 𝓢 ⊢ ◇p := (and₂' diaDuality) ⨀ h
 
+omit [DecidableEq F] in
 lemma dia_duality'! : 𝓢 ⊢! ◇p ↔ 𝓢 ⊢! ∼(□(∼p)) := ⟨
   λ h => ⟨diaDuality'.mp h.some⟩,
   λ h => ⟨diaDuality'.mpr h.some⟩
@@ -534,26 +535,26 @@ lemma multibox_duality'! : 𝓢 ⊢! □^[n]p ↔ 𝓢 ⊢! ∼(◇^[n](∼p)) :
 lemma box_duality'! : 𝓢 ⊢! □p ↔ 𝓢 ⊢! ∼(◇(∼p)) := multibox_duality'! (n := 1)
 
 def box_dne : 𝓢 ⊢ □(∼∼p) ➝ □p := axiomK' $ nec dne
-@[simp] lemma box_dne! : 𝓢 ⊢! □(∼∼p) ➝ □p := ⟨box_dne⟩
+omit [DecidableEq F] in @[simp] lemma box_dne! : 𝓢 ⊢! □(∼∼p) ➝ □p := ⟨box_dne⟩
 
 def box_dne' (h : 𝓢 ⊢ □(∼∼p)): 𝓢 ⊢ □p := box_dne ⨀ h
-lemma box_dne'! (h : 𝓢 ⊢! □(∼∼p)): 𝓢 ⊢! □p := ⟨box_dne' h.some⟩
+omit [DecidableEq F] in lemma box_dne'! (h : 𝓢 ⊢! □(∼∼p)): 𝓢 ⊢! □p := ⟨box_dne' h.some⟩
 
 
 def multiboxverum : 𝓢 ⊢ (□^[n]⊤ : F) := multinec verum
-@[simp] lemma multiboxverum! : 𝓢 ⊢! (□^[n]⊤ : F) := ⟨multiboxverum⟩
+omit [DecidableEq F] in @[simp] lemma multiboxverum! : 𝓢 ⊢! (□^[n]⊤ : F) := ⟨multiboxverum⟩
 
 def boxverum : 𝓢 ⊢ (□⊤ : F) := multiboxverum (n := 1)
-@[simp] lemma boxverum! : 𝓢 ⊢! (□⊤ : F) := ⟨boxverum⟩
+omit [DecidableEq F] in @[simp] lemma boxverum! : 𝓢 ⊢! (□⊤ : F) := ⟨boxverum⟩
 
 def boxdotverum : 𝓢 ⊢ (⊡⊤ : F) := andIntro verum boxverum
-@[simp] lemma boxdotverum! : 𝓢 ⊢! (⊡⊤ : F) := ⟨boxdotverum⟩
+omit [DecidableEq F] in @[simp] lemma boxdotverum! : 𝓢 ⊢! (⊡⊤ : F) := ⟨boxdotverum⟩
 
 def implyMultiboxDistribute' (h : 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ □^[n]p ➝ □^[n]q := multibox_axiomK' $ multinec h
-lemma imply_multibox_distribute'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! □^[n]p ➝ □^[n]q := ⟨implyMultiboxDistribute' h.some⟩
+omit [DecidableEq F] in lemma imply_multibox_distribute'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! □^[n]p ➝ □^[n]q := ⟨implyMultiboxDistribute' h.some⟩
 
 def implyBoxDistribute' (h : 𝓢 ⊢ p ➝ q) : 𝓢 ⊢ □p ➝ □q := implyMultiboxDistribute' (n := 1) h
-lemma imply_box_distribute'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! □p ➝ □q := ⟨implyBoxDistribute' h.some⟩
+omit [DecidableEq F] in lemma imply_box_distribute'! (h : 𝓢 ⊢! p ➝ q) : 𝓢 ⊢! □p ➝ □q := ⟨implyBoxDistribute' h.some⟩
 
 
 def distribute_multibox_and : 𝓢 ⊢ □^[n](p ⋏ q) ➝ □^[n]p ⋏ □^[n]q := implyRightAnd (implyMultiboxDistribute' and₁) (implyMultiboxDistribute' and₂)
@@ -603,16 +604,16 @@ def collect_multibox_and : 𝓢 ⊢ □^[n]p ⋏ □^[n]q ➝ □^[n](p ⋏ q) :
   have d₁ : 𝓢 ⊢ □^[n]p ➝ □^[n](q ➝ p ⋏ q) := implyMultiboxDistribute' and₃;
   have d₂ : 𝓢 ⊢ □^[n](q ➝ p ⋏ q) ➝ (□^[n]q ➝ □^[n](p ⋏ q)) := multibox_axiomK;
   exact (and₂' (andImplyIffImplyImply _ _ _)) ⨀ (impTrans'' d₁ d₂);
-@[simp] lemma collect_multibox_and! : 𝓢 ⊢! □^[n]p ⋏ □^[n]q ➝ □^[n](p ⋏ q) := ⟨collect_multibox_and⟩
+omit [DecidableEq F] in @[simp] lemma collect_multibox_and! : 𝓢 ⊢! □^[n]p ⋏ □^[n]q ➝ □^[n](p ⋏ q) := ⟨collect_multibox_and⟩
 
 def collect_box_and : 𝓢 ⊢ □p ⋏ □q ➝ □(p ⋏ q) := collect_multibox_and (n := 1)
-@[simp] lemma collect_box_and! : 𝓢 ⊢! □p ⋏ □q ➝ □(p ⋏ q) := ⟨collect_box_and⟩
+omit [DecidableEq F] in @[simp] lemma collect_box_and! : 𝓢 ⊢! □p ⋏ □q ➝ □(p ⋏ q) := ⟨collect_box_and⟩
 
 def collect_multibox_and' (h : 𝓢 ⊢ □^[n]p ⋏ □^[n]q) : 𝓢 ⊢ □^[n](p ⋏ q) := collect_multibox_and ⨀ h
-lemma collect_multibox_and'! (h : 𝓢 ⊢! □^[n]p ⋏ □^[n]q) : 𝓢 ⊢! □^[n](p ⋏ q) := ⟨collect_multibox_and' h.some⟩
+omit [DecidableEq F] in lemma collect_multibox_and'! (h : 𝓢 ⊢! □^[n]p ⋏ □^[n]q) : 𝓢 ⊢! □^[n](p ⋏ q) := ⟨collect_multibox_and' h.some⟩
 
 def collect_box_and' (h : 𝓢 ⊢ □p ⋏ □q) : 𝓢 ⊢ □(p ⋏ q) := collect_multibox_and' (n := 1) h
-lemma collect_box_and'! (h : 𝓢 ⊢! □p ⋏ □q) : 𝓢 ⊢! □(p ⋏ q) := ⟨collect_box_and' h.some⟩
+omit [DecidableEq F] in lemma collect_box_and'! (h : 𝓢 ⊢! □p ⋏ □q) : 𝓢 ⊢! □(p ⋏ q) := ⟨collect_box_and' h.some⟩
 
 
 lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n]⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! □^[n]p := by
@@ -665,16 +666,16 @@ lemma collect_box_conj! : 𝓢 ⊢! ⋀(□'Γ) ➝ □(⋀Γ) := collect_multib
 
 
 def collect_multibox_or : 𝓢 ⊢ □^[n]p ⋎ □^[n]q ➝ □^[n](p ⋎ q) := or₃'' (multibox_axiomK' $ multinec or₁) (multibox_axiomK' $ multinec or₂)
-@[simp] lemma collect_multibox_or! : 𝓢 ⊢! □^[n]p ⋎ □^[n]q ➝ □^[n](p ⋎ q) := ⟨collect_multibox_or⟩
+omit [DecidableEq F] in @[simp] lemma collect_multibox_or! : 𝓢 ⊢! □^[n]p ⋎ □^[n]q ➝ □^[n](p ⋎ q) := ⟨collect_multibox_or⟩
 
 def collect_box_or : 𝓢 ⊢ □p ⋎ □q ➝ □(p ⋎ q) := collect_multibox_or (n := 1)
-@[simp] lemma collect_box_or! : 𝓢 ⊢! □p ⋎ □q ➝ □(p ⋎ q) := ⟨collect_box_or⟩
+omit [DecidableEq F] in @[simp] lemma collect_box_or! : 𝓢 ⊢! □p ⋎ □q ➝ □(p ⋎ q) := ⟨collect_box_or⟩
 
 def collect_multibox_or' (h : 𝓢 ⊢ □^[n]p ⋎ □^[n]q) : 𝓢 ⊢ □^[n](p ⋎ q) := collect_multibox_or ⨀ h
-lemma collect_multibox_or'! (h : 𝓢 ⊢! □^[n]p ⋎ □^[n]q) : 𝓢 ⊢! □^[n](p ⋎ q) := ⟨collect_multibox_or' h.some⟩
+omit [DecidableEq F] in lemma collect_multibox_or'! (h : 𝓢 ⊢! □^[n]p ⋎ □^[n]q) : 𝓢 ⊢! □^[n](p ⋎ q) := ⟨collect_multibox_or' h.some⟩
 
 def collect_box_or' (h : 𝓢 ⊢ □p ⋎ □q) : 𝓢 ⊢ □(p ⋎ q) := collect_multibox_or' (n := 1) h
-lemma collect_box_or'! (h : 𝓢 ⊢! □p ⋎ □q) : 𝓢 ⊢! □(p ⋎ q) := ⟨collect_box_or' h.some⟩
+omit [DecidableEq F] in lemma collect_box_or'! (h : 𝓢 ⊢! □p ⋎ □q) : 𝓢 ⊢! □(p ⋎ q) := ⟨collect_box_or' h.some⟩
 
 def diaOrInst₁ : 𝓢 ⊢ ◇p ➝ ◇(p ⋎ q) := by
   apply impTrans'' (and₁' diaDuality);
@@ -743,13 +744,13 @@ def boxdotAxiomK : 𝓢 ⊢ ⊡(p ➝ q) ➝ (⊡p ➝ ⊡q) := by
 @[simp] lemma boxdot_axiomK! : 𝓢 ⊢! ⊡(p ➝ q) ➝ (⊡p ➝ ⊡q) := ⟨boxdotAxiomK⟩
 
 def boxdotAxiomT : 𝓢 ⊢ ⊡p ➝ p := by exact and₁;
-@[simp] lemma boxdot_axiomT! : 𝓢 ⊢! ⊡p ➝ p := ⟨boxdotAxiomT⟩
+omit [DecidableEq F] in @[simp] lemma boxdot_axiomT! : 𝓢 ⊢! ⊡p ➝ p := ⟨boxdotAxiomT⟩
 
 def boxdotNec (d : 𝓢 ⊢ p) : 𝓢 ⊢ ⊡p := and₃' d (nec d)
-lemma boxdot_nec! (d : 𝓢 ⊢! p) : 𝓢 ⊢! ⊡p := ⟨boxdotNec d.some⟩
+omit [DecidableEq F] in lemma boxdot_nec! (d : 𝓢 ⊢! p) : 𝓢 ⊢! ⊡p := ⟨boxdotNec d.some⟩
 
 def boxdotBox : 𝓢 ⊢ ⊡p ➝ □p := by exact and₂;
-lemma boxdot_box! : 𝓢 ⊢! ⊡p ➝ □p := ⟨boxdotBox⟩
+omit [DecidableEq F] in lemma boxdot_box! : 𝓢 ⊢! ⊡p ➝ □p := ⟨boxdotBox⟩
 
 def BoxBoxdot_BoxDotbox : 𝓢 ⊢ □⊡p ➝ ⊡□p := impTrans'' distribute_box_and (impId _)
 lemma boxboxdot_boxdotbox : 𝓢 ⊢! □⊡p ➝ ⊡□p := ⟨BoxBoxdot_BoxDotbox⟩

--- a/Foundation/Modal/System.lean
+++ b/Foundation/Modal/System.lean
@@ -1,124 +1,19 @@
 import Foundation.Logic.HilbertStyle.Supplemental
 import Foundation.Modal.Axioms
 
-set_option deprecated.oldSectionVars true
-
 namespace LO.System
 
-section Systems
+variable {S F : Type*} [LogicalConnective F] [System F S]
+variable {𝓢 : S}
 
-variable {S F : Type*} [LogicalConnective F] [Box F] [Dia F] [System F S]
-variable (𝓢 : S)
 
-class HasDiaDuality where
-  dia_dual (p : F) : 𝓢 ⊢ Axioms.DiaDuality p
-
-class Necessitation where
+class Necessitation [Box F] (𝓢 : S) where
   nec {p : F} : 𝓢 ⊢ p → 𝓢 ⊢ □p
 
-class Unnecessitation where
-  unnec {p : F} : 𝓢 ⊢ □p → 𝓢 ⊢ p
-
-class LoebRule where
-  loeb {p : F} : 𝓢 ⊢ □p ➝ p → 𝓢 ⊢ p
-
-class HenkinRule where
-  henkin {p : F} : 𝓢 ⊢ □p ⭤ p → 𝓢 ⊢ p
-
-class HasAxiomK where
-  K (p q : F) : 𝓢 ⊢ Axioms.K p q
-
-class HasAxiomT where
-  T (p : F) : 𝓢 ⊢ Axioms.T p
-
-class HasAxiomD where
-  D (p : F) : 𝓢 ⊢ Axioms.D p
-
-class HasAxiomP where
-  P : 𝓢 ⊢ Axioms.P
-
-class HasAxiomB where
-  B (p : F) : 𝓢 ⊢ Axioms.B p
-
-class HasAxiomFour where
-  Four (p : F) : 𝓢 ⊢ Axioms.Four p
-
-class HasAxiomFive where
-  Five (p : F) : 𝓢 ⊢ Axioms.Five p
-
-class HasAxiomL where
-  L (p : F) : 𝓢 ⊢ Axioms.L p
-
-class HasAxiomDot2 where
-  Dot2 (p : F) : 𝓢 ⊢ Axioms.Dot2 p
-
-class HasAxiomDot3 where
-  Dot3 (p q : F) : 𝓢 ⊢ Axioms.Dot3 p q
-
-class HasAxiomGrz where
-  Grz (p : F) : 𝓢 ⊢ Axioms.Grz p
-
-class HasAxiomTc where
-  Tc (p : F) : 𝓢 ⊢ Axioms.Tc p
-
-class HasAxiomVer where
-  Ver (p : F) : 𝓢 ⊢ Axioms.Ver p
-
-class HasAxiomH where
-  H (p : F) : 𝓢 ⊢ Axioms.H p
-
-protected class K extends System.Classical 𝓢, Necessitation 𝓢, HasAxiomK 𝓢, HasDiaDuality 𝓢
-
-protected class KT extends System.K 𝓢, HasAxiomT 𝓢
-
-protected class KD extends System.K 𝓢, HasAxiomD 𝓢
-
-protected class K4 extends System.K 𝓢, HasAxiomFour 𝓢
-
-protected class S4 extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomFour 𝓢
-
-protected class S5 extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomFive 𝓢
-
-protected class S4Dot2 extends System.S4 𝓢, HasAxiomDot2 𝓢
-
-protected class S4Dot3 extends System.S4 𝓢, HasAxiomDot3 𝓢
-
-protected class S4Grz extends System.S4 𝓢, HasAxiomGrz 𝓢
-
-protected class GL extends System.K 𝓢, HasAxiomL 𝓢
-
-protected class Grz extends System.K 𝓢, HasAxiomGrz 𝓢
-
-protected class Triv extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomTc 𝓢
-
-protected class Ver extends System.K 𝓢, HasAxiomVer 𝓢
-
-protected class K4H extends System.K4 𝓢, HasAxiomH 𝓢
-
-protected class K4Loeb extends System.K4 𝓢, LoebRule 𝓢
-
-protected class K4Henkin extends System.K4 𝓢, HenkinRule 𝓢
-
-end Systems
-
+omit [LogicalConnective F] in
 section
 
-
-variable {F : Type*} [DecidableEq F] [LogicalConnective F] [Box F] [Dia F]
-variable {S : Type*} [System F S]
-variable {p q r : F} {Γ Δ : List F}
-
-variable {𝓢 : S}
-variable [System.Classical 𝓢] [System.NegationEquiv 𝓢]
-
-open FiniteContext
-open Necessitation
-
-
-section Necessitation
-
-variable [Necessitation 𝓢]
-
+variable [Box F] [Necessitation 𝓢]
 alias nec := Necessitation.nec
 
 lemma nec! : 𝓢 ⊢! p → 𝓢 ⊢! □p := by rintro ⟨hp⟩; exact ⟨nec hp⟩
@@ -130,20 +25,85 @@ def multinec : 𝓢 ⊢ p → 𝓢 ⊢ □^[n]p := by
   | succ n ih => simpa using nec ih;
 lemma multinec! : 𝓢 ⊢! p → 𝓢 ⊢! □^[n]p := by rintro ⟨hp⟩; exact ⟨multinec hp⟩
 
-end Necessitation
+end
 
 
-section AxiomK
+class Unnecessitation [Box F] (𝓢 : S) where
+  unnec {p : F} : 𝓢 ⊢ □p → 𝓢 ⊢ p
 
-variable [HasAxiomK 𝓢]
+omit [LogicalConnective F] in
+section
 
-def axiomK [HasAxiomK 𝓢] : 𝓢 ⊢ □(p ➝ q) ➝ □p ➝ □q := HasAxiomK.K _ _
-@[simp] lemma axiomK! [HasAxiomK 𝓢] : 𝓢 ⊢! □(p ➝ q) ➝ □p ➝ □q := ⟨axiomK⟩
+variable [Box F] [Unnecessitation 𝓢]
 
-instance [HasAxiomK 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomK Γ := ⟨fun _ _ ↦ FiniteContext.of axiomK⟩
-instance [HasAxiomK 𝓢] (Γ : Context F 𝓢) : HasAxiomK Γ := ⟨fun _ _ ↦ Context.of axiomK⟩
+alias unnec := Unnecessitation.unnec
+lemma unnec! : 𝓢 ⊢! □p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨unnec hp⟩
 
-variable [HasAxiomK 𝓢]
+def multiunnec : 𝓢 ⊢ □^[n]p → 𝓢 ⊢ p := by
+  intro h;
+  induction n generalizing p with
+  | zero => simpa;
+  | succ n ih => exact unnec $ @ih (□p) h;
+lemma multiunnec! : 𝓢 ⊢! □^[n]p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨multiunnec hp⟩
+
+end
+
+
+class LoebRule [LogicalConnective F] [Box F] (𝓢 : S) where
+  loeb {p : F} : 𝓢 ⊢ □p ➝ p → 𝓢 ⊢ p
+
+section
+
+variable [Box F] [LoebRule 𝓢]
+
+alias loeb := LoebRule.loeb
+lemma loeb! : 𝓢 ⊢! □p ➝ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨loeb hp⟩
+
+end
+
+
+class HenkinRule [LogicalConnective F] [Box F] (𝓢 : S) where
+  henkin {p : F} : 𝓢 ⊢ □p ⭤ p → 𝓢 ⊢ p
+
+section
+
+variable [Box F] [HenkinRule 𝓢]
+
+alias henkin := HenkinRule.henkin
+lemma henkin! : 𝓢 ⊢! □p ⭤ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨henkin hp⟩
+
+end
+
+
+
+class HasDiaDuality [Box F] [Dia F] (𝓢 : S) where
+  dia_dual (p : F) : 𝓢 ⊢ Axioms.DiaDuality p
+
+section
+
+variable [Box F] [Dia F] [HasDiaDuality 𝓢]
+
+def diaDuality : 𝓢 ⊢ ◇p ⭤ ∼(□(∼p)) := HasDiaDuality.dia_dual _
+@[simp] lemma dia_duality! : 𝓢 ⊢! ◇p ⭤ ∼(□(∼p)) := ⟨diaDuality⟩
+
+end
+
+
+
+class HasAxiomK  [LogicalConnective F] [Box F](𝓢 : S) where
+  K (p q : F) : 𝓢 ⊢ Axioms.K p q
+
+section
+
+variable [Box F] [HasAxiomK 𝓢]
+
+def axiomK : 𝓢 ⊢ □(p ➝ q) ➝ □p ➝ □q := HasAxiomK.K _ _
+@[simp] lemma axiomK! : 𝓢 ⊢! □(p ➝ q) ➝ □p ➝ □q := ⟨axiomK⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomK Γ := ⟨fun _ _ ↦ FiniteContext.of axiomK⟩
+instance [System.Minimal 𝓢] [HasAxiomK 𝓢] (Γ : Context F 𝓢) : HasAxiomK Γ := ⟨fun _ _ ↦ Context.of axiomK⟩
 
 def axiomK' (h : 𝓢 ⊢ □(p ➝ q)) : 𝓢 ⊢ □p ➝ □q := axiomK ⨀ h
 @[simp] lemma axiomK'! (h : 𝓢 ⊢! □(p ➝ q)) : 𝓢 ⊢! □p ➝ □q := ⟨axiomK' h.some⟩
@@ -151,14 +111,323 @@ def axiomK' (h : 𝓢 ⊢ □(p ➝ q)) : 𝓢 ⊢ □p ➝ □q := axiomK ⨀ h
 def axiomK'' (h₁ : 𝓢 ⊢ □(p ➝ q)) (h₂ : 𝓢 ⊢ □p) : 𝓢 ⊢ □q := axiomK' h₁ ⨀ h₂
 @[simp] lemma axiomK''! (h₁ : 𝓢 ⊢! □(p ➝ q)) (h₂ : 𝓢 ⊢! □p) : 𝓢 ⊢! □q := ⟨axiomK'' h₁.some h₂.some⟩
 
+end
 
-variable [Necessitation 𝓢]
+
+class HasAxiomT [Box F] (𝓢 : S) where
+  T (p : F) : 𝓢 ⊢ Axioms.T p
+
+section
+
+variable [Box F] [HasAxiomT 𝓢]
+
+def axiomT : 𝓢 ⊢ □p ➝ p := HasAxiomT.T _
+@[simp] lemma axiomT! : 𝓢 ⊢! □p ➝ p := ⟨axiomT⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ FiniteContext.of axiomT⟩
+instance (Γ : Context F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ Context.of axiomT⟩
+
+def axiomT' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ p := axiomT ⨀ h
+@[simp] lemma axiomT'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! p := ⟨axiomT' h.some⟩
+
+end
+
+
+class HasAxiomD [Box F] [Dia F] (𝓢 : S) where
+  D (p : F) : 𝓢 ⊢ Axioms.D p
+
+section
+
+variable [Box F] [Dia F] [HasAxiomD 𝓢]
+
+def axiomD : 𝓢 ⊢ □p ➝ ◇p := HasAxiomD.D _
+@[simp] lemma axiomD! : 𝓢 ⊢! □p ➝ ◇p := ⟨axiomD⟩
+
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ FiniteContext.of axiomD⟩
+instance (Γ : Context F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ Context.of axiomD⟩
+
+def axiomD' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ ◇p := axiomD ⨀ h
+lemma axiomD'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! ◇p := ⟨axiomD' h.some⟩
+
+end
+
+
+
+class HasAxiomP [Box F] (𝓢 : S) where
+  P : 𝓢 ⊢ Axioms.P
+
+section
+
+variable [Box F] [HasAxiomP 𝓢]
+
+def axiomP : 𝓢 ⊢ ∼□⊥  := HasAxiomP.P
+@[simp] lemma axiomP! : 𝓢 ⊢! ∼□⊥ := ⟨axiomP⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomP Γ := ⟨FiniteContext.of axiomP⟩
+instance (Γ : Context F 𝓢) : HasAxiomP Γ := ⟨Context.of axiomP⟩
+
+end
+
+
+
+class HasAxiomB [Box F] [Dia F] (𝓢 : S) where
+  B (p : F) : 𝓢 ⊢ Axioms.B p
+
+section
+
+variable [Box F] [Dia F] [HasAxiomB 𝓢]
+
+def axiomB : 𝓢 ⊢ p ➝ □◇p := HasAxiomB.B _
+@[simp] lemma axiomB! : 𝓢 ⊢! p ➝ □◇p := ⟨axiomB⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ FiniteContext.of axiomB⟩
+instance (Γ : Context F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ Context.of axiomB⟩
+
+def axiomB' (h : 𝓢 ⊢ p) : 𝓢 ⊢ □◇p := axiomB ⨀ h
+@[simp] lemma axiomB'! (h : 𝓢 ⊢! p) : 𝓢 ⊢! □◇p := ⟨axiomB' h.some⟩
+
+end
+
+
+class HasAxiomFour [Box F] (𝓢 : S) where
+  Four (p : F) : 𝓢 ⊢ Axioms.Four p
+
+section
+
+variable [Box F] [HasAxiomFour 𝓢]
+
+def axiomFour : 𝓢 ⊢ □p ➝ □□p := HasAxiomFour.Four _
+@[simp] lemma axiomFour! : 𝓢 ⊢! □p ➝ □□p := ⟨axiomFour⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ FiniteContext.of axiomFour⟩
+instance (Γ : Context F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ Context.of axiomFour⟩
+
+def axiomFour' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ □□p := axiomFour ⨀ h
+def axiomFour'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! □□p := ⟨axiomFour' h.some⟩
+
+end
+
+
+class HasAxiomFive [Box F] [Dia F] (𝓢 : S) where
+  Five (p : F) : 𝓢 ⊢ Axioms.Five p
+
+section
+
+variable [Box F] [Dia F] [HasAxiomFive 𝓢]
+
+def axiomFive : 𝓢 ⊢ ◇p ➝ □◇p := HasAxiomFive.Five _
+@[simp] lemma axiomFive! : 𝓢 ⊢! ◇p ➝ □◇p := ⟨axiomFive⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomFive Γ := ⟨fun _ ↦ FiniteContext.of axiomFive⟩
+instance (Γ : Context F 𝓢) : HasAxiomFive Γ := ⟨fun _ ↦ Context.of axiomFive⟩
+
+end
+
+
+
+class HasAxiomL [Box F] (𝓢 : S) where
+  L (p : F) : 𝓢 ⊢ Axioms.L p
+
+section
+
+variable [Box F] [HasAxiomL 𝓢]
+
+def axiomL : 𝓢 ⊢ □(□p ➝ p) ➝ □p := HasAxiomL.L _
+@[simp] lemma axiomL! : 𝓢 ⊢! □(□p ➝ p) ➝ □p := ⟨axiomL⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomL Γ := ⟨fun _ ↦ FiniteContext.of axiomL⟩
+instance (Γ : Context F 𝓢) : HasAxiomL Γ := ⟨fun _ ↦ Context.of axiomL⟩
+
+end
+
+
+class HasAxiomDot2 [Box F] [Dia F] (𝓢 : S) where
+  Dot2 (p : F) : 𝓢 ⊢ Axioms.Dot2 p
+
+class HasAxiomDot3 [Box F] (𝓢 : S) where
+  Dot3 (p q : F) : 𝓢 ⊢ Axioms.Dot3 p q
+
+
+class HasAxiomGrz [Box F] (𝓢 : S) where
+  Grz (p : F) : 𝓢 ⊢ Axioms.Grz p
+
+section
+
+variable [Box F] [HasAxiomGrz 𝓢]
+
+def axiomGrz : 𝓢 ⊢ □(□(p ➝ □p) ➝ p) ➝ p := HasAxiomGrz.Grz _
+@[simp] lemma axiomGrz! : 𝓢 ⊢! □(□(p ➝ □p) ➝ p) ➝ p := ⟨axiomGrz⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomGrz Γ := ⟨fun _ ↦ FiniteContext.of axiomGrz⟩
+instance (Γ : Context F 𝓢) : HasAxiomGrz Γ := ⟨fun _ ↦ Context.of axiomGrz⟩
+
+end
+
+
+class HasAxiomTc [Box F] (𝓢 : S) where
+  Tc (p : F) : 𝓢 ⊢ Axioms.Tc p
+
+section
+
+variable [Box F] [HasAxiomTc 𝓢]
+
+def axiomTc : 𝓢 ⊢ p ➝ □p := HasAxiomTc.Tc _
+@[simp] lemma axiomTc! : 𝓢 ⊢! p ➝ □p := ⟨axiomTc⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomTc Γ := ⟨fun _ ↦ FiniteContext.of axiomTc⟩
+instance (Γ : Context F 𝓢) : HasAxiomTc Γ := ⟨fun _ ↦ Context.of axiomTc⟩
+
+end
+
+
+
+class HasAxiomVer [Box F] (𝓢 : S) where
+  Ver (p : F) : 𝓢 ⊢ Axioms.Ver p
+
+omit [LogicalConnective F] in
+section
+
+variable [Box F] [HasAxiomVer 𝓢]
+
+def axiomVer : 𝓢 ⊢ □p := HasAxiomVer.Ver _
+@[simp] lemma axiomVer! : 𝓢 ⊢! □p := ⟨axiomVer⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomVer Γ := ⟨fun _ ↦ FiniteContext.of axiomVer⟩
+instance (Γ : Context F 𝓢) : HasAxiomVer Γ := ⟨fun _ ↦ Context.of axiomVer⟩
+
+end
+
+
+
+class HasAxiomH [Box F] (𝓢 : S) where
+  H (p : F) : 𝓢 ⊢ Axioms.H p
+
+section
+
+variable [Box F] [HasAxiomH 𝓢]
+
+def axiomH : 𝓢 ⊢ □(□p ⭤ p) ➝ □p := HasAxiomH.H _
+@[simp] lemma axiomH! : 𝓢 ⊢! □(□p ⭤ p) ➝ □p := ⟨axiomH⟩
+
+variable [System.Minimal 𝓢]
+
+instance (Γ : FiniteContext F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ FiniteContext.of axiomH⟩
+instance (Γ : Context F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ Context.of axiomH⟩
+
+end
+
+
+section
+
+variable [BasicModalLogicalConnective F]
+variable (𝓢 : S)
+
+protected class K extends System.Classical 𝓢, Necessitation 𝓢, HasAxiomK 𝓢, HasDiaDuality 𝓢
+
+protected class KT extends System.K 𝓢, HasAxiomT 𝓢
+
+protected class KB extends System.K 𝓢, HasAxiomB 𝓢
+
+protected class KTc extends System.K 𝓢, HasAxiomTc 𝓢
+
+protected class KD extends System.K 𝓢, HasAxiomD 𝓢
+
+protected class KP extends System.K 𝓢, HasAxiomP 𝓢
+
+protected class K4 extends System.K 𝓢, HasAxiomFour 𝓢
+
+protected class K5 extends System.K 𝓢, HasAxiomFive 𝓢
+
+protected class S4 extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomFour 𝓢
+instance [System.S4 𝓢] : System.KT 𝓢 where
+instance [System.S4 𝓢] : System.K4 𝓢 where
+
+protected class S5 extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomFive 𝓢
+instance [System.S5 𝓢] : System.KT 𝓢 where
+instance [System.S5 𝓢] : System.K5 𝓢 where
+
+protected class S4Dot2 extends System.S4 𝓢, HasAxiomDot2 𝓢
+
+protected class S4Dot3 extends System.S4 𝓢, HasAxiomDot3 𝓢
+
+protected class S4Grz extends System.S4 𝓢, HasAxiomGrz 𝓢
+
+protected class S5Grz extends System.S5 𝓢, HasAxiomGrz 𝓢
+
+protected class GL extends System.K 𝓢, HasAxiomL 𝓢
+
+protected class Grz extends System.K 𝓢, HasAxiomGrz 𝓢
+
+protected class Triv extends System.K 𝓢, HasAxiomT 𝓢, HasAxiomTc 𝓢
+instance [System.Triv 𝓢] : System.KT 𝓢 where
+instance [System.Triv 𝓢] : System.KTc 𝓢 where
+
+protected class Ver extends System.K 𝓢, HasAxiomVer 𝓢
+
+protected class K4H extends System.K4 𝓢, HasAxiomH 𝓢
+
+protected class K4Loeb extends System.K4 𝓢, LoebRule 𝓢
+
+protected class K4Henkin extends System.K4 𝓢, HenkinRule 𝓢
+
+end
+
+
+section
+
+variable [BasicModalLogicalConnective F] [DecidableEq F]
+variable {p q r : F} {Γ Δ : List F}
+variable {𝓢 : S}
+
+instance [System.Minimal 𝓢] [ModalDeMorgan F] [HasAxiomDNE 𝓢] : HasDiaDuality 𝓢 := ⟨by
+  intro p;
+  simp only [Axioms.DiaDuality, ModalDeMorgan.box, DeMorgan.neg];
+  apply iffId;
+⟩
+
+instance [System.Minimal 𝓢] [DiaAbbrev F] : HasDiaDuality 𝓢 := ⟨by
+  intro p;
+  simp only [Axioms.DiaDuality, DiaAbbrev.dia_abbrev];
+  apply iffId;
+⟩
+
+instance [ModusPonens 𝓢] [HasAxiomT 𝓢] : Unnecessitation 𝓢 := ⟨by
+  intro p hp;
+  exact axiomT ⨀ hp;
+⟩
+
+
+open FiniteContext
+
+section K
+
+variable [System.K 𝓢]
 
 def multibox_axiomK : 𝓢 ⊢ □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := by
   induction n with
   | zero => simp; apply impId;
   | succ n ih => simpa using impTrans'' (axiomK' $ nec ih) (by apply axiomK);
-
 @[simp] lemma multibox_axiomK! : 𝓢 ⊢! □^[n](p ➝ q) ➝ □^[n]p ➝ □^[n]q := ⟨multibox_axiomK⟩
 
 def multibox_axiomK' (h : 𝓢 ⊢ □^[n](p ➝ q)) : 𝓢 ⊢ □^[n]p ➝ □^[n]q := multibox_axiomK ⨀ h
@@ -180,28 +449,6 @@ def multiboxIff' (h : 𝓢 ⊢ p ⭤ q) : 𝓢 ⊢ □^[n]p ⭤ □^[n]q := by
   | succ n ih => simpa using boxIff' ih;
 @[simp] lemma multibox_iff! (h : 𝓢 ⊢! p ⭤ q) : 𝓢 ⊢! □^[n]p ⭤ □^[n]q := ⟨multiboxIff' h.some⟩
 
-end AxiomK
-
-
-instance [ModalDeMorgan F] [HasAxiomDNE 𝓢] : HasDiaDuality 𝓢 := ⟨by
-  intro p;
-  simp only [Axioms.DiaDuality, ModalDeMorgan.box, DeMorgan.neg];
-  apply iffId;
-⟩
-
-instance [DiaAbbrev F] : HasDiaDuality 𝓢 := ⟨by
-  intro p;
-  simp only [Axioms.DiaDuality, DiaAbbrev.dia_abbrev];
-  apply iffId;
-⟩
-
-
-section Duality
-
-variable [HasDiaDuality 𝓢] [Necessitation 𝓢] [HasAxiomK 𝓢]
-
-def diaDuality : 𝓢 ⊢ ◇p ⭤ ∼(□(∼p)) := HasDiaDuality.dia_dual _
-@[simp] lemma dia_duality! : 𝓢 ⊢! ◇p ⭤ ∼(□(∼p)) := ⟨diaDuality⟩
 
 def diaDuality_mp : 𝓢 ⊢ ◇p ➝ ∼(□(∼p)) := and₁' diaDuality
 @[simp] lemma diaDuality_mp! : 𝓢 ⊢! ◇p ➝ ∼(□(∼p)) := ⟨diaDuality_mp⟩
@@ -285,13 +532,6 @@ lemma multibox_duality'! : 𝓢 ⊢! □^[n]p ↔ 𝓢 ⊢! ∼(◇^[n](∼p)) :
   . intro h; exact (and₂'! multibox_duality!) ⨀ h;
 
 lemma box_duality'! : 𝓢 ⊢! □p ↔ 𝓢 ⊢! ∼(◇(∼p)) := multibox_duality'! (n := 1)
-
-end Duality
-
-
-section
-
-variable [Necessitation 𝓢] [HasAxiomK 𝓢]
 
 def box_dne : 𝓢 ⊢ □(∼∼p) ➝ □p := axiomK' $ nec dne
 @[simp] lemma box_dne! : 𝓢 ⊢! □(∼∼p) ➝ □p := ⟨box_dne⟩
@@ -436,13 +676,6 @@ lemma collect_multibox_or'! (h : 𝓢 ⊢! □^[n]p ⋎ □^[n]q) : 𝓢 ⊢! �
 def collect_box_or' (h : 𝓢 ⊢ □p ⋎ □q) : 𝓢 ⊢ □(p ⋎ q) := collect_multibox_or' (n := 1) h
 lemma collect_box_or'! (h : 𝓢 ⊢! □p ⋎ □q) : 𝓢 ⊢! □(p ⋎ q) := ⟨collect_box_or' h.some⟩
 
-end
-
-
-section DiaDuality
-
-variable [Necessitation 𝓢] [HasAxiomK 𝓢] [HasDiaDuality 𝓢]
-
 def diaOrInst₁ : 𝓢 ⊢ ◇p ➝ ◇(p ⋎ q) := by
   apply impTrans'' (and₁' diaDuality);
   apply impTrans'' ?h (and₂' diaDuality);
@@ -521,74 +754,42 @@ lemma boxdot_box! : 𝓢 ⊢! ⊡p ➝ □p := ⟨boxdotBox⟩
 def BoxBoxdot_BoxDotbox : 𝓢 ⊢ □⊡p ➝ ⊡□p := impTrans'' distribute_box_and (impId _)
 lemma boxboxdot_boxdotbox : 𝓢 ⊢! □⊡p ➝ ⊡□p := ⟨BoxBoxdot_BoxDotbox⟩
 
-end DiaDuality
+end K
 
 
-section AxiomT
+section KT
 
-variable [HasAxiomT 𝓢]
+variable [System.KT 𝓢]
 
-def axiomT : 𝓢 ⊢ □p ➝ p := HasAxiomT.T _
-@[simp] lemma axiomT! : 𝓢 ⊢! □p ➝ p := ⟨axiomT⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ FiniteContext.of axiomT⟩
-instance (Γ : Context F 𝓢) : HasAxiomT Γ := ⟨fun _ ↦ Context.of axiomT⟩
-
-def axiomT' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ p := axiomT ⨀ h
-@[simp] lemma axiomT'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! p := ⟨axiomT' h.some⟩
-
-def diaTc [HasDiaDuality 𝓢] : 𝓢 ⊢ p ➝ ◇p := by
+def diaTc : 𝓢 ⊢ p ➝ ◇p := by
   apply impTrans'' ?_ (and₂' diaDuality);
   exact impTrans'' dni $ contra₀' axiomT;
-@[simp] lemma diaTc! [HasDiaDuality 𝓢] : 𝓢 ⊢! p ➝ ◇p := ⟨diaTc⟩
+@[simp] lemma diaTc! : 𝓢 ⊢! p ➝ ◇p := ⟨diaTc⟩
 
 def diaTc' [HasDiaDuality 𝓢] (h : 𝓢 ⊢ p) : 𝓢 ⊢ ◇p := diaTc ⨀ h
 lemma diaTc'! [HasDiaDuality 𝓢] (h : 𝓢 ⊢! p) : 𝓢 ⊢! ◇p := ⟨diaTc' h.some⟩
 
-end AxiomT
+end KT
 
 
-section AxiomB
 
-variable [HasAxiomB 𝓢]
+section KD
 
-def axiomB : 𝓢 ⊢ p ➝ □◇p := HasAxiomB.B _
-@[simp] lemma axiomB! : 𝓢 ⊢! p ➝ □◇p := ⟨axiomB⟩
+variable [System.KD 𝓢]
 
-instance (Γ : FiniteContext F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ FiniteContext.of axiomB⟩
-instance (Γ : Context F 𝓢) : HasAxiomB Γ := ⟨fun _ ↦ Context.of axiomB⟩
-
-end AxiomB
-
-
-section AxiomD
-
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomD 𝓢]
-
-def axiomD : 𝓢 ⊢ □p ➝ ◇p := HasAxiomD.D _
-@[simp] lemma axiomD! : 𝓢 ⊢! □p ➝ ◇p := ⟨axiomD⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ FiniteContext.of axiomD⟩
-instance (Γ : Context F 𝓢) : HasAxiomD Γ := ⟨fun _ ↦ Context.of axiomD⟩
-
-private def P_of_D [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.P := by
+private def P_of_D : 𝓢 ⊢ Axioms.P := by
   have : 𝓢 ⊢ ∼∼□(∼⊥) := dni' $ nec notbot;
   have : 𝓢 ⊢ ∼◇⊥ := (contra₀' $ and₁' diaDuality) ⨀ this;
   exact (contra₀' axiomD) ⨀ this;
-instance [HasDiaDuality 𝓢] : HasAxiomP 𝓢 := ⟨P_of_D⟩
+instance : HasAxiomP 𝓢 := ⟨P_of_D⟩
+instance : System.KP 𝓢 where
 
-end AxiomD
+end KD
 
 
-section AxiomP
+section KP
 
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomP 𝓢]
-
-def axiomP : 𝓢 ⊢ ∼□⊥  := HasAxiomP.P
-@[simp] lemma axiomP! : 𝓢 ⊢! ∼□⊥ := ⟨axiomP⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomP Γ := ⟨FiniteContext.of axiomP⟩
-instance (Γ : Context F 𝓢) : HasAxiomP Γ := ⟨Context.of axiomP⟩
+variable [System.KP 𝓢]
 
 private def D_of_P [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.D p := by
   have : 𝓢 ⊢ p ➝ (∼p ➝ ⊥) := impTrans'' dni (and₁' neg_equiv);
@@ -597,23 +798,15 @@ private def D_of_P [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.D p := by
   have : 𝓢 ⊢ □p ➝ (∼□⊥ ➝ ∼□(∼p)) := impTrans'' this contra₀;
   have : 𝓢 ⊢ □p ➝ ∼□(∼p) := impSwap' this ⨀ axiomP;
   exact impTrans'' this (and₂' diaDuality);
-instance [HasDiaDuality 𝓢] : HasAxiomD 𝓢 := ⟨fun _ ↦ D_of_P⟩
+instance : HasAxiomD 𝓢 := ⟨fun _ ↦ D_of_P⟩
+instance : System.KD 𝓢 where
 
-end AxiomP
+end KP
 
 
-section AxiomFour
+section K4
 
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomFour 𝓢]
-
-def axiomFour : 𝓢 ⊢ □p ➝ □□p := HasAxiomFour.Four _
-@[simp] lemma axiomFour! : 𝓢 ⊢! □p ➝ □□p := ⟨axiomFour⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ FiniteContext.of axiomFour⟩
-instance (Γ : Context F 𝓢) : HasAxiomFour Γ := ⟨fun _ ↦ Context.of axiomFour⟩
-
-def axiomFour' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ □□p := axiomFour ⨀ h
-def axiomFour'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! □□p := ⟨axiomFour' h.some⟩
+variable [System.K4 𝓢]
 
 def imply_BoxBoxdot_Box: 𝓢 ⊢  □⊡p ➝ □p := by
   exact impTrans'' distribute_box_and and₁
@@ -626,134 +819,134 @@ def imply_Box_BoxBoxdot : 𝓢 ⊢ □p ➝ □⊡p := by
 def imply_Box_BoxBoxdot' (h : 𝓢 ⊢ □p) : 𝓢 ⊢ □⊡p := imply_Box_BoxBoxdot ⨀ h
 def imply_Box_BoxBoxdot'! (h : 𝓢 ⊢! □p) : 𝓢 ⊢! □⊡p := ⟨imply_Box_BoxBoxdot' h.some⟩
 
-def iff_Box_BoxBoxdot [HasAxiomFour 𝓢] : 𝓢 ⊢ □p ⭤ □⊡p := by
+def iff_Box_BoxBoxdot : 𝓢 ⊢ □p ⭤ □⊡p := by
   apply iffIntro;
   . exact imply_Box_BoxBoxdot
   . exact imply_BoxBoxdot_Box;
-@[simp] lemma iff_box_boxboxdot! [HasAxiomFour 𝓢] : 𝓢 ⊢! □p ⭤ □⊡p := ⟨iff_Box_BoxBoxdot⟩
+@[simp] lemma iff_box_boxboxdot! : 𝓢 ⊢! □p ⭤ □⊡p := ⟨iff_Box_BoxBoxdot⟩
 
-def iff_Box_BoxdotBox [HasAxiomFour 𝓢] : 𝓢 ⊢ □p ⭤ ⊡□p := by
+def iff_Box_BoxdotBox : 𝓢 ⊢ □p ⭤ ⊡□p := by
   apply iffIntro;
   . exact impTrans'' (implyRightAnd (impId _) axiomFour) (impId _)
   . exact and₁
-@[simp] lemma iff_box_boxdotbox! [HasAxiomFour 𝓢] : 𝓢 ⊢! □p ⭤ ⊡□p := ⟨iff_Box_BoxdotBox⟩
+@[simp] lemma iff_box_boxdotbox! : 𝓢 ⊢! □p ⭤ ⊡□p := ⟨iff_Box_BoxdotBox⟩
 
-def iff_Boxdot_BoxdotBoxdot [HasAxiomFour 𝓢] : 𝓢 ⊢ ⊡p ⭤ ⊡⊡p := by
+def iff_Boxdot_BoxdotBoxdot : 𝓢 ⊢ ⊡p ⭤ ⊡⊡p := by
   apply iffIntro;
   . exact implyRightAnd (impId _) (impTrans'' boxdotBox (and₁' iff_Box_BoxBoxdot));
   . exact and₁;
-@[simp] lemma iff_boxdot_boxdotboxdot [HasAxiomFour 𝓢] : 𝓢 ⊢! ⊡p ⭤ ⊡⊡p := ⟨iff_Boxdot_BoxdotBoxdot⟩
+@[simp] lemma iff_boxdot_boxdotboxdot : 𝓢 ⊢! ⊡p ⭤ ⊡⊡p := ⟨iff_Boxdot_BoxdotBoxdot⟩
 
-def boxdotAxiomFour [HasAxiomFour 𝓢] : 𝓢 ⊢ ⊡p ➝ ⊡⊡p := and₁' iff_Boxdot_BoxdotBoxdot
-@[simp] lemma boxdot_axiomFour! [HasAxiomFour 𝓢] : 𝓢 ⊢! ⊡p ➝ ⊡⊡p := ⟨boxdotAxiomFour⟩
+def boxdotAxiomFour : 𝓢 ⊢ ⊡p ➝ ⊡⊡p := and₁' iff_Boxdot_BoxdotBoxdot
+@[simp] lemma boxdot_axiomFour! : 𝓢 ⊢! ⊡p ➝ ⊡⊡p := ⟨boxdotAxiomFour⟩
+
+end K4
 
 
-def iff_box_boxdot [HasAxiomT 𝓢] : 𝓢 ⊢ □p ⭤ ⊡p := by
+section K4Loeb
+
+variable [System.K4Loeb 𝓢]
+
+private def axiomL_of_K4Loeb : 𝓢 ⊢ Axioms.L p := by
+  dsimp [Axioms.L];
+  generalize e : □(□p ➝ p) ➝ □p = q;
+  have d₁ : [□(□p ➝ p), □q] ⊢[𝓢] □□(□p ➝ p) ➝ □□p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
+  have d₂ : [□(□p ➝ p), □q] ⊢[𝓢] □□p ➝ □p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
+  have d₃ : 𝓢 ⊢ □(□p ➝ p) ➝ □□(□p ➝ p) := axiomFour;
+  have : 𝓢 ⊢ □q ➝ q := by
+    nth_rw 2 [←e]; apply deduct'; apply deduct;
+    exact d₂ ⨀ (d₁ ⨀ ((of d₃) ⨀ (FiniteContext.byAxm)));
+  exact loeb this;
+instance : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_K4Loeb⟩
+instance : System.GL 𝓢 where
+
+end K4Loeb
+
+
+section K4Henkin
+
+variable [System.K4Henkin 𝓢]
+
+instance : LoebRule 𝓢 where
+  loeb h := h ⨀ (henkin $ iffIntro (axiomK' $ nec h) axiomFour);
+instance : System.K4Loeb 𝓢 where
+
+end K4Henkin
+
+
+section K4H
+
+variable [System.K4H 𝓢]
+
+instance : HenkinRule 𝓢 where
+  henkin h := (and₁' h) ⨀ (axiomH ⨀ nec h);
+instance : System.K4Henkin 𝓢 where
+
+end K4H
+
+
+section S4
+
+variable [System.S4 𝓢]
+
+def iff_box_boxdot : 𝓢 ⊢ □p ⭤ ⊡p := by
   apply iffIntro;
   . exact implyRightAnd (axiomT) (impId _);
   . exact and₂;
-@[simp] lemma iff_box_boxdot! [HasAxiomT 𝓢] : 𝓢 ⊢! □p ⭤ ⊡p := ⟨iff_box_boxdot⟩
+@[simp] lemma iff_box_boxdot! : 𝓢 ⊢! □p ⭤ ⊡p := ⟨iff_box_boxdot⟩
 
-def iff_dia_diadot [HasAxiomT 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢ ◇p ⭤ ⟐p := by
+def iff_dia_diadot : 𝓢 ⊢ ◇p ⭤ ⟐p := by
   apply iffIntro;
   . exact or₂;
-  . exact or₃'' (diaTc) (impId _)
-@[simp] lemma iff_dia_diadot! [HasAxiomT 𝓢] [HasAxiomFour 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢! ◇p ⭤ ⟐p := ⟨iff_dia_diadot⟩
+  . exact or₃'' diaTc (impId _)
+@[simp] lemma iff_dia_diadot! : 𝓢 ⊢! ◇p ⭤ ⟐p := ⟨iff_dia_diadot⟩
 
-end AxiomFour
-
-
-section AxiomFive
-
-variable [HasAxiomFive 𝓢]
-
-def axiomFive : 𝓢 ⊢ ◇p ➝ □◇p := HasAxiomFive.Five _
-@[simp] lemma axiomFive! : 𝓢 ⊢! ◇p ➝ □◇p := ⟨axiomFive⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomFive Γ := ⟨fun _ ↦ FiniteContext.of axiomFive⟩
-instance (Γ : Context F 𝓢) : HasAxiomFive Γ := ⟨fun _ ↦ Context.of axiomFive⟩
-
-end AxiomFive
+end S4
 
 
-section S5
-
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomT 𝓢] [HasAxiomFive 𝓢]
-
--- MEMO: need more simple proof
-def diabox_box : 𝓢 ⊢ ◇□p ➝ □p := by
-  have : 𝓢 ⊢ ◇(∼p) ➝ □◇(∼p) := axiomFive;
-  have : 𝓢 ⊢ ∼□◇(∼p) ➝ ∼◇(∼p) := contra₀' this;
-  have : 𝓢 ⊢ ∼□◇(∼p) ➝ □p := impTrans'' this boxDuality_mpr;
-  refine impTrans'' ?_ this;
-  refine impTrans'' diaDuality_mp $ ?_
-  apply contra₀';
-  apply implyBoxDistribute';
-  refine impTrans'' diaDuality_mp ?_;
-  apply contra₀';
-  apply implyBoxDistribute';
-  apply dni;
-@[simp] lemma diabox_box! : 𝓢 ⊢! ◇□p ➝ □p := ⟨diabox_box⟩
-
-def diabox_box' (h : 𝓢 ⊢ ◇□p) : 𝓢 ⊢ □p := diabox_box ⨀ h
-lemma diabox_box'! (h : 𝓢 ⊢! ◇□p) : 𝓢 ⊢! □p := ⟨diabox_box' h.some⟩
 
 
-def rm_diabox : 𝓢 ⊢ ◇□p ➝ p := impTrans'' diabox_box axiomT
-@[simp] lemma rm_diabox! : 𝓢 ⊢! ◇□p ➝ p := ⟨rm_diabox⟩
+section KTc
 
-def rm_diabox' (h : 𝓢 ⊢ ◇□p) : 𝓢 ⊢ p := rm_diabox ⨀ h
-lemma rm_diabox'! (h : 𝓢 ⊢! ◇□p) : 𝓢 ⊢! p := ⟨rm_diabox' h.some⟩
-
-end S5
-
-
-section AxiomTc
-
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomTc 𝓢]
-
-def axiomTc : 𝓢 ⊢ p ➝ □p := HasAxiomTc.Tc _
-@[simp] lemma axiomTc! : 𝓢 ⊢! p ➝ □p := ⟨axiomTc⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomTc Γ := ⟨fun _ ↦ FiniteContext.of axiomTc⟩
-instance (Γ : Context F 𝓢) : HasAxiomTc Γ := ⟨fun _ ↦ Context.of axiomTc⟩
+variable [System.KTc 𝓢]
 
 private def axiomFour_of_Tc : 𝓢 ⊢ Axioms.Four p := axiomTc
 instance : HasAxiomFour 𝓢 := ⟨fun _ ↦ axiomFour_of_Tc⟩
 
-def diaT [HasDiaDuality 𝓢] : 𝓢 ⊢ ◇p ➝ p := by
+def diaT : 𝓢 ⊢ ◇p ➝ p := by
   apply impTrans'' (and₁' diaDuality) ?_;
   apply contra₂';
   exact axiomTc;
-@[simp] lemma diaT! [HasDiaDuality 𝓢] : 𝓢 ⊢! ◇p ➝ p := ⟨diaT⟩
+@[simp] lemma diaT! : 𝓢 ⊢! ◇p ➝ p := ⟨diaT⟩
 
-def diaT' [HasDiaDuality 𝓢] (h : 𝓢 ⊢ ◇p) : 𝓢 ⊢ p := diaT ⨀ h
-lemma diaT'! [HasDiaDuality 𝓢] (h : 𝓢 ⊢! ◇p) : 𝓢 ⊢! p := ⟨diaT' h.some⟩
+def diaT' (h : 𝓢 ⊢ ◇p) : 𝓢 ⊢ p := diaT ⨀ h
+lemma diaT'! (h : 𝓢 ⊢! ◇p) : 𝓢 ⊢! p := ⟨diaT' h.some⟩
 
 private def axiomFive_of_Tc : 𝓢 ⊢ ◇p ➝ □◇p := axiomTc
 instance : HasAxiomFive 𝓢 := ⟨fun _ ↦ axiomFive_of_Tc⟩
 
-private def axiomGrz_of_Tc_and_T [HasAxiomT 𝓢] : 𝓢 ⊢ □(□(p ➝ □p) ➝ p) ➝ p := by
+end KTc
+
+
+section Triv
+
+variable [System.Triv 𝓢]
+
+private def axiomGrz_of_Tc_and_T : 𝓢 ⊢ □(□(p ➝ □p) ➝ p) ➝ p := by
   have : 𝓢 ⊢ p ➝ □p := axiomTc;
   have d₁ := nec this;
   have d₂ : 𝓢 ⊢ □(p ➝ □p) ➝ ((□(p ➝ □p)) ➝ p) ➝ p := p_pq_q;
   have := d₂ ⨀ d₁;
   exact impTrans'' axiomT this;
 
-instance [HasAxiomT 𝓢] : HasAxiomGrz 𝓢 := ⟨fun _ ↦ axiomGrz_of_Tc_and_T⟩
+instance : HasAxiomGrz 𝓢 := ⟨fun _ ↦ axiomGrz_of_Tc_and_T⟩
 
-end AxiomTc
+end Triv
 
 
-section AxiomVer
+section Ver
 
-variable [HasAxiomVer 𝓢]
-
-def axiomVer : 𝓢 ⊢ □p := HasAxiomVer.Ver _
-@[simp] lemma axiomVer! : 𝓢 ⊢! □p := ⟨axiomVer⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomVer Γ := ⟨fun _ ↦ FiniteContext.of axiomVer⟩
-instance (Γ : Context F 𝓢) : HasAxiomVer Γ := ⟨fun _ ↦ Context.of axiomVer⟩
+variable [System.Ver 𝓢]
 
 private def axiomTc_of_Ver : 𝓢 ⊢ Axioms.Tc p := dhyp _ axiomVer
 instance : HasAxiomTc 𝓢 := ⟨fun _ ↦ axiomTc_of_Ver⟩
@@ -761,29 +954,23 @@ instance : HasAxiomTc 𝓢 := ⟨fun _ ↦ axiomTc_of_Ver⟩
 private def axiomL_of_Ver : 𝓢 ⊢ Axioms.L p := dhyp _ axiomVer
 instance : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_Ver⟩
 
-def bot_of_dia [NegationEquiv 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢ ◇p ➝ ⊥ := by
+def bot_of_dia : 𝓢 ⊢ ◇p ➝ ⊥ := by
   have : 𝓢 ⊢ ∼◇p ➝ (◇p ➝ ⊥) := and₁' $ neg_equiv (𝓢 := 𝓢) (p := ◇p);
   exact this ⨀ (contra₀' (and₁' diaDuality) ⨀ by
     apply dni';
     apply axiomVer;
   );
-lemma bot_of_dia! [NegationEquiv 𝓢] [HasDiaDuality 𝓢] : 𝓢 ⊢! ◇p ➝ ⊥ := ⟨bot_of_dia⟩
+lemma bot_of_dia! : 𝓢 ⊢! ◇p ➝ ⊥ := ⟨bot_of_dia⟩
 
-def bot_of_dia' [NegationEquiv 𝓢] [HasDiaDuality 𝓢] (h : 𝓢 ⊢ ◇p) : 𝓢 ⊢ ⊥ := bot_of_dia ⨀ h
-lemma bot_of_dia'! [NegationEquiv 𝓢] [HasDiaDuality 𝓢] (h : 𝓢 ⊢! ◇p) : 𝓢 ⊢! ⊥ := ⟨bot_of_dia' h.some⟩
+def bot_of_dia' (h : 𝓢 ⊢ ◇p) : 𝓢 ⊢ ⊥ := bot_of_dia ⨀ h
+lemma bot_of_dia'! (h : 𝓢 ⊢! ◇p) : 𝓢 ⊢! ⊥ := ⟨bot_of_dia' h.some⟩
 
-end AxiomVer
+end Ver
 
 
-section AxiomL
+section GL
 
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomL 𝓢]
-
-def axiomL : 𝓢 ⊢ □(□p ➝ p) ➝ □p := HasAxiomL.L _
-@[simp] lemma axiomL! : 𝓢 ⊢! □(□p ➝ p) ➝ □p := ⟨axiomL⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomL Γ := ⟨fun _ ↦ FiniteContext.of axiomL⟩
-instance (Γ : Context F 𝓢) : HasAxiomL Γ := ⟨fun _ ↦ Context.of axiomL⟩
+variable [System.GL 𝓢]
 
 private def axiomFour_of_L : 𝓢 ⊢ Axioms.Four p := by
   dsimp [Axioms.Four];
@@ -794,6 +981,7 @@ private def axiomFour_of_L : 𝓢 ⊢ Axioms.Four p := by
   have : 𝓢 ⊢ p ➝ (□⊡p ➝ ⊡p) := impTrans'' this (implyLeftReplace BoxBoxdot_BoxDotbox);
   exact impTrans'' (impTrans'' (implyBoxDistribute' this) axiomL) (implyBoxDistribute' $ and₂);
 instance : HasAxiomFour 𝓢 := ⟨fun _ ↦ axiomFour_of_L⟩
+instance : System.K4 𝓢 where
 
 def goedel2 : 𝓢 ⊢ (∼(□⊥) ⭤ ∼(□(∼(□⊥))) : F) := by
   apply negReplaceIff';
@@ -838,87 +1026,6 @@ noncomputable def boxdot_Grz_of_L : 𝓢 ⊢ ⊡(⊡(p ➝ ⊡p) ➝ p) ➝ p :=
   exact mdp₁ boxdot_Grz_of_L1 this;
 @[simp] lemma boxdot_Grz_of_L! : 𝓢 ⊢! ⊡(⊡(p ➝ ⊡p) ➝ p) ➝ p := ⟨boxdot_Grz_of_L⟩
 
-end AxiomL
-
-
-section AxiomH
-
-variable [HasAxiomH 𝓢]
-
-def axiomH : 𝓢 ⊢ □(□p ⭤ p) ➝ □p := HasAxiomH.H _
-@[simp] lemma axiomH! : 𝓢 ⊢! □(□p ⭤ p) ➝ □p := ⟨axiomH⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ FiniteContext.of axiomH⟩
-instance (Γ : Context F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ Context.of axiomH⟩
-
-end AxiomH
-
-
-section LoebRule
-
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢]
-
-alias loeb := LoebRule.loeb
-lemma loeb! [LoebRule 𝓢] : 𝓢 ⊢! □p ➝ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨loeb hp⟩
-
-private def axiomL_of_K4Loeb [HasAxiomFour 𝓢] [LoebRule 𝓢] : 𝓢 ⊢ Axioms.L p := by
-  dsimp [Axioms.L];
-  generalize e : □(□p ➝ p) ➝ □p = q;
-  have d₁ : [□(□p ➝ p), □q] ⊢[𝓢] □□(□p ➝ p) ➝ □□p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
-  have d₂ : [□(□p ➝ p), □q] ⊢[𝓢] □□p ➝ □p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
-  have d₃ : 𝓢 ⊢ □(□p ➝ p) ➝ □□(□p ➝ p) := axiomFour;
-  have : 𝓢 ⊢ □q ➝ q := by
-    nth_rw 2 [←e]; apply deduct'; apply deduct;
-    exact d₂ ⨀ (d₁ ⨀ ((of d₃) ⨀ (FiniteContext.byAxm)));
-  exact loeb this;
-instance [System.K4Loeb 𝓢] : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_K4Loeb⟩
-
-end LoebRule
-
-
-section HenkinRule
-
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢]
-
-alias henkin := HenkinRule.henkin
-lemma henkin! [HenkinRule 𝓢] : 𝓢 ⊢! □p ⭤ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨henkin hp⟩
-
-instance [HasAxiomFour 𝓢] [HenkinRule 𝓢]  : LoebRule 𝓢 where
-  loeb h := h ⨀ (henkin $ iffIntro (axiomK' $ nec h) axiomFour);
-
-instance [HasAxiomFour 𝓢] [HasAxiomH 𝓢] : HenkinRule 𝓢 where
-  henkin h := (and₁' h) ⨀ (axiomH ⨀ nec h);
-
-end HenkinRule
-
-
-section Unnecessitation
-
-variable [Unnecessitation 𝓢]
-
-alias unnec := Unnecessitation.unnec
-lemma unnec! : 𝓢 ⊢! □p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨unnec hp⟩
-
-def multiunnec : 𝓢 ⊢ □^[n]p → 𝓢 ⊢ p := by
-  intro h;
-  induction n generalizing p with
-  | zero => simpa;
-  | succ n ih => exact unnec $ @ih (□p) h;
-lemma multiunnec! : 𝓢 ⊢! □^[n]p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨multiunnec hp⟩
-
-instance [HasAxiomT 𝓢] : Unnecessitation 𝓢 := ⟨by
-  intro p hp;
-  exact axiomT ⨀ hp;
-⟩
-
-end Unnecessitation
-
-
-
-section
-
-variable [Necessitation 𝓢] [HasAxiomK 𝓢] [HasAxiomFour 𝓢] [HasAxiomL 𝓢]
-
 def imply_boxdot_boxdot_of_imply_boxdot_plain (h : 𝓢 ⊢ ⊡p ➝ q) : 𝓢 ⊢ ⊡p ➝ ⊡q := by
   have : 𝓢 ⊢ □⊡p ➝ □q := implyBoxDistribute' h;
   have : 𝓢 ⊢ □p ➝ □q := impTrans'' imply_Box_BoxBoxdot this;
@@ -942,18 +1049,12 @@ lemma imply_box_box_of_imply_boxdot_axiomT! (h : 𝓢 ⊢! ⊡p ➝ (□q ➝ q)
 lemma imply_box_box_of_imply_boxdot_plain! (h : 𝓢 ⊢! ⊡p ➝ q) : 𝓢 ⊢! □p ➝ □q := by
   exact imply_box_box_of_imply_boxdot_axiomT! $ imply_boxdot_axiomT_of_imply_boxdot_boxdot! $ imply_boxdot_boxdot_of_imply_boxdot_plain! h
 
-end
+end GL
 
 
 section Grz
 
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomGrz 𝓢]
-
-def axiomGrz : 𝓢 ⊢ □(□(p ➝ □p) ➝ p) ➝ p := HasAxiomGrz.Grz _
-@[simp] lemma axiomGrz! : 𝓢 ⊢! □(□(p ➝ □p) ➝ p) ➝ p := ⟨axiomGrz⟩
-
-instance (Γ : FiniteContext F 𝓢) : HasAxiomGrz Γ := ⟨fun _ ↦ FiniteContext.of axiomGrz⟩
-instance (Γ : Context F 𝓢) : HasAxiomGrz Γ := ⟨fun _ ↦ Context.of axiomGrz⟩
+variable [System.Grz 𝓢]
 
 noncomputable def lemma_Grz₁ : 𝓢 ⊢ □p ➝ □(□((p ⋏ (□p ➝ □□p)) ➝ □(p ⋏ (□p ➝ □□p))) ➝ (p ⋏ (□p ➝ □□p))) := by
   let q := p ⋏ (□p ➝ □□p);
@@ -980,25 +1081,55 @@ lemma lemma_Grz₁! : 𝓢 ⊢! (□p ➝ □(□((p ⋏ (□p ➝ □□p)) ➝
 noncomputable def lemma_Grz₂ : 𝓢 ⊢ □p ➝ (p ⋏ (□p ➝ □□p)) := impTrans'' (lemma_Grz₁ (p := p)) axiomGrz
 
 private noncomputable def Four_of_Grz : 𝓢 ⊢ □p ➝ □□p := ppq $ impTrans'' lemma_Grz₂ and₂
-
 noncomputable instance : HasAxiomFour 𝓢 := ⟨fun _ ↦ Four_of_Grz⟩
 
 private noncomputable def T_of_Grz : 𝓢 ⊢ □p ➝ p := impTrans'' lemma_Grz₂ and₁
-
 noncomputable instance : HasAxiomT 𝓢 := ⟨fun _ ↦ T_of_Grz⟩
+
+noncomputable instance : System.S4 𝓢 where
 
 end Grz
 
 
-section Tc_of_S5Grz
+section S5
 
-variable [Necessitation 𝓢] [HasDiaDuality 𝓢] [HasAxiomK 𝓢] [HasAxiomT 𝓢] [HasAxiomFive 𝓢] [HasAxiomGrz 𝓢]
+variable [System.S5 𝓢]
 
-private def lem₁_diaT_of_S5Grz : 𝓢 ⊢ (∼□(∼p) ➝ ∼□(∼□p)) ➝ (◇p ➝ ◇□p)
-  := impTrans'' (rev_dhyp_imp' diaDuality_mp) (dhyp_imp' diaDuality_mpr)
+-- MEMO: need more simple proof
+def diabox_box : 𝓢 ⊢ ◇□p ➝ □p := by
+  have : 𝓢 ⊢ ◇(∼p) ➝ □◇(∼p) := axiomFive;
+  have : 𝓢 ⊢ ∼□◇(∼p) ➝ ∼◇(∼p) := contra₀' this;
+  have : 𝓢 ⊢ ∼□◇(∼p) ➝ □p := impTrans'' this boxDuality_mpr;
+  refine impTrans'' ?_ this;
+  refine impTrans'' diaDuality_mp $ ?_
+  apply contra₀';
+  apply implyBoxDistribute';
+  refine impTrans'' diaDuality_mp ?_;
+  apply contra₀';
+  apply implyBoxDistribute';
+  apply dni;
+@[simp] lemma diabox_box! : 𝓢 ⊢! ◇□p ➝ □p := ⟨diabox_box⟩
 
-private def lem₂_diaT_of_S5Grz : 𝓢 ⊢ (◇p ➝ ◇□p) ➝ (◇p ➝ p)
-  := dhyp_imp' rm_diabox
+def diabox_box' (h : 𝓢 ⊢ ◇□p) : 𝓢 ⊢ □p := diabox_box ⨀ h
+lemma diabox_box'! (h : 𝓢 ⊢! ◇□p) : 𝓢 ⊢! □p := ⟨diabox_box' h.some⟩
+
+
+def rm_diabox : 𝓢 ⊢ ◇□p ➝ p := impTrans'' diabox_box axiomT
+@[simp] lemma rm_diabox! : 𝓢 ⊢! ◇□p ➝ p := ⟨rm_diabox⟩
+
+def rm_diabox' (h : 𝓢 ⊢ ◇□p) : 𝓢 ⊢ p := rm_diabox ⨀ h
+lemma rm_diabox'! (h : 𝓢 ⊢! ◇□p) : 𝓢 ⊢! p := ⟨rm_diabox' h.some⟩
+
+private def lem₁_diaT_of_S5Grz : 𝓢 ⊢ (∼□(∼p) ➝ ∼□(∼□p)) ➝ (◇p ➝ ◇□p) := impTrans'' (rev_dhyp_imp' diaDuality_mp) (dhyp_imp' diaDuality_mpr)
+
+private def lem₂_diaT_of_S5Grz : 𝓢 ⊢ (◇p ➝ ◇□p) ➝ (◇p ➝ p) := dhyp_imp' rm_diabox
+
+end S5
+
+
+section S5Grz
+
+variable [System.S5Grz 𝓢]
 
 private def diaT_of_S5Grz : 𝓢 ⊢ ◇p ➝ p := by
   have : 𝓢 ⊢ (p ➝ □p) ➝ (∼□p ➝ ∼p) := contra₀;
@@ -1013,16 +1144,14 @@ private def diaT_of_S5Grz : 𝓢 ⊢ ◇p ➝ p := by
   have : 𝓢 ⊢ □◇p ➝ p := impTrans'' this axiomGrz;
   exact impTrans'' axiomFive this;
 
-private def Tc_of_S5Grz : 𝓢 ⊢ p ➝ □p :=
-  impTrans'' (contra₃' (impTrans'' (and₂' diaDuality) diaT_of_S5Grz)) box_dne
-
+private def Tc_of_S5Grz : 𝓢 ⊢ p ➝ □p := impTrans'' (contra₃' (impTrans'' (and₂' diaDuality) diaT_of_S5Grz)) box_dne
 instance : HasAxiomTc 𝓢 := ⟨fun _ ↦ Tc_of_S5Grz⟩
 
-end Tc_of_S5Grz
+end S5Grz
 
 
-lemma contextual_nec! [Necessitation 𝓢] [HasAxiomK 𝓢] (h : Γ ⊢[𝓢]! p) : (□'Γ) ⊢[𝓢]! □p
-  := provable_iff.mpr $ imp_trans''! collect_box_conj! $ imply_box_distribute'! $ provable_iff.mp h
+lemma contextual_nec! [System.K 𝓢] (h : Γ ⊢[𝓢]! p) : (□'Γ) ⊢[𝓢]! □p :=
+  provable_iff.mpr $ imp_trans''! collect_box_conj! $ imply_box_distribute'! $ provable_iff.mp h
 
 end
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,5 +11,3 @@ lean_lib Foundation {
 }
 
 require "leanprover-community" / "mathlib" @ git "master"
-
-require "leanprover-community" / "importGraph" @ git "main"


### PR DESCRIPTION
`Supplemtanl.lean`および`Modal/System.lean`のクラス系を全部書き換えるのは現実的ではない/あまりにもコードが長くなりすぎるという気がして

```
set_option deprecated.oldSectionVars true
```

などを使って一旦延期してしまっている．