### PR TITLE
Refactoring about Hilbert Deduction System

### DIFF
--- a/Foundation/IntProp/ConsistentTableau.lean
+++ b/Foundation/IntProp/ConsistentTableau.lean
@@ -9,7 +9,7 @@ open System FiniteContext
 open Formula
 
 variable {α : Type u}
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 def Tableau (α : Type u) := Theory α × Theory α
 
@@ -24,7 +24,7 @@ instance : HasSubset (Tableau α) := ⟨λ t₁ t₂ => t₁.1 ⊆ t₂.1 ∧ t�
   . intro h; cases h; simp;
   . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all;
 
-def Consistent (Λ : Hilbert α) (t : Tableau α) := ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ t.1) → (∀ φ ∈ Δ, φ ∈ t.2) → Λ ⊬ ⋀Γ ➝ ⋁Δ
+def Consistent (H : Hilbert α) (t : Tableau α) := ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ t.1) → (∀ φ ∈ Δ, φ ∈ t.2) → H ⊬ ⋀Γ ➝ ⋁Δ
 
 variable {φ ψ: Formula α} {T U : Theory α}
 
@@ -32,16 +32,16 @@ section
 
 variable [DecidableEq α]
 
-lemma iff_consistent_insert₁ : Tableau.Consistent Λ ((insert φ T), U) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ T) → (∀ φ ∈ Δ, φ ∈ U) → Λ ⊬ φ ⋏ ⋀Γ ➝ ⋁Δ := by
+lemma iff_consistent_insert₁ : Tableau.Consistent H ((insert φ T), U) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ T) → (∀ φ ∈ Δ, φ ∈ U) → H ⊬ φ ⋏ ⋀Γ ➝ ⋁Δ := by
   constructor;
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
-    have : Λ ⊬ ⋀(φ :: Γ) ➝ ⋁Δ := h (by simp; intro ψ hq; right; exact hΓ ψ hq;) hΔ;
-    have : Λ ⊢! ⋀(φ :: Γ) ➝ ⋁Δ := iff_imply_left_cons_conj'!.mpr hC;
+    have : H ⊬ ⋀(φ :: Γ) ➝ ⋁Δ := h (by simp; intro ψ hq; right; exact hΓ ψ hq;) hΔ;
+    have : H ⊢! ⋀(φ :: Γ) ➝ ⋁Δ := iff_imply_left_cons_conj'!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all only [Set.mem_insert_iff];
-    have : Λ ⊬ φ ⋏ ⋀(Γ.remove φ) ➝ ⋁Δ := h (by
+    have : H ⊬ φ ⋏ ⋀(Γ.remove φ) ➝ ⋁Δ := h (by
       intro ψ hq;
       have := by simpa using hΓ ψ $ List.mem_of_mem_remove hq;
       cases this with
@@ -49,26 +49,26 @@ lemma iff_consistent_insert₁ : Tableau.Consistent Λ ((insert φ T), U) ↔ �
       | inr h => assumption;
     ) hΔ;
     by_contra hC;
-    have : Λ ⊢! φ ⋏ ⋀(Γ.remove φ) ➝ ⋁Δ := imp_trans''! and_comm! $ imply_left_remove_conj! (φ := φ) hC;
+    have : H ⊢! φ ⋏ ⋀(Γ.remove φ) ➝ ⋁Δ := imp_trans''! and_comm! $ imply_left_remove_conj! (φ := φ) hC;
     contradiction;
 
-lemma iff_not_consistent_insert₁ : ¬Tableau.Consistent Λ ((insert φ T), U) ↔ ∃ Γ Δ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ (∀ φ ∈ Δ, φ ∈ U) ∧ Λ ⊢! φ ⋏ ⋀Γ ➝ ⋁Δ := by
+lemma iff_not_consistent_insert₁ : ¬Tableau.Consistent H ((insert φ T), U) ↔ ∃ Γ Δ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ (∀ φ ∈ Δ, φ ∈ U) ∧ H ⊢! φ ⋏ ⋀Γ ➝ ⋁Δ := by
   constructor;
   . contrapose; push_neg; apply iff_consistent_insert₁.mpr;
   . contrapose; push_neg; apply iff_consistent_insert₁.mp;
 
-variable [Λ.IncludeEFQ]
+variable [H.IncludeEFQ]
 
-lemma iff_consistent_insert₂ : Tableau.Consistent Λ (T, (insert φ U)) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ T) → (∀ φ ∈ Δ, φ ∈ U) → Λ ⊬ ⋀Γ ➝ φ ⋎ ⋁Δ := by
+lemma iff_consistent_insert₂ : Tableau.Consistent H (T, (insert φ U)) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ φ ∈ Γ, φ ∈ T) → (∀ φ ∈ Δ, φ ∈ U) → H ⊬ ⋀Γ ➝ φ ⋎ ⋁Δ := by
   constructor;
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
-    have : Λ ⊬ ⋀Γ ➝ ⋁(φ :: Δ) := h hΓ (by simp; intro ψ hq; right; exact hΔ ψ hq);
-    have : Λ ⊢! ⋀Γ ➝ ⋁(φ :: Δ) := implyRight_cons_disj!.mpr hC;
+    have : H ⊬ ⋀Γ ➝ ⋁(φ :: Δ) := h hΓ (by simp; intro ψ hq; right; exact hΔ ψ hq);
+    have : H ⊢! ⋀Γ ➝ ⋁(φ :: Δ) := implyRight_cons_disj!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all;
-    have : Λ ⊬ ⋀Γ ➝ φ ⋎ ⋁(Δ.remove φ) := h hΓ (by
+    have : H ⊬ ⋀Γ ➝ φ ⋎ ⋁(Δ.remove φ) := h hΓ (by
       intro ψ hq;
       have := by simpa using hΔ ψ $ List.mem_of_mem_remove hq;
       cases this with
@@ -76,11 +76,11 @@ lemma iff_consistent_insert₂ : Tableau.Consistent Λ (T, (insert φ U)) ↔ �
       | inr h => assumption;
     );
     by_contra hC;
-    have : Λ ⊢! ⋀Γ ➝ φ ⋎ ⋁(Δ.remove φ) := imp_trans''! hC $ forthback_disj_remove;
+    have : H ⊢! ⋀Γ ➝ φ ⋎ ⋁(Δ.remove φ) := imp_trans''! hC $ forthback_disj_remove;
     contradiction;
 
 
-lemma iff_not_consistent_insert₂ : ¬Tableau.Consistent Λ (T, (insert φ U)) ↔ ∃ Γ Δ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ (∀ φ ∈ Δ, φ ∈ U) ∧ Λ ⊢! ⋀Γ ➝ φ ⋎ ⋁Δ := by
+lemma iff_not_consistent_insert₂ : ¬Tableau.Consistent H (T, (insert φ U)) ↔ ∃ Γ Δ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ (∀ φ ∈ Δ, φ ∈ U) ∧ H ⊢! ⋀Γ ➝ φ ⋎ ⋁Δ := by
   constructor;
   . contrapose; push_neg; apply iff_consistent_insert₂.mpr;
   . contrapose; push_neg; apply iff_consistent_insert₂.mp;
@@ -89,7 +89,7 @@ section Consistent
 
 variable {t : Tableau α}
 
-lemma consistent_either (hCon : Tableau.Consistent Λ t) (φ : Formula α) : Tableau.Consistent Λ ((insert φ t.1), t.2) ∨ Tableau.Consistent Λ (t.1, (insert φ t.2)) := by
+lemma consistent_either (hCon : Tableau.Consistent H t) (φ : Formula α) : Tableau.Consistent H ((insert φ t.1), t.2) ∨ Tableau.Consistent H (t.1, (insert φ t.2)) := by
   by_contra hC;
   push_neg at hC;
   have ⟨hC₁, hC₂⟩ := hC;
@@ -99,27 +99,27 @@ lemma consistent_either (hCon : Tableau.Consistent Λ t) (φ : Formula α) : Tab
 
   obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_consistent_insert₂.mp hC₂;
 
-  have : Λ ⊢! ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := imp_trans''! (and₁'! iff_concat_conj!) $ imp_trans''! (cut! h₁ h₂) (and₂'! iff_concact_disj!);
-  have : Λ ⊬ ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := hCon (by simp; rintro ψ (hq₁ | hq₂); exact hΓ₁ ψ hq₁; exact hΓ₂ ψ hq₂) (by simp; rintro ψ (hq₁ | hq₂); exact hΔ₁ ψ hq₁; exact hΔ₂ ψ hq₂);
+  have : H ⊢! ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := imp_trans''! (and₁'! iff_concat_conj!) $ imp_trans''! (cut! h₁ h₂) (and₂'! iff_concact_disj!);
+  have : H ⊬ ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := hCon (by simp; rintro ψ (hq₁ | hq₂); exact hΓ₁ ψ hq₁; exact hΓ₂ ψ hq₂) (by simp; rintro ψ (hq₁ | hq₂); exact hΔ₁ ψ hq₁; exact hΔ₂ ψ hq₂);
   contradiction;
 
-omit [DecidableEq α] [Λ.IncludeEFQ] in
-lemma disjoint_of_consistent (hCon : Tableau.Consistent Λ t) : Disjoint t.1 t.2 := by
+omit [DecidableEq α] [H.IncludeEFQ] in
+lemma disjoint_of_consistent (hCon : Tableau.Consistent H t) : Disjoint t.1 t.2 := by
   by_contra h;
   obtain ⟨T, hp₁, hp₂, hp⟩ := by simpa [Disjoint] using h;
   obtain ⟨φ, hp⟩ := Set.nonempty_def.mp $ Set.nonempty_iff_ne_empty.mpr hp;
   simp [Consistent] at hCon;
-  have : Λ ⊬ ⋀[φ] ➝ ⋁[φ] := hCon
+  have : H ⊬ ⋀[φ] ➝ ⋁[φ] := hCon
     (by simp_all; apply hp₁; assumption)
     (by simp_all; apply hp₂; assumption);
-  have : Λ ⊢! ⋀[φ] ➝ ⋁[φ] := by simp;
+  have : H ⊢! ⋀[φ] ➝ ⋁[φ] := by simp;
   contradiction;
 
-omit [DecidableEq α] [Λ.IncludeEFQ] in
-lemma not_mem₂ (hCon : Tableau.Consistent Λ t) {Γ : List (Formula α)} (hΓ : ∀ φ ∈ Γ, φ ∈ t.1) (h : Λ ⊢! ⋀Γ ➝ ψ) : ψ ∉ t.2 := by
+omit [DecidableEq α] [H.IncludeEFQ] in
+lemma not_mem₂ (hCon : Tableau.Consistent H t) {Γ : List (Formula α)} (hΓ : ∀ φ ∈ Γ, φ ∈ t.1) (h : H ⊢! ⋀Γ ➝ ψ) : ψ ∉ t.2 := by
   by_contra hC;
-  have : Λ ⊢! ⋀Γ ➝ ⋁[ψ] := by simpa;
-  have : Λ ⊬ ⋀Γ ➝ ⋁[ψ] := hCon (by aesop) (by aesop);
+  have : H ⊢! ⋀Γ ➝ ⋁[ψ] := by simpa;
+  have : H ⊬ ⋀Γ ➝ ⋁[ψ] := hCon (by aesop) (by aesop);
   contradiction;
 
 end Consistent
@@ -146,19 +146,19 @@ lemma mem₁_of_not_mem₂ (hMat : Saturated t) : φ ∉ t.2 → φ ∈ t.1 := b
   | inr h' => exact absurd h' h;
 
 
-lemma not_mem₁_iff_mem₂ (hCon : Tableau.Consistent Λ t) (hMat : Saturated t) : φ ∉ t.1 ↔ φ ∈ t.2 := by
+lemma not_mem₁_iff_mem₂ (hCon : Tableau.Consistent H t) (hMat : Saturated t) : φ ∉ t.1 ↔ φ ∈ t.2 := by
   constructor;
   . apply mem₂_of_not_mem₁ hMat;
   . apply Set.disjoint_right.mp $ disjoint_of_consistent hCon;
 
-lemma not_mem₂_iff_mem₁ (hCon : Tableau.Consistent Λ t) (hMat : Saturated t) : φ ∉ t.2 ↔ φ ∈ t.1 := by
+lemma not_mem₂_iff_mem₁ (hCon : Tableau.Consistent H t) (hMat : Saturated t) : φ ∉ t.2 ↔ φ ∈ t.1 := by
   constructor;
   . apply mem₁_of_not_mem₂ hMat;
   . apply Set.disjoint_left.mp $ disjoint_of_consistent hCon;
 
 lemma saturated_duality
   {t₁ t₂ : Tableau α}
-  (ct₁ : Tableau.Consistent Λ t₁) (ct₂ : Tableau.Consistent Λ t₂)
+  (ct₁ : Tableau.Consistent H t₁) (ct₂ : Tableau.Consistent H t₂)
   (st₁ : Saturated t₁) (st₂ : Saturated t₂)
   : t₁.1 = t₂.1 ↔ t₁.2 = t₂.2 := by
   constructor;
@@ -181,14 +181,14 @@ lemma saturated_duality
 
 end Saturated
 
-variable [Λ.IncludeEFQ]
+variable [H.IncludeEFQ]
 
-lemma self_consistent [h : System.Consistent Λ] : Tableau.Consistent Λ (Λ.axioms, ∅) := by
+lemma self_consistent [h : System.Consistent H] : Tableau.Consistent H (H.axioms, ∅) := by
   intro Γ Δ hΓ hΔ;
   replace hΔ : Δ = [] := List.nil_iff.mpr hΔ;
   obtain ⟨ψ, hq⟩ := h.exists_unprovable;
   by_contra hC;
-  have : Λ ⊢! ψ := by
+  have : H ⊢! ψ := by
     subst hΔ;
     simp at hC;
     exact imp_trans''! hC efq! ⨀ (by
@@ -201,60 +201,60 @@ lemma self_consistent [h : System.Consistent Λ] : Tableau.Consistent Λ (Λ.axi
 section lindenbaum
 
 variable [Encodable α]
-variable (Λ)
+variable (H)
 variable {t : Tableau α}
 
 open Classical
 open Encodable
 
-def lindenbaum_next (φ : Formula α) (t : Tableau α) : Tableau α := if Tableau.Consistent Λ (insert φ t.1, t.2) then (insert φ t.1, t.2) else (t.1, insert φ t.2)
+def lindenbaum_next (φ : Formula α) (t : Tableau α) : Tableau α := if Tableau.Consistent H (insert φ t.1, t.2) then (insert φ t.1, t.2) else (t.1, insert φ t.2)
 
 def lindenbaum_next_indexed [Encodable α] (t : Tableau α) : ℕ → Tableau α
   | 0 => t
   | i + 1 =>
     match (decode i) with
-    | some φ => (lindenbaum_next_indexed t i).lindenbaum_next Λ φ
+    | some φ => (lindenbaum_next_indexed t i).lindenbaum_next H φ
     | none => lindenbaum_next_indexed t i
-local notation:max t"[" i "]" => lindenbaum_next_indexed Λ t i
+local notation:max t"[" i "]" => lindenbaum_next_indexed H t i
 
 def lindenbaum_maximal (t : Tableau α) : Tableau α := (⋃ i, t[i].1, ⋃ i, t[i].2)
-local notation:max t"∞" => lindenbaum_maximal Λ t
+local notation:max t"∞" => lindenbaum_maximal H t
 
-variable {Λ}
+variable {H}
 
 omit [Encodable α] in
-lemma next_parametericConsistent (consistent : Tableau.Consistent Λ t) (φ : Formula α) : Tableau.Consistent Λ (t.lindenbaum_next Λ φ) := by
+lemma next_parametericConsistent (consistent : Tableau.Consistent H t) (φ : Formula α) : Tableau.Consistent H (t.lindenbaum_next H φ) := by
   simp [lindenbaum_next];
   split;
   . simpa;
   . have := consistent_either consistent φ;
     simp_all only [false_or];
 
-omit [Λ.IncludeEFQ] in
+omit [H.IncludeEFQ] in
 @[simp]
-lemma lindenbaum_next_indexed_zero {t : Tableau α} : (t.lindenbaum_next_indexed Λ 0) = t := by simp [lindenbaum_next_indexed]
+lemma lindenbaum_next_indexed_zero {t : Tableau α} : (t.lindenbaum_next_indexed H 0) = t := by simp [lindenbaum_next_indexed]
 
-lemma lindenbaum_next_indexed_parametricConsistent_succ {i : ℕ} : Tableau.Consistent Λ t[i] → Tableau.Consistent Λ t[i + 1] := by
+lemma lindenbaum_next_indexed_parametricConsistent_succ {i : ℕ} : Tableau.Consistent H t[i] → Tableau.Consistent H t[i + 1] := by
   simp [lindenbaum_next_indexed];
   split;
   . intro h; apply next_parametericConsistent; assumption;
   . tauto;
 
-omit [Λ.IncludeEFQ] in
+omit [H.IncludeEFQ] in
 lemma mem_lindenbaum_next_indexed (t) (φ : Formula α) : φ ∈ t[(encode φ) + 1].1 ∨ φ ∈ t[(encode φ) + 1].2 := by
   simp [lindenbaum_next_indexed, lindenbaum_next];
   split;
   . left; tauto;
   . right; tauto;
 
-lemma lindenbaum_next_indexed_parametricConsistent (consistent : Tableau.Consistent Λ t) (i : ℕ) : Tableau.Consistent Λ t[i] := by
+lemma lindenbaum_next_indexed_parametricConsistent (consistent : Tableau.Consistent H t) (i : ℕ) : Tableau.Consistent H t[i] := by
   induction i with
   | zero => simpa;
   | succ i ih => apply lindenbaum_next_indexed_parametricConsistent_succ; assumption;
 
 variable {m n : ℕ}
 
-omit [Λ.IncludeEFQ] in
+omit [H.IncludeEFQ] in
 lemma lindenbaum_next_indexed_subset₁_of_lt (h : m ≤ n) : t[m].1 ⊆ t[n].1 := by
   induction h with
   | refl => simp;
@@ -264,7 +264,7 @@ lemma lindenbaum_next_indexed_subset₁_of_lt (h : m ≤ n) : t[m].1 ⊆ t[n].1 
     . split <;> tauto;
     . tauto;
 
-omit [Λ.IncludeEFQ] in
+omit [H.IncludeEFQ] in
 lemma lindenbaum_next_indexed_subset₂_of_lt (h : m ≤ n) : t[m].2 ⊆ t[n].2 := by
   induction h with
   | refl => simp;
@@ -274,7 +274,7 @@ lemma lindenbaum_next_indexed_subset₂_of_lt (h : m ≤ n) : t[m].2 ⊆ t[n].2 
     . split <;> tauto;
     . tauto;
 
-lemma exists_parametricConsistent_saturated_tableau (hCon : Tableau.Consistent Λ t) : ∃ u, t ⊆ u ∧ (Tableau.Consistent Λ u) ∧ (Saturated u) := by
+lemma exists_parametricConsistent_saturated_tableau (hCon : Tableau.Consistent H t) : ∃ u, t ⊆ u ∧ (Tableau.Consistent H u) ∧ (Saturated u) := by
   use t∞;
   refine ⟨?subset, ?consistent, ?saturated⟩;
   case subset => constructor <;> apply Set.subset_iUnion_of_subset 0 (by simp);
@@ -324,10 +324,10 @@ end Tableau
 
 open Tableau
 
-structure SaturatedConsistentTableau (Λ : Hilbert α) where
+structure SaturatedConsistentTableau (H : Hilbert α) where
   tableau : Tableau α
   saturated : Saturated tableau
-  consistent : Tableau.Consistent Λ tableau
+  consistent : Tableau.Consistent H tableau
 
 alias SCT := SaturatedConsistentTableau
 
@@ -335,13 +335,13 @@ namespace SaturatedConsistentTableau
 
 variable {t₀ : Tableau α} {φ ψ : Formula α}
 
-lemma lindenbaum [Λ.IncludeEFQ] [Encodable α] (hCon : Tableau.Consistent Λ t₀) : ∃ (t : SaturatedConsistentTableau Λ), t₀ ⊆ t.tableau := by
+lemma lindenbaum [H.IncludeEFQ] [Encodable α] (hCon : Tableau.Consistent H t₀) : ∃ (t : SaturatedConsistentTableau H), t₀ ⊆ t.tableau := by
   obtain ⟨t, ht, hCon, hMax⟩ := Tableau.lindenbaum hCon;
   exact ⟨⟨t, hMax, hCon⟩, ht⟩;
 
-instance [System.Consistent Λ] [Λ.IncludeEFQ] [Encodable α] : Nonempty (SCT Λ) := ⟨lindenbaum Tableau.self_consistent |>.choose⟩
+instance [System.Consistent H] [H.IncludeEFQ] [Encodable α] : Nonempty (SCT H) := ⟨lindenbaum Tableau.self_consistent |>.choose⟩
 
-variable {t : SCT Λ}
+variable {t : SCT H}
 
 @[simp] lemma disjoint : Disjoint t.tableau.1 t.tableau.2 := t.tableau.disjoint_of_consistent t.consistent
 
@@ -349,7 +349,7 @@ lemma not_mem₁_iff_mem₂ : φ ∉ t.tableau.1 ↔ φ ∈ t.tableau.2 := Table
 
 lemma not_mem₂_iff_mem₁ : φ ∉ t.tableau.2 ↔ φ ∈ t.tableau.1 := Tableau.not_mem₂_iff_mem₁ t.consistent t.saturated
 
-variable {t t₁ t₂ : SCT Λ}
+variable {t t₁ t₂ : SCT H}
 
 lemma saturated_duality: t₁.tableau.1 = t₂.tableau.1 ↔ t₁.tableau.2 = t₂.tableau.2 := Tableau.saturated_duality t₁.consistent t₂.consistent t₁.saturated t₂.saturated
 
@@ -362,27 +362,27 @@ lemma equality_of₁ (e₁ : t₁.tableau.1 = t₂.tableau.1) : t₁ = t₂ := b
 
 lemma equality_of₂ (e₂ : t₁.tableau.2 = t₂.tableau.2) : t₁ = t₂ := equality_of₁ $ saturated_duality.mpr e₂
 
-lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ φ ∈ Γ, φ ∈ t.tableau.1) (h : Λ ⊢! ⋀Γ ➝ ψ) : ψ ∉ t.tableau.2 := t.tableau.not_mem₂ t.consistent hΓ h
+lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ φ ∈ Γ, φ ∈ t.tableau.1) (h : H ⊢! ⋀Γ ➝ ψ) : ψ ∉ t.tableau.2 := t.tableau.not_mem₂ t.consistent hΓ h
 
-lemma mdp₁ (hp₁ : φ ∈ t.tableau.1) (h : Λ ⊢! φ ➝ ψ) : ψ ∈ t.tableau.1 := by
+lemma mdp₁ (hp₁ : φ ∈ t.tableau.1) (h : H ⊢! φ ➝ ψ) : ψ ∈ t.tableau.1 := by
   apply not_mem₂_iff_mem₁.mp;
   by_contra hq₂;
-  have : Λ ⊬ φ ➝ ψ := by simpa using t.consistent (Γ := [φ]) (Δ := [ψ]) (by simpa) (by simpa);
+  have : H ⊬ φ ➝ ψ := by simpa using t.consistent (Γ := [φ]) (Δ := [ψ]) (by simpa) (by simpa);
   contradiction;
 
 @[simp]
 lemma mem₁_verum : ⊤ ∈ t.tableau.1 := by
   apply not_mem₂_iff_mem₁.mp;
   by_contra hC;
-  have : Λ ⊬ ⋀[] ➝ ⋁[⊤] := t.consistent (by simp) (by simpa);
-  have : Λ ⊢! ⋀[] ➝ ⋁[⊤] := by simp;
+  have : H ⊬ ⋀[] ➝ ⋁[⊤] := t.consistent (by simp) (by simpa);
+  have : H ⊢! ⋀[] ➝ ⋁[⊤] := by simp;
   contradiction;
 
 @[simp]
 lemma not_mem₁_falsum : ⊥ ∉ t.tableau.1 := by
   by_contra hC;
-  have : Λ ⊬ ⋀[⊥] ➝ ⋁[] := t.consistent (by simpa) (by simp);
-  have : Λ ⊢! ⋀[⊥] ➝ ⋁[] := by simp;
+  have : H ⊬ ⋀[⊥] ➝ ⋁[] := t.consistent (by simpa) (by simp);
+  have : H ⊢! ⋀[⊥] ➝ ⋁[] := by simp;
   contradiction;
 
 @[simp]
@@ -392,8 +392,8 @@ lemma iff_mem₁_and : φ ⋏ ψ ∈ t.tableau.1 ↔ φ ∈ t.tableau.1 ∧ ψ �
   . rintro ⟨hp, hq⟩;
     apply not_mem₂_iff_mem₁.mp;
     by_contra hC;
-    have : Λ ⊢! ⋀[φ, ψ] ➝ ⋁[φ ⋏ ψ] := by simp;
-    have : Λ ⊬ ⋀[φ, ψ] ➝ ⋁[φ ⋏ ψ] := t.consistent (by simp_all) (by simp_all);
+    have : H ⊢! ⋀[φ, ψ] ➝ ⋁[φ ⋏ ψ] := by simp;
+    have : H ⊬ ⋀[φ, ψ] ➝ ⋁[φ ⋏ ψ] := t.consistent (by simp_all) (by simp_all);
     contradiction;
 
 lemma iff_mem₁_conj {Γ : List (Formula α)} : ⋀Γ ∈ t.tableau.1 ↔ ∀ φ ∈ Γ, φ ∈ t.tableau.1 := by
@@ -417,8 +417,8 @@ lemma iff_mem₁_or : φ ⋎ ψ ∈ t.tableau.1 ↔ φ ∈ t.tableau.1 ∨ ψ �
     by_contra hC; push_neg at hC;
     have : φ ∈ t.tableau.2 := not_mem₁_iff_mem₂.mp hC.1;
     have : ψ ∈ t.tableau.2 := not_mem₁_iff_mem₂.mp hC.2;
-    have : Λ ⊢! ⋀[φ ⋎ ψ] ➝ ⋁[φ, ψ] := by simp;
-    have : Λ ⊬ ⋀[φ ⋎ ψ] ➝ ⋁[φ, ψ] := t.consistent (by simp_all) (by simp_all);
+    have : H ⊢! ⋀[φ ⋎ ψ] ➝ ⋁[φ, ψ] := by simp;
+    have : H ⊬ ⋀[φ ⋎ ψ] ➝ ⋁[φ, ψ] := t.consistent (by simp_all) (by simp_all);
     contradiction;
   . intro h;
     cases h with
@@ -437,15 +437,15 @@ lemma mem₂_neg_of_mem₁ [DecidableEq α] : φ ∈ t.tableau.1 → ∼φ ∈ t
   intro h;
   exact not_mem₁_iff_mem₂ (φ := ∼φ) (t := t) |>.mp $ not_mem₁_neg_of_mem₁ h;
 
-lemma mem₁_of_provable : Λ ⊢! φ → φ ∈ t.tableau.1 := by
+lemma mem₁_of_provable : H ⊢! φ → φ ∈ t.tableau.1 := by
   intro h;
   exact mdp₁ mem₁_verum $ imply₁'! h;
 
 lemma mdp₁_mem [DecidableEq α] (hp : φ ∈ t.tableau.1) (h : φ ➝ ψ ∈ t.tableau.1) : ψ ∈ t.tableau.1 := by
   apply not_mem₂_iff_mem₁.mp;
   by_contra hC;
-  have : Λ ⊬ (φ ⋏ (φ ➝ ψ)) ➝ ψ := t.consistent (Γ := [φ, φ ➝ ψ]) (Δ := [ψ]) (by aesop) (by simpa);
-  have : Λ ⊢! (φ ⋏ (φ ➝ ψ)) ➝ ψ := mdp_in!
+  have : H ⊬ (φ ⋏ (φ ➝ ψ)) ➝ ψ := t.consistent (Γ := [φ, φ ➝ ψ]) (Δ := [ψ]) (by aesop) (by simpa);
+  have : H ⊢! (φ ⋏ (φ ➝ ψ)) ➝ ψ := mdp_in!
   contradiction;
 
 end SaturatedConsistentTableau

--- a/Foundation/IntProp/ConsistentTableau.lean
+++ b/Foundation/IntProp/ConsistentTableau.lean
@@ -183,7 +183,7 @@ end Saturated
 
 variable [Λ.IncludeEFQ]
 
-lemma self_consistent [h : System.Consistent Λ] : Tableau.Consistent Λ (Ax(Λ), ∅) := by
+lemma self_consistent [h : System.Consistent Λ] : Tableau.Consistent Λ (Λ.axioms, ∅) := by
   intro Γ Δ hΓ hΔ;
   replace hΔ : Δ = [] := List.nil_iff.mpr hΔ;
   obtain ⟨ψ, hq⟩ := h.exists_unprovable;
@@ -193,7 +193,8 @@ lemma self_consistent [h : System.Consistent Λ] : Tableau.Consistent Λ (Ax(Λ)
     simp at hC;
     exact imp_trans''! hC efq! ⨀ (by
       apply iff_provable_list_conj.mpr;
-      exact λ _ hp => ⟨Deduction.eaxm $ hΓ _ hp⟩;
+      intro φ hφ;
+      exact Hilbert.Deduction.eaxm! $ hΓ _ hφ;
     );
   contradiction;
 

--- a/Foundation/IntProp/Deduction.lean
+++ b/Foundation/IntProp/Deduction.lean
@@ -7,24 +7,29 @@ namespace LO.IntProp
 variable {α : Type u}
 
 structure Hilbert (α) where
-  axiomSet : Theory α
-notation "Ax(" Λ ")" => Hilbert.axiomSet Λ
+  axioms : Theory α
 
 namespace Hilbert
 
+variable {Λ : Hilbert α}
+
+
+section
+
 class IncludeEFQ (Λ : Hilbert α) where
-  include_EFQ : 𝗘𝗙𝗤 ⊆ Ax(Λ) := by simp
+  include_EFQ : 𝗘𝗙𝗤 ⊆ Λ.axioms := by simp
 
 class IncludeLEM (Λ : Hilbert α) where
-  include_LEM : 𝗟𝗘𝗠 ⊆ Ax(Λ) := by simp
+  include_LEM : 𝗟𝗘𝗠 ⊆ Λ.axioms := by simp
 
 class IncludeDNE (Λ : Hilbert α) where
-  include_DNE : 𝗗𝗡𝗘 ⊆ Ax(Λ) := by simp
+  include_DNE : 𝗗𝗡𝗘 ⊆ Λ.axioms := by simp
 
-end Hilbert
+end
+
 
 inductive Deduction (Λ : Hilbert α) : Formula α → Type _
-  | eaxm {φ}     : φ ∈ Ax(Λ) → Deduction Λ φ
+  | eaxm {φ}     : φ ∈ Λ.axioms → Deduction Λ φ
   | mdp {φ ψ}    : Deduction Λ (φ ➝ ψ) → Deduction Λ φ → Deduction Λ ψ
   | verum        : Deduction Λ $ ⊤
   | imply₁ φ ψ   : Deduction Λ $ φ ➝ ψ ➝ φ
@@ -42,7 +47,7 @@ instance : System (Formula α) (Hilbert α) := ⟨Deduction⟩
 open Deduction
 open Hilbert
 
-variable {Λ : Hilbert α}
+section
 
 instance : System.Minimal Λ where
   mdp := mdp
@@ -72,61 +77,68 @@ instance [Λ.IncludeDNE] : System.Classical Λ where
 
 instance [DecidableEq α] [Λ.IncludeEFQ] [Λ.IncludeLEM] : System.Classical Λ where
 
-lemma Deduction.eaxm! {Λ : Hilbert α} {φ : Formula α} (h : φ ∈ Ax(Λ)) : Λ ⊢! φ := ⟨eaxm h⟩
+end
 
-
-namespace Hilbert
 
 abbrev theorems (Λ : Hilbert α) : Set (Formula α) := System.theory Λ
 
+
+section systems
+
+variable (α)
+
 protected abbrev Minimal : Hilbert α := ⟨∅⟩
 
-protected abbrev Intuitionistic : Hilbert α := ⟨𝗘𝗙𝗤⟩
-notation "𝐈𝐧𝐭" => Hilbert.Intuitionistic
-instance : IncludeEFQ (α := α) 𝐈𝐧𝐭 where
-instance : System.Intuitionistic (𝐈𝐧𝐭 : Hilbert α) where
+protected abbrev Int : Hilbert α := ⟨𝗘𝗙𝗤⟩
+instance : IncludeEFQ (Hilbert.Int α) where
+instance : System.Intuitionistic (Hilbert.Int α) where
 
-protected abbrev Classical : Hilbert α := ⟨𝗘𝗙𝗤 ∪ 𝗟𝗘𝗠⟩
-notation "𝐂𝐥" => Hilbert.Classical
-instance : IncludeLEM (α := α) 𝐂𝐥 where
-instance : IncludeEFQ (α := α) 𝐂𝐥 where
+protected abbrev Cl : Hilbert α := ⟨𝗘𝗙𝗤 ∪ 𝗟𝗘𝗠⟩
+instance : IncludeLEM (α := α) (Hilbert.Cl α) where
+instance : IncludeEFQ (α := α) (Hilbert.Cl α) where
 
--- `𝐊𝐂` from chagrov & zakharyaschev (1997)
+/--
+  `KC` from Chagrov & Zakharyaschev (1997)
+-/
 protected abbrev KC : Hilbert α := ⟨𝗘𝗙𝗤 ∪ 𝗪𝗟𝗘𝗠⟩
-notation "𝐊𝐂" => Hilbert.KC
-instance : IncludeEFQ (α := α) 𝐊𝐂 where
-instance : System.HasAxiomWeakLEM (𝐊𝐂 : Hilbert α) where
+instance : IncludeEFQ (α := α) (Hilbert.KC α) where
+instance : System.HasAxiomWeakLEM (Hilbert.KC α) where
   wlem φ := by apply eaxm; aesop;
 
--- `𝐋𝐂` from chagrov & zakharyaschev (1997)
+/--
+  `LC` from Chagrov & Zakharyaschev (1997)
+-/
 protected abbrev LC : Hilbert α := ⟨𝗘𝗙𝗤 ∪ 𝗗𝘂𝗺⟩
-notation "𝐋𝐂" => Hilbert.LC
-instance : IncludeEFQ (α := α) 𝐋𝐂 where
-instance : System.HasAxiomDummett (𝐋𝐂 : Hilbert α) where
+instance : IncludeEFQ (α := α) (Hilbert.LC α) where
+instance : System.HasAxiomDummett (Hilbert.LC α) where
   dummett φ ψ := by apply eaxm; aesop;
 
-/- MEMO:
-  Term `WeakMinimal` and `WeakClassical` are from Ariola (2007)
-  Minimal <ₛ WeakMinimal <ₛ WeakClassical <ₛ Classical
--/
+-- MEMO: Minimal <ₛ WeakMinimal <ₛ WeakClassical <ₛ Classical
 
+/--
+  `WeakMinimal` from Ariola (2007)
+-/
 protected abbrev WeakMinimal : Hilbert α := ⟨𝗟𝗘𝗠⟩
 
+
+/--
+  `WeakClassical` from Ariola (2007)
+-/
 protected abbrev WeakClassical : Hilbert α := ⟨𝗣𝗲⟩
 
+end systems
 
-end Hilbert
 
 
 namespace Deduction
 
-variable {Λ : Hilbert α}
-
 open System
+
+lemma eaxm! {Λ : Hilbert α} {φ : Formula α} (h : φ ∈ Λ.axioms) : Λ ⊢! φ := ⟨eaxm h⟩
 
 noncomputable def rec! {α : Type u} {Λ : Hilbert α}
   {motive : (a : Formula α) → Λ ⊢! a → Sort u_1}
-  (eaxm   : ∀ {φ}, (a : φ ∈ Ax(Λ)) → motive φ ⟨eaxm a⟩)
+  (eaxm   : ∀ {φ}, (a : φ ∈ Λ.axioms) → motive φ ⟨eaxm a⟩)
   (mdp    : ∀ {φ ψ}, {hpq : Λ ⊢! (φ ➝ ψ)} → {hp : Λ ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ (hpq ⨀ hp))
   (verum  : motive ⊤ verum!)
   (imply₁ : ∀ {φ ψ},   motive (φ ➝ ψ ➝ φ) imply₁!)
@@ -150,9 +162,9 @@ end Deduction
 
 open System
 
-variable {Λ₁ Λ₂ : Hilbert α}
+section
 
-lemma weaker_than_of_subset_axiomset' (hMaxm : ∀ {φ : Formula α}, φ ∈ Ax(Λ₁) → Λ₂ ⊢! φ)
+lemma weaker_than_of_subset_axiomset' {Λ₁ Λ₂ : Hilbert α} (hMaxm : ∀ {φ : Formula α}, φ ∈ Λ₁.axioms → Λ₂ ⊢! φ)
   : Λ₁ ≤ₛ Λ₂ := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
@@ -161,30 +173,30 @@ lemma weaker_than_of_subset_axiomset' (hMaxm : ∀ {φ : Formula α}, φ ∈ Ax(
   | mdp ihpq ihp => exact ihpq ⨀ ihp;
   | _ => simp;
 
-lemma weaker_than_of_subset_axiomset (hSubset : Ax(Λ₁) ⊆ Ax(Λ₂) := by aesop) : Λ₁ ≤ₛ Λ₂ := by
+lemma weaker_than_of_subset_axiomset {Λ₁ Λ₂ : Hilbert α} (hSubset : Λ₁.axioms ⊆ Λ₂.axioms := by aesop) : Λ₁ ≤ₛ Λ₂ := by
   apply weaker_than_of_subset_axiomset';
   intro φ hp;
   apply eaxm! $ hSubset hp;
 
-lemma Int_weaker_than_Cl : (𝐈𝐧𝐭 : Hilbert α) ≤ₛ 𝐂𝐥 := weaker_than_of_subset_axiomset
+lemma Int_weaker_than_Cl : (Hilbert.Int α) ≤ₛ (Hilbert.Cl α) := weaker_than_of_subset_axiomset
 
-lemma Int_weaker_than_KC : (𝐈𝐧𝐭 : Hilbert α) ≤ₛ 𝐊𝐂 := weaker_than_of_subset_axiomset
+lemma Int_weaker_than_KC : (Hilbert.Int α) ≤ₛ (Hilbert.KC α) := weaker_than_of_subset_axiomset
 
-lemma Int_weaker_than_LC : (𝐈𝐧𝐭 : Hilbert α) ≤ₛ 𝐋𝐂 := weaker_than_of_subset_axiomset
+lemma Int_weaker_than_LC : (Hilbert.Int α) ≤ₛ (Hilbert.LC α) := weaker_than_of_subset_axiomset
 
-lemma KC_weaker_than_Cl : (𝐊𝐂 : Hilbert α) ≤ₛ 𝐂𝐥 := by
+lemma KC_weaker_than_Cl : (Hilbert.KC α) ≤ₛ (Hilbert.Cl α) := weaker_than_of_subset_axiomset' $ by
+  rintro φ (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
+
+lemma LC_weaker_than_Cl [DecidableEq α] : (Hilbert.LC α) ≤ₛ (Hilbert.Cl α) := by
   apply weaker_than_of_subset_axiomset';
-  intro φ hp;
-  rcases hp with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
+  rintro φ (⟨_, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
 
-lemma LC_weaker_than_Cl [DecidableEq α] : (𝐋𝐂 : Hilbert α) ≤ₛ 𝐂𝐥 := by
-  apply weaker_than_of_subset_axiomset';
-  intro φ hp;
-  rcases hp with (⟨_, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
+end
 
-variable {φ : Formula α}
 
-theorem iff_provable_dn_efq_dne_provable [DecidableEq α] : 𝐈𝐧𝐭 ⊢! ∼∼φ ↔ 𝐂𝐥 ⊢! φ := by
+section Glivenko
+
+theorem iff_provable_dn_efq_dne_provable [DecidableEq α] : (Hilbert.Int α) ⊢! ∼∼φ ↔ (Hilbert.Cl α) ⊢! φ := by
   constructor;
   . intro d; exact dne'! $ Int_weaker_than_Cl d;
   . intro d;
@@ -199,7 +211,7 @@ theorem iff_provable_dn_efq_dne_provable [DecidableEq α] : 𝐈𝐧𝐭 ⊢! �
         subst hq;
         apply neg_equiv'!.mpr;
         apply FiniteContext.deduct'!;
-        have : [∼(ψ ⋎ ∼ψ)] ⊢[𝐈𝐧𝐭]! ∼ψ ⋏ ∼∼ψ := demorgan₃'! $ FiniteContext.id!;
+        have : [∼(ψ ⋎ ∼ψ)] ⊢[Hilbert.Int α]! ∼ψ ⋏ ∼∼ψ := demorgan₃'! $ FiniteContext.id!;
         exact neg_mdp! (and₂'! this) (and₁'! this);
     | @mdp φ ψ h₁ h₂ ih₁ ih₂ =>
       exact (dn_distribute_imply'! $ ih₁ ⟨h₁⟩) ⨀ ih₂ ⟨h₂⟩;
@@ -207,9 +219,14 @@ theorem iff_provable_dn_efq_dne_provable [DecidableEq α] : 𝐈𝐧𝐭 ⊢! �
 
 alias glivenko := iff_provable_dn_efq_dne_provable
 
-theorem iff_provable_neg_efq_provable_neg_efq [DecidableEq α] : 𝐈𝐧𝐭 ⊢! ∼φ ↔ 𝐂𝐥 ⊢! ∼φ := by
+theorem iff_provable_neg_efq_provable_neg_efq [DecidableEq α] : (Hilbert.Int α) ⊢! ∼φ ↔ (Hilbert.Cl α) ⊢! ∼φ := by
   constructor;
   . intro d; exact glivenko.mp $ dni'! d;
   . intro d; exact tne'! $ glivenko.mpr d;
+
+end Glivenko
+
+
+end Hilbert
 
 end LO.IntProp

--- a/Foundation/IntProp/Deduction.lean
+++ b/Foundation/IntProp/Deduction.lean
@@ -11,36 +11,36 @@ structure Hilbert (α) where
 
 namespace Hilbert
 
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 
 section
 
-class IncludeEFQ (Λ : Hilbert α) where
-  include_EFQ : 𝗘𝗙𝗤 ⊆ Λ.axioms := by simp
+class IncludeEFQ (H : Hilbert α) where
+  include_EFQ : 𝗘𝗙𝗤 ⊆ H.axioms := by simp
 
-class IncludeLEM (Λ : Hilbert α) where
-  include_LEM : 𝗟𝗘𝗠 ⊆ Λ.axioms := by simp
+class IncludeLEM (H : Hilbert α) where
+  include_LEM : 𝗟𝗘𝗠 ⊆ H.axioms := by simp
 
-class IncludeDNE (Λ : Hilbert α) where
-  include_DNE : 𝗗𝗡𝗘 ⊆ Λ.axioms := by simp
+class IncludeDNE (H : Hilbert α) where
+  include_DNE : 𝗗𝗡𝗘 ⊆ H.axioms := by simp
 
 end
 
 
-inductive Deduction (Λ : Hilbert α) : Formula α → Type _
-  | eaxm {φ}     : φ ∈ Λ.axioms → Deduction Λ φ
-  | mdp {φ ψ}    : Deduction Λ (φ ➝ ψ) → Deduction Λ φ → Deduction Λ ψ
-  | verum        : Deduction Λ $ ⊤
-  | imply₁ φ ψ   : Deduction Λ $ φ ➝ ψ ➝ φ
-  | imply₂ φ ψ χ : Deduction Λ $ (φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ
-  | and₁ φ ψ     : Deduction Λ $ φ ⋏ ψ ➝ φ
-  | and₂ φ ψ     : Deduction Λ $ φ ⋏ ψ ➝ ψ
-  | and₃ φ ψ     : Deduction Λ $ φ ➝ ψ ➝ φ ⋏ ψ
-  | or₁ φ ψ      : Deduction Λ $ φ ➝ φ ⋎ ψ
-  | or₂ φ ψ      : Deduction Λ $ ψ ➝ φ ⋎ ψ
-  | or₃ φ ψ χ    : Deduction Λ $ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ)
-  | neg_equiv φ  : Deduction Λ $ Axioms.NegEquiv φ
+inductive Deduction (H : Hilbert α) : Formula α → Type _
+  | eaxm {φ}     : φ ∈ H.axioms → Deduction H φ
+  | mdp {φ ψ}    : Deduction H (φ ➝ ψ) → Deduction H φ → Deduction H ψ
+  | verum        : Deduction H $ ⊤
+  | imply₁ φ ψ   : Deduction H $ φ ➝ ψ ➝ φ
+  | imply₂ φ ψ χ : Deduction H $ (φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ
+  | and₁ φ ψ     : Deduction H $ φ ⋏ ψ ➝ φ
+  | and₂ φ ψ     : Deduction H $ φ ⋏ ψ ➝ ψ
+  | and₃ φ ψ     : Deduction H $ φ ➝ ψ ➝ φ ⋏ ψ
+  | or₁ φ ψ      : Deduction H $ φ ➝ φ ⋎ ψ
+  | or₂ φ ψ      : Deduction H $ ψ ➝ φ ⋎ ψ
+  | or₃ φ ψ χ    : Deduction H $ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ)
+  | neg_equiv φ  : Deduction H $ Axioms.NegEquiv φ
 
 instance : System (Formula α) (Hilbert α) := ⟨Deduction⟩
 
@@ -49,7 +49,7 @@ open Hilbert
 
 section
 
-instance : System.Minimal Λ where
+instance : System.Minimal H where
   mdp := mdp
   verum := verum
   imply₁ := imply₁
@@ -62,25 +62,25 @@ instance : System.Minimal Λ where
   or₃ := or₃
   neg_equiv := neg_equiv
 
-instance [Λ.IncludeEFQ] : System.HasAxiomEFQ Λ where
+instance [H.IncludeEFQ] : System.HasAxiomEFQ H where
   efq _ := eaxm $ Set.mem_of_subset_of_mem IncludeEFQ.include_EFQ (by simp);
 
-instance [Λ.IncludeLEM] : System.HasAxiomLEM Λ where
+instance [H.IncludeLEM] : System.HasAxiomLEM H where
   lem _ := eaxm $ Set.mem_of_subset_of_mem IncludeLEM.include_LEM (by simp);
 
-instance [Λ.IncludeDNE] : System.HasAxiomDNE Λ where
+instance [H.IncludeDNE] : System.HasAxiomDNE H where
   dne _ := eaxm $ Set.mem_of_subset_of_mem IncludeDNE.include_DNE (by simp);
 
-instance [Λ.IncludeEFQ] : System.Intuitionistic Λ where
+instance [H.IncludeEFQ] : System.Intuitionistic H where
 
-instance [Λ.IncludeDNE] : System.Classical Λ where
+instance [H.IncludeDNE] : System.Classical H where
 
-instance [DecidableEq α] [Λ.IncludeEFQ] [Λ.IncludeLEM] : System.Classical Λ where
+instance [DecidableEq α] [H.IncludeEFQ] [H.IncludeLEM] : System.Classical H where
 
 end
 
 
-abbrev theorems (Λ : Hilbert α) : Set (Formula α) := System.theory Λ
+abbrev theorems (H : Hilbert α) : Set (Formula α) := System.theory H
 
 
 section systems
@@ -134,12 +134,12 @@ namespace Deduction
 
 open System
 
-lemma eaxm! {Λ : Hilbert α} {φ : Formula α} (h : φ ∈ Λ.axioms) : Λ ⊢! φ := ⟨eaxm h⟩
+lemma eaxm! {H : Hilbert α} {φ : Formula α} (h : φ ∈ H.axioms) : H ⊢! φ := ⟨eaxm h⟩
 
-noncomputable def rec! {α : Type u} {Λ : Hilbert α}
-  {motive : (a : Formula α) → Λ ⊢! a → Sort u_1}
-  (eaxm   : ∀ {φ}, (a : φ ∈ Λ.axioms) → motive φ ⟨eaxm a⟩)
-  (mdp    : ∀ {φ ψ}, {hpq : Λ ⊢! (φ ➝ ψ)} → {hp : Λ ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ (hpq ⨀ hp))
+noncomputable def rec! {α : Type u} {H : Hilbert α}
+  {motive : (a : Formula α) → H ⊢! a → Sort u_1}
+  (eaxm   : ∀ {φ}, (a : φ ∈ H.axioms) → motive φ ⟨eaxm a⟩)
+  (mdp    : ∀ {φ ψ}, {hpq : H ⊢! (φ ➝ ψ)} → {hp : H ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ (hpq ⨀ hp))
   (verum  : motive ⊤ verum!)
   (imply₁ : ∀ {φ ψ},   motive (φ ➝ ψ ➝ φ) imply₁!)
   (imply₂ : ∀ {φ ψ χ}, motive ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ) imply₂!)
@@ -150,7 +150,7 @@ noncomputable def rec! {α : Type u} {Λ : Hilbert α}
   (or₂    : ∀ {φ ψ},   motive (ψ ➝ φ ⋎ ψ) or₂!)
   (or₃    : ∀ {φ ψ χ}, motive ((φ ➝ χ) ➝ (ψ ➝ χ) ➝ φ ⋎ ψ ➝ χ) or₃!)
   (neg_equiv : ∀ {φ}, motive (Axioms.NegEquiv φ) neg_equiv!) :
-  {a : Formula α} → (t : Λ ⊢! a) → motive a t := by
+  {a : Formula α} → (t : H ⊢! a) → motive a t := by
   intro φ d;
   induction d.some with
   | eaxm h => exact eaxm h
@@ -164,8 +164,8 @@ open System
 
 section
 
-lemma weaker_than_of_subset_axiomset' {Λ₁ Λ₂ : Hilbert α} (hMaxm : ∀ {φ : Formula α}, φ ∈ Λ₁.axioms → Λ₂ ⊢! φ)
-  : Λ₁ ≤ₛ Λ₂ := by
+lemma weaker_than_of_subset_axiomset' {H₁ H₂ : Hilbert α} (hMaxm : ∀ {φ : Formula α}, φ ∈ H₁.axioms → H₂ ⊢! φ)
+  : H₁ ≤ₛ H₂ := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   induction h using Deduction.rec! with
@@ -173,7 +173,7 @@ lemma weaker_than_of_subset_axiomset' {Λ₁ Λ₂ : Hilbert α} (hMaxm : ∀ {�
   | mdp ihpq ihp => exact ihpq ⨀ ihp;
   | _ => simp;
 
-lemma weaker_than_of_subset_axiomset {Λ₁ Λ₂ : Hilbert α} (hSubset : Λ₁.axioms ⊆ Λ₂.axioms := by aesop) : Λ₁ ≤ₛ Λ₂ := by
+lemma weaker_than_of_subset_axiomset {H₁ H₂ : Hilbert α} (hSubset : H₁.axioms ⊆ H₂.axioms := by aesop) : H₁ ≤ₛ H₂ := by
   apply weaker_than_of_subset_axiomset';
   intro φ hp;
   apply eaxm! $ hSubset hp;

--- a/Foundation/IntProp/Heyting/Semantics.lean
+++ b/Foundation/IntProp/Heyting/Semantics.lean
@@ -92,17 +92,17 @@ lemma val_not (φ : Formula α) : ℍ ⊧ ∼φ ↔ (ℍ ⊧ₕ φ) = ⊥ := by 
 @[simp] lemma val_or (φ ψ : Formula α) : ℍ ⊧ φ ⋎ ψ ↔ (ℍ ⊧ₕ φ) ⊔ (ℍ ⊧ₕ ψ) = ⊤ := by
   simp [val_def]; rfl
 
-def mod (Λ : Hilbert α) : Set (HeytingSemantics α) := Semantics.models (HeytingSemantics α) Λ.axiomSet
+def mod (H : Hilbert α) : Set (HeytingSemantics α) := Semantics.models (HeytingSemantics α) H.axiomSet
 
-variable {Λ : Hilbert α} [Λ.IncludeEFQ]
+variable {H : Hilbert α} [H.IncludeEFQ]
 
-instance : System.Intuitionistic Λ where
+instance : System.Intuitionistic H where
 
 lemma mod_models_iff {φ : Formula α} :
-    mod.{_,w} Λ ⊧ φ ↔ ∀ ℍ : HeytingSemantics.{_,w} α, ℍ ⊧* Λ.axiomSet → ℍ ⊧ φ := by
+    mod.{_,w} H ⊧ φ ↔ ∀ ℍ : HeytingSemantics.{_,w} α, ℍ ⊧* H.axiomSet → ℍ ⊧ φ := by
   simp [mod, Semantics.models, Semantics.set_models_iff]
 
-lemma sound {φ : Formula α} (d : Λ ⊢! φ) : mod Λ ⊧ φ := by
+lemma sound {φ : Formula α} (d : H ⊢! φ) : mod H ⊧ φ := by
   rcases d with ⟨d⟩
   apply mod_models_iff.mpr fun ℍ hℍ ↦ ?_
   induction d
@@ -123,20 +123,20 @@ lemma sound {φ : Formula α} (d : Λ ⊢! φ) : mod Λ ⊧ φ := by
   case neg_equiv φ =>
     simp [Axioms.NegEquiv]
 
-instance : Sound Λ (mod Λ) := ⟨sound⟩
+instance : Sound H (mod H) := ⟨sound⟩
 
 section
 
 open System.LindenbaumAlgebra
 
-variable (Λ)
-variable [System.Consistent Λ]
+variable (H)
+variable [System.Consistent H]
 
 def lindenbaum : HeytingSemantics α where
-  Algebra := System.LindenbaumAlgebra Λ
+  Algebra := System.LindenbaumAlgebra H
   valAtom a := ⟦.atom a⟧
 
-lemma lindenbaum_val_eq : (lindenbaum Λ ⊧ₕ φ) = ⟦φ⟧ := by
+lemma lindenbaum_val_eq : (lindenbaum H ⊧ₕ φ) = ⟦φ⟧ := by
   induction φ using Formula.rec' <;> try simp [top_def, bot_def]
   case hatom => rfl
   case hverum => rfl
@@ -146,23 +146,23 @@ lemma lindenbaum_val_eq : (lindenbaum Λ ⊧ₕ φ) = ⟦φ⟧ := by
   case himp ihp ihq => simp [ihp, ihq]; rw [himp_def]
   case hneg ih => simp [ih]; rw [compl_def]
 
-variable {Λ}
+variable {H}
 
-lemma lindenbaum_complete_iff [System.Consistent Λ] {φ : Formula α} : lindenbaum Λ ⊧ φ ↔ Λ ⊢! φ := by
+lemma lindenbaum_complete_iff [System.Consistent H] {φ : Formula α} : lindenbaum H ⊧ φ ↔ H ⊢! φ := by
   simp [val_def', lindenbaum_val_eq, provable_iff_eq_top]
 
-instance : Sound Λ (lindenbaum Λ) := ⟨lindenbaum_complete_iff.mpr⟩
+instance : Sound H (lindenbaum H) := ⟨lindenbaum_complete_iff.mpr⟩
 
-instance : Complete Λ (lindenbaum Λ) := ⟨lindenbaum_complete_iff.mp⟩
+instance : Complete H (lindenbaum H) := ⟨lindenbaum_complete_iff.mp⟩
 
 end
 
-lemma complete {φ : Formula α} (h : mod.{_,u} Λ ⊧ φ) : Λ ⊢! φ := by
-  wlog Con : System.Consistent Λ
+lemma complete {φ : Formula α} (h : mod.{_,u} H ⊧ φ) : H ⊢! φ := by
+  wlog Con : System.Consistent H
   · exact System.not_consistent_iff_inconsistent.mp Con φ
   exact lindenbaum_complete_iff.mp <|
-    mod_models_iff.mp h (lindenbaum Λ) ⟨fun ψ hq ↦ lindenbaum_complete_iff.mpr <| Deduction.eaxm! hq⟩
+    mod_models_iff.mp h (lindenbaum H) ⟨fun ψ hq ↦ lindenbaum_complete_iff.mpr <| Deduction.eaxm! hq⟩
 
-instance : Complete Λ (mod.{_,u} Λ) := ⟨complete⟩
+instance : Complete H (mod.{_,u} H) := ⟨complete⟩
 
 end HeytingSemantics

--- a/Foundation/IntProp/Heyting/Semantics.lean
+++ b/Foundation/IntProp/Heyting/Semantics.lean
@@ -92,14 +92,14 @@ lemma val_not (φ : Formula α) : ℍ ⊧ ∼φ ↔ (ℍ ⊧ₕ φ) = ⊥ := by 
 @[simp] lemma val_or (φ ψ : Formula α) : ℍ ⊧ φ ⋎ ψ ↔ (ℍ ⊧ₕ φ) ⊔ (ℍ ⊧ₕ ψ) = ⊤ := by
   simp [val_def]; rfl
 
-def mod (H : Hilbert α) : Set (HeytingSemantics α) := Semantics.models (HeytingSemantics α) H.axiomSet
+def mod (H : Hilbert α) : Set (HeytingSemantics α) := Semantics.models (HeytingSemantics α) H.axioms
 
 variable {H : Hilbert α} [H.IncludeEFQ]
 
 instance : System.Intuitionistic H where
 
 lemma mod_models_iff {φ : Formula α} :
-    mod.{_,w} H ⊧ φ ↔ ∀ ℍ : HeytingSemantics.{_,w} α, ℍ ⊧* H.axiomSet → ℍ ⊧ φ := by
+    mod.{_,w} H ⊧ φ ↔ ∀ ℍ : HeytingSemantics.{_,w} α, ℍ ⊧* H.axioms → ℍ ⊧ φ := by
   simp [mod, Semantics.models, Semantics.set_models_iff]
 
 lemma sound {φ : Formula α} (d : H ⊢! φ) : mod H ⊧ φ := by
@@ -157,11 +157,13 @@ instance : Complete H (lindenbaum H) := ⟨lindenbaum_complete_iff.mp⟩
 
 end
 
+open Hilbert.Deduction
+
 lemma complete {φ : Formula α} (h : mod.{_,u} H ⊧ φ) : H ⊢! φ := by
   wlog Con : System.Consistent H
   · exact System.not_consistent_iff_inconsistent.mp Con φ
   exact lindenbaum_complete_iff.mp <|
-    mod_models_iff.mp h (lindenbaum H) ⟨fun ψ hq ↦ lindenbaum_complete_iff.mpr <| Deduction.eaxm! hq⟩
+    mod_models_iff.mp h (lindenbaum H) ⟨fun ψ hq ↦ lindenbaum_complete_iff.mpr <| eaxm! hq⟩
 
 instance : Complete H (mod.{_,u} H) := ⟨complete⟩
 

--- a/Foundation/IntProp/Kripke/Completeness.lean
+++ b/Foundation/IntProp/Kripke/Completeness.lean
@@ -14,39 +14,39 @@ open Kripke
 namespace Kripke
 
 variable {α : Type u}
-         {Λ : Hilbert α}
+         {H : Hilbert α}
 
 open SaturatedConsistentTableau
 
-def CanonicalFrame (Λ : Hilbert α) [Nonempty (SCT Λ)] : Kripke.Frame.Dep α where
-  World := SCT Λ
+def CanonicalFrame (H : Hilbert α) [Nonempty (SCT H)] : Kripke.Frame.Dep α where
+  World := SCT H
   Rel t₁ t₂ := t₁.tableau.1 ⊆ t₂.tableau.1
 
 namespace CanonicalFrame
 
-variable [Nonempty (SCT Λ)]
+variable [Nonempty (SCT H)]
 
-lemma reflexive : Reflexive (CanonicalFrame Λ) := by
+lemma reflexive : Reflexive (CanonicalFrame H) := by
   simp [CanonicalFrame];
   intro x;
   apply Set.Subset.refl;
 
-lemma antisymmetric : Antisymmetric (CanonicalFrame Λ) := by
+lemma antisymmetric : Antisymmetric (CanonicalFrame H) := by
   simp [CanonicalFrame];
   intro x y Rxy Ryx;
   exact equality_of₁ $ Set.Subset.antisymm Rxy Ryx;
 
-lemma transitive : Transitive (CanonicalFrame Λ) := by
+lemma transitive : Transitive (CanonicalFrame H) := by
   simp [CanonicalFrame];
   intro x y z;
   apply Set.Subset.trans;
 
 open Classical in
-lemma confluent [Encodable α] [Λ.IncludeEFQ] [HasAxiomWeakLEM Λ] : Confluent (CanonicalFrame Λ) := by
+lemma confluent [Encodable α] [H.IncludeEFQ] [HasAxiomWeakLEM H] : Confluent (CanonicalFrame H) := by
   simp [Confluent, CanonicalFrame];
   intro x y z Rxy Rxz;
-  suffices Tableau.Consistent Λ (y.tableau.1 ∪ z.tableau.1, ∅) by
-    obtain ⟨w, hw⟩ := lindenbaum (Λ := Λ) this;
+  suffices Tableau.Consistent H (y.tableau.1 ∪ z.tableau.1, ∅) by
+    obtain ⟨w, hw⟩ := lindenbaum (H := H) this;
     use w;
     simp_all;
 
@@ -77,17 +77,17 @@ lemma confluent [Encodable α] [Λ.IncludeEFQ] [HasAxiomWeakLEM Λ] : Confluent 
       intro φ hp;
       have := by simpa using List.of_mem_filter hp;
       exact this.1;
-    have : Λ ⊬ ⋀Θy ⋏ ∼⋀Θy ➝ ⊥ := y.consistent (Γ := [⋀Θy, ∼⋀Θy]) (Δ := []) (by simp; constructor <;> assumption) (by simp);
-    have : Λ ⊢! ⋀Θy ⋏ ∼⋀Θy ➝ ⊥ := by simp;
+    have : H ⊬ ⋀Θy ⋏ ∼⋀Θy ➝ ⊥ := y.consistent (Γ := [⋀Θy, ∼⋀Θy]) (Δ := []) (by simp; constructor <;> assumption) (by simp);
+    have : H ⊢! ⋀Θy ⋏ ∼⋀Θy ➝ ⊥ := by simp;
     contradiction;
 
-  have : Λ ⊢! (⋀Θx ⋏ (⋀Θy ⋏ ⋀Θz)) ➝ ⊥ := imp_trans''! (by
+  have : H ⊢! (⋀Θx ⋏ (⋀Θy ⋏ ⋀Θz)) ➝ ⊥ := imp_trans''! (by
     -- TODO: need more refactor
-    have d₁ : Λ ⊢! ⋀Θx ⋏ ⋀(Θy ++ Θz) ➝ ⋀(Θx ++ (Θy ++ Θz)) := and₂'! $ iff_concat_conj!;
-    have d₂ : Λ ⊢! ⋀Θy ⋏ ⋀Θz ➝ ⋀(Θy ++ Θz) := and₂'! $ iff_concat_conj!;
-    have d₃ : Λ ⊢! ⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz ➝ ⋀(Θx ++ (Θy ++ Θz)) := imp_trans''! (by
+    have d₁ : H ⊢! ⋀Θx ⋏ ⋀(Θy ++ Θz) ➝ ⋀(Θx ++ (Θy ++ Θz)) := and₂'! $ iff_concat_conj!;
+    have d₂ : H ⊢! ⋀Θy ⋏ ⋀Θz ➝ ⋀(Θy ++ Θz) := and₂'! $ iff_concat_conj!;
+    have d₃ : H ⊢! ⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz ➝ ⋀(Θx ++ (Θy ++ Θz)) := imp_trans''! (by
       apply deduct'!;
-      have : [⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz] ⊢[Λ]! ⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz := FiniteContext.by_axm!;
+      have : [⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz] ⊢[H]! ⋀Θx ⋏ ⋀Θy ⋏ ⋀Θz := FiniteContext.by_axm!;
       apply and₃'!;
       . exact and₁'! this;
       . exact (FiniteContext.of'! d₂) ⨀ (and₂'! this);
@@ -112,9 +112,9 @@ lemma confluent [Encodable α] [Λ.IncludeEFQ] [HasAxiomWeakLEM Λ] : Confluent 
         . assumption;
         . exact hz₁ hz;
   ) h;
-  have : Λ ⊢! ⋀Θx ➝ ⋀Θy ➝ ∼⋀Θz := and_imply_iff_imply_imply'!.mp $
+  have : H ⊢! ⋀Θx ➝ ⋀Θy ➝ ∼⋀Θz := and_imply_iff_imply_imply'!.mp $
     (imp_trans''! (and_imply_iff_imply_imply'!.mp $ imp_trans''! (and₁'! and_assoc!) this) (and₂'! $ neg_equiv!));
-  have d : Λ ⊢! ⋀Θx ➝ ∼∼⋀Θz ➝ ∼⋀Θy := imp_trans''! this contra₀!;
+  have d : H ⊢! ⋀Θx ➝ ∼∼⋀Θz ➝ ∼⋀Θy := imp_trans''! this contra₀!;
 
   have mem_Θx_x : ⋀Θx ∈ x.tableau.1 := iff_mem₁_conj.mpr $ by
     intro φ hp;
@@ -132,7 +132,7 @@ lemma confluent [Encodable α] [Λ.IncludeEFQ] [HasAxiomWeakLEM Λ] : Confluent 
   exact mdp₁_mem mem_nnΘz_x $ mdp₁ mem_Θx_x d;
 
 
-lemma connected [DecidableEq α] [HasAxiomDummett Λ] : Connected (CanonicalFrame Λ) := by
+lemma connected [DecidableEq α] [HasAxiomDummett H] : Connected (CanonicalFrame H) := by
   simp [Connected, CanonicalFrame];
   intro x y z Rxy Ryz;
   apply or_iff_not_imp_left.mpr;
@@ -153,45 +153,45 @@ lemma connected [DecidableEq α] [HasAxiomDummett Λ] : Connected (CanonicalFram
 end CanonicalFrame
 
 
-def CanonicalModel (Λ : Hilbert α) [Nonempty (SCT Λ)] : Kripke.Model α where
-  Frame := CanonicalFrame Λ
+def CanonicalModel (H : Hilbert α) [Nonempty (SCT H)] : Kripke.Model α where
+  Frame := CanonicalFrame H
   Valuation t a := (atom a) ∈ t.tableau.1
   -- hereditary := by aesop;
 
 namespace CanonicalModel
 
-variable [Nonempty (SCT Λ)] {t t₁ t₂ : SCT Λ}
+variable [Nonempty (SCT H)] {t t₁ t₂ : SCT H}
 
-lemma hereditary : (CanonicalModel Λ).Valuation.atomic_hereditary := by
+lemma hereditary : (CanonicalModel H).Valuation.atomic_hereditary := by
   intros _ _;
   aesop;
 
 @[reducible]
-instance : Semantics (Formula α) (CanonicalModel Λ).World := Formula.Kripke.Satisfies.semantics (CanonicalModel Λ)
+instance : Semantics (Formula α) (CanonicalModel H).World := Formula.Kripke.Satisfies.semantics (CanonicalModel H)
 
-@[simp] lemma frame_def : (CanonicalModel Λ).Frame t₁ t₂ ↔ t₁.tableau.1 ⊆ t₂.tableau.1 := by rfl
-@[simp] lemma valuation_def {a : α} : (CanonicalModel Λ).Valuation t a ↔ (atom a) ∈ t.tableau.1 := by rfl
+@[simp] lemma frame_def : (CanonicalModel H).Frame t₁ t₂ ↔ t₁.tableau.1 ⊆ t₂.tableau.1 := by rfl
+@[simp] lemma valuation_def {a : α} : (CanonicalModel H).Valuation t a ↔ (atom a) ∈ t.tableau.1 := by rfl
 
 end CanonicalModel
 
 section
 
-variable [Nonempty (SCT Λ)]
+variable [Nonempty (SCT H)]
 
-variable {t : SCT Λ} {φ ψ : Formula α}
+variable {t : SCT H} {φ ψ : Formula α}
 
 private lemma truthlemma.himp
-  [Λ.IncludeEFQ] [Encodable α] [DecidableEq α]
-  {t : (CanonicalModel Λ).World}
-  (ihp : ∀ {t : (CanonicalModel Λ).World}, t ⊧ φ ↔ φ ∈ t.tableau.1)
-  (ihq : ∀ {t : (CanonicalModel Λ).World}, t ⊧ ψ ↔ ψ ∈ t.tableau.1)
+  [H.IncludeEFQ] [Encodable α] [DecidableEq α]
+  {t : (CanonicalModel H).World}
+  (ihp : ∀ {t : (CanonicalModel H).World}, t ⊧ φ ↔ φ ∈ t.tableau.1)
+  (ihq : ∀ {t : (CanonicalModel H).World}, t ⊧ ψ ↔ ψ ∈ t.tableau.1)
   : t ⊧ φ ➝ ψ ↔ φ ➝ ψ ∈ t.tableau.1 := by
   constructor;
   . contrapose;
     simp_all [Satisfies];
     intro h;
     replace h := not_mem₁_iff_mem₂.mp h;
-    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (Λ := Λ) (t₀ := (insert φ t.tableau.1, {ψ})) $ by
+    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (H := H) (t₀ := (insert φ t.tableau.1, {ψ})) $ by
       simp only [Tableau.Consistent];
       intro Γ Δ hΓ hΔ;
       replace hΓ : ∀ χ, χ ∈ Γ.remove φ → χ ∈ t.tableau.1 := by
@@ -200,14 +200,14 @@ private lemma truthlemma.himp
         have := by simpa using hΓ χ hr₁;
         simp_all;
       by_contra hC;
-      have : Λ ⊢! ⋀(Γ.remove φ) ➝ (φ ➝ ψ) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (by
+      have : H ⊢! ⋀(Γ.remove φ) ➝ (φ ➝ ψ) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (by
         apply deduct'!;
         apply deduct!;
-        have : [φ, φ ➝ ⋁Δ] ⊢[Λ]! φ := by_axm!;
-        have : [φ, φ ➝ ⋁Δ] ⊢[Λ]! ⋁Δ := by_axm! ⨀ this;
+        have : [φ, φ ➝ ⋁Δ] ⊢[H]! φ := by_axm!;
+        have : [φ, φ ➝ ⋁Δ] ⊢[H]! ⋁Δ := by_axm! ⨀ this;
         exact disj_allsame'! (by simpa using hΔ) this;
       )
-      have : Λ ⊬ ⋀(Γ.remove φ) ➝ (φ ➝ ψ) := by simpa using (t.consistent hΓ (show ∀ χ ∈ [φ ➝ ψ], χ ∈ t.tableau.2 by simp_all));
+      have : H ⊬ ⋀(Γ.remove φ) ➝ (φ ➝ ψ) := by simpa using (t.consistent hΓ (show ∀ χ ∈ [φ ➝ ψ], χ ∈ t.tableau.2 by simp_all));
       contradiction;
     have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
     use t';
@@ -225,7 +225,7 @@ private lemma truthlemma.himp
     apply not_mem₂_iff_mem₁.mp;
     exact not_mem₂
       (by simp_all)
-      (show Λ ⊢! ⋀[φ, φ ➝ ψ] ➝ ψ by
+      (show H ⊢! ⋀[φ, φ ➝ ψ] ➝ ψ by
         simp;
         apply and_imply_iff_imply_imply'!.mpr;
         apply deduct'!;
@@ -234,16 +234,16 @@ private lemma truthlemma.himp
       );
 
 private lemma truthlemma.hneg
-  [Λ.IncludeEFQ] [Encodable α] [DecidableEq α]
-  {t : (CanonicalModel Λ).World}
-  (ihp : ∀ {t : (CanonicalModel Λ).World}, t ⊧ φ ↔ φ ∈ t.tableau.1)
+  [H.IncludeEFQ] [Encodable α] [DecidableEq α]
+  {t : (CanonicalModel H).World}
+  (ihp : ∀ {t : (CanonicalModel H).World}, t ⊧ φ ↔ φ ∈ t.tableau.1)
   : t ⊧ ∼φ ↔ ∼φ ∈ t.tableau.1 := by
   constructor;
   . contrapose;
     simp_all [Satisfies];
     intro h;
     replace h := not_mem₁_iff_mem₂.mp h;
-    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (Λ := Λ) (t₀ := (insert φ t.tableau.1, ∅)) $ by
+    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (H := H) (t₀ := (insert φ t.tableau.1, ∅)) $ by
       simp only [Tableau.Consistent];
       intro Γ Δ hΓ hΔ;
       replace hΓ : ∀ ψ, ψ ∈ Γ.remove φ → ψ ∈ t.tableau.1 := by
@@ -253,8 +253,8 @@ private lemma truthlemma.hneg
         simp_all;
       replace hΔ : Δ = [] := List.nil_iff.mpr hΔ; subst hΔ;
       by_contra hC; simp at hC;
-      have : Λ ⊢! ⋀(Γ.remove φ) ➝ ∼φ := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (and₂'! neg_equiv!);
-      have : Λ ⊬ ⋀(Γ.remove φ) ➝ ∼φ := by simpa using t.consistent (Δ := [∼φ]) hΓ (by simpa);
+      have : H ⊢! ⋀(Γ.remove φ) ➝ ∼φ := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (and₂'! neg_equiv!);
+      have : H ⊬ ⋀(Γ.remove φ) ➝ ∼φ := by simpa using t.consistent (Δ := [∼φ]) hΓ (by simpa);
       contradiction;
     have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
     use t';
@@ -262,31 +262,31 @@ private lemma truthlemma.hneg
     intro ht t' htt';
     apply ihp.not.mpr;
     by_contra hC;
-    have : Λ ⊬ φ ⋏ ∼φ ➝ ⊥ := by simpa using t'.consistent (Γ := [φ, ∼φ]) (Δ := []) (by aesop) (by simp);
-    have : Λ ⊢! φ ⋏ ∼φ ➝ ⊥ := intro_bot_of_and!;
+    have : H ⊬ φ ⋏ ∼φ ➝ ⊥ := by simpa using t'.consistent (Γ := [φ, ∼φ]) (Δ := []) (by aesop) (by simp);
+    have : H ⊢! φ ⋏ ∼φ ➝ ⊥ := intro_bot_of_and!;
     contradiction;
 
 lemma truthlemma
-  [Λ.IncludeEFQ] [Encodable α] [DecidableEq α]
-  {t : (CanonicalModel Λ).World} : t ⊧ φ ↔ φ ∈ t.tableau.1 := by
+  [H.IncludeEFQ] [Encodable α] [DecidableEq α]
+  {t : (CanonicalModel H).World} : t ⊧ φ ↔ φ ∈ t.tableau.1 := by
   induction φ using Formula.rec' generalizing t with
   | himp φ ψ ihp ihq => exact truthlemma.himp ihp ihq
   | hneg φ ihp => exact truthlemma.hneg ihp;
   | _ => simp [Satisfies.iff_models, Satisfies, *];
 
 lemma deducible_of_validOnCanonicelModel
-  [Λ.IncludeEFQ] [Encodable α] [DecidableEq α]
-  : (CanonicalModel Λ) ⊧ φ ↔ Λ ⊢! φ := by
+  [H.IncludeEFQ] [Encodable α] [DecidableEq α]
+  : (CanonicalModel H) ⊧ φ ↔ H ⊢! φ := by
   constructor;
   . contrapose;
     intro h;
-    have : Tableau.Consistent Λ (∅, {φ}) := by
+    have : Tableau.Consistent H (∅, {φ}) := by
       simp only [Tableau.Consistent, Collection.not_mem_empty, imp_false, Set.mem_singleton_iff];
       rintro Γ Δ hΓ hΔ;
       by_contra hC;
       replace hΓ : Γ = [] := List.nil_iff.mpr hΓ;
       subst hΓ;
-      have : Λ ⊢! φ := disj_allsame'! hΔ (hC ⨀ verum!);
+      have : H ⊢! φ := disj_allsame'! hΔ (hC ⨀ verum!);
       contradiction;
     obtain ⟨t', ht'⟩ := lindenbaum this;
     simp [ValidOnModel.iff_models, ValidOnModel]
@@ -301,19 +301,19 @@ lemma deducible_of_validOnCanonicelModel
 
 section
 
-variable [System.Consistent Λ]
-variable [DecidableEq α] [Encodable α] [Λ.IncludeEFQ]
+variable [System.Consistent H]
+variable [DecidableEq α] [Encodable α] [H.IncludeEFQ]
 variable {𝔽 : Kripke.FrameClass}
 
-omit [Consistent Λ] in
-lemma complete (H : CanonicalFrame Λ ∈ 𝔽) {φ : Formula α} : 𝔽#α ⊧ φ → Λ ⊢! φ := by
+omit [Consistent H] in
+lemma complete (hC : CanonicalFrame H ∈ 𝔽) {φ : Formula α} : 𝔽#α ⊧ φ → H ⊢! φ := by
   intro h;
   apply deducible_of_validOnCanonicelModel.mp;
   apply h;
-  . exact H;
+  . exact hC;
   . exact CanonicalModel.hereditary;
 
-instance instComplete (H : CanonicalFrame Λ ∈ 𝔽) : Complete Λ (𝔽#α) := ⟨complete H⟩
+instance instComplete (hC : CanonicalFrame H ∈ 𝔽) : Complete H (𝔽#α) := ⟨complete hC⟩
 
 instance Int_complete : Complete (Hilbert.Int α) (Kripke.ReflexiveTransitiveFrameClass.{u}#α) := instComplete $ by
   refine ⟨

--- a/Foundation/IntProp/Kripke/Completeness.lean
+++ b/Foundation/IntProp/Kripke/Completeness.lean
@@ -13,7 +13,6 @@ open Kripke
 
 namespace Kripke
 
--- variable [Inhabited α] [DecidableEq α] [Encodable α] [Λ.IncludeEFQ]
 variable {α : Type u}
          {Λ : Hilbert α}
 
@@ -316,20 +315,20 @@ lemma complete (H : CanonicalFrame Λ ∈ 𝔽) {φ : Formula α} : 𝔽#α ⊧ 
 
 instance instComplete (H : CanonicalFrame Λ ∈ 𝔽) : Complete Λ (𝔽#α) := ⟨complete H⟩
 
-instance Int_complete : Complete 𝐈𝐧𝐭 (Kripke.ReflexiveTransitiveFrameClass.{u}#α) := instComplete $ by
+instance Int_complete : Complete (Hilbert.Int α) (Kripke.ReflexiveTransitiveFrameClass.{u}#α) := instComplete $ by
   refine ⟨
     CanonicalFrame.reflexive,
     CanonicalFrame.transitive,
   ⟩
 
-instance LC_complete : Complete 𝐋𝐂 (Kripke.ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete $ by
+instance LC_complete : Complete (Hilbert.LC α) (Kripke.ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete $ by
   refine ⟨
     CanonicalFrame.reflexive,
     CanonicalFrame.transitive,
     CanonicalFrame.connected
   ⟩;
 
-instance KC_complete : Complete 𝐊𝐂 (Kripke.ReflexiveTransitiveConfluentFrameClass.{u}#α) := instComplete $ by
+instance KC_complete : Complete (Hilbert.KC α) (Kripke.ReflexiveTransitiveConfluentFrameClass.{u}#α) := instComplete $ by
   refine ⟨
     CanonicalFrame.reflexive,
     CanonicalFrame.transitive,

--- a/Foundation/IntProp/Kripke/DP.lean
+++ b/Foundation/IntProp/Kripke/DP.lean
@@ -110,7 +110,7 @@ lemma satisfies_right_on_IntDPCounterexampleModel :
       exact ihq.mpr $ h (by simpa) $ ihp.mp hp;
   | _ => simp_all [IntDPCounterexampleModel, Satisfies.iff_models, Satisfies];
 
-theorem disjunctive_int [Inhabited α] [DecidableEq α] [Encodable α] : 𝐈𝐧𝐭 ⊢! φ ⋎ ψ → 𝐈𝐧𝐭 ⊢! φ ∨ 𝐈𝐧𝐭 ⊢! ψ := by
+theorem disjunctive_int [Inhabited α] [DecidableEq α] [Encodable α] : (Hilbert.Int α) ⊢! φ ⋎ ψ → (Hilbert.Int α) ⊢! φ ∨ (Hilbert.Int α) ⊢! ψ := by
   contrapose;
   intro hC; push_neg at hC;
   have ⟨hnp, hnq⟩ := hC;
@@ -140,7 +140,7 @@ theorem disjunctive_int [Inhabited α] [DecidableEq α] [Encodable α] : 𝐈�
           (w := Sum.inl ()) (w' := Sum.inr $ Sum.inr wq) (by aesop))
         $ satisfies_right_on_IntDPCounterexampleModel |>.not.mp hq;
 
-instance [DecidableEq α] [Inhabited α] [Encodable α] : Disjunctive (𝐈𝐧𝐭 : Hilbert α) := ⟨disjunctive_int⟩
+instance [DecidableEq α] [Inhabited α] [Encodable α] : Disjunctive (Hilbert.Int α) := ⟨disjunctive_int⟩
 
 end Kripke
 

--- a/Foundation/IntProp/Kripke/LEM.lean
+++ b/Foundation/IntProp/Kripke/LEM.lean
@@ -7,11 +7,11 @@ import Foundation.IntProp.Kripke.Semantics
   - `noLEM`: LEM is not always valid in intuitionistic logic.
 -/
 
-namespace LO.IntProp.Kripke
+namespace LO.IntProp
 
 open System
-
 open Formula Formula.Kripke
+
 
 variable {α : Type u}
 
@@ -24,32 +24,38 @@ abbrev NoLEMFrame : Kripke.Frame where
     | .inl _, .inr _ => True
     | _, _ => False
 
-lemma NoLEMFrame.transitive : Transitive NoLEMFrame.Rel := by simp [Transitive];
+namespace NoLEMFrame
 
-lemma NoLEMFrame.reflexive : Reflexive NoLEMFrame.Rel := by simp [Reflexive];
+lemma is_transitive : Transitive NoLEMFrame.Rel := by simp [Transitive];
 
-lemma NoLEMFrame.confluent : Confluent NoLEMFrame.Rel := by simp [Confluent];
+lemma is_reflexive : Reflexive NoLEMFrame.Rel := by simp [Reflexive];
 
-lemma NoLEMFrame.connected : Connected NoLEMFrame.Rel := by simp [Connected];
+lemma is_confluent : Confluent NoLEMFrame.Rel := by simp [Confluent];
 
-lemma noLEM_on_frameclass [Inhabited α] : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} 𝐈𝐧𝐭) ⊧ φ ⋎ ∼φ) := by
+lemma is_connected : Connected NoLEMFrame.Rel := by simp [Connected];
+
+end NoLEMFrame
+
+
+lemma Kripke.noLEM_on_frameclass [Inhabited α] : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} (Hilbert.Int α)) ⊧ φ ⋎ ∼φ) := by
   use (atom default);
   simp [Semantics.Realize];
   use NoLEMFrame;
   constructor;
   . apply Int_Characteraizable.characterize;
-    exact ⟨NoLEMFrame.reflexive, NoLEMFrame.transitive⟩;
+    exact ⟨NoLEMFrame.is_reflexive, NoLEMFrame.is_transitive⟩;
   . simp [ValidOnFrame];
     use (λ w _ => match w with | .inr _ => True | .inl _ => False);
     constructor;
     . simp;
     . simp [ValidOnModel, Satisfies];
 
+
 /--
   Law of Excluded Middle is not always provable in intuitionistic logic.
 -/
-theorem noLEM [Inhabited α] : ∃ (φ : Formula α), 𝐈𝐧𝐭 ⊬ φ ⋎ ∼φ := by
-  obtain ⟨φ, hp⟩ := noLEM_on_frameclass (α := α);
+theorem Hilbert.Int.noLEM [Inhabited α] : ∃ (φ : Formula α), (Hilbert.Int α) ⊬ φ ⋎ ∼φ := by
+  obtain ⟨φ, hp⟩ := Kripke.noLEM_on_frameclass (α := α);
   use φ;
   by_contra hC;
   have := @Kripke.sound _ _ _ hC;
@@ -58,47 +64,46 @@ theorem noLEM [Inhabited α] : ∃ (φ : Formula α), 𝐈𝐧𝐭 ⊬ φ ⋎ �
 /--
   Intuitionistic logic is proper weaker than classical logic.
 -/
-theorem Int_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (𝐈𝐧𝐭 : Hilbert α) <ₛ 𝐂𝐥 := by
+theorem Hilbert.Int_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (Hilbert.Int α) <ₛ (Hilbert.Cl α) := by
   constructor;
-  . exact Int_weaker_than_Cl;
+  . exact Hilbert.Int_weaker_than_Cl;
   . apply weakerThan_iff.not.mpr;
     push_neg;
-    obtain ⟨φ, hp⟩ := noLEM (α := α);
+    obtain ⟨φ, hp⟩ := Hilbert.Int.noLEM (α := α);
     use (φ ⋎ ∼φ);
     constructor;
     . exact lem!;
     . assumption;
 
 
-
 section
 
-lemma noLEM_on_frameclass_KC [DecidableEq α] [Inhabited α]  : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} 𝐊𝐂) ⊧ φ ⋎ ∼φ) := by
+lemma Kripke.noLEM_on_frameclass_KC [DecidableEq α] [Inhabited α]  : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} (Hilbert.KC α)) ⊧ φ ⋎ ∼φ) := by
   use (atom default);
   simp [Semantics.Realize];
   use NoLEMFrame;
   constructor;
-  . apply KC_Characteraizable.characterize;
-    exact ⟨NoLEMFrame.reflexive, NoLEMFrame.transitive, NoLEMFrame.confluent⟩;
+  . apply Kripke.KC_Characteraizable.characterize;
+    exact ⟨NoLEMFrame.is_reflexive, NoLEMFrame.is_transitive, NoLEMFrame.is_confluent⟩;
   . simp [ValidOnFrame];
     use (λ w _ => match w with | .inr _ => True | .inl _ => False);
     constructor;
     . simp;
     . simp [ValidOnModel, Satisfies];
 
-lemma noLEM_KC [DecidableEq α] [Inhabited α] : ∃ (φ : Formula α), 𝐊𝐂 ⊬ φ ⋎ ∼φ := by
-  obtain ⟨φ, hp⟩ := noLEM_on_frameclass_KC (α := α);
+lemma Hilbert.KC.noLEM [DecidableEq α] [Inhabited α] : ∃ (φ : Formula α), (Hilbert.KC α) ⊬ φ ⋎ ∼φ := by
+  obtain ⟨φ, hp⟩ := Kripke.noLEM_on_frameclass_KC (α := α);
   use φ;
   by_contra hC;
   have := @Kripke.sound _ _ _ hC;
   contradiction;
 
-theorem KC_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (𝐊𝐂 : Hilbert α) <ₛ 𝐂𝐥 := by
+theorem Hilbert.KC_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (Hilbert.KC α) <ₛ (Hilbert.Cl α) := by
   constructor;
-  . exact KC_weaker_than_Cl;
+  . exact Hilbert.KC_weaker_than_Cl;
   . apply weakerThan_iff.not.mpr;
     push_neg;
-    obtain ⟨φ, hp⟩ := noLEM_KC (α := α);
+    obtain ⟨φ, hp⟩ := Hilbert.KC.noLEM (α := α);
     use (φ ⋎ ∼φ);
     constructor;
     . exact lem!;
@@ -109,32 +114,32 @@ end
 
 section
 
-lemma noLEM_on_frameclass_LC [Inhabited α] : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} 𝐋𝐂) ⊧ φ ⋎ ∼φ) := by
+lemma Kripke.noLEM_on_frameclass_LC [Inhabited α] : ∃ (φ : Formula α), ¬((Kripke.FrameClassOfHilbert.{u, 0} (Hilbert.LC α)) ⊧ φ ⋎ ∼φ) := by
   use (atom default);
   simp [Semantics.Realize];
   use NoLEMFrame;
   constructor;
   . apply LC_Characteraizable.characterize;
-    exact ⟨NoLEMFrame.reflexive, NoLEMFrame.transitive, NoLEMFrame.connected⟩;
+    exact ⟨NoLEMFrame.is_reflexive, NoLEMFrame.is_transitive, NoLEMFrame.is_connected⟩;
   . simp [ValidOnFrame];
     use (λ w _ => match w with | .inr _ => True | .inl _ => False);
     constructor;
     . simp;
     . simp [ValidOnModel, Satisfies];
 
-lemma noLEM_LC [Inhabited α] : ∃ (φ : Formula α), 𝐋𝐂 ⊬ φ ⋎ ∼φ := by
-  obtain ⟨φ, hp⟩ := noLEM_on_frameclass_LC (α := α);
+lemma Hilbert.LC.noLEM [Inhabited α] : ∃ (φ : Formula α), (Hilbert.LC α) ⊬ φ ⋎ ∼φ := by
+  obtain ⟨φ, hp⟩ := Kripke.noLEM_on_frameclass_LC (α := α);
   use φ;
   by_contra hC;
   have := @Kripke.sound _ _ _ hC;
   contradiction;
 
-theorem LC_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (𝐋𝐂 : Hilbert α) <ₛ 𝐂𝐥 := by
+theorem Hilbert.LC_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (Hilbert.LC α) <ₛ (Hilbert.Cl α) := by
   constructor;
-  . exact LC_weaker_than_Cl;
+  . exact Hilbert.LC_weaker_than_Cl;
   . apply weakerThan_iff.not.mpr;
     push_neg;
-    obtain ⟨φ, hp⟩ := noLEM_LC (α := α);
+    obtain ⟨φ, hp⟩ := Hilbert.LC.noLEM (α := α);
     use (φ ⋎ ∼φ);
     constructor;
     . exact lem!;
@@ -142,5 +147,4 @@ theorem LC_strictly_weaker_than_Cl [DecidableEq α] [Inhabited α] : (𝐋𝐂 :
 
 end
 
-
-end LO.IntProp.Kripke
+end LO.IntProp

--- a/Foundation/IntProp/Kripke/Semantics.lean
+++ b/Foundation/IntProp/Kripke/Semantics.lean
@@ -309,11 +309,11 @@ section
 
 variable {α : Type u}
 
-instance Int_Characteraizable : 𝔽((𝐈𝐧𝐭 : Hilbert α)).Characteraizable ReflexiveTransitiveFrameClass where
+instance Int_Characteraizable : 𝔽((Hilbert.Int α)).Characteraizable ReflexiveTransitiveFrameClass where
   characterize := by
     simp [System.theory];
     rintro F hTrans hRefl φ hp;
-    induction hp using Deduction.rec! with
+    induction hp using Hilbert.Deduction.rec! with
     | verum => apply ValidOnFrame.verum;
     | imply₁ => apply ValidOnFrame.imply₁; simpa;
     | imply₂ => apply ValidOnFrame.imply₂; simpa; simpa;
@@ -335,16 +335,16 @@ instance Int_Characteraizable : 𝔽((𝐈𝐧𝐭 : Hilbert α)).Characteraizab
     refine ⟨by simp [Reflexive], by simp [Transitive]⟩;
 
 
-instance Int_sound : Sound 𝐈𝐧𝐭 (ReflexiveTransitiveFrameClass#α) := inferInstance
+instance Int_sound : Sound (Hilbert.Int α) (ReflexiveTransitiveFrameClass#α) := inferInstance
 
-instance : System.Consistent (𝐈𝐧𝐭 : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.Int α) := inferInstance
 
 
-instance Cl_Characteraizable : 𝔽((𝐂𝐥 : Hilbert α)).Characteraizable ReflexiveTransitiveSymmetricFrameClass#α where
+instance Cl_Characteraizable : 𝔽(Hilbert.Cl α).Characteraizable ReflexiveTransitiveSymmetricFrameClass#α where
   characterize := by
     simp [System.theory];
     rintro F hTrans hRefl hSymm φ hp;
-    induction hp using Deduction.rec! with
+    induction hp using Hilbert.Deduction.rec! with
     | verum => apply ValidOnFrame.verum;
     | imply₁ => apply ValidOnFrame.imply₁; simpa;
     | imply₂ => apply ValidOnFrame.imply₂; simpa; simpa;
@@ -366,18 +366,18 @@ instance Cl_Characteraizable : 𝔽((𝐂𝐥 : Hilbert α)).Characteraizable Re
     use { World := PUnit, Rel := λ _ _ => True };
     refine ⟨by simp [Reflexive], by simp [Transitive], by simp [Symmetric]⟩;
 
-instance : Sound 𝐂𝐥 (ReflexiveTransitiveSymmetricFrameClass#α) := inferInstance
+instance : Sound (Hilbert.Cl α) (ReflexiveTransitiveSymmetricFrameClass#α) := inferInstance
 
-instance : System.Consistent (𝐂𝐥 : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.Cl α) := inferInstance
 
 
 
-instance KC_Characteraizable : 𝔽((𝐊𝐂 : Hilbert α)).Characteraizable ReflexiveTransitiveConfluentFrameClass where
+instance KC_Characteraizable : 𝔽(Hilbert.KC α).Characteraizable ReflexiveTransitiveConfluentFrameClass where
   characterize := by
     rintro F ⟨F_trans, F_refl, F_confl⟩;
     simp [System.theory];
     intro φ hp;
-    induction hp using Deduction.rec! with
+    induction hp using Hilbert.Deduction.rec! with
     | verum => apply ValidOnFrame.verum;
     | imply₁ => apply ValidOnFrame.imply₁; simpa;
     | imply₂ => apply ValidOnFrame.imply₂; simpa; simpa;
@@ -399,17 +399,17 @@ instance KC_Characteraizable : 𝔽((𝐊𝐂 : Hilbert α)).Characteraizable Re
     use { World := PUnit, Rel := λ _ _ => True };
     refine ⟨by simp [Reflexive], by simp [Transitive], by simp [Confluent]⟩;
 
-instance : Sound 𝐊𝐂 (ReflexiveTransitiveConfluentFrameClass#α) := inferInstance
+instance : Sound (Hilbert.KC α) (ReflexiveTransitiveConfluentFrameClass#α) := inferInstance
 
-instance : System.Consistent (𝐊𝐂 : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.KC α) := inferInstance
 
 
-instance LC_Characteraizable : 𝔽((𝐋𝐂 : Hilbert α)).Characteraizable ReflexiveTransitiveConnectedFrameClass where
+instance LC_Characteraizable : 𝔽((Hilbert.LC α)).Characteraizable ReflexiveTransitiveConnectedFrameClass where
   characterize := by
     rintro F ⟨F_trans, F_refl, F_conn⟩;
     simp [System.theory];
     intro φ hp;
-    induction hp using Deduction.rec! with
+    induction hp using Hilbert.Deduction.rec! with
     | verum => apply ValidOnFrame.verum;
     | imply₁ => apply ValidOnFrame.imply₁; simpa;
     | imply₂ => apply ValidOnFrame.imply₂; simpa; simpa;
@@ -431,9 +431,9 @@ instance LC_Characteraizable : 𝔽((𝐋𝐂 : Hilbert α)).Characteraizable Re
     use { World := PUnit, Rel := λ _ _ => True };
     refine ⟨by simp [Reflexive], by simp [Transitive], by simp [Connected]⟩;
 
-instance : Sound 𝐋𝐂 (ReflexiveTransitiveConnectedFrameClass#α) := inferInstance
+instance : Sound (Hilbert.LC α) (ReflexiveTransitiveConnectedFrameClass#α) := inferInstance
 
-instance : System.Consistent (𝐋𝐂 : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.LC α) := inferInstance
 
 end
 
@@ -473,18 +473,18 @@ namespace Kripke
 
 open Formula.Kripke (ClassicalSatisfies)
 
-lemma ValidOnClassicalFrame_iff : (Kripke.FrameClassOfHilbert.{u, 0} 𝐂𝐥) ⊧ φ → ∀ (V : ClassicalValuation α), V ⊧ φ := by
+lemma ValidOnClassicalFrame_iff : (Kripke.FrameClassOfHilbert.{u, 0} (Hilbert.Cl α)) ⊧ φ → ∀ (V : ClassicalValuation α), V ⊧ φ := by
   intro h V;
   refine @h (ClassicalFrame) ?_ (λ _ a => V a) (by simp [Valuation.atomic_hereditary]) ();
   . apply @Cl_Characteraizable α |>.characterize;
     refine ⟨ClassicalFrame.reflexive, ClassicalFrame.transitive, ClassicalFrame.symmetric⟩;
 
-lemma notClassicalValid_of_exists_ClassicalValuation : (∃ (V : ClassicalValuation α), ¬(V ⊧ φ)) → ¬(Kripke.FrameClassOfHilbert.{u, 0} 𝐂𝐥) ⊧ φ := by
+lemma notClassicalValid_of_exists_ClassicalValuation : (∃ (V : ClassicalValuation α), ¬(V ⊧ φ)) → ¬(Kripke.FrameClassOfHilbert.{u, 0} (Hilbert.Cl α)) ⊧ φ := by
   contrapose; push_neg;
   have := @ValidOnClassicalFrame_iff α φ;
   exact this;
 
-lemma unprovable_classical_of_exists_ClassicalValuation (h : ∃ (V : ClassicalValuation α), ¬(V ⊧ φ)) : 𝐂𝐥 ⊬ φ := by
+lemma unprovable_classical_of_exists_ClassicalValuation (h : ∃ (V : ClassicalValuation α), ¬(V ⊧ φ)) : (Hilbert.Cl α) ⊬ φ := by
   apply not_imp_not.mpr $ Kripke.sound.{u, 0};
   apply notClassicalValid_of_exists_ClassicalValuation;
   assumption;

--- a/Foundation/IntProp/Kripke/Semantics.lean
+++ b/Foundation/IntProp/Kripke/Semantics.lean
@@ -260,22 +260,22 @@ namespace Kripke
 abbrev FrameClassOfTheory (T : Theory α) : FrameClass.Dep α := { F | F#α ⊧* T }
 notation "𝔽(" T ")" => FrameClassOfTheory T
 
-abbrev FrameClassOfHilbert (Λ : Hilbert α) : FrameClass.Dep α := 𝔽((System.theory Λ))
-notation "𝔽(" Λ ")" => FrameClassOfHilbert Λ
+abbrev FrameClassOfHilbert (H : Hilbert α) : FrameClass.Dep α := 𝔽((System.theory H))
+notation "𝔽(" H ")" => FrameClassOfHilbert H
 
 section Soundness
 
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
          {φ : Formula α}
 
-lemma sound : Λ ⊢! φ → 𝔽(Λ) ⊧ φ := by
+lemma sound : H ⊢! φ → 𝔽(H) ⊧ φ := by
   intro hp F hF;
   simp [System.theory] at hF;
   exact hF φ hp;
 
-instance : Sound Λ 𝔽(Λ) := ⟨sound⟩
+instance : Sound H 𝔽(H) := ⟨sound⟩
 
-lemma unprovable_bot (hc : 𝔽(Λ).Nonempty) : Λ ⊬ ⊥ := by
+lemma unprovable_bot (hc : 𝔽(H).Nonempty) : H ⊬ ⊥ := by
   apply (not_imp_not.mpr (sound (α := α)));
   simp [Semantics.Realize];
   obtain ⟨F, hF⟩ := hc;
@@ -284,23 +284,23 @@ lemma unprovable_bot (hc : 𝔽(Λ).Nonempty) : Λ ⊬ ⊥ := by
   . exact hF;
   . exact Semantics.Bot.realize_bot (F := Formula α) (M := Frame.Dep α) F;
 
-instance (hc : 𝔽(Λ).Nonempty) : System.Consistent Λ := System.Consistent.of_unprovable $ unprovable_bot hc
+instance (hc : 𝔽(H).Nonempty) : System.Consistent H := System.Consistent.of_unprovable $ unprovable_bot hc
 
 
-lemma sound_of_characterizability [characterizability : 𝔽(Λ).Characteraizable 𝔽₂] : Λ ⊢! φ → 𝔽₂#α ⊧ φ := by
+lemma sound_of_characterizability [characterizability : 𝔽(H).Characteraizable 𝔽₂] : H ⊢! φ → 𝔽₂#α ⊧ φ := by
   intro h F hF;
   apply sound h;
   apply characterizability.characterize hF;
 
-instance instSoundOfCharacterizability [𝔽(Λ).Characteraizable 𝔽₂] : Sound Λ (𝔽₂#α) := ⟨sound_of_characterizability⟩
+instance instSoundOfCharacterizability [𝔽(H).Characteraizable 𝔽₂] : Sound H (𝔽₂#α) := ⟨sound_of_characterizability⟩
 
-lemma unprovable_bot_of_characterizability [characterizability : 𝔽(Λ).Characteraizable 𝔽₂] : Λ ⊬ ⊥ := by
+lemma unprovable_bot_of_characterizability [characterizability : 𝔽(H).Characteraizable 𝔽₂] : H ⊬ ⊥ := by
   apply unprovable_bot;
   obtain ⟨F, hF⟩ := characterizability.nonempty;
   use F;
   apply characterizability.characterize hF;
 
-instance instConsistentOfCharacterizability [FrameClass.Characteraizable.{u} 𝔽(Λ) 𝔽₂] : System.Consistent Λ := System.Consistent.of_unprovable $ unprovable_bot_of_characterizability
+instance instConsistentOfCharacterizability [FrameClass.Characteraizable.{u} 𝔽(H) 𝔽₂] : System.Consistent H := System.Consistent.of_unprovable $ unprovable_bot_of_characterizability
 
 end Soundness
 

--- a/Foundation/Modal/Boxdot/Basic.lean
+++ b/Foundation/Modal/Boxdot/Basic.lean
@@ -12,8 +12,8 @@ def Formula.BoxdotTranslation : Formula α → Formula α
 postfix:90 "ᵇ" => Formula.BoxdotTranslation
 
 
-class BoxdotProperty (Λ₁ Λ₂ : Hilbert α) where
-  bdp {φ} : Λ₁ ⊢! φ ↔ Λ₂ ⊢! φᵇ
+class BoxdotProperty (H₁ H₂ : Hilbert α) where
+  bdp {φ} : H₁ ⊢! φ ↔ H₂ ⊢! φᵇ
 
 
 open System
@@ -23,8 +23,8 @@ open Hilbert.Deduction
 variable {φ : Formula α}
 
 theorem boxdotTranslated
-  {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
-  (h : ∀ φ ∈ Λ₁.axioms, Λ₂ ⊢! φᵇ) : Λ₁ ⊢! φ → Λ₂ ⊢! φᵇ := by
+  {H₁ H₂ : Hilbert α} [H₁.IsNormal] [H₂.IsNormal]
+  (h : ∀ φ ∈ H₁.axioms, H₂ ⊢! φᵇ) : H₁ ⊢! φ → H₂ ⊢! φᵇ := by
   intro d;
   induction d using inducition_with_necOnly! with
   | hMaxm hs => exact h _ hs;

--- a/Foundation/Modal/Boxdot/Basic.lean
+++ b/Foundation/Modal/Boxdot/Basic.lean
@@ -18,6 +18,7 @@ class BoxdotProperty (Λ₁ Λ₂ : Hilbert α) where
 
 open System
 open Formula
+open Hilbert.Deduction
 
 variable {φ : Formula α}
 
@@ -25,7 +26,7 @@ theorem boxdotTranslated
   {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
   (h : ∀ φ ∈ Λ₁.axioms, Λ₂ ⊢! φᵇ) : Λ₁ ⊢! φ → Λ₂ ⊢! φᵇ := by
   intro d;
-  induction d using Deduction.inducition_with_necOnly! with
+  induction d using inducition_with_necOnly! with
   | hMaxm hs => exact h _ hs;
   | hNec ihp =>
     dsimp [BoxdotTranslation];

--- a/Foundation/Modal/Boxdot/Basic.lean
+++ b/Foundation/Modal/Boxdot/Basic.lean
@@ -37,7 +37,7 @@ theorem boxdotTranslated
     dsimp only [BoxdotTranslation];
     trivial;
 
-lemma boxdotTranslatedK4_of_S4 : 𝐒𝟒 ⊢! φ → 𝐊𝟒 ⊢! φᵇ := boxdotTranslated $ by
+lemma boxdotTranslatedK4_of_S4 : (Hilbert.S4 α) ⊢! φ → (Hilbert.K4 α) ⊢! φᵇ := boxdotTranslated $ by
   intro φ hp;
   simp at hp;
   rcases hp with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩);
@@ -45,19 +45,19 @@ lemma boxdotTranslatedK4_of_S4 : 𝐒𝟒 ⊢! φ → 𝐊𝟒 ⊢! φᵇ := box
   . dsimp [BoxdotTranslation]; exact boxdot_axiomT!;
   . dsimp [BoxdotTranslation]; exact boxdot_axiomFour!
 
-lemma iff_boxdotTranslation_S4 : 𝐒𝟒 ⊢! φ ⭤ φᵇ := by
+lemma iff_boxdotTranslation_S4 : (Hilbert.S4 α) ⊢! φ ⭤ φᵇ := by
   induction φ using Formula.rec' with
   | hbox φ ihp => exact iff_trans''! (box_iff! ihp) iff_box_boxdot!;
   | himp φ ψ ihp ihq => exact imp_replace_iff! ihp ihq;
   | _ => exact iff_id!;
 
-lemma S4_of_boxdotTranslatedK4 (h : 𝐊𝟒 ⊢! φᵇ) : 𝐒𝟒 ⊢! φ := by
-  exact (and₂'! iff_boxdotTranslation_S4) ⨀ (weakerThan_iff.mp $ K4_weakerThan_S4) h
+lemma S4_of_boxdotTranslatedK4 (h : (Hilbert.K4 α) ⊢! φᵇ) : (Hilbert.S4 α) ⊢! φ := by
+  exact (and₂'! iff_boxdotTranslation_S4) ⨀ (weakerThan_iff.mp $ Hilbert.K4_weakerThan_S4) h
 
-theorem iff_S4_boxdotTranslatedK4 : 𝐒𝟒 ⊢! φ ↔ 𝐊𝟒 ⊢! φᵇ := by
+theorem iff_S4_boxdotTranslatedK4 : (Hilbert.S4 α) ⊢! φ ↔ (Hilbert.K4 α) ⊢! φᵇ := by
   constructor;
   . apply boxdotTranslatedK4_of_S4;
   . apply S4_of_boxdotTranslatedK4;
-instance : BoxdotProperty (𝐒𝟒 : Hilbert α) 𝐊𝟒 := ⟨iff_S4_boxdotTranslatedK4⟩
+instance : BoxdotProperty (Hilbert.S4 α) (Hilbert.K4 α) := ⟨iff_S4_boxdotTranslatedK4⟩
 
 end LO.Modal

--- a/Foundation/Modal/Boxdot/GL_Grz.lean
+++ b/Foundation/Modal/Boxdot/GL_Grz.lean
@@ -105,13 +105,13 @@ variable {φ : Formula α}
 
 open Formula (BoxdotTranslation)
 open System in
-lemma boxdotTranslatedGL_of_Grz : 𝐆𝐫𝐳 ⊢! φ → 𝐆𝐋 ⊢! φᵇ := boxdotTranslated $ by
+lemma boxdotTranslatedGL_of_Grz : (Hilbert.Grz α) ⊢! φ → (Hilbert.GL α) ⊢! φᵇ := boxdotTranslated $ by
   intro φ hp;
   rcases hp with (⟨_, _, rfl⟩ | ⟨_, rfl⟩);
   . dsimp [BoxdotTranslation]; exact boxdot_axiomK!;
   . dsimp [BoxdotTranslation]; exact boxdot_Grz_of_L!
 
-lemma Grz_of_boxdotTranslatedGL [Inhabited α] : 𝐆𝐋 ⊢! φᵇ → 𝐆𝐫𝐳 ⊢! φ := by
+lemma Grz_of_boxdotTranslatedGL [Inhabited α] : (Hilbert.GL α) ⊢! φᵇ → (Hilbert.Grz α) ⊢! φ := by
   contrapose;
   intro h;
   apply (not_imp_not.mpr $ Kripke.GL_finite_sound.sound);
@@ -134,11 +134,11 @@ lemma Grz_of_boxdotTranslatedGL [Inhabited α] : 𝐆𝐋 ⊢! φᵇ → 𝐆�
     use V, x;
     exact iff_reflexivize_irreflexivize FF_refl |>.not.mp h;
 
-theorem iff_Grz_boxdotTranslatedGL [Inhabited α] : 𝐆𝐫𝐳 ⊢! φ ↔ 𝐆𝐋 ⊢! φᵇ := by
+theorem iff_Grz_boxdotTranslatedGL [Inhabited α] : (Hilbert.Grz α) ⊢! φ ↔ (Hilbert.GL α) ⊢! φᵇ := by
   constructor;
   . apply boxdotTranslatedGL_of_Grz;
   . apply Grz_of_boxdotTranslatedGL;
 
-instance [Inhabited α] : BoxdotProperty (α := α) 𝐆𝐫𝐳 𝐆𝐋 := ⟨iff_Grz_boxdotTranslatedGL⟩
+instance [Inhabited α] : BoxdotProperty (Hilbert.Grz α) (Hilbert.GL α) := ⟨iff_Grz_boxdotTranslatedGL⟩
 
 end LO.Modal

--- a/Foundation/Modal/Complemental.lean
+++ b/Foundation/Modal/Complemental.lean
@@ -2,7 +2,7 @@ import Foundation.Modal.ConsistentTheory
 
 namespace LO.Modal
 
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 namespace Formula
 
@@ -127,58 +127,58 @@ def SubformulaeComplementaryClosed (P : Formulae α) (φ : Formula α) : Prop :=
 
 section Consistent
 
-def Consistent (Λ : Hilbert α) (P : Formulae α) : Prop := P *⊬[Λ] ⊥
+def Consistent (H : Hilbert α) (P : Formulae α) : Prop := P *⊬[H] ⊥
 
 open Theory
 
 omit [DecidableEq α] in
 @[simp]
-lemma iff_theory_consistent_formulae_consistent {P : Formulae α} : Theory.Consistent Λ P ↔ Formulae.Consistent Λ P := by
+lemma iff_theory_consistent_formulae_consistent {P : Formulae α} : Theory.Consistent H P ↔ Formulae.Consistent H P := by
   simp [Consistent, Theory.Consistent]
 
 omit [DecidableEq α] in
 @[simp]
-lemma empty_conisistent [System.Consistent Λ] : Formulae.Consistent Λ ∅ := by
+lemma empty_conisistent [System.Consistent H] : Formulae.Consistent H ∅ := by
   rw [←iff_theory_consistent_formulae_consistent];
   convert Theory.emptyset_consistent (α := α);
   . simp;
   . assumption;
 
-lemma provable_iff_insert_neg_not_consistent : ↑P *⊢[Λ]! φ ↔ ¬(Formulae.Consistent Λ (insert (∼φ) P)) := by
+lemma provable_iff_insert_neg_not_consistent : ↑P *⊢[H]! φ ↔ ¬(Formulae.Consistent H (insert (∼φ) P)) := by
   rw [←iff_theory_consistent_formulae_consistent];
   simpa only [Finset.coe_insert, not_not] using Theory.provable_iff_insert_neg_not_consistent;
 
-lemma neg_provable_iff_insert_not_consistent : ↑P *⊢[Λ]! ∼φ ↔ ¬(Formulae.Consistent Λ (insert (φ) P)) := by
+lemma neg_provable_iff_insert_not_consistent : ↑P *⊢[H]! ∼φ ↔ ¬(Formulae.Consistent H (insert (φ) P)) := by
   rw [←iff_theory_consistent_formulae_consistent];
   simpa only [Finset.coe_insert, not_not] using Theory.neg_provable_iff_insert_not_consistent;
 
-lemma unprovable_iff_singleton_neg_consistent : Λ ⊬ φ ↔ Formulae.Consistent Λ ({∼φ}) := by
+lemma unprovable_iff_singleton_neg_consistent : H ⊬ φ ↔ Formulae.Consistent H ({∼φ}) := by
   rw [←iff_theory_consistent_formulae_consistent];
   simpa using Theory.unprovable_iff_singleton_neg_consistent;
 
-lemma unprovable_iff_singleton_compl_consistent : Λ ⊬ φ ↔ Formulae.Consistent Λ ({-φ}) := by
+lemma unprovable_iff_singleton_compl_consistent : H ⊬ φ ↔ Formulae.Consistent H ({-φ}) := by
   rcases (Formula.complement.or φ) with (hp | ⟨ψ, rfl⟩);
   . rw [hp];
-    convert Theory.unprovable_iff_singleton_neg_consistent (Λ := Λ) (φ := φ);
+    convert Theory.unprovable_iff_singleton_neg_consistent (H := H) (φ := φ);
     simp;
   . simp only [Formula.complement];
-    convert Theory.unprovable_iff_singleton_consistent (Λ := Λ) (φ := ψ);
+    convert Theory.unprovable_iff_singleton_consistent (H := H) (φ := ψ);
     simp;
 
-lemma provable_iff_singleton_compl_inconsistent : Λ ⊢! φ ↔ ¬(Formulae.Consistent Λ ({-φ})) := by
+lemma provable_iff_singleton_compl_inconsistent : H ⊢! φ ↔ ¬(Formulae.Consistent H ({-φ})) := by
   constructor;
   . contrapose; push_neg; apply unprovable_iff_singleton_compl_consistent.mpr;
   . contrapose; push_neg; apply unprovable_iff_singleton_compl_consistent.mp;
 
 lemma intro_union_consistent
-  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ P₁) ∧ (∀ φ ∈ Γ₂, φ ∈ P₂) → Λ ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ➝ ⊥)
-  : Formulae.Consistent Λ (P₁ ∪ P₂) := by
+  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ P₁) ∧ (∀ φ ∈ Γ₂, φ ∈ P₂) → H ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ➝ ⊥)
+  : Formulae.Consistent H (P₁ ∪ P₂) := by
   rw [←iff_theory_consistent_formulae_consistent];
   simpa using Theory.intro_union_consistent h;
 
 lemma intro_triunion_consistent
-  (h : ∀ {Γ₁ Γ₂ Γ₃ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ P₁) ∧ (∀ φ ∈ Γ₂, φ ∈ P₂) ∧ (∀ φ ∈ Γ₃, φ ∈ P₃) → Λ ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ⋏ ⋀Γ₃ ➝ ⊥)
-  : Formulae.Consistent Λ (P₁ ∪ P₂ ∪ P₃) := by
+  (h : ∀ {Γ₁ Γ₂ Γ₃ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ P₁) ∧ (∀ φ ∈ Γ₂, φ ∈ P₂) ∧ (∀ φ ∈ Γ₃, φ ∈ P₃) → H ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ⋏ ⋀Γ₃ ➝ ⊥)
+  : Formulae.Consistent H (P₁ ∪ P₂ ∪ P₃) := by
   rw [←iff_theory_consistent_formulae_consistent];
   convert Theory.intro_triunion_consistent h;
   ext;
@@ -199,33 +199,33 @@ namespace exists_consistent_complementary_closed
 
 open Classical
 
-variable (Λ)
+variable (H)
 
 noncomputable def next (φ : Formula α) (P : Formulae α) : Formulae α :=
-  if Formulae.Consistent Λ (insert φ P) then insert φ P else insert (-φ) P
+  if Formulae.Consistent H (insert φ P) then insert φ P else insert (-φ) P
 
 noncomputable def enum (P : Formulae α) : (List (Formula α)) → Formulae α
   | [] => P
-  | ψ :: qs => next Λ ψ (enum P qs)
-local notation:max t"[" l "]" => enum Λ t l
+  | ψ :: qs => next H ψ (enum P qs)
+local notation:max t"[" l "]" => enum H t l
 
 lemma next_consistent
-  (P_consis : Formulae.Consistent Λ P) (φ : Formula α)
-  : Formulae.Consistent Λ (next Λ φ P) := by
+  (P_consis : Formulae.Consistent H P) (φ : Formula α)
+  : Formulae.Consistent H (next H φ P) := by
   simp only [next];
   split;
   . simpa;
   . rename_i h;
     by_contra hC;
-    have h₁ := Formulae.neg_provable_iff_insert_not_consistent (Λ := Λ) (P := P) (φ := φ) |>.mpr h;
-    have h₂ := Formulae.neg_provable_iff_insert_not_consistent (Λ := Λ) (P := P) (φ := -φ) |>.mpr hC;
+    have h₁ := Formulae.neg_provable_iff_insert_not_consistent (H := H) (P := P) (φ := φ) |>.mpr h;
+    have h₂ := Formulae.neg_provable_iff_insert_not_consistent (H := H) (P := P) (φ := -φ) |>.mpr hC;
     have := neg_complement_derive_bot h₁ h₂;
     contradiction;
 
 lemma enum_consistent
-  (P_consis : Formulae.Consistent Λ P)
+  (P_consis : Formulae.Consistent H P)
   {l : List (Formula α)}
-  : Formulae.Consistent Λ (P[l]) := by
+  : Formulae.Consistent H (P[l]) := by
   induction l with
   | nil => exact P_consis;
   | cons ψ qs ih =>
@@ -276,16 +276,16 @@ end exists_consistent_complementary_closed
 open exists_consistent_complementary_closed in
 lemma exists_consistent_complementary_closed
   (S : Formulae α)
-  (h_sub : P ⊆ S⁻) (P_consis : Formulae.Consistent Λ P)
-  : ∃ P', P ⊆ P' ∧ Formulae.Consistent Λ P' ∧ P'.ComplementaryClosed S := by
-  use exists_consistent_complementary_closed.enum Λ P S.toList;
+  (h_sub : P ⊆ S⁻) (P_consis : Formulae.Consistent H P)
+  : ∃ P', P ⊆ P' ∧ Formulae.Consistent H P' ∧ P'.ComplementaryClosed S := by
+  use exists_consistent_complementary_closed.enum H P S.toList;
   refine ⟨?_, ?_, ?_, ?_⟩;
   . apply enum_subset;
-  . exact enum_consistent Λ P_consis;
+  . exact enum_consistent H P_consis;
   . simp [Formulae.complementary];
     intro φ hp;
     simp only [Finset.mem_union, Finset.mem_image];
-    rcases subset Λ hp with (h | h | ⟨ψ, hq₁, hq₂⟩);
+    rcases subset H hp with (h | h | ⟨ψ, hq₁, hq₂⟩);
     . replace h := h_sub h;
       simp [complementary] at h;
       rcases h with (_ | ⟨a, b, rfl⟩);
@@ -298,7 +298,7 @@ lemma exists_consistent_complementary_closed
       . exact Finset.mem_toList.mp hq₁;
       . assumption;
   . intro φ hp;
-    exact either Λ (by simpa);
+    exact either H (by simpa);
 
 end Consistent
 
@@ -307,9 +307,9 @@ end Formulae
 
 variable [DecidableEq α]
 
-structure ComplementaryClosedConsistentFormulae (Λ) (S : Formulae α) where
+structure ComplementaryClosedConsistentFormulae (H) (S : Formulae α) where
   formulae : Formulae α
-  consistent : formulae.Consistent Λ
+  consistent : formulae.Consistent H
   closed : formulae.ComplementaryClosed S
 alias CCF := ComplementaryClosedConsistentFormulae
 
@@ -317,20 +317,20 @@ namespace ComplementaryClosedConsistentFormulae
 
 open System
 open Formula (atom)
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 lemma lindenbaum
   (S : Formulae α)
-  {X : Formulae α} (X_sub : X ⊆ S⁻) (X_consis : X.Consistent Λ)
-  : ∃ X' : CCF Λ S, X ⊆ X'.formulae := by
+  {X : Formulae α} (X_sub : X ⊆ S⁻) (X_consis : X.Consistent H)
+  : ∃ X' : CCF H S, X ⊆ X'.formulae := by
   obtain ⟨X', ⟨X'_sub, x, b⟩⟩ := Formulae.exists_consistent_complementary_closed S X_sub X_consis;
   use ⟨X', (by assumption), (by assumption)⟩;
 
-noncomputable instance [System.Consistent Λ] : Inhabited (CCF Λ S) := ⟨lindenbaum (X := ∅) S (by simp) (by simp) |>.choose⟩
+noncomputable instance [System.Consistent H] : Inhabited (CCF H S) := ⟨lindenbaum (X := ∅) S (by simp) (by simp) |>.choose⟩
 
-variable {S} {X X₁ X₂ : CCF Λ S}
+variable {S} {X X₁ X₂ : CCF H S}
 
-@[simp] lemma unprovable_falsum : X.formulae *⊬[Λ] ⊥ := X.consistent
+@[simp] lemma unprovable_falsum : X.formulae *⊬[H] ⊥ := X.consistent
 
 lemma mem_compl_of_not_mem (hs : ψ ∈ S) : ψ ∉ X.formulae → -ψ ∈ X.formulae := by
   intro h;
@@ -342,7 +342,7 @@ lemma mem_of_not_mem_compl (hs : ψ ∈ S) : -ψ ∉ X.formulae → ψ ∈ X.for
   apply Not.imp_symm;
   exact mem_compl_of_not_mem hs;
 
-lemma membership_iff (hq_sub : ψ ∈ S) : (ψ ∈ X.formulae) ↔ (X.formulae *⊢[Λ]! ψ) := by
+lemma membership_iff (hq_sub : ψ ∈ S) : (ψ ∈ X.formulae) ↔ (X.formulae *⊢[H]! ψ) := by
   constructor;
   . intro h; exact Context.by_axm! h;
   . intro hp;
@@ -351,7 +351,7 @@ lemma membership_iff (hq_sub : ψ ∈ S) : (ψ ∈ X.formulae) ↔ (X.formulae *
       assumption;
       exact X.closed.either ψ hq_sub;
     by_contra hC;
-    have hnp : X.formulae *⊢[Λ]! -ψ := Context.by_axm! hC;
+    have hnp : X.formulae *⊢[H]! -ψ := Context.by_axm! hC;
     have := complement_derive_bot hp hnp;
     simpa;
 
@@ -370,23 +370,23 @@ lemma iff_mem_compl (hq_sub : ψ ∈ S) : (ψ ∈ X.formulae) ↔ (-ψ ∉ X.for
     | hfalsum => exact unprovable_falsum hq;
     | hatom a =>
       simp only [Formula.complement] at hnq;
-      have : ↑X.formulae *⊢[Λ]! ∼(atom a) := Context.by_axm! hnq;
-      have : ↑X.formulae *⊢[Λ]! ⊥ := complement_derive_bot hq this;
+      have : ↑X.formulae *⊢[H]! ∼(atom a) := Context.by_axm! hnq;
+      have : ↑X.formulae *⊢[H]! ⊥ := complement_derive_bot hq this;
       simpa;
     | hbox ψ =>
       simp only [Formula.complement] at hnq;
-      have : ↑X.formulae *⊢[Λ]! ∼(□ψ) := Context.by_axm! hnq;
-      have : ↑X.formulae *⊢[Λ]! ⊥ := complement_derive_bot hq this;
+      have : ↑X.formulae *⊢[H]! ∼(□ψ) := Context.by_axm! hnq;
+      have : ↑X.formulae *⊢[H]! ⊥ := complement_derive_bot hq this;
       simpa;
     | hneg ψ =>
       simp only [Formula.complement] at hnq;
-      have : ↑X.formulae *⊢[Λ]! ψ := Context.by_axm! hnq;
-      have : ↑X.formulae *⊢[Λ]! ⊥ := complement_derive_bot hq this;
+      have : ↑X.formulae *⊢[H]! ψ := Context.by_axm! hnq;
+      have : ↑X.formulae *⊢[H]! ⊥ := complement_derive_bot hq this;
       simpa;
     | himp ψ χ h =>
       simp only [Formula.complement.imp_def₁ h] at hnq;
-      have : ↑X.formulae *⊢[Λ]! ∼(ψ ➝ χ) := Context.by_axm! hnq;
-      have : ↑X.formulae *⊢[Λ]! ⊥ := this ⨀ hq;
+      have : ↑X.formulae *⊢[H]! ∼(ψ ➝ χ) := Context.by_axm! hnq;
+      have : ↑X.formulae *⊢[H]! ⊥ := this ⨀ hq;
       simpa;
   . intro h; exact mem_of_not_mem_compl (by assumption) h;
 
@@ -419,15 +419,15 @@ lemma iff_mem_imp
 lemma iff_not_mem_imp
   (hsub_qr : (ψ ➝ χ) ∈ S) (hsub_q : ψ ∈ S := by trivial)  (hsub_r : χ ∈ S := by trivial)
   : ((ψ ➝ χ) ∉ X.formulae) ↔ (ψ ∈ X.formulae) ∧ (-χ ∈ X.formulae) := by
-  simpa using @iff_mem_imp α _ Λ S X ψ χ hsub_qr hsub_q hsub_r |>.not;
+  simpa using @iff_mem_imp α _ H S X ψ χ hsub_qr hsub_q hsub_r |>.not;
 
 lemma equality_def : X₁ = X₂ ↔ X₁.formulae = X₂.formulae := by
   constructor;
   . intro h; cases h; rfl;
   . intro h; cases X₁; cases X₂; simp_all;
 
-instance : Finite (CCF Λ S) := by
-  let f : CCF Λ S → (Finset.powerset (S⁻)) := λ X => ⟨X.formulae, by simpa using X.closed.subset⟩
+instance : Finite (CCF H S) := by
+  let f : CCF H S → (Finset.powerset (S⁻)) := λ X => ⟨X.formulae, by simpa using X.closed.subset⟩
   have hf : Function.Injective f := by
     intro X₁ X₂ h;
     apply equality_def.mpr;

--- a/Foundation/Modal/ConsistentTheory.lean
+++ b/Foundation/Modal/ConsistentTheory.lean
@@ -6,6 +6,7 @@ variable {α : Type*}
 variable {Λ : Hilbert α}
 
 open System
+open Hilbert.Deduction
 
 abbrev Theory.Consistent (Λ : Hilbert α) (T : Theory α) := T *⊬[Λ] ⊥
 
@@ -32,7 +33,7 @@ lemma self_consistent [Λ_consis : System.Consistent Λ] : Λ.axioms.Consistent 
   apply def_consistent.mpr;
   intro Γ hΓ;
   by_contra hC;
-  have : Λ ⊢! ψ := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => Deduction.maxm! $ hΓ _ h);
+  have : Λ ⊢! ψ := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => maxm! $ hΓ _ h);
   contradiction;
 
 lemma union_consistent : Theory.Consistent Λ (T₁ ∪ T₂) → T₁.Consistent Λ ∧ T₂.Consistent Λ := by
@@ -340,7 +341,7 @@ lemma subset_axiomset : Λ.axioms ⊆ Ω.theory := by
   intro φ hp;
   apply membership_iff.mpr;
   apply Context.of!;
-  exact Deduction.maxm! (by aesop);
+  exact maxm! (by aesop);
 
 @[simp] lemma not_mem_falsum : ⊥ ∉ Ω.theory := not_mem_falsum_of_consistent Ω.consistent
 

--- a/Foundation/Modal/ConsistentTheory.lean
+++ b/Foundation/Modal/ConsistentTheory.lean
@@ -3,20 +3,20 @@ import Foundation.Modal.Hilbert
 namespace LO.Modal
 
 variable {α : Type*}
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 open System
 open Hilbert.Deduction
 
-abbrev Theory.Consistent (Λ : Hilbert α) (T : Theory α) := T *⊬[Λ] ⊥
+abbrev Theory.Consistent (H : Hilbert α) (T : Theory α) := T *⊬[H] ⊥
 
-abbrev Theory.Inconsistent (Λ : Hilbert α) (T : Theory α) := ¬(T.Consistent Λ)
+abbrev Theory.Inconsistent (H : Hilbert α) (T : Theory α) := ¬(T.Consistent H)
 
 namespace Theory
 
-variable {T : Theory α} (T_consis : T.Consistent Λ)
+variable {T : Theory α} (T_consis : T.Consistent H)
 
-lemma def_consistent : T.Consistent Λ ↔ ∀ (Γ : List (Formula α)), (∀ ψ ∈ Γ, ψ ∈ T) → Γ ⊬[Λ] ⊥ := by
+lemma def_consistent : T.Consistent H ↔ ∀ (Γ : List (Formula α)), (∀ ψ ∈ Γ, ψ ∈ T) → Γ ⊬[H] ⊥ := by
   constructor;
   . intro h;
     simpa using Context.provable_iff.not.mp h;
@@ -24,42 +24,42 @@ lemma def_consistent : T.Consistent Λ ↔ ∀ (Γ : List (Formula α)), (∀ ψ
     apply Context.provable_iff.not.mpr; push_neg;
     assumption;
 
-lemma def_inconsistent : ¬T.Consistent Λ ↔ ∃ (Γ : List (Formula α)), (∀ ψ ∈ Γ, ψ ∈ T) ∧ Γ ⊢[Λ]! ⊥ := by
+lemma def_inconsistent : ¬T.Consistent H ↔ ∃ (Γ : List (Formula α)), (∀ ψ ∈ Γ, ψ ∈ T) ∧ Γ ⊢[H]! ⊥ := by
   simp only [def_consistent]; push_neg; tauto;
 
 @[simp]
-lemma self_consistent [Λ_consis : System.Consistent Λ] : Λ.axioms.Consistent Λ := by
-  obtain ⟨ψ, hq⟩ := Λ_consis.exists_unprovable;
+lemma self_consistent [H_consis : System.Consistent H] : H.axioms.Consistent H := by
+  obtain ⟨ψ, hq⟩ := H_consis.exists_unprovable;
   apply def_consistent.mpr;
   intro Γ hΓ;
   by_contra hC;
-  have : Λ ⊢! ψ := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => maxm! $ hΓ _ h);
+  have : H ⊢! ψ := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => maxm! $ hΓ _ h);
   contradiction;
 
-lemma union_consistent : Theory.Consistent Λ (T₁ ∪ T₂) → T₁.Consistent Λ ∧ T₂.Consistent Λ := by
+lemma union_consistent : Theory.Consistent H (T₁ ∪ T₂) → T₁.Consistent H ∧ T₂.Consistent H := by
   intro h;
   replace h := def_consistent.mp h;
   constructor <;> { apply def_consistent.mpr; intro Γ hΓ; exact h Γ (by simp_all); }
 
-lemma union_not_consistent : ¬T₁.Consistent Λ ∨ ¬T₂.Consistent Λ → ¬(Theory.Consistent Λ (T₁ ∪ T₂)) := by
+lemma union_not_consistent : ¬T₁.Consistent H ∨ ¬T₂.Consistent H → ¬(Theory.Consistent H (T₁ ∪ T₂)) := by
   contrapose; push_neg;
   exact union_consistent;
 
-lemma emptyset_consistent [Λ_consis : System.Consistent Λ] : Theory.Consistent Λ ∅ := by
-  obtain ⟨f, hf⟩ := Λ_consis.exists_unprovable;
+lemma emptyset_consistent [H_consis : System.Consistent H] : Theory.Consistent H ∅ := by
+  obtain ⟨f, hf⟩ := H_consis.exists_unprovable;
   apply def_consistent.mpr;
   intro Γ hΓ; by_contra hC;
   replace hΓ := List.nil_iff.mpr hΓ; subst hΓ;
-  have : Λ ⊢! f := efq'! $ hC ⨀ verum!;
+  have : H ⊢! f := efq'! $ hC ⨀ verum!;
   contradiction;
 
 variable [DecidableEq α]
 
-lemma iff_insert_consistent : Theory.Consistent Λ (insert φ T) ↔ ∀ {Γ : List (Formula α)}, (∀ ψ ∈ Γ, ψ ∈ T) → Λ ⊬ φ ⋏ ⋀Γ ➝ ⊥ := by
+lemma iff_insert_consistent : Theory.Consistent H (insert φ T) ↔ ∀ {Γ : List (Formula α)}, (∀ ψ ∈ Γ, ψ ∈ T) → H ⊬ φ ⋏ ⋀Γ ➝ ⊥ := by
   constructor;
   . intro h Γ hΓ;
     by_contra hC;
-    have : Λ ⊬ φ ⋏ ⋀Γ ➝ ⊥ := iff_imply_left_cons_conj'!.not.mp $ (def_consistent.mp h) (φ :: Γ) (by
+    have : H ⊬ φ ⋏ ⋀Γ ➝ ⊥ := iff_imply_left_cons_conj'!.not.mp $ (def_consistent.mp h) (φ :: Γ) (by
       rintro ψ hq;
       simp at hq;
       cases hq with
@@ -70,7 +70,7 @@ lemma iff_insert_consistent : Theory.Consistent Λ (insert φ T) ↔ ∀ {Γ : L
   . intro h;
     apply def_consistent.mpr;
     intro Γ hΓ;
-    have  : Λ ⊬ φ ⋏ ⋀List.remove φ Γ ➝ ⊥ := @h (Γ.remove φ) (by
+    have  : H ⊬ φ ⋏ ⋀List.remove φ Γ ➝ ⊥ := @h (Γ.remove φ) (by
       intro ψ hq;
       have := by simpa using hΓ ψ $ List.mem_of_mem_remove hq;
       cases this with
@@ -82,12 +82,12 @@ lemma iff_insert_consistent : Theory.Consistent Λ (insert φ T) ↔ ∀ {Γ : L
     have := imp_trans''! and_comm! $ imply_left_remove_conj! (φ := φ) $ FiniteContext.provable_iff.mp hC;
     contradiction;
 
-lemma iff_insert_inconsistent : ¬(insert φ T).Consistent Λ ↔ ∃ Γ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ Λ ⊢! φ ⋏ ⋀Γ ➝ ⊥ := by
+lemma iff_insert_inconsistent : ¬(insert φ T).Consistent H ↔ ∃ Γ : List (Formula α), (∀ φ ∈ Γ, φ ∈ T) ∧ H ⊢! φ ⋏ ⋀Γ ➝ ⊥ := by
   constructor;
   . contrapose; push_neg; apply iff_insert_consistent.mpr;
   . contrapose; push_neg; apply iff_insert_consistent.mp;
 
-lemma provable_iff_insert_neg_not_consistent : T *⊢[Λ]! φ ↔ ¬Theory.Consistent Λ (insert (∼φ) T) := by
+lemma provable_iff_insert_neg_not_consistent : T *⊢[H]! φ ↔ ¬Theory.Consistent H (insert (∼φ) T) := by
   constructor;
   . intro h;
     apply iff_insert_inconsistent.mpr;
@@ -104,19 +104,19 @@ lemma provable_iff_insert_neg_not_consistent : T *⊢[Λ]! φ ↔ ¬Theory.Consi
     existsi Γ;
     constructor;
     . exact hΓ₁;
-    . have : Γ ⊢[Λ]! ∼φ ➝ ⊥ := imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
+    . have : Γ ⊢[H]! ∼φ ➝ ⊥ := imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
       exact dne'! $ neg_equiv'!.mpr this;
 
-lemma unprovable_iff_insert_neg_consistent : T *⊬[Λ] φ ↔ Theory.Consistent Λ (insert (∼φ) T) := by
+lemma unprovable_iff_insert_neg_consistent : T *⊬[H] φ ↔ Theory.Consistent H (insert (∼φ) T) := by
   simpa [not_not] using provable_iff_insert_neg_not_consistent.not;
 
-lemma unprovable_iff_singleton_neg_consistent : Λ ⊬ φ ↔ Theory.Consistent Λ {∼φ} := by
+lemma unprovable_iff_singleton_neg_consistent : H ⊬ φ ↔ Theory.Consistent H {∼φ} := by
   have e : insert (∼φ) ∅ = ({∼φ} : Theory α) := by aesop;
-  have H := unprovable_iff_insert_neg_consistent (Λ := Λ) (T := ∅) (φ := φ);
+  have H := unprovable_iff_insert_neg_consistent (H := H) (T := ∅) (φ := φ);
   rw [e] at H;
   exact Iff.trans Context.provable_iff_provable.not H;
 
-lemma neg_provable_iff_insert_not_consistent : T *⊢[Λ]! ∼φ ↔ ¬Theory.Consistent Λ (insert (φ) T) := by
+lemma neg_provable_iff_insert_not_consistent : T *⊢[H]! ∼φ ↔ ¬Theory.Consistent H (insert (φ) T) := by
   constructor;
   . intro h;
     apply iff_insert_inconsistent.mpr;
@@ -136,53 +136,53 @@ lemma neg_provable_iff_insert_not_consistent : T *⊢[Λ]! ∼φ ↔ ¬Theory.Co
     . apply neg_equiv'!.mpr;
       exact imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
 
-lemma neg_unprovable_iff_insert_consistent : T *⊬[Λ] ∼φ ↔ Theory.Consistent Λ (insert (φ) T) := by
+lemma neg_unprovable_iff_insert_consistent : T *⊬[H] ∼φ ↔ Theory.Consistent H (insert (φ) T) := by
   simpa [not_not] using neg_provable_iff_insert_not_consistent.not;
 
-lemma unprovable_iff_singleton_consistent : Λ ⊬ ∼φ ↔ Theory.Consistent Λ {φ} := by
+lemma unprovable_iff_singleton_consistent : H ⊬ ∼φ ↔ Theory.Consistent H {φ} := by
   have e : insert (φ) ∅ = ({φ} : Theory α) := by aesop;
-  have H := neg_unprovable_iff_insert_consistent (Λ := Λ) (T := ∅) (φ := φ);
+  have H := neg_unprovable_iff_insert_consistent (H := H) (T := ∅) (φ := φ);
   rw [e] at H;
   exact Iff.trans Context.provable_iff_provable.not H;
 
 omit [DecidableEq α] in
-lemma unprovable_falsum (T_consis : T.Consistent Λ) : T *⊬[Λ] ⊥ := by
+lemma unprovable_falsum (T_consis : T.Consistent H) : T *⊬[H] ⊥ := by
   by_contra hC;
   obtain ⟨Γ, hΓ₁, _⟩ := Context.provable_iff.mp $ hC;
-  have : Γ ⊬[Λ] ⊥ := (def_consistent.mp T_consis) _ hΓ₁;
+  have : Γ ⊬[H] ⊥ := (def_consistent.mp T_consis) _ hΓ₁;
   contradiction;
 
-lemma unprovable_either (T_consis : T.Consistent Λ) : ¬(T *⊢[Λ]! φ ∧ T *⊢[Λ]! ∼φ) := by
+lemma unprovable_either (T_consis : T.Consistent H) : ¬(T *⊢[H]! φ ∧ T *⊢[H]! ∼φ) := by
   by_contra hC;
   have ⟨hC₁, hC₂⟩ := hC;
-  have : T *⊢[Λ]! ⊥ := neg_mdp! hC₂ hC₁;
-  have : T *⊬[Λ] ⊥ := unprovable_falsum T_consis;
+  have : T *⊢[H]! ⊥ := neg_mdp! hC₂ hC₁;
+  have : T *⊬[H] ⊥ := unprovable_falsum T_consis;
   contradiction;
 
-lemma not_mem_falsum_of_consistent (T_consis : T.Consistent Λ) : ⊥ ∉ T := by
+lemma not_mem_falsum_of_consistent (T_consis : T.Consistent H) : ⊥ ∉ T := by
   by_contra hC;
-  have : Λ ⊬ ⊥ ➝ ⊥ := (def_consistent.mp T_consis) [⊥] (by simpa);
-  have : Λ ⊢! ⊥ ➝ ⊥ := efq!;
+  have : H ⊬ ⊥ ➝ ⊥ := (def_consistent.mp T_consis) [⊥] (by simpa);
+  have : H ⊢! ⊥ ➝ ⊥ := efq!;
   contradiction;
 
-lemma not_singleton_consistent [Λ.HasNecessitation] (T_consis : T.Consistent Λ) (h : ∼□φ ∈ T) : Theory.Consistent Λ {∼φ} := by
+lemma not_singleton_consistent [H.HasNecessitation] (T_consis : T.Consistent H) (h : ∼□φ ∈ T) : Theory.Consistent H {∼φ} := by
   apply def_consistent.mpr;
   intro Γ hΓ;
   simp only [Set.mem_singleton_iff] at hΓ;
   by_contra hC;
-  have : Λ ⊢! ∼(□φ) ➝ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
-  have : Λ ⊬ ∼(□φ) ➝ ⊥ := def_consistent.mp T_consis (Γ := [∼(□φ)]) (by aesop)
+  have : H ⊢! ∼(□φ) ➝ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
+  have : H ⊬ ∼(□φ) ➝ ⊥ := def_consistent.mp T_consis (Γ := [∼(□φ)]) (by aesop)
   contradiction;
 
-lemma either_consistent (T_consis : T.Consistent Λ) (φ) : Theory.Consistent Λ (insert φ T) ∨ Theory.Consistent Λ (insert (∼φ) T) := by
+lemma either_consistent (T_consis : T.Consistent H) (φ) : Theory.Consistent H (insert φ T) ∨ Theory.Consistent H (insert (∼φ) T) := by
   by_contra hC; push_neg at hC;
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp hC.1;
   obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_inconsistent.mp hC.2;
 
   replace hΓ₂ := neg_equiv'!.mpr hΓ₂;
   replace hΔ₂ := neg_equiv'!.mpr hΔ₂;
-  have : Λ ⊢! ⋀Γ ⋏ ⋀Δ ➝ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
-  have : Λ ⊬ ⋀Γ ⋏ ⋀Δ ➝ ⊥ := unprovable_imp_trans''! imply_left_concat_conj! $ def_consistent.mp T_consis (Γ ++ Δ) $ by
+  have : H ⊢! ⋀Γ ⋏ ⋀Δ ➝ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
+  have : H ⊬ ⋀Γ ⋏ ⋀Δ ➝ ⊥ := unprovable_imp_trans''! imply_left_concat_conj! $ def_consistent.mp T_consis (Γ ++ Δ) $ by
     simp;
     rintro ψ (hqΓ | hqΔ);
     . exact hΓ₁ ψ hqΓ;
@@ -190,9 +190,9 @@ lemma either_consistent (T_consis : T.Consistent Λ) (φ) : Theory.Consistent Λ
   contradiction;
 
 lemma exists_maximal_consistent_theory
-  (T_consis : T.Consistent Λ)
-  : ∃ Z, Theory.Consistent Λ Z ∧ T ⊆ Z ∧ ∀ U, Theory.Consistent Λ U → Z ⊆ U → U = Z := by
-  obtain ⟨Z, h₁, ⟨h₂, h₃⟩⟩ := zorn_subset_nonempty { T : Theory α | T.Consistent Λ } (by
+  (T_consis : T.Consistent H)
+  : ∃ Z, Theory.Consistent H Z ∧ T ⊆ Z ∧ ∀ U, Theory.Consistent H U → Z ⊆ U → U = Z := by
+  obtain ⟨Z, h₁, ⟨h₂, h₃⟩⟩ := zorn_subset_nonempty { T : Theory α | T.Consistent H } (by
     intro c hc chain hnc;
     existsi (⋃₀ c);
     simp only [Set.mem_setOf_eq, Set.mem_sUnion];
@@ -204,8 +204,8 @@ lemma exists_maximal_consistent_theory
           (s := ↑Γ.toFinset) (by simp)
           (by intro φ hp; simp_all);
       simp [List.coe_toFinset] at hUs;
-      have : Theory.Consistent Λ U := hc hUc;
-      have : ¬Theory.Consistent Λ U := by
+      have : Theory.Consistent H U := hc hUc;
+      have : ¬Theory.Consistent H U := by
         apply def_inconsistent.mpr;
         use Γ;
         constructor;
@@ -227,12 +227,12 @@ protected alias lindenbaum := exists_maximal_consistent_theory
 
 open Classical in
 lemma intro_union_consistent
-  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ T₁) ∧ (∀ φ ∈ Γ₂, φ ∈ T₂) → Λ ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ➝ ⊥) : Theory.Consistent Λ (T₁ ∪ T₂) := by
+  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ T₁) ∧ (∀ φ ∈ Γ₂, φ ∈ T₂) → H ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ➝ ⊥) : Theory.Consistent H (T₁ ∪ T₂) := by
   apply def_consistent.mpr;
   intro Δ hΔ;
   let Δ₁ := (Δ.filter (· ∈ T₁));
   let Δ₂ := (Δ.filter (· ∈ T₂));
-  have : Λ ⊬ ⋀Δ₁ ⋏ ⋀Δ₂ ➝ ⊥ := @h Δ₁ Δ₂ ⟨(by intro _ h; simpa using List.of_mem_filter h), (by intro _ h; simpa using List.of_mem_filter h)⟩;
+  have : H ⊬ ⋀Δ₁ ⋏ ⋀Δ₂ ➝ ⊥ := @h Δ₁ Δ₂ ⟨(by intro _ h; simpa using List.of_mem_filter h), (by intro _ h; simpa using List.of_mem_filter h)⟩;
   exact unprovable_imp_trans''! (by
     apply FiniteContext.deduct'!;
     apply iff_provable_list_conj.mpr;
@@ -244,8 +244,8 @@ lemma intro_union_consistent
 
 open Classical in
 lemma intro_triunion_consistent
-  (h : ∀ {Γ₁ Γ₂ Γ₃ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ T₁) ∧ (∀ φ ∈ Γ₂, φ ∈ T₂) ∧ (∀ φ ∈ Γ₃, φ ∈ T₃) → Λ ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ⋏ ⋀Γ₃ ➝ ⊥)
-  : Theory.Consistent Λ (T₁ ∪ T₂ ∪ T₃) := by
+  (h : ∀ {Γ₁ Γ₂ Γ₃ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ T₁) ∧ (∀ φ ∈ Γ₂, φ ∈ T₂) ∧ (∀ φ ∈ Γ₃, φ ∈ T₃) → H ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ⋏ ⋀Γ₃ ➝ ⊥)
+  : Theory.Consistent H (T₁ ∪ T₂ ∪ T₃) := by
   apply intro_union_consistent;
   rintro Γ₁₂ Γ₃ ⟨h₁₂, h₃⟩;
   simp at h₁₂;
@@ -272,23 +272,23 @@ lemma intro_triunion_consistent
         simpa using List.of_mem_filter hp;
       . assumption;
 
-lemma not_mem_of_mem_neg (T_consis : T.Consistent Λ) (h : ∼φ ∈ T) : φ ∉ T := by
+lemma not_mem_of_mem_neg (T_consis : T.Consistent H) (h : ∼φ ∈ T) : φ ∉ T := by
   by_contra hC;
-  have : [φ, ∼φ] ⊬[Λ] ⊥ := (Theory.def_consistent.mp T_consis) [φ, ∼φ] (by simp_all);
-  have : [φ, ∼φ] ⊢[Λ]! ⊥ := System.bot_of_mem_either! (φ := φ) (Γ := [φ, ∼φ]) (by simp) (by simp);
+  have : [φ, ∼φ] ⊬[H] ⊥ := (Theory.def_consistent.mp T_consis) [φ, ∼φ] (by simp_all);
+  have : [φ, ∼φ] ⊢[H]! ⊥ := System.bot_of_mem_either! (φ := φ) (Γ := [φ, ∼φ]) (by simp) (by simp);
   contradiction;
 
-lemma not_mem_neg_of_mem (T_consis : T.Consistent Λ) (h : φ ∈ T) : ∼φ ∉ T := by
+lemma not_mem_neg_of_mem (T_consis : T.Consistent H) (h : φ ∈ T) : ∼φ ∉ T := by
   by_contra hC;
-  have : [φ, ∼φ] ⊬[Λ] ⊥ := (Theory.def_consistent.mp T_consis) [φ, ∼φ] (by simp_all);
-  have : [φ, ∼φ] ⊢[Λ]! ⊥ := System.bot_of_mem_either! (φ := φ) (Γ := [φ, ∼φ]) (by simp) (by simp);
+  have : [φ, ∼φ] ⊬[H] ⊥ := (Theory.def_consistent.mp T_consis) [φ, ∼φ] (by simp_all);
+  have : [φ, ∼φ] ⊢[H]! ⊥ := System.bot_of_mem_either! (φ := φ) (Γ := [φ, ∼φ]) (by simp) (by simp);
   contradiction;
 end Theory
 
-structure MaximalConsistentTheory (Λ : Hilbert α) where
+structure MaximalConsistentTheory (H : Hilbert α) where
   theory : Theory α
-  consistent : theory.Consistent Λ
-  maximal : ∀ {U}, theory ⊂ U → ¬Theory.Consistent Λ U
+  consistent : theory.Consistent H
+  maximal : ∀ {U}, theory ⊂ U → ¬Theory.Consistent H U
 alias MCT := MaximalConsistentTheory
 
 namespace MaximalConsistentTheory
@@ -296,11 +296,11 @@ namespace MaximalConsistentTheory
 open Theory
 
 variable [DecidableEq α]
-variable {Λ : Hilbert α}
-variable {Ω Ω₁ Ω₂ : MCT Λ}
+variable {H : Hilbert α}
+variable {Ω Ω₁ Ω₂ : MCT H}
 variable {φ : Formula α}
 
-lemma exists_maximal_Lconsistented_theory (consisT : T.Consistent Λ) : ∃ Ω : MCT Λ, (T ⊆ Ω.theory) := by
+lemma exists_maximal_Lconsistented_theory (consisT : T.Consistent H) : ∃ Ω : MCT H, (T ⊆ Ω.theory) := by
   have ⟨Ω, hΩ₁, hΩ₂, hΩ₃⟩ := Theory.lindenbaum consisT;
   use {
     theory := Ω,
@@ -315,29 +315,29 @@ lemma exists_maximal_Lconsistented_theory (consisT : T.Consistent Λ) : ∃ Ω :
 
 alias lindenbaum := exists_maximal_Lconsistented_theory
 
-instance [System.Consistent Λ] : Nonempty (MCT Λ) := ⟨lindenbaum emptyset_consistent |>.choose⟩
+instance [System.Consistent H] : Nonempty (MCT H) := ⟨lindenbaum emptyset_consistent |>.choose⟩
 
-lemma either_mem (Ω : MCT Λ) (φ) : φ ∈ Ω.theory ∨ ∼φ ∈ Ω.theory := by
+lemma either_mem (Ω : MCT H) (φ) : φ ∈ Ω.theory ∨ ∼φ ∈ Ω.theory := by
   by_contra hC; push_neg at hC;
   cases either_consistent Ω.consistent φ with
   | inl h => have := Ω.maximal (Set.ssubset_insert hC.1); contradiction;
   | inr h => have := Ω.maximal (Set.ssubset_insert hC.2); contradiction;
 
 omit [DecidableEq α] in
-lemma maximal' {φ : Formula α} (hp : φ ∉ Ω.theory) : ¬Theory.Consistent Λ (insert φ Ω.theory) := Ω.maximal (Set.ssubset_insert hp)
+lemma maximal' {φ : Formula α} (hp : φ ∉ Ω.theory) : ¬Theory.Consistent H (insert φ Ω.theory) := Ω.maximal (Set.ssubset_insert hp)
 
-lemma membership_iff : (φ ∈ Ω.theory) ↔ (Ω.theory *⊢[Λ]! φ) := by
+lemma membership_iff : (φ ∈ Ω.theory) ↔ (Ω.theory *⊢[H]! φ) := by
   constructor;
   . intro h; exact Context.by_axm! h;
   . intro hp;
     suffices ∼φ ∉ Ω.theory by apply or_iff_not_imp_right.mp $ (either_mem Ω φ); assumption;
     by_contra hC;
-    have hnp : Ω.theory *⊢[Λ]! ∼φ := Context.by_axm! hC;
+    have hnp : Ω.theory *⊢[H]! ∼φ := Context.by_axm! hC;
     have := neg_mdp! hnp hp;
     have := Ω.consistent;
     contradiction;
 
-lemma subset_axiomset : Λ.axioms ⊆ Ω.theory := by
+lemma subset_axiomset : H.axioms ⊆ Ω.theory := by
   intro φ hp;
   apply membership_iff.mpr;
   apply Context.of!;
@@ -348,7 +348,7 @@ lemma subset_axiomset : Λ.axioms ⊆ Ω.theory := by
 @[simp] lemma mem_verum : ⊤ ∈ Ω.theory := by apply membership_iff.mpr; apply verum!;
 
 @[simp]
-lemma unprovable_falsum : Ω.theory *⊬[Λ] ⊥ := by apply membership_iff.not.mp; simp
+lemma unprovable_falsum : Ω.theory *⊬[H] ⊥ := by apply membership_iff.not.mp; simp
 
 @[simp]
 lemma iff_mem_neg : (∼φ ∈ Ω.theory) ↔ (φ ∉ Ω.theory) := by
@@ -357,8 +357,8 @@ lemma iff_mem_neg : (∼φ ∈ Ω.theory) ↔ (φ ∉ Ω.theory) := by
     by_contra hp;
     replace hp := membership_iff.mp hp;
     replace hnp := membership_iff.mp hnp;
-    have : Ω.theory *⊢[Λ]! ⊥ := neg_mdp! hnp hp;
-    have : Ω.theory *⊬[Λ] ⊥ := unprovable_falsum;
+    have : Ω.theory *⊢[H]! ⊥ := neg_mdp! hnp hp;
+    have : Ω.theory *⊬[H] ⊥ := unprovable_falsum;
     contradiction;
   . intro hp;
     have := provable_iff_insert_neg_not_consistent.not.mp $ membership_iff.not.mp hp;
@@ -412,8 +412,8 @@ lemma iff_mem_or : ((φ ⋎ ψ) ∈ Ω.theory) ↔ (φ ∈ Ω.theory) ∨ (ψ �
     have ⟨hp, hq⟩ := hC;
     replace hp := membership_iff.mp $ iff_mem_neg.mpr hp;
     replace hq := membership_iff.mp $ iff_mem_neg.mpr hq;
-    have : Ω.theory *⊢[Λ]! ⊥ := or₃'''! (neg_equiv'!.mp hp) (neg_equiv'!.mp hq) hpq;
-    have : Ω.theory *⊬[Λ] ⊥ := unprovable_falsum;
+    have : Ω.theory *⊢[H]! ⊥ := or₃'''! (neg_equiv'!.mp hp) (neg_equiv'!.mp hq) hpq;
+    have : Ω.theory *⊬[H] ⊥ := unprovable_falsum;
     contradiction;
   . rintro (hp | hq);
     . apply membership_iff.mpr;
@@ -421,7 +421,7 @@ lemma iff_mem_or : ((φ ⋎ ψ) ∈ Ω.theory) ↔ (φ ∈ Ω.theory) ∨ (ψ �
     . apply membership_iff.mpr;
       exact or₂'! (membership_iff.mp hq);
 
-lemma iff_congr : (Ω.theory *⊢[Λ]! (φ ⭤ ψ)) → ((φ ∈ Ω.theory) ↔ (ψ ∈ Ω.theory)) := by
+lemma iff_congr : (Ω.theory *⊢[H]! (φ ⭤ ψ)) → ((φ ∈ Ω.theory) ↔ (ψ ∈ Ω.theory)) := by
   intro hpq;
   constructor;
   . intro hp; exact iff_mem_imp.mp (membership_iff.mpr $ and₁'! hpq) hp;
@@ -457,26 +457,26 @@ lemma neg_imp (h : ψ ∈ Ω₂.theory → φ ∈ Ω₁.theory) : (∼φ ∈ Ω�
 
 lemma neg_iff (h : φ ∈ Ω₁.theory ↔ ψ ∈ Ω₂.theory) : (∼φ ∈ Ω₁.theory) ↔ (∼ψ ∈ Ω₂.theory) := ⟨neg_imp $ h.mpr, neg_imp $ h.mp⟩
 
--- These lemmata require Λ normality
+-- These lemmata require H normality
 section Normal
 
-variable [Λ.IsNormal]
+variable [H.IsNormal]
 
-lemma iff_mem_multibox : (□^[n]φ ∈ Ω.theory) ↔ (∀ {Ω' : MCT Λ}, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) → (φ ∈ Ω'.theory)) := by
+lemma iff_mem_multibox : (□^[n]φ ∈ Ω.theory) ↔ (∀ {Ω' : MCT H}, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) → (φ ∈ Ω'.theory)) := by
   constructor;
   . intro hp Ω' hΩ'; apply hΩ'; simpa;
   . contrapose;
     push_neg;
     intro hp;
-    obtain ⟨Ω', hΩ'⟩ := lindenbaum (Λ := Λ) (T := insert (∼φ) (□''⁻¹^[n]Ω.theory)) (by
+    obtain ⟨Ω', hΩ'⟩ := lindenbaum (H := H) (T := insert (∼φ) (□''⁻¹^[n]Ω.theory)) (by
       apply unprovable_iff_insert_neg_consistent.mp;
       by_contra hC;
       obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp hC;
-      have : Λ ⊢! □^[n]⋀Γ ➝ □^[n]φ := imply_multibox_distribute'! hΓ₂;
-      have : Λ ⊬ □^[n]⋀Γ ➝ □^[n]φ := by
+      have : H ⊢! □^[n]⋀Γ ➝ □^[n]φ := imply_multibox_distribute'! hΓ₂;
+      have : H ⊬ □^[n]⋀Γ ➝ □^[n]φ := by
         have := Context.provable_iff.not.mp $ membership_iff.not.mp hp;
         push_neg at this;
-        have : Λ ⊬ ⋀□'^[n]Γ ➝ □^[n]φ := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
+        have : H ⊬ ⋀□'^[n]Γ ➝ □^[n]φ := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
           intro ψ hq;
           obtain ⟨χ, hr₁, hr₂⟩ := by simpa using hq;
           subst hr₂;
@@ -494,7 +494,7 @@ lemma iff_mem_multibox : (□^[n]φ ∈ Ω.theory) ↔ (∀ {Ω' : MCT Λ}, (□
     . apply iff_mem_neg.mp;
       apply hΩ';
       simp only [Set.mem_insert_iff, true_or]
-lemma iff_mem_box : (□φ ∈ Ω.theory) ↔ (∀ {Ω' : MCT Λ}, (□''⁻¹Ω.theory ⊆ Ω'.theory) → (φ ∈ Ω'.theory)) := iff_mem_multibox (n := 1)
+lemma iff_mem_box : (□φ ∈ Ω.theory) ↔ (∀ {Ω' : MCT H}, (□''⁻¹Ω.theory ⊆ Ω'.theory) → (φ ∈ Ω'.theory)) := iff_mem_multibox (n := 1)
 
 lemma multibox_dn_iff : (□^[n](∼∼φ) ∈ Ω.theory) ↔ (□^[n]φ ∈ Ω.theory) := by
   simp only [iff_mem_multibox];
@@ -545,7 +545,7 @@ lemma mem_multidia_dual : ◇^[n]φ ∈ Ω.theory ↔ ∼(□^[n](∼φ)) ∈ Ω
     . exact FiniteContext.provable_iff.mpr $ imp_trans''! (FiniteContext.provable_iff.mp hΓ₂) (and₂'! multidia_duality!);
 lemma mem_dia_dual : ◇φ ∈ Ω.theory ↔ (∼(□(∼φ)) ∈ Ω.theory) := mem_multidia_dual (n := 1)
 
-lemma iff_mem_multidia : (◇^[n]φ ∈ Ω.theory) ↔ (∃ Ω' : MCT Λ, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) ∧ (φ ∈ Ω'.theory)) := by
+lemma iff_mem_multidia : (◇^[n]φ ∈ Ω.theory) ↔ (∃ Ω' : MCT H, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) ∧ (φ ∈ Ω'.theory)) := by
   constructor;
   . intro h;
     have := mem_multidia_dual.mp h;
@@ -566,7 +566,7 @@ lemma iff_mem_multidia : (◇^[n]φ ∈ Ω.theory) ↔ (∃ Ω' : MCT Λ, (□''
     constructor;
     . exact h₁;
     . exact iff_mem_neg.mp $ mem_dn_iff.mp h₂;
-lemma iff_mem_dia : (◇φ ∈ Ω.theory) ↔ (∃ Ω' : MCT Λ, (□''⁻¹Ω.theory ⊆ Ω'.theory) ∧ (φ ∈ Ω'.theory)) := iff_mem_multidia (n := 1)
+lemma iff_mem_dia : (◇φ ∈ Ω.theory) ↔ (∃ Ω' : MCT H, (□''⁻¹Ω.theory ⊆ Ω'.theory) ∧ (φ ∈ Ω'.theory)) := iff_mem_multidia (n := 1)
 
 lemma multibox_multidia : (∀ {φ : Formula α}, (□^[n]φ ∈ Ω₁.theory → φ ∈ Ω₂.theory)) ↔ (∀ {φ : Formula α}, (φ ∈ Ω₂.theory → ◇^[n]φ ∈ Ω₁.theory)) := by
   constructor;
@@ -589,7 +589,7 @@ lemma multibox_multidia : (∀ {φ : Formula α}, (□^[n]φ ∈ Ω₁.theory �
 
 variable {Γ : List (Formula α)}
 
-omit [Λ.IsNormal] in
+omit [H.IsNormal] in
 lemma iff_mem_conj : (⋀Γ ∈ Ω.theory) ↔ (∀ φ ∈ Γ, φ ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
 
 lemma iff_mem_multibox_conj : (□^[n]⋀Γ ∈ Ω.theory) ↔ (∀ φ ∈ Γ, □^[n]φ ∈ Ω.theory) := by

--- a/Foundation/Modal/Geach.lean
+++ b/Foundation/Modal/Geach.lean
@@ -156,7 +156,7 @@ attribute [simp] Hilbert.IsGeach.char
 
 namespace IsGeach
 
-lemma ax {Λ : Hilbert α} [geach : Λ.IsGeach ts] : Λ.axioms = (𝗞 ∪ 𝗚𝗲(ts)) := by
+lemma ax {H : Hilbert α} [geach : H.IsGeach ts] : H.axioms = (𝗞 ∪ 𝗚𝗲(ts)) := by
   have e := geach.char;
   simp [Hilbert.Geach] at e;
   simp_all;

--- a/Foundation/Modal/Geach.lean
+++ b/Foundation/Modal/Geach.lean
@@ -50,8 +50,7 @@ lemma dense_def : Dense R ↔ (GeachConfluent ⟨0, 1, 2, 0⟩ R) := by
   . rintro h x y z rfl Rxz; exact h Rxz;
   . intro h x y Rxy; exact h rfl Rxy;
 
-@[simp]
-lemma satisfies_eq : GeachConfluent (α := α) t (· = ·) := by simp [GeachConfluent];
+@[simp] lemma satisfies_eq : GeachConfluent (α := α) t (· = ·) := by simp [GeachConfluent];
 
 end GeachConfluent
 
@@ -144,15 +143,14 @@ variable {Ax : Theory α}
 
 open System
 
-protected abbrev Geach (l : List GeachTaple) : Hilbert α := 𝜿(𝗚𝗲(l))
-notation "𝐆𝐞(" l ")" => Modal.Geach l
+protected abbrev Hilbert.Geach (α) (l : List GeachTaple) : Hilbert α := Hilbert.ExtK (𝗚𝗲(l))
 
 namespace Geach
 
 end Geach
 
 protected class Hilbert.IsGeach (L : Hilbert α) (ts : List GeachTaple) where
-  char : L = 𝐆𝐞(ts) := by aesop;
+  char : L = Hilbert.Geach _ ts := by aesop;
 
 attribute [simp] Hilbert.IsGeach.char
 
@@ -160,28 +158,28 @@ namespace IsGeach
 
 lemma ax {Λ : Hilbert α} [geach : Λ.IsGeach ts] : Λ.axioms = (𝗞 ∪ 𝗚𝗲(ts)) := by
   have e := geach.char;
-  simp [Modal.Geach] at e;
+  simp [Hilbert.Geach] at e;
   simp_all;
 
-instance : 𝐊.IsGeach (α := α) [] where
+instance : (Hilbert.K α).IsGeach [] where
 
-instance : 𝐊𝐃.IsGeach (α := α) [⟨0, 0, 1, 1⟩] where
+instance : (Hilbert.KD α).IsGeach [⟨0, 0, 1, 1⟩] where
 
-instance : 𝐊𝐓.IsGeach (α := α) [⟨0, 0, 1, 0⟩] where
+instance : (Hilbert.KT α).IsGeach [⟨0, 0, 1, 0⟩] where
 
-instance : 𝐊𝐓𝐁.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨0, 1, 0, 1⟩] where
+instance : (Hilbert.KTB α).IsGeach [⟨0, 0, 1, 0⟩, ⟨0, 1, 0, 1⟩] where
 
-instance : 𝐊𝟒.IsGeach (α := α) [⟨0, 2, 1, 0⟩] where
+instance : (Hilbert.K4 α).IsGeach [⟨0, 2, 1, 0⟩] where
 
-instance : 𝐒𝟒.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩] where
+instance : (Hilbert.S4 α).IsGeach [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩] where
 
-instance : 𝐒𝟒.𝟐.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩, ⟨1, 1, 1, 1⟩] where
+instance : (Hilbert.S4Dot2 α).IsGeach [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩, ⟨1, 1, 1, 1⟩] where
 
-instance : 𝐒𝟓.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨1, 1, 0, 1⟩] where
+instance : (Hilbert.S5 α).IsGeach [⟨0, 0, 1, 0⟩, ⟨1, 1, 0, 1⟩] where
 
-instance : 𝐊𝐓𝟒𝐁.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩, ⟨0, 1, 0, 1⟩] where
+instance : (Hilbert.KT4B α).IsGeach [⟨0, 0, 1, 0⟩, ⟨0, 2, 1, 0⟩, ⟨0, 1, 0, 1⟩] where
 
-instance : 𝐓𝐫𝐢𝐯.IsGeach (α := α) [⟨0, 0, 1, 0⟩, ⟨0, 1, 0, 0⟩] where
+instance : (Hilbert.Triv α).IsGeach [⟨0, 0, 1, 0⟩, ⟨0, 1, 0, 0⟩] where
 
 end IsGeach
 

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -44,31 +44,31 @@ structure Hilbert (α : Type*) where
   rules : Set (Hilbert.InferenceRule α)
 
 
-inductive Hilbert.Deduction (Λ : Hilbert α) : (Formula α) → Type _
-  | maxm {φ}     : φ ∈ Λ.axioms → Deduction Λ φ
-  | rule {rl}    : rl ∈ Λ.rules → (∀ {φ}, φ ∈ rl.antecedents → Deduction Λ φ) → Deduction Λ rl.consequence
-  | mdp {φ ψ}    : Deduction Λ (φ ➝ ψ) → Deduction Λ φ → Deduction Λ ψ
-  | imply₁ φ ψ   : Deduction Λ $ Axioms.Imply₁ φ ψ
-  | imply₂ φ ψ χ : Deduction Λ $ Axioms.Imply₂ φ ψ χ
-  | ec φ ψ       : Deduction Λ $ Axioms.ElimContra φ ψ
+inductive Hilbert.Deduction (H : Hilbert α) : (Formula α) → Type _
+  | maxm {φ}     : φ ∈ H.axioms → Deduction H φ
+  | rule {rl}    : rl ∈ H.rules → (∀ {φ}, φ ∈ rl.antecedents → Deduction H φ) → Deduction H rl.consequence
+  | mdp {φ ψ}    : Deduction H (φ ➝ ψ) → Deduction H φ → Deduction H ψ
+  | imply₁ φ ψ   : Deduction H $ Axioms.Imply₁ φ ψ
+  | imply₂ φ ψ χ : Deduction H $ Axioms.Imply₂ φ ψ χ
+  | ec φ ψ       : Deduction H $ Axioms.ElimContra φ ψ
 
 namespace Hilbert.Deduction
 
-variable {Λ Λ₁ Λ₂ : Hilbert α}
+variable {H H₁ H₂ : Hilbert α}
 
 instance : System (Formula α) (Hilbert α) := ⟨Deduction⟩
 
-instance : System.Lukasiewicz Λ where
+instance : System.Lukasiewicz H where
   mdp := mdp
   imply₁ := imply₁
   imply₂ := imply₂
   elim_contra := ec
 
-instance : System.Classical Λ where
+instance : System.Classical H where
 
-instance : System.HasDiaDuality Λ := inferInstance
+instance : System.HasDiaDuality H := inferInstance
 
-lemma maxm! {φ} (h : φ ∈ Λ.axioms) : Λ ⊢! φ := ⟨maxm h⟩
+lemma maxm! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := ⟨maxm h⟩
 
 end Hilbert.Deduction
 
@@ -77,42 +77,42 @@ namespace Hilbert
 
 open Deduction
 
-class HasNecessitation (Λ : Hilbert α) where
-  has_necessitation : ⟮Nec⟯ ⊆ Λ.rules := by aesop
+class HasNecessitation (H : Hilbert α) where
+  has_necessitation : ⟮Nec⟯ ⊆ H.rules := by aesop
 
-instance [HasNecessitation Λ] : System.Necessitation Λ where
-  nec := @λ φ d => rule (show { antecedents := [φ], consequence := □φ } ∈ Λ.rules by apply HasNecessitation.has_necessitation; simp_all) (by aesop);
-
-
-class HasLoebRule (Λ : Hilbert α) where
-  has_loeb : ⟮Loeb⟯ ⊆ Λ.rules := by aesop
-
-instance [HasLoebRule Λ] : System.LoebRule Λ where
-  loeb := @λ φ d => rule (show { antecedents := [□φ ➝ φ], consequence := φ } ∈ Λ.rules by apply HasLoebRule.has_loeb; simp_all) (by aesop);
+instance [HasNecessitation H] : System.Necessitation H where
+  nec := @λ φ d => rule (show { antecedents := [φ], consequence := □φ } ∈ H.rules by apply HasNecessitation.has_necessitation; simp_all) (by aesop);
 
 
-class HasHenkinRule (Λ : Hilbert α) where
-  has_henkin : ⟮Henkin⟯ ⊆ Λ.rules := by aesop
+class HasLoebRule (H : Hilbert α) where
+  has_loeb : ⟮Loeb⟯ ⊆ H.rules := by aesop
 
-instance [HasHenkinRule Λ] : System.HenkinRule Λ where
-  henkin := @λ φ d => rule (show { antecedents := [□φ ⭤ φ], consequence := φ } ∈ Λ.rules by apply HasHenkinRule.has_henkin; simp_all) (by aesop);
+instance [HasLoebRule H] : System.LoebRule H where
+  loeb := @λ φ d => rule (show { antecedents := [□φ ➝ φ], consequence := φ } ∈ H.rules by apply HasLoebRule.has_loeb; simp_all) (by aesop);
 
 
-class HasNecOnly (Λ : Hilbert α) where
-  has_necessitation_only : Λ.rules = ⟮Nec⟯ := by rfl
+class HasHenkinRule (H : Hilbert α) where
+  has_henkin : ⟮Henkin⟯ ⊆ H.rules := by aesop
 
-instance [h : HasNecOnly Λ] : Λ.HasNecessitation where
+instance [HasHenkinRule H] : System.HenkinRule H where
+  henkin := @λ φ d => rule (show { antecedents := [□φ ⭤ φ], consequence := φ } ∈ H.rules by apply HasHenkinRule.has_henkin; simp_all) (by aesop);
+
+
+class HasNecOnly (H : Hilbert α) where
+  has_necessitation_only : H.rules = ⟮Nec⟯ := by rfl
+
+instance [h : HasNecOnly H] : H.HasNecessitation where
   has_necessitation := by rw [h.has_necessitation_only]
 
-class HasAxiomK (Λ : Hilbert α) where
-  has_axiomK : 𝗞 ⊆ Λ.axioms := by aesop
+class HasAxiomK (H : Hilbert α) where
+  has_axiomK : 𝗞 ⊆ H.axioms := by aesop
 
-instance [HasAxiomK Λ] : System.HasAxiomK Λ where
+instance [HasAxiomK H] : System.HasAxiomK H where
   K _ _ := maxm (by apply HasAxiomK.has_axiomK; simp_all)
 
-class IsNormal (Λ : Hilbert α) extends Λ.HasNecOnly, Λ.HasAxiomK where
+class IsNormal (H : Hilbert α) extends H.HasNecOnly, H.HasAxiomK where
 
-instance [IsNormal Λ] : System.K Λ where
+instance {H : Hilbert α} [H.IsNormal] : System.K H where
 
 end Hilbert
 
@@ -121,20 +121,20 @@ namespace Hilbert.Deduction
 
 open Hilbert
 
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 noncomputable def inducition!
-  {motive  : (φ : Formula α) → Λ ⊢! φ → Sort*}
-  (hRules  : (r : InferenceRule α) → (hr : r ∈ Λ.rules) →
-             (hant : ∀ {φ}, φ ∈ r.antecedents → Λ ⊢! φ) →
+  {motive  : (φ : Formula α) → H ⊢! φ → Sort*}
+  (hRules  : (r : InferenceRule α) → (hr : r ∈ H.rules) →
+             (hant : ∀ {φ}, φ ∈ r.antecedents → H ⊢! φ) →
              (ih : ∀ {φ}, (hp : φ ∈ r.antecedents) →
              motive φ (hant hp)) → motive r.consequence ⟨rule hr (λ hp => (hant hp).some)⟩)
-  (hMaxm     : ∀ {φ}, (h : φ ∈ Λ.axioms) → motive φ ⟨maxm h⟩)
-  (hMdp      : ∀ {φ ψ}, {hpq : Λ ⊢! φ ➝ ψ} → {hp : Λ ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ ⟨mdp hpq.some hp.some⟩)
+  (hMaxm     : ∀ {φ}, (h : φ ∈ H.axioms) → motive φ ⟨maxm h⟩)
+  (hMdp      : ∀ {φ ψ}, {hpq : H ⊢! φ ➝ ψ} → {hp : H ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ ⟨mdp hpq.some hp.some⟩)
   (hImply₁     : ∀ {φ ψ}, motive (φ ➝ ψ ➝ φ) $ ⟨imply₁ φ ψ⟩)
   (hImply₂     : ∀ {φ ψ χ}, motive ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ) $ ⟨imply₂ φ ψ χ⟩)
   (hElimContra : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ ⟨ec φ ψ⟩)
-  : ∀ {φ}, (d : Λ ⊢! φ) → motive φ d := by
+  : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
   intro φ d;
   induction d.some with
   | maxm h => exact hMaxm h
@@ -145,15 +145,15 @@ noncomputable def inducition!
   | ec => exact hElimContra
 
 /-- Useful induction for normal modal logic. -/
-noncomputable def inducition_with_necOnly! [Λ.HasNecOnly]
-  {motive  : (φ : Formula α) → Λ ⊢! φ → Prop}
-  (hMaxm   : ∀ {φ}, (h : φ ∈ Λ.axioms) → motive φ ⟨maxm h⟩)
-  (hMdp    : ∀ {φ ψ}, {hpq : Λ ⊢! φ ➝ ψ} → {hp : Λ ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ (hpq ⨀ hp))
-  (hNec    : ∀ {φ}, {hp : Λ ⊢! φ} → (ihp : motive φ hp) → motive (□φ) (System.nec! hp))
+noncomputable def inducition_with_necOnly! [H.HasNecOnly]
+  {motive  : (φ : Formula α) → H ⊢! φ → Prop}
+  (hMaxm   : ∀ {φ}, (h : φ ∈ H.axioms) → motive φ ⟨maxm h⟩)
+  (hMdp    : ∀ {φ ψ}, {hpq : H ⊢! φ ➝ ψ} → {hp : H ⊢! φ} → motive (φ ➝ ψ) hpq → motive φ hp → motive ψ (hpq ⨀ hp))
+  (hNec    : ∀ {φ}, {hp : H ⊢! φ} → (ihp : motive φ hp) → motive (□φ) (System.nec! hp))
   (hImply₁   : ∀ {φ ψ}, motive (φ ➝ ψ ➝ φ) $ ⟨imply₁ φ ψ⟩)
   (hImply₂   : ∀ {φ ψ χ}, motive ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ) $ ⟨imply₂ φ ψ χ⟩)
   (hElimContra : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ ⟨ec φ ψ⟩)
-  : ∀ {φ}, (d : Λ ⊢! φ) → motive φ d := by
+  : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
   intro φ d;
   induction d using Deduction.inducition! with
   | hMaxm h => exact hMaxm h
@@ -182,7 +182,7 @@ end Hilbert.Deduction
 
 namespace Hilbert
 
-abbrev theorems (Λ : Hilbert α) := System.theory Λ
+abbrev theorems (H : Hilbert α) := System.theory H
 
 
 section K
@@ -342,9 +342,9 @@ variable [DecidableEq α]
 open System
 open Formula (atom)
 
-lemma normal_weakerThan_of_maxm {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal]
-  (hMaxm : ∀ {φ : Formula α}, φ ∈ Λ₁.axioms → Λ₂ ⊢! φ)
-  : Λ₁ ≤ₛ Λ₂ := by
+lemma normal_weakerThan_of_maxm {H₁ H₂ : Hilbert α} [H₁.IsNormal] [H₂.IsNormal]
+  (hMaxm : ∀ {φ : Formula α}, φ ∈ H₁.axioms → H₂ ⊢! φ)
+  : H₁ ≤ₛ H₂ := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   induction h using Deduction.inducition_with_necOnly! with
@@ -353,8 +353,8 @@ lemma normal_weakerThan_of_maxm {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ�
   | hNec ihp => exact nec! ihp;
   | _ => trivial;
 
-lemma normal_weakerThan_of_subset {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [Λ₂.IsNormal] (hSubset : Λ₁.axioms ⊆ Λ₂.axioms)
-  : Λ₁ ≤ₛ Λ₂ := by
+lemma normal_weakerThan_of_subset {H₁ H₂ : Hilbert α} [H₁.IsNormal] [H₂.IsNormal] (hSubset : H₁.axioms ⊆ H₂.axioms)
+  : H₁ ≤ₛ H₂ := by
   apply normal_weakerThan_of_maxm;
   intro φ hp;
   exact ⟨Deduction.maxm $ hSubset hp⟩;

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -6,10 +6,11 @@ namespace LO.Modal
 
 variable {α : Type*}
 
+
 section
 
 /-- instance of inference rule -/
-structure InferenceRule (α : Type*) where
+structure Hilbert.InferenceRule (α : Type*) where
   antecedents : List (Formula α)
   consequence : Formula α
   /--
@@ -18,6 +19,8 @@ structure InferenceRule (α : Type*) where
   so more than one antecedent is required.
   -/
   antecedents_nonempty : antecedents ≠ [] := by simp
+
+namespace Hilbert.InferenceRule
 
 abbrev Necessitation (φ : Formula α) : InferenceRule α := ⟨[φ], □φ, by simp⟩
 abbrev Necessitation.set : Set (InferenceRule α) := { Necessitation φ | φ }
@@ -31,13 +34,17 @@ abbrev HenkinRule (φ : Formula α) : InferenceRule α := ⟨[□φ ⭤ φ], φ,
 abbrev HenkinRule.set : Set (InferenceRule α) := { HenkinRule φ | φ }
 notation "⟮Henkin⟯" => HenkinRule.set
 
+end Hilbert.InferenceRule
+
 end
+
 
 structure Hilbert (α : Type*) where
   axioms : Theory α
-  rules : Set (InferenceRule α)
+  rules : Set (Hilbert.InferenceRule α)
 
-inductive Deduction (Λ : Hilbert α) : (Formula α) → Type _
+
+inductive Hilbert.Deduction (Λ : Hilbert α) : (Formula α) → Type _
   | maxm {φ}     : φ ∈ Λ.axioms → Deduction Λ φ
   | rule {rl}    : rl ∈ Λ.rules → (∀ {φ}, φ ∈ rl.antecedents → Deduction Λ φ) → Deduction Λ rl.consequence
   | mdp {φ ψ}    : Deduction Λ (φ ➝ ψ) → Deduction Λ φ → Deduction Λ ψ
@@ -45,7 +52,7 @@ inductive Deduction (Λ : Hilbert α) : (Formula α) → Type _
   | imply₂ φ ψ χ : Deduction Λ $ Axioms.Imply₂ φ ψ χ
   | ec φ ψ       : Deduction Λ $ Axioms.ElimContra φ ψ
 
-namespace Deduction
+namespace Hilbert.Deduction
 
 variable {Λ Λ₁ Λ₂ : Hilbert α}
 
@@ -63,7 +70,7 @@ instance : System.HasDiaDuality Λ := inferInstance
 
 lemma maxm! {φ} (h : φ ∈ Λ.axioms) : Λ ⊢! φ := ⟨maxm h⟩
 
-end Deduction
+end Hilbert.Deduction
 
 
 namespace Hilbert
@@ -110,7 +117,7 @@ instance [IsNormal Λ] : System.K Λ where
 end Hilbert
 
 
-namespace Deduction
+namespace Hilbert.Deduction
 
 open Hilbert
 
@@ -170,7 +177,7 @@ macro_rules | `(tactic| trivial) => `(tactic|
   )
 macro_rules | `(tactic| trivial) => `(tactic | apply dne!)
 
-end Deduction
+end Hilbert.Deduction
 
 
 namespace Hilbert

--- a/Foundation/Modal/Hilbert.lean
+++ b/Foundation/Modal/Hilbert.lean
@@ -173,174 +173,160 @@ macro_rules | `(tactic| trivial) => `(tactic | apply dne!)
 end Deduction
 
 
-abbrev Hilbert.theorems (Λ : Hilbert α) := System.theory Λ
+namespace Hilbert
 
+abbrev theorems (Λ : Hilbert α) := System.theory Λ
+
+
+section K
+
+variable (α)
 
 protected abbrev K : Hilbert α := ⟨𝗞, ⟮Nec⟯⟩
-notation "𝐊" => Modal.K
-instance : 𝐊.IsNormal (α := α) where
+instance : (Hilbert.K α).IsNormal where
 
-abbrev ExtK (Ax : Theory α) : Hilbert α := ⟨𝗞 ∪ Ax, ⟮Nec⟯⟩
-prefix:max "𝜿" => ExtK
-instance : (𝜿Ax).IsNormal (α := α) where
-
-lemma K_is_extK_of_empty : (𝐊 : Hilbert α) = 𝜿∅ := by aesop;
-
-lemma K_is_extK_of_AxiomK : (𝐊 : Hilbert α) = 𝜿𝗞 := by aesop;
-
-namespace Normal
-
-open System
-
-variable {Ax : Theory α}
-
-lemma def_ax : (𝜿Ax).axioms = (𝗞 ∪ Ax) := by simp;
-
-lemma maxm! (h : φ ∈ Ax) : 𝜿Ax ⊢! φ := ⟨Deduction.maxm (by simp [def_ax]; right; assumption)⟩
-
-end Normal
+end K
 
 
--- tools of Modal Companion
-section
+section K_extension
 
-abbrev ExtS4 (Ax : Theory α) : Hilbert α := 𝜿(𝗧 ∪ 𝟰 ∪ Ax)
-prefix:max "𝝈" => ExtS4
-instance : System.S4 (𝝈Ax) where
+protected abbrev ExtK (Ax : Theory α) : Hilbert α := ⟨𝗞 ∪ Ax, ⟮Nec⟯⟩
+instance : (Hilbert.ExtK Ax).IsNormal where
+
+namespace ExtK
+
+lemma K_is_extK_of_empty : (Hilbert.K α) = (Hilbert.ExtK ∅) := by aesop;
+
+lemma K_is_extK_of_AxiomK : (Hilbert.K α) = (Hilbert.ExtK 𝗞) := by aesop;
+
+lemma def_ax : (Hilbert.ExtK Ax).axioms = (𝗞 ∪ Ax) := rfl
+
+lemma maxm! (h : φ ∈ Ax) : (Hilbert.ExtK Ax) ⊢! φ := ⟨Deduction.maxm (by simp [Hilbert.ExtK]; tauto)⟩
+
+end ExtK
+
+end K_extension
+
+
+section S4_extension
+
+protected abbrev ExtS4 (Ax : Theory α) : Hilbert α := Hilbert.ExtK (𝗧 ∪ 𝟰 ∪ Ax)
+instance : System.S4 (Hilbert.ExtS4 Ax) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-@[simp] lemma ExtS4.def_ax : (𝝈Ax).axioms = (𝗞 ∪ 𝗧 ∪ 𝟰 ∪ Ax) := by aesop;
+@[simp] lemma ExtS4.def_ax : (Hilbert.ExtS4 Ax).axioms = (𝗞 ∪ 𝗧 ∪ 𝟰 ∪ Ax) := by aesop;
 
-end
+end S4_extension
 
 
-protected abbrev KT : Hilbert α := 𝜿(𝗧)
-notation "𝐊𝐓" => Modal.KT
-instance : System.KT (𝐊𝐓 : Hilbert α) where
+section systems
+
+variable (α)
+
+protected abbrev KT : Hilbert α := Hilbert.ExtK $ 𝗧
+instance : System.KT (Hilbert.KT α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev KB : Hilbert α := 𝜿(𝗕)
-notation "𝐊𝐁" => Modal.KB
-instance : System.KB (𝐊𝐁 : Hilbert α) where
+protected abbrev KB : Hilbert α := Hilbert.ExtK $ 𝗕
+instance : System.KB (Hilbert.KB α) where
   B _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev KD : Hilbert α := 𝜿(𝗗)
-notation "𝐊𝐃" => Modal.KD
-instance : System.KD (𝐊𝐃 : Hilbert α) where
+protected abbrev KD : Hilbert α := Hilbert.ExtK $ 𝗗
+instance : System.KD (Hilbert.KD α) where
   D _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev KP : Hilbert α := 𝜿(𝗣)
-notation "𝐊𝐏" => Modal.KP
-instance : System.KP (𝐊𝐏 : Hilbert α) where
+protected abbrev KP : Hilbert α := Hilbert.ExtK $ 𝗣
+instance : System.KP (Hilbert.KP α) where
   P := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev KTB : Hilbert α := 𝜿(𝗧 ∪ 𝗕)
-notation "𝐊𝐓𝐁" => Modal.KTB
+protected abbrev KTB : Hilbert α := Hilbert.ExtK $ 𝗧 ∪ 𝗕
 
-protected abbrev K4 : Hilbert α := 𝜿(𝟰)
-notation "𝐊𝟒" => Modal.K4
-instance : System.K4 (𝐊𝟒 : Hilbert α) where
+protected abbrev K4 : Hilbert α := Hilbert.ExtK $ 𝟰
+instance : System.K4 (Hilbert.K4 α) where
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev K5 : Hilbert α := 𝜿(𝟱)
-notation "𝐊𝟓" => Modal.K5
-instance : System.K5 (𝐊𝟓 : Hilbert α) where
+protected abbrev K5 : Hilbert α := Hilbert.ExtK $ 𝟱
+instance : System.K5 (Hilbert.K5 α) where
   Five _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev S4 : Hilbert α := 𝝈(∅)
-notation "𝐒𝟒" => Modal.S4
-instance : System.S4 (𝐒𝟒 : Hilbert α) where
+protected abbrev S4 : Hilbert α := Hilbert.ExtS4 $ ∅
+instance : System.S4 (Hilbert.S4 α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev S4Dot2 : Hilbert α := 𝝈(.𝟮)
-notation "𝐒𝟒.𝟐" => Modal.S4Dot2
+protected abbrev S4Dot2 : Hilbert α := Hilbert.ExtS4 $ .𝟮
 
-protected abbrev S4Dot3 : Hilbert α := 𝝈(.𝟯)
-notation "𝐒𝟒.𝟑" => Modal.S4Dot3
+protected abbrev S4Dot3 : Hilbert α := Hilbert.ExtS4 $ .𝟯
 
-protected abbrev S4Grz : Hilbert α := 𝝈(𝗚𝗿𝘇) -- S4 + 𝗚𝗿𝘇
-notation "𝐒𝟒𝐆𝐫𝐳" => Modal.S4Grz
+protected abbrev S4Grz : Hilbert α := Hilbert.ExtS4 $ 𝗚𝗿𝘇
 
-protected abbrev KT4B : Hilbert α := 𝝈(𝗕)
-notation "𝐊𝐓𝟒𝐁" => Modal.KT4B
+protected abbrev KT4B : Hilbert α := Hilbert.ExtS4 $ 𝗕
 
-protected abbrev S5 : Hilbert α := 𝜿(𝗧 ∪ 𝟱)
-notation "𝐒𝟓" => Modal.S5
-instance : System.S5 (𝐒𝟓 : Hilbert α) where
+protected abbrev S5 : Hilbert α := Hilbert.ExtK $ 𝗧 ∪ 𝟱
+instance : System.S5 (Hilbert.S5 α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Five _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev S5Grz : Hilbert α := 𝜿(𝗧 ∪ 𝟱 ∪ 𝗚𝗿𝘇) -- 𝐒𝟓 + 𝗚𝗿𝘇
-notation "𝐒𝟓𝐆𝐫𝐳" => Modal.S5Grz
-instance : System.S5Grz (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) where
+protected abbrev S5Grz : Hilbert α := Hilbert.ExtK $ 𝗧 ∪ 𝟱 ∪ 𝗚𝗿𝘇
+instance : System.S5Grz (Hilbert.S5Grz α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Five _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Grz _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev Triv : Hilbert α := 𝜿(𝗧 ∪ 𝗧𝗰)
-notation "𝐓𝐫𝐢𝐯" => Modal.Triv
-instance : System.Triv (𝐓𝐫𝐢𝐯 : Hilbert α) where
+protected abbrev Triv : Hilbert α := Hilbert.ExtK $ 𝗧 ∪ 𝗧𝗰
+instance : System.Triv (Hilbert.Triv α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   Tc _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev Ver : Hilbert α := 𝜿(𝗩𝗲𝗿)
-notation "𝐕𝐞𝐫" => Modal.Ver
-instance : System.Ver (𝐕𝐞𝐫 : Hilbert α) where
+protected abbrev Ver : Hilbert α := Hilbert.ExtK $ 𝗩𝗲𝗿
+instance : System.Ver (Hilbert.Ver α) where
   Ver _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev GL : Hilbert α := 𝜿(𝗟)
-notation "𝐆𝐋" => Modal.GL
-instance : System.GL (𝐆𝐋 : Hilbert α) where
+protected abbrev GL : Hilbert α := Hilbert.ExtK $ 𝗟
+instance : System.GL (Hilbert.GL α) where
   L _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev Grz : Hilbert α := 𝜿(𝗚𝗿𝘇)
-notation "𝐆𝐫𝐳" => Modal.Grz
-instance : System.Grz (𝐆𝐫𝐳 : Hilbert α) where
+protected abbrev Grz : Hilbert α := Hilbert.ExtK $ 𝗚𝗿𝘇
+instance : System.Grz (Hilbert.Grz α) where
   Grz _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
-protected abbrev K4H : Hilbert α := 𝜿(𝟰 ∪ 𝗛)
-notation "𝐊𝟒𝐇" => Modal.K4H
-instance : System.K4H (𝐊𝟒𝐇 : Hilbert α) where
+protected abbrev K4H : Hilbert α := Hilbert.ExtK $ 𝟰 ∪ 𝗛
+instance : System.K4H (Hilbert.K4H α) where
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
   H _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
--- Non-normal modal logic
-
 protected abbrev K4Loeb : Hilbert α := ⟨𝗞 ∪ 𝟰, ⟮Nec⟯ ∪ ⟮Loeb⟯⟩
-notation "𝐊𝟒(𝐋)" => Modal.K4Loeb
-instance : 𝐊𝟒(𝐋).HasAxiomK (α := α) where
-instance : 𝐊𝟒(𝐋).HasNecessitation (α := α) where
-instance : 𝐊𝟒(𝐋).HasLoebRule (α := α) where
-instance : System.K4Loeb (𝐊𝟒(𝐋) : Hilbert α) where
+instance : (Hilbert.K4Loeb α).HasAxiomK where
+instance : (Hilbert.K4Loeb α).HasNecessitation where
+instance : (Hilbert.K4Loeb α).HasLoebRule where
+instance : System.K4Loeb (Hilbert.K4Loeb α) where
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev K4Henkin : Hilbert α := ⟨𝗞 ∪ 𝟰, ⟮Nec⟯ ∪ ⟮Henkin⟯⟩
-notation "𝐊𝟒(𝐇)" => Modal.K4Henkin
-instance : 𝐊𝟒(𝐇).HasAxiomK (α := α)  where
-instance : 𝐊𝟒(𝐇).HasNecessitation (α := α) where
-instance : 𝐊𝟒(𝐇).HasHenkinRule (α := α) where
-instance : System.K4Henkin (𝐊𝟒(𝐇) : Hilbert α) where
+instance : (Hilbert.K4Henkin α).HasAxiomK  where
+instance : (Hilbert.K4Henkin α).HasNecessitation where
+instance : (Hilbert.K4Henkin α).HasHenkinRule where
+instance : System.K4Henkin (Hilbert.K4Henkin α) where
   Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 /--
   Solovey's Provability Logic of True Arithmetic.
   Remark necessitation is *not* permitted.
 -/
-protected abbrev GLS : Hilbert α := ⟨𝐆𝐋.theorems ∪ 𝗧, ∅⟩
-notation "𝐆𝐋𝐒" => Modal.GLS
-instance : System.HasAxiomK (𝐆𝐋𝐒 : Hilbert α) where
+protected abbrev GLS : Hilbert α := ⟨(Hilbert.GL α).theorems ∪ 𝗧, ∅⟩
+instance : System.HasAxiomK (Hilbert.GLS α) where
   K _ _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) $ by simp [Hilbert.theorems, System.theory, System.axiomK!];
-instance : System.HasAxiomL (𝐆𝐋𝐒 : Hilbert α) where
+instance : System.HasAxiomL (Hilbert.GLS α) where
   L _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) $ by simp [Hilbert.theorems, System.theory, System.axiomK!];
-instance : System.HasAxiomT (𝐆𝐋𝐒 : Hilbert α) where
+instance : System.HasAxiomT (Hilbert.GLS α) where
   T _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 /-- Logic of Pure Necessitation -/
 protected abbrev N : Hilbert α := ⟨∅, ⟮Nec⟯⟩
-notation "𝐍" => Modal.N
-instance : 𝐍.HasNecOnly (α := α) where
+instance : (Hilbert.N α).HasNecOnly where
+
+end systems
 
 
 section
@@ -366,71 +352,50 @@ lemma normal_weakerThan_of_subset {Λ₁ Λ₂ : Hilbert α} [Λ₁.IsNormal] [�
   intro φ hp;
   exact ⟨Deduction.maxm $ hSubset hp⟩;
 
-lemma K_weakerThan_KD : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐃 := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_KB : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐁 := normal_weakerThan_of_subset $ by aesop;
+lemma K_weakerThan_KD : (Hilbert.K α) ≤ₛ (Hilbert.KD α) := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_KT : (𝐊 : Hilbert α) ≤ₛ 𝐊𝐓 := normal_weakerThan_of_subset $ by aesop;
+lemma K_weakerThan_KB : (Hilbert.K α) ≤ₛ (Hilbert.KB α) := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_K4 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟒 := normal_weakerThan_of_subset $ by aesop;
+lemma K_weakerThan_KT : (Hilbert.K α) ≤ₛ (Hilbert.KT α) := normal_weakerThan_of_subset $ by aesop;
 
-lemma K_weakerThan_K5 : (𝐊 : Hilbert α) ≤ₛ 𝐊𝟓 := normal_weakerThan_of_subset $ by aesop;
+lemma K_weakerThan_K4 : (Hilbert.K α) ≤ₛ (Hilbert.K4 α) := normal_weakerThan_of_subset $ by aesop;
 
-lemma KT_weakerThan_S4 : (𝐊𝐓 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma K_weakerThan_K5 : (Hilbert.K α) ≤ₛ (Hilbert.K5 α) := normal_weakerThan_of_subset $ by aesop;
 
-lemma K4_weakerThan_S4 : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐒𝟒 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma KT_weakerThan_S4 : (Hilbert.KT α) ≤ₛ (Hilbert.S4 α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Dot2 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟐 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma K4_weakerThan_S4 : (Hilbert.K4 α) ≤ₛ (Hilbert.S4 α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Dot3 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒.𝟑 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma S4_weakerThan_S4Dot2 : (Hilbert.S4 α) ≤ₛ (Hilbert.S4Dot2 α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma S4_weakerThan_S4Grz : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟒𝐆𝐫𝐳 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma S4_weakerThan_S4Dot3 : (Hilbert.S4 α) ≤ₛ (Hilbert.S4Dot3 α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma K_weakerThan_GL : (𝐊 : Hilbert α) ≤ₛ 𝐆𝐋 := normal_weakerThan_of_subset $ by intro; aesop;
+lemma S4_weakerThan_S4Grz : (Hilbert.S4 α) ≤ₛ (Hilbert.S4Grz α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma K4_weakerThan_Triv : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐓𝐫𝐢𝐯 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with (hK | hFour)
-  . obtain ⟨_, _, rfl⟩ := hK; exact axiomK!;
-  . obtain ⟨_, _, rfl⟩ := hFour; exact axiomFour!;
+lemma K_weakerThan_GL : (Hilbert.K α) ≤ₛ (Hilbert.GL α) := normal_weakerThan_of_subset $ by intro; aesop;
 
-lemma K4_weakerThan_GL : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐆𝐋 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with (hK | hFour)
-  . obtain ⟨_, _, rfl⟩ := hK; exact axiomK!;
-  . obtain ⟨_, _, rfl⟩ := hFour; exact axiomFour!;
+lemma K4_weakerThan_Triv : (Hilbert.K4 α) ≤ₛ (Hilbert.Triv α) := normal_weakerThan_of_maxm $ by
+  rintro φ (⟨_, _, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
 
-lemma KT_weakerThan_Grz : (𝐊𝐓 : Hilbert α) ≤ₛ 𝐆𝐫𝐳 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with (hK | hGrz)
-  . obtain ⟨_, _, rfl⟩ := hK; exact axiomK!;
-  . obtain ⟨_, _, rfl⟩ := hGrz; exact axiomT!;
+lemma K4_weakerThan_GL : (Hilbert.K4 α) ≤ₛ (Hilbert.GL α) := normal_weakerThan_of_maxm $ by
+  rintro _ (⟨_, _, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
 
-lemma K4_weakerThan_Grz : (𝐊𝟒 : Hilbert α) ≤ₛ 𝐆𝐫𝐳 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with (hK | hGrz)
-  . obtain ⟨_, _, rfl⟩ := hK; exact axiomK!;
-  . obtain ⟨_, _, rfl⟩ := hGrz; exact axiomFour!;
+lemma KT_weakerThan_Grz : (Hilbert.KT α) ≤ₛ (Hilbert.Grz α) := normal_weakerThan_of_maxm $ by
+  rintro _ (⟨_, _, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
 
+lemma K4_weakerThan_Grz : (Hilbert.K4 α) ≤ₛ (Hilbert.Grz α) := normal_weakerThan_of_maxm $ by
+  rintro _ (⟨_, _, rfl⟩ | ⟨_, _, rfl⟩) <;> simp;
 
-lemma KD_weakerThan_KP : (𝐊𝐃 : Hilbert α) ≤ₛ 𝐊𝐏 := normal_weakerThan_of_maxm $ by
-  rintro φ (⟨φ, ψ, rfl⟩ | ⟨φ, rfl⟩);
-  . exact axiomK!;
-  . exact axiomD!;
+lemma KD_weakerThan_KP : (Hilbert.KD α) ≤ₛ (Hilbert.KP α) := normal_weakerThan_of_maxm $ by
+  rintro _ (⟨_, _, rfl⟩ | ⟨_, rfl⟩) <;> simp;
 
-lemma KP_weakerThan_KD : (𝐊𝐏 : Hilbert α) ≤ₛ 𝐊𝐃 := normal_weakerThan_of_maxm $ by
-  rintro φ (⟨φ, ψ, rfl⟩ | ⟨_, rfl⟩);
-  . exact axiomK!;
-  . exact axiomP!;
+lemma KP_weakerThan_KD : (Hilbert.KP α) ≤ₛ (Hilbert.KD α) := normal_weakerThan_of_maxm $ by
+  rintro _ (⟨_, _, rfl⟩ | ⟨_, rfl⟩) <;> simp;
 
-lemma KD_equiv_KP : (𝐊𝐃 : Hilbert α) =ₛ 𝐊𝐏 := Equiv.antisymm_iff.mpr ⟨KD_weakerThan_KP, KP_weakerThan_KD⟩
+lemma KD_equiv_KP : (Hilbert.KD α) =ₛ (Hilbert.KP α) := Equiv.antisymm_iff.mpr ⟨KD_weakerThan_KP, KP_weakerThan_KD⟩
 
-
-lemma GL_weakerThan_K4Loeb : (𝐆𝐋 : Hilbert α) ≤ₛ 𝐊𝟒(𝐋) := by
+lemma GL_weakerThan_K4Loeb : (Hilbert.GL α) ≤ₛ (Hilbert.K4Loeb α) := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   induction h using Deduction.inducition_with_necOnly! with
@@ -442,7 +407,7 @@ lemma GL_weakerThan_K4Loeb : (𝐆𝐋 : Hilbert α) ≤ₛ 𝐊𝟒(𝐋) := by
   | hNec ihp => exact nec! ihp;
   | _ => trivial;
 
-lemma K4Loeb_weakerThan_K4Henkin : (𝐊𝟒(𝐋) : Hilbert α) ≤ₛ 𝐊𝟒(𝐇) := by
+lemma K4Loeb_weakerThan_K4Henkin : (Hilbert.K4Loeb α) ≤ₛ (Hilbert.K4Henkin α) := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   induction h using Deduction.inducition! with
@@ -457,7 +422,7 @@ lemma K4Loeb_weakerThan_K4Henkin : (𝐊𝟒(𝐋) : Hilbert α) ≤ₛ 𝐊𝟒
     . obtain ⟨φ, rfl⟩ := hLoeb; exact loeb! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
   | _ => trivial;
 
-lemma K4Henkin_weakerThan_K4H : (𝐊𝟒(𝐇) : Hilbert α) ≤ₛ 𝐊𝟒𝐇 := by
+lemma K4Henkin_weakerThan_K4H : (Hilbert.K4Henkin α) ≤ₛ (Hilbert.K4H α) := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   induction h using Deduction.inducition! with
@@ -472,7 +437,7 @@ lemma K4Henkin_weakerThan_K4H : (𝐊𝟒(𝐇) : Hilbert α) ≤ₛ 𝐊𝟒�
     . obtain ⟨φ, rfl⟩ := hHenkin; exact henkin! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
   | _ => trivial;
 
-lemma K4Henkin_weakerThan_GL : (𝐊𝟒𝐇 : Hilbert α) ≤ₛ 𝐆𝐋 := by
+lemma K4Henkin_weakerThan_GL : (Hilbert.K4H α) ≤ₛ (Hilbert.GL α) := by
   apply normal_weakerThan_of_maxm;
   intro φ hp;
   rcases hp with hK | hFour | hH
@@ -480,38 +445,30 @@ lemma K4Henkin_weakerThan_GL : (𝐊𝟒𝐇 : Hilbert α) ≤ₛ 𝐆𝐋 := by
   . obtain ⟨_, _, rfl⟩ := hFour; exact axiomFour!;
   . obtain ⟨_, _, rfl⟩ := hH; exact axiomH!;
 
-lemma GL_equiv_K4Loeb : (𝐆𝐋 : Hilbert α) =ₛ 𝐊𝟒(𝐋) := by
+lemma GL_equiv_K4Loeb : (Hilbert.GL α) =ₛ (Hilbert.K4Loeb α) := by
   apply Equiv.antisymm_iff.mpr;
   constructor;
   . exact GL_weakerThan_K4Loeb;
   . exact WeakerThan.trans (K4Loeb_weakerThan_K4Henkin) $ WeakerThan.trans K4Henkin_weakerThan_K4H K4Henkin_weakerThan_GL
 
-set_option linter.unusedSectionVars false in -- TODO: remove
-lemma GL_weakerThan_GLS : (𝐆𝐋 : Hilbert α) ≤ₛ 𝐆𝐋𝐒 := by
+omit [DecidableEq α] in
+lemma GL_weakerThan_GLS : (Hilbert.GL α) ≤ₛ (Hilbert.GLS α) := by
   apply System.weakerThan_iff.mpr;
   intro φ h;
   exact Deduction.maxm! (by left; simpa);
 
-lemma S5Grz_weakerThan_Triv : (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) ≤ₛ 𝐓𝐫𝐢𝐯 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with ⟨_, _, rfl⟩ | (⟨_, rfl⟩ | ⟨_, rfl⟩) | ⟨_, rfl⟩
-  . exact axiomK!;
-  . exact axiomT!;
-  . exact axiomFive!;
-  . exact axiomGrz!;
+lemma S5Grz_weakerThan_Triv : (Hilbert.S5Grz α) ≤ₛ (Hilbert.Triv α) := normal_weakerThan_of_maxm $ by
+  rintro φ (⟨_, _, rfl⟩ | (⟨_, rfl⟩ | ⟨_, rfl⟩) | ⟨_, rfl⟩) <;> simp;
 
-lemma Triv_weakerThan_S5Grz : (𝐓𝐫𝐢𝐯 : Hilbert α) ≤ₛ 𝐒𝟓𝐆𝐫𝐳 := by
-  apply normal_weakerThan_of_maxm;
-  intro φ hp;
-  rcases hp with ⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩
-  . exact axiomK!;
-  . exact axiomT!;
-  . exact axiomTc!;
+lemma Triv_weakerThan_S5Grz : (Hilbert.Triv α) ≤ₛ (Hilbert.S5Grz α) := normal_weakerThan_of_maxm $ by
+  rintro φ (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
 
-lemma S5Grz_equiv_Triv : (𝐒𝟓𝐆𝐫𝐳 : Hilbert α) =ₛ 𝐓𝐫𝐢𝐯
+lemma S5Grz_equiv_Triv : (Hilbert.S5Grz α) =ₛ (Hilbert.Triv α)
   := Equiv.antisymm_iff.mpr ⟨S5Grz_weakerThan_Triv, Triv_weakerThan_S5Grz⟩
 
 end
+
+
+end Hilbert
 
 end LO.Modal

--- a/Foundation/Modal/Kripke/Completeness.lean
+++ b/Foundation/Modal/Kripke/Completeness.lean
@@ -7,6 +7,7 @@ open LO.Kripke
 open System
 open Formula
 open MaximalConsistentTheory
+open Hilbert.Deduction
 
 variable {α : Type u} [DecidableEq α]
 variable {Λ : Hilbert α} [Λ.IsNormal]
@@ -169,7 +170,7 @@ lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Λ) ⊧* Λ.axio
   apply Semantics.realizeSet_iff.mpr;
   intro φ hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;
-  exact Deduction.maxm! (by assumption);
+  exact maxm! hp;
 
 lemma realize_theory_of_self_canonicalModel : (CanonicalModel Λ) ⊧* (System.theory Λ) := by
   apply Semantics.realizeSet_iff.mpr;

--- a/Foundation/Modal/Kripke/Completeness.lean
+++ b/Foundation/Modal/Kripke/Completeness.lean
@@ -192,9 +192,9 @@ lemma complete_of_mem_canonicalFrame [Nonempty (MCT Λ)] {𝔽 : FrameClass} (hF
 
 instance instComplete_of_mem_canonicalFrame [Nonempty (MCT Λ)] (𝔽 : FrameClass) (hFC : CanonicalFrame Λ ∈ 𝔽) : Complete (Λ) (𝔽#α) := ⟨complete_of_mem_canonicalFrame hFC⟩
 
-instance K_complete : Complete 𝐊 (AllFrameClass.{u}#α) := by
+instance K_complete : Complete (Hilbert.K α) (AllFrameClass.{u}#α) := by
   convert instComplete_of_mem_canonicalFrame (α := α) AllFrameClass trivial;
-  rw [K_is_extK_of_empty];
+  rw [Hilbert.ExtK.K_is_extK_of_empty];
   . tauto;
   . infer_instance;
 

--- a/Foundation/Modal/Kripke/Completeness.lean
+++ b/Foundation/Modal/Kripke/Completeness.lean
@@ -10,20 +10,20 @@ open MaximalConsistentTheory
 open Hilbert.Deduction
 
 variable {α : Type u} [DecidableEq α]
-variable {Λ : Hilbert α} [Λ.IsNormal]
+variable {H : Hilbert α} [H.IsNormal]
 
 namespace Kripke
 
-abbrev CanonicalFrame (Λ : Hilbert α) [Nonempty (MCT Λ)] : Kripke.Frame where
-  World := MCT Λ
+abbrev CanonicalFrame (H : Hilbert α) [Nonempty (MCT H)] : Kripke.Frame where
+  World := MCT H
   Rel Ω₁ Ω₂ := □''⁻¹Ω₁.theory ⊆ Ω₂.theory
 
 namespace CanonicalFrame
 
-variable [Nonempty (MCT Λ)]
-variable {Ω₁ Ω₂ : (CanonicalFrame Λ).World}
+variable [Nonempty (MCT H)]
+variable {Ω₁ Ω₂ : (CanonicalFrame H).World}
 
-omit [DecidableEq α] [Λ.IsNormal] in
+omit [DecidableEq α] [H.IsNormal] in
 @[simp] lemma rel_def_box: Ω₁ ≺ Ω₂ ↔ ∀ {φ}, □φ ∈ Ω₁.theory → φ ∈ Ω₂.theory := by simp [Frame.Rel']; aesop;
 
 lemma multirel_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {φ}, □^[n]φ ∈ Ω₁.theory → φ ∈ Ω₂.theory := by
@@ -39,12 +39,12 @@ lemma multirel_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {φ}, □^[n]φ ∈ Ω
       obtain ⟨⟨Ω₃, _⟩, R₁₃, R₃₂⟩ := h;
       apply ih.mp R₃₂ $ rel_def_box.mp R₁₃ (by simpa using hp);
     . intro h;
-      obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := Λ) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
+      obtain ⟨Ω, hΩ⟩ := lindenbaum (H := H) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
         apply Theory.intro_union_consistent;
         rintro Γ Δ ⟨hΓ, hΔ⟩ hC;
 
         replace hΓ : ∀ φ ∈ Γ, □φ ∈ Ω₁.theory := by simpa using hΓ;
-        have dΓconj : Ω₁.theory *⊢[Λ]! □⋀Γ := membership_iff.mp $ iff_mem_box_conj.mpr hΓ;
+        have dΓconj : Ω₁.theory *⊢[H]! □⋀Γ := membership_iff.mp $ iff_mem_box_conj.mpr hΓ;
 
         have hΔ₂ : ∀ φ ∈ ◇'⁻¹^[n]Δ, φ ∈ Ω₂.theory := by
           intro φ hp;
@@ -53,19 +53,19 @@ lemma multirel_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {φ}, □^[n]φ ∈ Ω
         have hΔconj : ⋀◇'⁻¹^[n]Δ ∈ Ω₂.theory := iff_mem_conj.mpr hΔ₂;
 
         have : ⋀◇'⁻¹^[n]Δ ∉ Ω₂.theory := by {
-          have d₁ : Λ ⊢! ⋀Γ ➝ ⋀Δ ➝ ⊥ := and_imply_iff_imply_imply'!.mp hC;
-          have : Λ ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ➝ ⋀Δ := by
+          have d₁ : H ⊢! ⋀Γ ➝ ⋀Δ ➝ ⊥ := and_imply_iff_imply_imply'!.mp hC;
+          have : H ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ➝ ⋀Δ := by
             apply conjconj_subset!;
             intro ψ hq;
             obtain ⟨χ, _, _⟩ := hΔ ψ hq;
             subst_vars;
             simpa;
-          have : Λ ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ➝ ⋀Δ := imp_trans''! iff_conjmultidia_multidiaconj! $ this;
-          have : Λ ⊢! ∼(□^[n](∼⋀◇'⁻¹^[n]Δ)) ➝ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
-          have : Λ ⊢! ∼⋀Δ ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := contra₂'! this;
-          have : Λ ⊢! (⋀Δ ➝ ⊥) ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
-          have : Λ ⊢! ⋀Γ ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := imp_trans''! d₁ this;
-          have : Λ ⊢! □⋀Γ ➝ □^[(n + 1)](∼⋀◇'⁻¹^[n]Δ) := by simpa using imply_box_distribute'! this;
+          have : H ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ➝ ⋀Δ := imp_trans''! iff_conjmultidia_multidiaconj! $ this;
+          have : H ⊢! ∼(□^[n](∼⋀◇'⁻¹^[n]Δ)) ➝ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
+          have : H ⊢! ∼⋀Δ ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := contra₂'! this;
+          have : H ⊢! (⋀Δ ➝ ⊥) ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
+          have : H ⊢! ⋀Γ ➝ □^[n](∼⋀◇'⁻¹^[n]Δ) := imp_trans''! d₁ this;
+          have : H ⊢! □⋀Γ ➝ □^[(n + 1)](∼⋀◇'⁻¹^[n]Δ) := by simpa using imply_box_distribute'! this;
           exact iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
         }
 
@@ -93,17 +93,17 @@ lemma rel_def_dia : Ω₁ ≺ Ω₂ ↔ ∀ {φ}, φ ∈ Ω₂.theory → ◇φ 
 end CanonicalFrame
 
 
-abbrev CanonicalModel (Λ : Hilbert α) [Nonempty (MCT Λ)]  : Model α where
-  Frame := CanonicalFrame Λ
+abbrev CanonicalModel (H : Hilbert α) [Nonempty (MCT H)]  : Model α where
+  Frame := CanonicalFrame H
   Valuation Ω a := (atom a) ∈ Ω.theory
 
 
 namespace CanonicalModel
 
-variable [Nonempty (MCT Λ)]
+variable [Nonempty (MCT H)]
 
 @[reducible]
-instance : Semantics (Formula α) (CanonicalModel Λ).World := Formula.Kripke.Satisfies.semantics (M := CanonicalModel Λ)
+instance : Semantics (Formula α) (CanonicalModel H).World := Formula.Kripke.Satisfies.semantics (M := CanonicalModel H)
 
 -- @[simp] lemma frame_def : (CanonicalModel Ax).Rel' Ω₁ Ω₂ ↔ (□''⁻¹Ω₁.theory : Theory α) ⊆ Ω₂.theory := by rfl
 -- @[simp] lemma val_def : (CanonicalModel Ax).Valuation Ω a ↔ (atom a) ∈ Ω.theory := by rfl
@@ -113,9 +113,9 @@ end CanonicalModel
 
 section
 
-variable [Nonempty (MCT Λ)] {φ : Formula α}
+variable [Nonempty (MCT H)] {φ : Formula α}
 
-lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ φ ↔ (φ ∈ Ω.theory) := by
+lemma truthlemma : ∀ {Ω : (CanonicalModel H).World}, Ω ⊧ φ ↔ (φ ∈ Ω.theory) := by
   induction φ using Formula.rec' with
   | hbox φ ih =>
     intro Ω;
@@ -144,15 +144,15 @@ lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ φ ↔ (φ ∈ �
   | _ => simp_all [Kripke.Satisfies];
 
 
-lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Λ) ⊧ φ ↔ Λ ⊢! φ := by
+lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel H) ⊧ φ ↔ H ⊢! φ := by
   constructor;
   . contrapose;
     intro h;
-    have : Theory.Consistent Λ ({∼φ}) := by
+    have : Theory.Consistent H ({∼φ}) := by
       apply Theory.def_consistent.mpr;
       intro Γ hΓ;
       by_contra hC;
-      have : Λ ⊢! φ := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
+      have : H ⊢! φ := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
       contradiction;
     obtain ⟨Ω, hΩ⟩ := lindenbaum this;
     simp [Kripke.ValidOnModel];
@@ -162,17 +162,17 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Λ) ⊧ φ ↔ Λ 
     suffices φ ∈ Ω.theory by exact truthlemma.mpr this;
     by_contra hC;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Theory.iff_insert_inconsistent.mp $ (MaximalConsistentTheory.maximal' hC);
-    have : Γ ⊢[Λ]! ⊥ := FiniteContext.provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
-    have : Γ ⊬[Λ] ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
+    have : Γ ⊢[H]! ⊥ := FiniteContext.provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
+    have : Γ ⊬[H] ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
     contradiction;
 
-lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Λ) ⊧* Λ.axioms := by
+lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel H) ⊧* H.axioms := by
   apply Semantics.realizeSet_iff.mpr;
   intro φ hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;
   exact maxm! hp;
 
-lemma realize_theory_of_self_canonicalModel : (CanonicalModel Λ) ⊧* (System.theory Λ) := by
+lemma realize_theory_of_self_canonicalModel : (CanonicalModel H) ⊧* (System.theory H) := by
   apply Semantics.realizeSet_iff.mpr;
   intro φ hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;
@@ -180,18 +180,18 @@ lemma realize_theory_of_self_canonicalModel : (CanonicalModel Λ) ⊧* (System.t
 
 end
 
-lemma complete_of_mem_canonicalFrame [Nonempty (MCT Λ)] {𝔽 : FrameClass} (hFC : CanonicalFrame Λ ∈ 𝔽) : 𝔽#α ⊧ φ → (Λ) ⊢! φ := by
+lemma complete_of_mem_canonicalFrame [Nonempty (MCT H)] {𝔽 : FrameClass} (hFC : CanonicalFrame H ∈ 𝔽) : 𝔽#α ⊧ φ → (H) ⊢! φ := by
   simp [Semantics.Realize, Kripke.ValidOnFrame];
   contrapose;
   push_neg;
   intro h;
-  use (CanonicalFrame Λ);
+  use (CanonicalFrame H);
   constructor;
   . assumption;
-  . use (CanonicalModel Λ).Valuation;
+  . use (CanonicalModel H).Valuation;
     exact iff_valid_on_canonicalModel_deducible.not.mpr h;
 
-instance instComplete_of_mem_canonicalFrame [Nonempty (MCT Λ)] (𝔽 : FrameClass) (hFC : CanonicalFrame Λ ∈ 𝔽) : Complete (Λ) (𝔽#α) := ⟨complete_of_mem_canonicalFrame hFC⟩
+instance instComplete_of_mem_canonicalFrame [Nonempty (MCT H)] (𝔽 : FrameClass) (hFC : CanonicalFrame H ∈ 𝔽) : Complete (H) (𝔽#α) := ⟨complete_of_mem_canonicalFrame hFC⟩
 
 instance K_complete : Complete (Hilbert.K α) (AllFrameClass.{u}#α) := by
   convert instComplete_of_mem_canonicalFrame (α := α) AllFrameClass trivial;

--- a/Foundation/Modal/Kripke/Dot3.lean
+++ b/Foundation/Modal/Kripke/Dot3.lean
@@ -73,14 +73,14 @@ instance axiomS4Dot3_defines [Atleast 2 α] [Inhabited α] [DecidableEq α] : �
     simp [Reflexive, Transitive, Connected];
     refine ⟨⟨?_, ?_⟩, ?_⟩ <;> tauto;
 
-instance S4Dot3_defines [Inhabited α] [DecidableEq α] [Atleast 2 α] : 𝔽((𝐒𝟒.𝟑 : Hilbert α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := inferInstance
+instance S4Dot3_defines [Inhabited α] [DecidableEq α] [Atleast 2 α] : 𝔽((Hilbert.S4Dot3 α)).DefinedBy ReflexiveTransitiveConnectedFrameClass := inferInstance
 
-instance  [Inhabited α] [DecidableEq α] [Atleast 2 α] : System.Consistent (𝐒𝟒.𝟑 : Hilbert α) := inferInstance
+instance  [Inhabited α] [DecidableEq α] [Atleast 2 α] : System.Consistent (Hilbert.S4Dot3 α) := inferInstance
 
 open MaximalConsistentTheory in
 lemma connected_CanonicalFrame
   [Inhabited α] [DecidableEq α] [Atleast 2 α]
-  {Ax : Theory α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (𝜿Ax)] : Connected (CanonicalFrame 𝜿Ax) := by
+  {Ax : Theory α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (Hilbert.ExtK Ax)] : Connected (CanonicalFrame (Hilbert.ExtK Ax)) := by
   dsimp only [Connected];
   intro X Y Z ⟨hXY, hXZ⟩;
   by_contra hC; push_neg at hC;
@@ -108,7 +108,7 @@ lemma connected_CanonicalFrame
 
 instance
   [Inhabited α] [DecidableEq α] [Atleast 2 α]
-  : Complete (𝐒𝟒.𝟑 : Hilbert α) (ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame ReflexiveTransitiveConnectedFrameClass $ by
+  : Complete (Hilbert.S4Dot3 α) (ReflexiveTransitiveConnectedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame ReflexiveTransitiveConnectedFrameClass $ by
   refine ⟨?reflexive, ?transitive, ?connective⟩;
   . simp [GeachConfluent.reflexive_def];
     apply geachConfluent_CanonicalFrame;

--- a/Foundation/Modal/Kripke/Filteration.lean
+++ b/Foundation/Modal/Kripke/Filteration.lean
@@ -180,7 +180,7 @@ theorem filteration {x : M.World} {φ : Formula α} (hs : φ ∈ T := by trivial
 
 end
 
-instance K_finite_complete [DecidableEq α] : Complete 𝐊 (AllFrameClass.{u}ꟳ#α) := ⟨by
+instance K_finite_complete [DecidableEq α] : Complete (Hilbert.K α) (AllFrameClass.{u}ꟳ#α) := ⟨by
   intro φ hp;
   apply K_complete.complete;
   intro F _ V x;
@@ -195,10 +195,10 @@ instance K_finite_complete [DecidableEq α] : Complete 𝐊 (AllFrameClass.{u}�
   ) FM.Valuation
 ⟩
 
-instance  [DecidableEq α] : FiniteFrameProperty (α := α) 𝐊 AllFrameClass where
+instance  [DecidableEq α] : FiniteFrameProperty (Hilbert.K α) AllFrameClass where
 
 
-instance KTB_finite_complete [DecidableEq α] [Inhabited α] : Complete 𝐊𝐓𝐁 (ReflexiveSymmetricFrameClass.{u}ꟳ#α) := ⟨by
+instance KTB_finite_complete [DecidableEq α] [Inhabited α] : Complete (Hilbert.KTB α) (ReflexiveSymmetricFrameClass.{u}ꟳ#α) := ⟨by
   intro φ hp;
   apply KTB_complete.complete;
   intro F ⟨F_refl, F_symm⟩ V x;
@@ -219,7 +219,7 @@ instance KTB_finite_complete [DecidableEq α] [Inhabited α] : Complete 𝐊𝐓
   ) FM.Valuation
 ⟩
 
-instance [DecidableEq α] [Inhabited α] : FiniteFrameProperty (α := α) 𝐊𝐓𝐁 ReflexiveSymmetricFrameClass where
+instance [DecidableEq α] [Inhabited α] : FiniteFrameProperty (Hilbert.KTB α) ReflexiveSymmetricFrameClass where
 
 section
 
@@ -272,7 +272,7 @@ end FinestFilterationTransitiveClosureModel
 end
 
 open FinestFilterationTransitiveClosureModel in
-instance S4_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐒𝟒 (PreorderFrameClass.{u}ꟳ#α) := ⟨by
+instance S4_finite_complete [Inhabited α] [DecidableEq α] : Complete (Hilbert.S4 α) (PreorderFrameClass.{u}ꟳ#α) := ⟨by
   intro φ hp;
   apply S4_complete.complete;
   intro F ⟨F_refl, F_trans⟩ V x;
@@ -291,11 +291,11 @@ instance S4_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐒𝟒 
     exact F_trans;
 ⟩
 
-instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (α := α) 𝐒𝟒 PreorderFrameClass where
+instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (Hilbert.S4 α) PreorderFrameClass where
 
 
 open FinestFilterationTransitiveClosureModel in
-instance KT4B_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐊𝐓𝟒𝐁 (EquivalenceFrameClass.{u}ꟳ#α) := ⟨by
+instance KT4B_finite_complete [Inhabited α] [DecidableEq α] : Complete (Hilbert.KT4B α) (EquivalenceFrameClass.{u}ꟳ#α) := ⟨by
   intro φ hp;
   apply KT4B_complete.complete;
   intro F ⟨F_refl, F_trans, F_symm⟩ V x;
@@ -315,7 +315,7 @@ instance KT4B_finite_complete [Inhabited α] [DecidableEq α] : Complete 𝐊�
     exact F_trans;
 ⟩
 
-instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (α := α) 𝐊𝐓𝟒𝐁 EquivalenceFrameClass where
+instance [Inhabited α] [DecidableEq α] : FiniteFrameProperty (Hilbert.KT4B α) EquivalenceFrameClass where
 -- MEMO: `𝐒𝟓 =ₛ 𝐊𝐓𝟒𝐁`だから決定可能性という面では`𝐒𝟓`も決定可能．
 
 end Kripke

--- a/Foundation/Modal/Kripke/GL/Completeness.lean
+++ b/Foundation/Modal/Kripke/GL/Completeness.lean
@@ -13,7 +13,7 @@ namespace Kripke
 open Formula
 
 abbrev GLCompleteFrame (φ : Formula α) : Kripke.FiniteFrame where
-  World := CCF 𝐆𝐋 φ.subformulae
+  World := CCF (Hilbert.GL α) φ.subformulae
   Rel X Y :=
     (∀ ψ ∈ □''⁻¹φ.subformulae, □ψ ∈ X.formulae → (ψ ∈ Y.formulae ∧ □ψ ∈ Y.formulae)) ∧
     (∃ χ ∈ □''⁻¹φ.subformulae, □χ ∉ X.formulae ∧ □χ ∈ Y.formulae)
@@ -45,7 +45,7 @@ open ComplementaryClosedConsistentFormulae
 
 omit [Inhabited α] in
 private lemma GL_truthlemma.lemma1
-  {X : CCF 𝐆𝐋 φ.subformulae} (hq : □ψ ∈ φ.subformulae)
+  {X : CCF (Hilbert.GL α) φ.subformulae} (hq : □ψ ∈ φ.subformulae)
   : ((X.formulae.prebox ∪ X.formulae.prebox.box) ∪ {□ψ, -ψ}) ⊆ φ.subformulae⁻ := by
   simp only [Formulae.complementary];
   intro χ hr;
@@ -68,8 +68,8 @@ private lemma GL_truthlemma.lemma1
 
 omit [Inhabited α] in
 private lemma GL_truthlemma.lemma2
-  {X : CCF 𝐆𝐋 φ.subformulae} (hq₁ : □ψ ∈ φ.subformulae) (hq₂ : □ψ ∉ X.formulae)
-  : Formulae.Consistent 𝐆𝐋 ((X.formulae.prebox ∪ X.formulae.prebox.box) ∪ {□ψ, -ψ}) := by
+  {X : CCF (Hilbert.GL α) φ.subformulae} (hq₁ : □ψ ∈ φ.subformulae) (hq₂ : □ψ ∉ X.formulae)
+  : Formulae.Consistent (Hilbert.GL α) ((X.formulae.prebox ∪ X.formulae.prebox.box) ∪ {□ψ, -ψ}) := by
   apply Formulae.intro_union_consistent;
   rintro Γ₁ Γ₂ ⟨hΓ₁, hΓ₂⟩;
 
@@ -78,29 +78,29 @@ private lemma GL_truthlemma.lemma2
     simpa using hΓ₂ χ hr;
 
   by_contra hC;
-  have : Γ₁ ⊢[𝐆𝐋]! ⋀Γ₂ ➝ ⊥ := provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hC;
-  have : Γ₁ ⊢[𝐆𝐋]! (□ψ ⋏ -ψ) ➝ ⊥ := imp_trans''! (by
-    suffices Γ₁ ⊢[𝐆𝐋]! ⋀[□ψ, -ψ] ➝ ⋀Γ₂ by
+  have : Γ₁ ⊢[_]! ⋀Γ₂ ➝ ⊥ := provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hC;
+  have : Γ₁ ⊢[_]! (□ψ ⋏ -ψ) ➝ ⊥ := imp_trans''! (by
+    suffices Γ₁ ⊢[(Hilbert.GL α)]! ⋀[□ψ, -ψ] ➝ ⋀Γ₂ by
       simpa only [ne_eq, List.cons_ne_self, not_false_eq_true, List.conj₂_cons_nonempty, List.conj₂_singleton];
     apply conjconj_subset!;
     simpa using hΓ₂;
   ) this;
-  have : Γ₁ ⊢[𝐆𝐋]! □ψ ➝ -ψ ➝ ⊥ := and_imply_iff_imply_imply'!.mp this;
-  have : Γ₁ ⊢[𝐆𝐋]! □ψ ➝ ψ := by
+  have : Γ₁ ⊢[_]! □ψ ➝ -ψ ➝ ⊥ := and_imply_iff_imply_imply'!.mp this;
+  have : Γ₁ ⊢[(Hilbert.GL α)]! □ψ ➝ ψ := by
     rcases Formula.complement.or (φ := ψ) with (hp | ⟨ψ, rfl⟩);
     . rw [hp] at this;
       exact imp_trans''! this dne!;
     . simpa only [complement] using this;
-  have : (□'Γ₁) ⊢[𝐆𝐋]! □(□ψ ➝ ψ) := contextual_nec! this;
-  have : (□'Γ₁) ⊢[𝐆𝐋]! □ψ := axiomL! ⨀ this;
-  have : 𝐆𝐋 ⊢! ⋀□'Γ₁ ➝ □ψ := provable_iff.mp this;
-  have : 𝐆𝐋 ⊢! ⋀□'(X.formulae.prebox ∪ X.formulae.prebox.box |>.toList) ➝ □ψ := imp_trans''! (conjconj_subset! (by
+  have : (□'Γ₁) ⊢[_]! □(□ψ ➝ ψ) := contextual_nec! this;
+  have : (□'Γ₁) ⊢[_]! □ψ := axiomL! ⨀ this;
+  have : _ ⊢! ⋀□'Γ₁ ➝ □ψ := provable_iff.mp this;
+  have : _ ⊢! ⋀□'(X.formulae.prebox ∪ X.formulae.prebox.box |>.toList) ➝ □ψ := imp_trans''! (conjconj_subset! (by
     simp;
     intro χ hr;
     have := hΓ₁ _ hr; simp at this;
     tauto;
   )) this;
-  have : 𝐆𝐋 ⊢! ⋀□'(X.formulae.prebox.toList) ➝ □ψ := imp_trans''! (conjconj_provable! (by
+  have : _ ⊢! ⋀□'(X.formulae.prebox.toList) ➝ □ψ := imp_trans''! (conjconj_provable! (by
     intro ψ hq;
     simp at hq;
     obtain ⟨χ, hr, rfl⟩ := hq;
@@ -111,7 +111,7 @@ private lemma GL_truthlemma.lemma2
       apply FiniteContext.by_axm!;
       simpa;
   )) this;
-  have : X.formulae *⊢[𝐆𝐋]! □ψ := by
+  have : X.formulae *⊢[(Hilbert.GL α)]! □ψ := by
     apply Context.provable_iff.mpr;
     use □'X.formulae.prebox.toList;
     constructor;
@@ -169,7 +169,7 @@ lemma GL_truthlemma {X : (GLCompleteModel φ)} (q_sub : ψ ∈ φ.subformulae) :
       refine RXY.1 ψ ?_ h |>.1;
       assumption;
 
-private lemma GL_completeAux : TransitiveIrreflexiveFrameClass.{u}ꟳ#α ⊧ φ → 𝐆𝐋 ⊢! φ := by
+private lemma GL_completeAux : TransitiveIrreflexiveFrameClass.{u}ꟳ#α ⊧ φ → (Hilbert.GL α) ⊢! φ := by
   contrapose;
   intro h;
   apply exists_finite_frame.mpr;
@@ -190,9 +190,9 @@ private lemma GL_completeAux : TransitiveIrreflexiveFrameClass.{u}ꟳ#α ⊧ φ 
       apply hX₁;
       tauto;
 
-instance GL_complete : Complete (𝐆𝐋 : Hilbert α) TransitiveIrreflexiveFrameClass.{u}ꟳ#α := ⟨GL_completeAux⟩
+instance GL_complete : Complete (Hilbert.GL α) TransitiveIrreflexiveFrameClass.{u}ꟳ#α := ⟨GL_completeAux⟩
 
-instance : FiniteFrameProperty (α := α) 𝐆𝐋 TransitiveIrreflexiveFrameClass where
+instance : FiniteFrameProperty (Hilbert.GL α) TransitiveIrreflexiveFrameClass where
 
 end Kripke
 

--- a/Foundation/Modal/Kripke/GL/Definability.lean
+++ b/Foundation/Modal/Kripke/GL/Definability.lean
@@ -88,8 +88,8 @@ instance axiomL_definability : 𝔽((𝗟 : Theory α)).DefinedBy (TransitiveCon
     simp [Transitive, ConverseWellFounded];
     apply WellFounded.trivial_wellfounded;
 
-instance : Sound (𝐆𝐋 : Hilbert α) (TransitiveConverseWellFoundedFrameClass#α) := inferInstance
-instance : System.Consistent (𝐆𝐋 : Hilbert α) := inferInstance
+instance : Sound (Hilbert.GL α) (TransitiveConverseWellFoundedFrameClass#α) := inferInstance
+instance : System.Consistent (Hilbert.GL α) := inferInstance
 
 instance axiomL_finite_definability : 𝔽ꟳ((𝗟 : Theory α)).DefinedBy (TransitiveIrreflexiveFrameClassꟳ) where
   define := by
@@ -111,7 +111,7 @@ instance axiomL_finite_definability : 𝔽ꟳ((𝗟 : Theory α)).DefinedBy (Tra
     use ⟨PUnit,  λ _ _ => False⟩;
     refine ⟨?_, ?_⟩ <;> tauto;
 
-instance GL_finite_sound : Sound 𝐆𝐋 (TransitiveIrreflexiveFrameClassꟳ#α) := inferInstance
+instance GL_finite_sound : Sound (Hilbert.GL α) (TransitiveIrreflexiveFrameClassꟳ#α) := inferInstance
 
 end Kripke
 

--- a/Foundation/Modal/Kripke/GL/MDP.lean
+++ b/Foundation/Modal/Kripke/GL/MDP.lean
@@ -119,16 +119,16 @@ end Kripke
 
 variable {X : Theory α} {φ₁ φ₂ : Formula α}
 
-lemma GL_MDP_Aux [Inhabited α] (h : (□''X) *⊢[𝐆𝐋]! □φ₁ ⋎ □φ₂) : (□''X) *⊢[𝐆𝐋]! □φ₁ ∨ (□''X) *⊢[𝐆𝐋]! □φ₂ := by
+lemma GL_MDP_Aux [Inhabited α] (h : (□''X) *⊢[(Hilbert.GL α)]! □φ₁ ⋎ □φ₂) : (□''X) *⊢[(Hilbert.GL α)]! □φ₁ ∨ (□''X) *⊢[(Hilbert.GL α)]! □φ₂ := by
   obtain ⟨Δ, sΓ, hΓ⟩ := Context.provable_iff_boxed.mp h;
 
-  have : 𝐆𝐋 ⊢! ⋀□'Δ ➝ (□φ₁ ⋎ □φ₂) := FiniteContext.provable_iff.mp hΓ;
-  have : 𝐆𝐋 ⊢! □⋀Δ ➝ (□φ₁ ⋎ □φ₂) := imp_trans''! (by simp) this;
+  have : (Hilbert.GL α) ⊢! ⋀□'Δ ➝ (□φ₁ ⋎ □φ₂) := FiniteContext.provable_iff.mp hΓ;
+  have : (Hilbert.GL α) ⊢! □⋀Δ ➝ (□φ₁ ⋎ □φ₂) := imp_trans''! (by simp) this;
   generalize e : ⋀Δ = c at this;
 
-  have : (𝐆𝐋 ⊢! ⊡c ➝ φ₁) ⋎ (𝐆𝐋 ⊢! ⊡c ➝ φ₂) := by
+  have : ((Hilbert.GL α) ⊢! ⊡c ➝ φ₁) ⋎ ((Hilbert.GL α) ⊢! ⊡c ➝ φ₂) := by
     by_contra hC;
-    have ⟨h₁, h₂⟩ : (𝐆𝐋 ⊬ ⊡c ➝ φ₁) ∧ (𝐆𝐋 ⊬ ⊡c ➝ φ₂) := not_or.mp hC;
+    have ⟨h₁, h₂⟩ : ((Hilbert.GL α) ⊬ ⊡c ➝ φ₁) ∧ ((Hilbert.GL α) ⊬ ⊡c ➝ φ₂) := not_or.mp hC;
 
     obtain ⟨M₁, hM₁⟩ := iff_unprovable_GL_exists_unsatisfies_at_root_on_FiniteTransitiveTree.mp h₁;
     obtain ⟨M₂, hM₂⟩ := iff_unprovable_GL_exists_unsatisfies_at_root_on_FiniteTransitiveTree.mp h₂;
@@ -175,7 +175,7 @@ lemma GL_MDP_Aux [Inhabited α] (h : (□''X) *⊢[𝐆𝐋]! □φ₁ ⋎ □φ
     tauto;
   };
 
-theorem GL_MDP [Inhabited α] (h : 𝐆𝐋 ⊢! □φ₁ ⋎ □φ₂) : 𝐆𝐋 ⊢! φ₁ ∨ 𝐆𝐋 ⊢! φ₂ := by
+theorem GL_MDP [Inhabited α] (h : (Hilbert.GL α) ⊢! □φ₁ ⋎ □φ₂) : (Hilbert.GL α) ⊢! φ₁ ∨ (Hilbert.GL α) ⊢! φ₂ := by
   have := GL_MDP_Aux (X := ∅) (φ₁ := φ₁) (φ₂ := φ₂) $ Context.of! h;
   simp at this;
   rcases this with (h | h) <;> {
@@ -183,6 +183,6 @@ theorem GL_MDP [Inhabited α] (h : 𝐆𝐋 ⊢! □φ₁ ⋎ □φ₂) : 𝐆�
     tauto;
   }
 
-instance [Inhabited α] : System.ModalDisjunctive (𝐆𝐋 : Hilbert α) := ⟨GL_MDP⟩
+instance [Inhabited α] : System.ModalDisjunctive (Hilbert.GL α) := ⟨GL_MDP⟩
 
 end LO.Modal

--- a/Foundation/Modal/Kripke/GL/Tree.lean
+++ b/Foundation/Modal/Kripke/GL/Tree.lean
@@ -48,7 +48,7 @@ lemma valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTra
   exact H ⟨(F.FiniteTransitiveTreeUnravelling F_trans F_irrefl r), (M.FiniteTransitiveTreeUnravelling r).Valuation⟩;
 
 variable [Inhabited α] [DecidableEq α]
-theorem iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree : 𝐆𝐋 ⊢! φ ↔ (∀ M : FiniteTransitiveTreeModel.{u, u} α, M.root ⊧ φ) := by
+theorem iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree : (Hilbert.GL α) ⊢! φ ↔ (∀ M : FiniteTransitiveTreeModel.{u, u} α, M.root ⊧ φ) := by
   constructor;
   . intro h M;
     have : TransitiveIrreflexiveFrameClassꟳ#α ⊧ φ := GL_finite_sound.sound h;
@@ -59,15 +59,13 @@ theorem iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree : 𝐆𝐋 ⊢
     intro F hF V;
     apply valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTransitiveTree h hF;
 
-lemma iff_unprovable_GL_exists_unsatisfies_at_root_on_FiniteTransitiveTree : 𝐆𝐋 ⊬ φ ↔ ∃ M : FiniteTransitiveTreeModel.{u, u} α, ¬M.root ⊧ φ := by
+lemma iff_unprovable_GL_exists_unsatisfies_at_root_on_FiniteTransitiveTree : (Hilbert.GL α) ⊬ φ ↔ ∃ M : FiniteTransitiveTreeModel.{u, u} α, ¬M.root ⊧ φ := by
   constructor;
   . contrapose; simp; apply iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree.mpr;
   . contrapose; simp; apply iff_provable_GL_satisfies_at_root_on_FiniteTransitiveTree.mp;
 
 end
 
-
-#check Finite
 
 def FiniteTransitiveTree.SimpleExtension (F : FiniteTransitiveTree) : Kripke.FiniteTransitiveTree where
   World := (Fin 1) ⊕ F.World
@@ -171,7 +169,7 @@ variable {φ ψ : Formula α}
   - `System.imply_boxdot_axiomT_of_imply_boxdot_boxdot`
   - `System.imply_box_box_of_imply_boxdot_axiomT`
 -/
-lemma GL_imply_boxdot_plain_of_imply_box_box : 𝐆𝐋 ⊢! □φ ➝ □ψ → 𝐆𝐋 ⊢! ⊡φ ➝ ψ := by
+lemma GL_imply_boxdot_plain_of_imply_box_box : (Hilbert.GL α) ⊢! □φ ➝ □ψ → (Hilbert.GL α) ⊢! ⊡φ ➝ ψ := by
   contrapose;
   intro h;
   have := iff_unprovable_GL_exists_unsatisfies_at_root_on_FiniteTransitiveTree.mp h;
@@ -199,13 +197,13 @@ lemma GL_imply_boxdot_plain_of_imply_box_box : 𝐆𝐋 ⊢! □φ ➝ □ψ →
   use M↧;
   exact _root_.not_imp.mpr ⟨hbp, hbq⟩;
 
-theorem GL_unnecessitation! : 𝐆𝐋 ⊢! □φ → 𝐆𝐋 ⊢! φ := by
+theorem GL_unnecessitation! : (Hilbert.GL α) ⊢! □φ → (Hilbert.GL α) ⊢! φ := by
   intro h;
-  have : 𝐆𝐋 ⊢! □⊤ ➝ □φ := imply₁'! (ψ := □⊤) h;
-  have : 𝐆𝐋 ⊢! ⊡⊤ ➝ φ := GL_imply_boxdot_plain_of_imply_box_box this;
+  have : (Hilbert.GL α) ⊢! □⊤ ➝ □φ := imply₁'! (ψ := □⊤) h;
+  have : (Hilbert.GL α) ⊢! ⊡⊤ ➝ φ := GL_imply_boxdot_plain_of_imply_box_box this;
   exact this ⨀ boxdotverum!;
 
-noncomputable instance : System.Unnecessitation (𝐆𝐋 : Hilbert α) where
+noncomputable instance : System.Unnecessitation (Hilbert.GL α) where
   unnec := λ h => GL_unnecessitation! ⟨h⟩ |>.some
 
 end Unnecessitation

--- a/Foundation/Modal/Kripke/Geach.lean
+++ b/Foundation/Modal/Kripke/Geach.lean
@@ -219,7 +219,7 @@ instance : System.Consistent (Hilbert.Geach α ts) := inferInstance
 
 
 instance instGeachLogicSound
-  {Λ : Hilbert α} {𝔽 : FrameClass} [logic_geach : Λ.IsGeach ts] [class_geach : 𝔽.IsGeach ts] : Sound Λ (𝔽#α) := by
+  {H : Hilbert α} {𝔽 : FrameClass} [logic_geach : H.IsGeach ts] [class_geach : 𝔽.IsGeach ts] : Sound H (𝔽#α) := by
   convert sound_Geach (α := α) (ts := ts);
   . exact logic_geach.char;
   . exact class_geach.equality;
@@ -251,7 +251,7 @@ variable {Ax : Theory α} [System.Consistent (Hilbert.ExtK Ax)] [DecidableEq α]
 lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame (Hilbert.ExtK Ax)).Rel := by
   rintro Ω₁ Ω₂ Ω₃ h;
   have ⟨r₁₂, r₁₃⟩ := h; clear h;
-  have ⟨Ω, hΩ⟩ := lindenbaum (Λ := (Hilbert.ExtK Ax)) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
+  have ⟨Ω, hΩ⟩ := lindenbaum (H := (Hilbert.ExtK Ax)) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
     apply intro_union_consistent;
     rintro Γ Δ ⟨hΓ, hΔ⟩ hC;
 
@@ -301,7 +301,7 @@ instance instMultiGeachComplete : Complete (Hilbert.ExtK (𝗚𝗲(ts))) ((Multi
     apply multiGeachConfluent_CanonicalFrame;
     tauto;
 
-instance {Λ : Hilbert α} {𝔽 : FrameClass.{u}} [logic_geach : Λ.IsGeach ts] [class_geach : 𝔽.IsGeach ts] : Complete Λ (𝔽#α) := by
+instance {H : Hilbert α} {𝔽 : FrameClass.{u}} [logic_geach : H.IsGeach ts] [class_geach : 𝔽.IsGeach ts] : Complete H (𝔽#α) := by
   convert instMultiGeachComplete (α := α) (ts := ts);
   . exact logic_geach.char;
   . exact class_geach.equality;

--- a/Foundation/Modal/Kripke/Geach.lean
+++ b/Foundation/Modal/Kripke/Geach.lean
@@ -211,11 +211,11 @@ instance axiomMultiGeach_definability : 𝔽((𝗚𝗲(ts) : Theory α)).Defined
   define := axiomMultiGeach_defines;
   nonempty := MultiGeachConfluentFrameClass.nonempty
 
-instance Geach_definability : 𝔽((𝐆𝐞(ts) : Hilbert α)).DefinedBy (MultiGeachConfluentFrameClass ts) := inferInstance
+instance Geach_definability : 𝔽(Hilbert.Geach α ts).DefinedBy (MultiGeachConfluentFrameClass ts) := inferInstance
 
-instance sound_Geach : Sound 𝐆𝐞(ts) ((MultiGeachConfluentFrameClass ts)#α) := inferInstance
+instance sound_Geach : Sound (Hilbert.Geach α ts) ((MultiGeachConfluentFrameClass ts)#α) := inferInstance
 
-instance : System.Consistent (𝐆𝐞(ts) : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.Geach α ts) := inferInstance
 
 
 instance instGeachLogicSound
@@ -224,21 +224,21 @@ instance instGeachLogicSound
   . exact logic_geach.char;
   . exact class_geach.equality;
 
-instance KD_sound : Sound 𝐊𝐃 (SerialFrameClass#α) := inferInstance
+instance KD_sound : Sound (Hilbert.KD α) (SerialFrameClass#α) := inferInstance
 
-instance KT_sound : Sound 𝐊𝐓 (ReflexiveFrameClass#α) := inferInstance
+instance KT_sound : Sound (Hilbert.KT α) (ReflexiveFrameClass#α) := inferInstance
 
-instance KTB_sound : Sound 𝐊𝐓𝐁 (ReflexiveSymmetricFrameClass#α) := inferInstance
+instance KTB_sound : Sound (Hilbert.KTB α) (ReflexiveSymmetricFrameClass#α) := inferInstance
 
-instance K4_sound : Sound 𝐊𝟒 (TransitiveFrameClass#α) := inferInstance
+instance K4_sound : Sound (Hilbert.K4 α) (TransitiveFrameClass#α) := inferInstance
 
-instance S4_sound : Sound 𝐒𝟒 (PreorderFrameClass#α) := inferInstance
+instance S4_sound : Sound (Hilbert.S4 α) (PreorderFrameClass#α) := inferInstance
 
-@[deprecated] lemma S4_sound_aux : 𝐒𝟒 ⊢! φ → (PreorderFrameClass#α) ⊧ φ := S4_sound.sound
+@[deprecated] lemma S4_sound_aux : (Hilbert.S4 α) ⊢! φ → (PreorderFrameClass#α) ⊧ φ := S4_sound.sound
 
-instance S5_sound : Sound 𝐒𝟓 (ReflexiveEuclideanFrameClass#α) := inferInstance
+instance S5_sound : Sound (Hilbert.S5 α) (ReflexiveEuclideanFrameClass#α) := inferInstance
 
-instance KT4B_sound : Sound 𝐊𝐓𝟒𝐁 (EquivalenceFrameClass#α) := inferInstance
+instance KT4B_sound : Sound (Hilbert.KT4B α) (EquivalenceFrameClass#α) := inferInstance
 
 end
 
@@ -246,12 +246,12 @@ end
 open System
 open Theory MaximalConsistentTheory CanonicalFrame
 
-variable {Ax : Theory α} [System.Consistent (𝜿Ax)] [DecidableEq α]
+variable {Ax : Theory α} [System.Consistent (Hilbert.ExtK Ax)] [DecidableEq α]
 
-lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame 𝜿Ax).Rel := by
+lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame (Hilbert.ExtK Ax)).Rel := by
   rintro Ω₁ Ω₂ Ω₃ h;
   have ⟨r₁₂, r₁₃⟩ := h; clear h;
-  have ⟨Ω, hΩ⟩ := lindenbaum (Λ := 𝜿Ax) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
+  have ⟨Ω, hΩ⟩ := lindenbaum (Λ := (Hilbert.ExtK Ax)) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
     apply intro_union_consistent;
     rintro Γ Δ ⟨hΓ, hΔ⟩ hC;
 
@@ -262,17 +262,17 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
     have : □^[t.n]⋀Δ ∈ Ω₃.theory := iff_mem_multibox_conj.mpr hΔ;
 
     have : □^[t.j](◇^[t.n]⋀Γ) ∈ Ω₁.theory := iff_mem_imp.mp
-      (membership_iff.mpr $ Context.of! $ Normal.maxm! (by aesop))
+      (membership_iff.mpr $ Context.of! $ Hilbert.ExtK.maxm! (by aesop))
       (multirel_def_multidia.mp r₁₂ hΓconj)
     have : ◇^[t.n]⋀Γ ∈ Ω₃.theory := multirel_def_multibox.mp r₁₃ this;
 
-    have : 𝜿Ax ⊢! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ➝ ⊥ := by {
+    have : (Hilbert.ExtK Ax) ⊢! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ➝ ⊥ := by {
       apply and_imply_iff_imply_imply'!.mpr;
       exact imp_trans''!
-        (show 𝜿Ax ⊢! □^[t.n]⋀Δ ➝ □^[t.n](∼⋀Γ) by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
-        (show 𝜿Ax ⊢! □^[t.n](∼⋀Γ) ➝ (◇^[t.n]⋀Γ) ➝ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
+        (show _ ⊢! □^[t.n]⋀Δ ➝ □^[t.n](∼⋀Γ) by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
+        (show _ ⊢! □^[t.n](∼⋀Γ) ➝ (◇^[t.n]⋀Γ) ➝ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
     }
-    have : 𝜿Ax ⊬ □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ➝ ⊥ := by simpa using (def_consistent.mp Ω₃.consistent) (Γ := [□^[t.n]⋀Δ, ◇^[t.n]⋀Γ]) (by simp_all)
+    have : (Hilbert.ExtK Ax) ⊬ □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ➝ ⊥ := by simpa using (def_consistent.mp Ω₃.consistent) (Γ := [□^[t.n]⋀Δ, ◇^[t.n]⋀Γ]) (by simp_all)
 
     contradiction;
 
@@ -281,7 +281,7 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
   . apply multirel_def_multibox.mpr; apply hΩ.1;
   . apply multirel_def_multibox.mpr; apply hΩ.2;
 
-lemma multiGeachConfluent_CanonicalFrame (h : 𝗚𝗲(ts) ⊆ Ax) : MultiGeachConfluent ts (CanonicalFrame 𝜿Ax).Rel := by
+lemma multiGeachConfluent_CanonicalFrame (h : 𝗚𝗲(ts) ⊆ Ax) : MultiGeachConfluent ts (CanonicalFrame (Hilbert.ExtK Ax)).Rel := by
   induction ts using List.induction_with_singleton with
   | hnil => simp [MultiGeachConfluent];
   | hsingle t =>
@@ -296,7 +296,7 @@ lemma multiGeachConfluent_CanonicalFrame (h : 𝗚𝗲(ts) ⊆ Ax) : MultiGeachC
 
 variable [Inhabited α]
 
-instance instMultiGeachComplete : Complete 𝜿(𝗚𝗲(ts)) ((MultiGeachConfluentFrameClass.{u} ts)#α) :=
+instance instMultiGeachComplete : Complete (Hilbert.ExtK (𝗚𝗲(ts))) ((MultiGeachConfluentFrameClass.{u} ts)#α) :=
   instComplete_of_mem_canonicalFrame (MultiGeachConfluentFrameClass ts) $ by
     apply multiGeachConfluent_CanonicalFrame;
     tauto;
@@ -307,22 +307,22 @@ instance {Λ : Hilbert α} {𝔽 : FrameClass.{u}} [logic_geach : Λ.IsGeach ts]
   . exact class_geach.equality;
 
 
-instance KT_complete : Complete 𝐊𝐓 ReflexiveFrameClass.{u}#α := inferInstance
+instance KT_complete : Complete (Hilbert.KT α) ReflexiveFrameClass.{u}#α := inferInstance
 
-instance KTB_complete : Complete 𝐊𝐓𝐁 ReflexiveSymmetricFrameClass.{u}#α := inferInstance
+instance KTB_complete : Complete (Hilbert.KTB α) ReflexiveSymmetricFrameClass.{u}#α := inferInstance
 
-instance S4_complete : Complete 𝐒𝟒 PreorderFrameClass.{u}#α := inferInstance
+instance S4_complete : Complete (Hilbert.S4 α) PreorderFrameClass.{u}#α := inferInstance
 
-instance K4_complete : Complete 𝐊𝟒 TransitiveFrameClass.{u}#α := inferInstance
+instance K4_complete : Complete (Hilbert.K4 α) TransitiveFrameClass.{u}#α := inferInstance
 
-instance KT4B_complete : Complete 𝐊𝐓𝟒𝐁 EquivalenceFrameClass.{u}#α := inferInstance
+instance KT4B_complete : Complete (Hilbert.KT4B α) EquivalenceFrameClass.{u}#α := inferInstance
 
-instance S5_complete : Complete 𝐒𝟓 ReflexiveEuclideanFrameClass.{u}#α := inferInstance
+instance S5_complete : Complete (Hilbert.S5 α) ReflexiveEuclideanFrameClass.{u}#α := inferInstance
 
 end Kripke
 
 
-section
+namespace Hilbert
 
 open System
 open LO.Kripke
@@ -332,11 +332,11 @@ open Formula.Kripke
 
 variable [Inhabited α] [DecidableEq α]
 
-lemma KD_weakerThan_KT : (𝐊𝐃 : Hilbert α) ≤ₛ 𝐊𝐓 := by
+lemma KD_weakerThan_KT : (Hilbert.KD α) ≤ₛ (Hilbert.KT α) := by
   apply weakerThan_of_subset_FrameClass SerialFrameClass ReflexiveFrameClass;
   intro F hF; apply serial_of_refl hF;
 
-theorem KD_strictlyWeakerThan_KT : (𝐊𝐃 : Hilbert α) <ₛ 𝐊𝐓 := by
+theorem KD_strictlyWeakerThan_KT : (Hilbert.KD α) <ₛ (Hilbert.KT α) := by
   constructor;
   . apply KD_weakerThan_KT;
   . simp [weakerThan_iff];
@@ -352,9 +352,9 @@ theorem KD_strictlyWeakerThan_KT : (𝐊𝐃 : Hilbert α) <ₛ 𝐊𝐓 := by
         use (λ w _ => w = 1), 0;
         simp [Satisfies];
 
-theorem K_strictlyWeakerThan_KT : (𝐊 : Hilbert α) <ₛ 𝐊𝐓 := strictlyWeakerThan.trans K_strictlyWeakerThan_KD KD_strictlyWeakerThan_KT
+theorem K_strictlyWeakerThan_KT : (Hilbert.K α) <ₛ (Hilbert.KT α) := strictlyWeakerThan.trans K_strictlyWeakerThan_KD KD_strictlyWeakerThan_KT
 
-theorem K4_strictlyWeakerThan_S4 : (𝐊𝟒 : Hilbert α) <ₛ 𝐒𝟒 := by
+theorem K4_strictlyWeakerThan_S4 : (Hilbert.K4 α) <ₛ (Hilbert.S4 α) := by
   constructor;
   . apply K4_weakerThan_S4;
   . simp [weakerThan_iff]
@@ -370,12 +370,12 @@ theorem K4_strictlyWeakerThan_S4 : (𝐊𝟒 : Hilbert α) <ₛ 𝐒𝟒 := by
         use (λ w _ => w = 1), 0;
         simp [Satisfies];
 
-lemma S4_weakerThan_S5 : (𝐒𝟒 : Hilbert α) ≤ₛ 𝐒𝟓 := by
+lemma S4_weakerThan_S5 : (Hilbert.S4 α) ≤ₛ (Hilbert.S5 α) := by
   apply weakerThan_of_subset_FrameClass PreorderFrameClass ReflexiveEuclideanFrameClass;
   rintro _ ⟨F_refl, F_eucl⟩;
   refine ⟨F_refl, trans_of_refl_eucl F_refl F_eucl⟩;
 
-theorem S4_strictlyWeakerThan_S5 : (𝐒𝟒 : Hilbert α) <ₛ 𝐒𝟓 := by
+theorem S4_strictlyWeakerThan_S5 : (Hilbert.S4 α) <ₛ (Hilbert.S5 α) := by
   constructor;
   . apply S4_weakerThan_S5;
   . simp [weakerThan_iff];
@@ -395,7 +395,7 @@ theorem S4_strictlyWeakerThan_S5 : (𝐒𝟒 : Hilbert α) <ₛ 𝐒𝟓 := by
         . omega;
         . use 1; omega;
 
-theorem equiv_S5_KT4B : (𝐒𝟓 : Hilbert α) =ₛ 𝐊𝐓𝟒𝐁 := by
+theorem equiv_S5_KT4B : (Hilbert.S5 α) =ₛ (Hilbert.KT4B α) := by
   apply equiv_of_eq_FrameClass ReflexiveEuclideanFrameClass EquivalenceFrameClass;
   apply Set.eq_of_subset_of_subset;
   . rintro F ⟨F_refl, F_eucl⟩;
@@ -403,6 +403,6 @@ theorem equiv_S5_KT4B : (𝐒𝟓 : Hilbert α) =ₛ 𝐊𝐓𝟒𝐁 := by
   . rintro F ⟨F_refl, F_eucl, F_symm⟩;
     refine ⟨F_refl, eucl_of_symm_trans F_symm F_eucl⟩;
 
-end
+end Hilbert
 
 end LO.Modal

--- a/Foundation/Modal/Kripke/Grz/Completeness.lean
+++ b/Foundation/Modal/Kripke/Grz/Completeness.lean
@@ -47,7 +47,7 @@ namespace Kripke
 open Formula
 
 abbrev GrzCompleteFrame [Inhabited α] (φ : Formula α) : Kripke.FiniteFrame where
-  World := CCF 𝐆𝐫𝐳 (φ.subformulaeGrz)
+  World := CCF (Hilbert.Grz α) (φ.subformulaeGrz)
   Rel X Y :=
     (∀ ψ ∈ □''⁻¹(φ.subformulaeGrz), □ψ ∈ X.formulae → □ψ ∈ Y.formulae) ∧
     ((∀ ψ ∈ □''⁻¹(φ.subformulaeGrz), □ψ ∈ Y.formulae → □ψ ∈ X.formulae) → X = Y)
@@ -90,7 +90,7 @@ open Formula.Kripke
 open ComplementaryClosedConsistentFormulae
 
 private lemma Grz_truthlemma.lemma1
-  {X : CCF 𝐆𝐫𝐳 (φ.subformulaeGrz)} (hq : □ψ ∈ φ.subformulae)
+  {X : CCF (Hilbert.Grz α) (φ.subformulaeGrz)} (hq : □ψ ∈ φ.subformulae)
   : ((X.formulae.prebox.box) ∪ {□(ψ ➝ □ψ), -ψ}) ⊆ (φ.subformulaeGrz)⁻ := by
   simp only [Formulae.complementary];
   intro χ hr;
@@ -111,8 +111,8 @@ private lemma Grz_truthlemma.lemma1
     . rfl;
 
 private lemma Grz_truthlemma.lemma2
-  {X : CCF 𝐆𝐫𝐳 (φ.subformulaeGrz)} (hq₁ : □ψ ∈ φ.subformulae) (hq₂ : □ψ ∉ X.formulae)
-  : Formulae.Consistent 𝐆𝐫𝐳 ((X.formulae.prebox.box) ∪ {□(ψ ➝ □ψ), -ψ}) := by
+  {X : CCF (Hilbert.Grz α) (φ.subformulaeGrz)} (hq₁ : □ψ ∈ φ.subformulae) (hq₂ : □ψ ∉ X.formulae)
+  : Formulae.Consistent (Hilbert.Grz α) ((X.formulae.prebox.box) ∪ {□(ψ ➝ □ψ), -ψ}) := by
     apply Formulae.intro_union_consistent;
     rintro Γ₁ Γ₂ ⟨hΓ₁, hΓ₂⟩;
     replace hΓ₂ : ∀ χ ∈ Γ₂, χ = □(ψ ➝ □ψ) ∨ χ = -ψ := by
@@ -120,34 +120,34 @@ private lemma Grz_truthlemma.lemma2
       simpa using hΓ₂ χ hr;
 
     by_contra hC;
-    have : Γ₁ ⊢[𝐆𝐫𝐳]! ⋀Γ₂ ➝ ⊥ := provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hC;
-    have : Γ₁ ⊢[𝐆𝐫𝐳]! (□(ψ ➝ □ψ) ⋏ -ψ) ➝ ⊥ := imp_trans''! (by
-      suffices Γ₁ ⊢[𝐆𝐫𝐳]! ⋀[□(ψ ➝ □ψ), -ψ] ➝ ⋀Γ₂ by
+    have : Γ₁ ⊢[(Hilbert.Grz α)]! ⋀Γ₂ ➝ ⊥ := provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hC;
+    have : Γ₁ ⊢[(Hilbert.Grz α)]! (□(ψ ➝ □ψ) ⋏ -ψ) ➝ ⊥ := imp_trans''! (by
+      suffices Γ₁ ⊢[(Hilbert.Grz α)]! ⋀[□(ψ ➝ □ψ), -ψ] ➝ ⋀Γ₂ by
         simpa only [ne_eq, List.cons_ne_self, not_false_eq_true, List.conj₂_cons_nonempty, List.conj₂_singleton];
       apply conjconj_subset!;
       simpa using hΓ₂;
     ) this;
-    have : Γ₁ ⊢[𝐆𝐫𝐳]! □(ψ ➝ □ψ) ➝ -ψ ➝ ⊥ := and_imply_iff_imply_imply'!.mp this;
-    have : Γ₁ ⊢[𝐆𝐫𝐳]! □(ψ ➝ □ψ) ➝ ψ := by
+    have : Γ₁ ⊢[(Hilbert.Grz α)]! □(ψ ➝ □ψ) ➝ -ψ ➝ ⊥ := and_imply_iff_imply_imply'!.mp this;
+    have : Γ₁ ⊢[(Hilbert.Grz α)]! □(ψ ➝ □ψ) ➝ ψ := by
       rcases Formula.complement.or (φ := ψ) with (hp | ⟨ψ, rfl⟩);
       . rw [hp] at this;
         exact imp_trans''! this dne!;
       . simpa only [complement] using this;
-    have : (□'Γ₁) ⊢[𝐆𝐫𝐳]! □(□(ψ ➝ □ψ) ➝ ψ) := contextual_nec! this;
-    have : (□'Γ₁) ⊢[𝐆𝐫𝐳]! ψ := axiomGrz! ⨀ this;
-    have : (□'□'Γ₁) ⊢[𝐆𝐫𝐳]! □ψ := contextual_nec! this;
+    have : (□'Γ₁) ⊢[(Hilbert.Grz α)]! □(□(ψ ➝ □ψ) ➝ ψ) := contextual_nec! this;
+    have : (□'Γ₁) ⊢[(Hilbert.Grz α)]! ψ := axiomGrz! ⨀ this;
+    have : (□'□'Γ₁) ⊢[(Hilbert.Grz α)]! □ψ := contextual_nec! this;
     -- TODO: `contextual_axiomFour`
-    have : 𝐆𝐫𝐳 ⊢! ⋀□'□'Γ₁ ➝ □ψ := provable_iff.mp this;
-    have : 𝐆𝐫𝐳 ⊢! □□⋀Γ₁ ➝ □ψ := imp_trans''! (imp_trans''! (distribute_multibox_conj! (n := 2)) $ conjconj_subset! (by simp)) this;
-    have : 𝐆𝐫𝐳 ⊢! □⋀Γ₁ ➝ □ψ := imp_trans''! axiomFour! this;
-    have : 𝐆𝐫𝐳 ⊢! ⋀□'Γ₁ ➝ □ψ := imp_trans''! collect_box_conj! this;
-    have : 𝐆𝐫𝐳 ⊢! ⋀□'(X.formulae.prebox.box |>.toList) ➝ □ψ := imp_trans''! (conjconj_subset! (by
+    have : (Hilbert.Grz α) ⊢! ⋀□'□'Γ₁ ➝ □ψ := provable_iff.mp this;
+    have : (Hilbert.Grz α) ⊢! □□⋀Γ₁ ➝ □ψ := imp_trans''! (imp_trans''! (distribute_multibox_conj! (n := 2)) $ conjconj_subset! (by simp)) this;
+    have : (Hilbert.Grz α) ⊢! □⋀Γ₁ ➝ □ψ := imp_trans''! axiomFour! this;
+    have : (Hilbert.Grz α) ⊢! ⋀□'Γ₁ ➝ □ψ := imp_trans''! collect_box_conj! this;
+    have : (Hilbert.Grz α) ⊢! ⋀□'(X.formulae.prebox.box |>.toList) ➝ □ψ := imp_trans''! (conjconj_subset! (by
       simp;
       intro χ hr;
       have := hΓ₁ _ hr; simp at this;
       tauto;
     )) this;
-    have : 𝐆𝐫𝐳 ⊢! ⋀□'(X.formulae.prebox.toList) ➝ □ψ := imp_trans''! (conjconj_provable! (by
+    have : (Hilbert.Grz α) ⊢! ⋀□'(X.formulae.prebox.toList) ➝ □ψ := imp_trans''! (conjconj_provable! (by
       intro ψ hq;
       simp at hq;
       obtain ⟨χ, hr, rfl⟩ := hq;
@@ -155,7 +155,7 @@ private lemma Grz_truthlemma.lemma2
       apply FiniteContext.by_axm!;
       simpa;
     )) this;
-    have : X.formulae *⊢[𝐆𝐫𝐳]! □ψ := by
+    have : X.formulae *⊢[(Hilbert.Grz α)]! □ψ := by
       apply Context.provable_iff.mpr;
       use □'X.formulae.prebox.toList;
       constructor;
@@ -165,7 +165,7 @@ private lemma Grz_truthlemma.lemma2
     contradiction;
 
 -- TODO: syntactical proof
-private lemma Grz_truthlemma.lemma3 [Inhabited α] : 𝐊𝐓 ⊢! (φ ⋏ □(φ ➝ □φ)) ➝ □φ := by
+private lemma Grz_truthlemma.lemma3 [Inhabited α] : (Hilbert.KT α) ⊢! (φ ⋏ □(φ ➝ □φ)) ➝ □φ := by
   by_contra hC;
   have := (not_imp_not.mpr $ KT_complete (α := α) |>.complete) hC;
   simp at this;
@@ -233,10 +233,10 @@ lemma Grz_truthlemma [Inhabited α] {X : (GrzCompleteModel φ).World} (q_sub : �
             . simp_all;
             . apply hY.2; simp;
             . by_contra hC;
-              have : ↑X.formulae *⊢[𝐆𝐫𝐳]! ψ := membership_iff (by simp; left; aesop) |>.mp w;
-              have : ↑X.formulae *⊢[𝐆𝐫𝐳]! □(ψ ➝ □ψ) := membership_iff (by simp; right; assumption) |>.mp hC;
-              have : ↑X.formulae *⊢[𝐆𝐫𝐳]! (ψ ⋏ □(ψ ➝ □ψ)) ➝ □ψ := Context.of! $ KT_weakerThan_Grz Grz_truthlemma.lemma3;
-              have : ↑X.formulae *⊢[𝐆𝐫𝐳]! □ψ := this ⨀ and₃'! (by assumption) (by assumption);
+              have : ↑X.formulae *⊢[(Hilbert.Grz α)]! ψ := membership_iff (by simp; left; aesop) |>.mp w;
+              have : ↑X.formulae *⊢[(Hilbert.Grz α)]! □(ψ ➝ □ψ) := membership_iff (by simp; right; assumption) |>.mp hC;
+              have : ↑X.formulae *⊢[(Hilbert.Grz α)]! (ψ ⋏ □(ψ ➝ □ψ)) ➝ □ψ := Context.of! $ Hilbert.KT_weakerThan_Grz Grz_truthlemma.lemma3;
+              have : ↑X.formulae *⊢[(Hilbert.Grz α)]! □ψ := this ⨀ and₃'! (by assumption) (by assumption);
               have : □ψ ∈ X.formulae := membership_iff (subformulaeGrz.mem_origin (by assumption)) |>.mpr this;
               contradiction;
         . apply ih (by aesop) |>.not.mpr;
@@ -252,11 +252,11 @@ lemma Grz_truthlemma [Inhabited α] {X : (GrzCompleteModel φ).World} (q_sub : �
         . exact ih (by aesop) |>.not.mpr w;
     . intro h Y RXY;
       apply ih (subformulae.mem_box q_sub) |>.mpr;
-      have : ↑Y.formulae *⊢[𝐆𝐫𝐳]! □ψ ➝ ψ := Context.of! $ axiomT!;
-      have : ↑Y.formulae *⊢[𝐆𝐫𝐳]! ψ := this ⨀ (membership_iff (by simp; left; trivial) |>.mp (RXY.1 ψ (by simp; tauto) h));
+      have : ↑Y.formulae *⊢[(Hilbert.Grz α)]! □ψ ➝ ψ := Context.of! $ axiomT!;
+      have : ↑Y.formulae *⊢[(Hilbert.Grz α)]! ψ := this ⨀ (membership_iff (by simp; left; trivial) |>.mp (RXY.1 ψ (by simp; tauto) h));
       exact membership_iff (by simp; left; exact subformulae.mem_box q_sub) |>.mpr this;
 
-private lemma Grz_completeAux [Inhabited α] {φ : Formula α} : ReflexiveTransitiveAntisymmetricFrameClass.{u}ꟳ#α ⊧ φ → 𝐆𝐫𝐳 ⊢! φ := by
+private lemma Grz_completeAux [Inhabited α] {φ : Formula α} : ReflexiveTransitiveAntisymmetricFrameClass.{u}ꟳ#α ⊧ φ → (Hilbert.Grz α) ⊢! φ := by
   contrapose;
   intro h;
   apply exists_finite_frame.mpr;
@@ -275,9 +275,9 @@ private lemma Grz_completeAux [Inhabited α] {φ : Formula α} : ReflexiveTransi
       apply hX₁;
       tauto;
 
-instance Grz_complete [Inhabited α] : Complete (𝐆𝐫𝐳 : Hilbert α) (ReflexiveTransitiveAntisymmetricFrameClass.{u}ꟳ#α) := ⟨Grz_completeAux⟩
+instance Grz_complete [Inhabited α] : Complete (Hilbert.Grz α) (ReflexiveTransitiveAntisymmetricFrameClass.{u}ꟳ#α) := ⟨Grz_completeAux⟩
 
-instance [Inhabited α] : FiniteFrameProperty (α := α) 𝐆𝐫𝐳 ReflexiveTransitiveAntisymmetricFrameClass where
+instance [Inhabited α] : FiniteFrameProperty (Hilbert.Grz α) ReflexiveTransitiveAntisymmetricFrameClass where
 
 end Kripke
 

--- a/Foundation/Modal/Kripke/Grz/Definability.lean
+++ b/Foundation/Modal/Kripke/Grz/Definability.lean
@@ -178,8 +178,8 @@ instance axiomGrz_defineability : 𝔽((𝗚𝗿𝘇 : Theory α)).DefinedBy Ref
     simp [WeaklyConverseWellFounded, ConverseWellFounded, IrreflGen];
     apply WellFounded.trivial_wellfounded;
 
-instance : Sound (𝐆𝐫𝐳 : Hilbert α) (ReflexiveTransitiveWeaklyConverseWellFoundedFrameClass#α) := inferInstance
-instance : System.Consistent (𝐆𝐫𝐳 : Hilbert α) := inferInstance
+instance : Sound (Hilbert.Grz α) (ReflexiveTransitiveWeaklyConverseWellFoundedFrameClass#α) := inferInstance
+instance : System.Consistent (Hilbert.Grz α) := inferInstance
 
 instance axiomGrz_finite_defines : 𝔽ꟳ((𝗚𝗿𝘇 : Theory α)).DefinedBy ReflexiveTransitiveAntisymmetricFrameClassꟳ where
   define := by
@@ -199,7 +199,7 @@ instance axiomGrz_finite_defines : 𝔽ꟳ((𝗚𝗿𝘇 : Theory α)).DefinedBy
     use ⟨PUnit, λ _ _ => True⟩;
     refine ⟨?_, ?_, ?_⟩ <;> tauto;
 
-instance : Sound (𝐆𝐫𝐳 : Hilbert α) (ReflexiveTransitiveAntisymmetricFrameClassꟳ#α) := inferInstance
+instance : Sound (Hilbert.Grz α) (ReflexiveTransitiveAntisymmetricFrameClassꟳ#α) := inferInstance
 
 end Kripke
 

--- a/Foundation/Modal/Kripke/Preservation.lean
+++ b/Foundation/Modal/Kripke/Preservation.lean
@@ -72,7 +72,7 @@ lemma iff_theory_valid_on_frame_surjective_morphism (f : F₁ →ₚ F₂) (f_su
   intro h φ hp;
   exact iff_formula_valid_on_frame_surjective_morphism f f_surjective (h hp);
 
-theorem undefinable_irreflexive : ¬∃ (Λ : Hilbert α), ∀ F, F ∈ 𝔽(Λ) ↔ F ∈ IrreflexiveFrameClass.{0} := by
+theorem undefinable_irreflexive : ¬∃ (H : Hilbert α), ∀ F, F ∈ 𝔽(H) ↔ F ∈ IrreflexiveFrameClass.{0} := by
   by_contra hC;
   obtain ⟨Ax, h⟩ := hC;
 

--- a/Foundation/Modal/Kripke/S5.lean
+++ b/Foundation/Modal/Kripke/S5.lean
@@ -17,7 +17,7 @@ lemma iff_Universal_ReflexiveEuclidean_validOnFrameClass : UniversalFrameClass.{
   . rintro h F F_univ;
     exact @h F (⟨refl_of_universal F_univ, eucl_of_universal F_univ⟩);
 
-instance S5_complete_universal [Inhabited α] [DecidableEq α] : Complete 𝐒𝟓 (UniversalFrameClass.{u}#α) := ⟨by
+instance S5_complete_universal [Inhabited α] [DecidableEq α] : Complete (Hilbert.S5 α) (UniversalFrameClass.{u}#α) := ⟨by
   intro φ hF;
   exact S5_complete.complete $ iff_Universal_ReflexiveEuclidean_validOnFrameClass.mp hF;
 ⟩

--- a/Foundation/Modal/Kripke/Semantics.lean
+++ b/Foundation/Modal/Kripke/Semantics.lean
@@ -292,7 +292,7 @@ def characterizability_union_frameclass_of_theory {T₁ T₂ : Theory α}
 abbrev FrameClassOfHilbert (Λ : Hilbert α) : FrameClass.Dep α := 𝔽(Λ.theorems)
 notation "𝔽(" Λ ")"  => FrameClassOfHilbert Λ
 
-instance {Ax : Theory α} {𝔽 : FrameClass} [defi : 𝔽(Ax).DefinedBy 𝔽] : 𝔽(𝜿(Ax)).DefinedBy 𝔽 where
+instance {Ax : Theory α} {𝔽 : FrameClass} [defi : 𝔽(Ax).DefinedBy 𝔽] : 𝔽(Hilbert.ExtK Ax).DefinedBy 𝔽 where
   define := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F;
@@ -319,7 +319,7 @@ instance {Ax : Theory α} {𝔽 : FrameClass} [defi : 𝔽(Ax).DefinedBy 𝔽] :
         | exact Formula.Kripke.ValidOnFrame.elimContra;
   nonempty := defi.nonempty
 
-instance {Ax : Theory α} {𝔽 : FrameClass} [char : 𝔽(Ax).Characteraizable 𝔽] : 𝔽(𝜿(Ax)).Characteraizable 𝔽 where
+instance {Ax : Theory α} {𝔽 : FrameClass} [char : 𝔽(Ax).Characteraizable 𝔽] : 𝔽(Hilbert.ExtK Ax).Characteraizable 𝔽 where
   characterize := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F hF φ hp;
@@ -343,7 +343,7 @@ instance {Ax : Theory α} {𝔽 : FrameClass} [char : 𝔽(Ax).Characteraizable 
 abbrev FiniteFrameClassOfHilbert (Λ : Hilbert α) : FiniteFrameClass.Dep α := 𝔽(Λ)ꟳ
 notation "𝔽ꟳ(" Λ ")"  => FiniteFrameClassOfHilbert Λ
 
-instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass}  [defi : 𝔽ꟳ(Ax).DefinedBy 𝔽] : 𝔽ꟳ(𝜿(Ax)).DefinedBy 𝔽 where
+instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass}  [defi : 𝔽ꟳ(Ax).DefinedBy 𝔽] : 𝔽ꟳ(Hilbert.ExtK Ax).DefinedBy 𝔽 where
   define := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F;
@@ -370,7 +370,7 @@ instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass}  [defi : 𝔽ꟳ(Ax).
         | exact Formula.Kripke.ValidOnFrame.elimContra;
   nonempty := defi.nonempty
 
-instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(Ax).Characteraizable 𝔽] : 𝔽ꟳ(𝜿(Ax)).Characteraizable 𝔽 where
+instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(Ax).Characteraizable 𝔽] : 𝔽ꟳ(Hilbert.ExtK Ax).Characteraizable 𝔽 where
   characterize := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F hF φ hp;
@@ -468,15 +468,15 @@ instance empty_axiom_definability : 𝔽((∅ : Theory α)).DefinedBy AllFrameCl
   define := by simp;
   nonempty :=  ⟨⟨PUnit,  λ _ _ => True⟩, trivial⟩
 
-private instance K_definability' : 𝔽((𝜿(∅) : Hilbert α)).DefinedBy AllFrameClass := inferInstance
+private instance K_definability' : 𝔽(((Hilbert.ExtK ∅) : Hilbert α)).DefinedBy AllFrameClass := inferInstance
 
-instance K_definability : 𝔽((𝐊 : Hilbert α)).DefinedBy AllFrameClass := by
+instance K_definability : 𝔽(Hilbert.K α).DefinedBy AllFrameClass := by
   convert K_definability';
-  exact K_is_extK_of_empty;
+  exact Hilbert.ExtK.K_is_extK_of_empty;
 
-instance K_sound : Sound 𝐊 (AllFrameClass#α) := inferInstance
+instance K_sound : Sound (Hilbert.K α) (AllFrameClass#α) := inferInstance
 
-instance K_consistent : System.Consistent (𝐊 : Hilbert α) := inferInstance
+instance K_consistent : System.Consistent (Hilbert.K α) := inferInstance
 
 
 lemma restrict_finite : 𝔽#α ⊧ φ → 𝔽ꟳ#α ⊧ φ := by
@@ -489,7 +489,7 @@ instance {Λ : Hilbert α} [sound : Sound Λ 𝔽#α] : Sound Λ 𝔽ꟳ#α := �
   exact restrict_finite $ sound.sound h;
 ⟩
 
-instance : Sound 𝐊 (AllFrameClassꟳ#α) := inferInstance
+instance : Sound (Hilbert.K α) (AllFrameClassꟳ#α) := inferInstance
 
 lemma exists_finite_frame : ¬𝔽ꟳ#α ⊧ φ ↔ ∃ F ∈ 𝔽ꟳ, ¬F#α ⊧ φ := by simp;
 
@@ -500,14 +500,16 @@ class FiniteFrameProperty (Λ : Hilbert α) (𝔽 : FrameClass) where
 end Kripke
 
 
+
+namespace Hilbert
+
 section
 
 open Formula (atom)
 open Formula.Kripke
 open Kripke (K_sound)
 
-
-theorem K_strictlyWeakerThan_KD [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝐃 := by
+theorem K_strictlyWeakerThan_KD [DecidableEq α] [Inhabited α] : (Hilbert.K α) <ₛ (Hilbert.KD α) := by
   constructor;
   . apply K_weakerThan_KD;
   . simp [weakerThan_iff];
@@ -519,7 +521,7 @@ theorem K_strictlyWeakerThan_KD [DecidableEq α] [Inhabited α] : (𝐊 : Hilber
       use ⟨Fin 1, λ _ _ => False⟩, (λ w _ => w = 0), 0;
       simp [Satisfies];
 
-theorem K_strictlyWeakerThan_KB [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝐁 := by
+theorem K_strictlyWeakerThan_KB [DecidableEq α] [Inhabited α] : (Hilbert.K α) <ₛ (Hilbert.KB α) := by
   constructor;
   . apply K_weakerThan_KB;
   . simp [weakerThan_iff];
@@ -532,7 +534,7 @@ theorem K_strictlyWeakerThan_KB [DecidableEq α] [Inhabited α] : (𝐊 : Hilber
       simp [Satisfies];
       use 1;
 
-theorem K_strictlyWeakerThan_K4 [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝟒 := by
+theorem K_strictlyWeakerThan_K4 [DecidableEq α] [Inhabited α] : (Hilbert.K α) <ₛ (Hilbert.K4 α) := by
   constructor;
   . apply K_weakerThan_K4;
   . simp [weakerThan_iff];
@@ -553,7 +555,7 @@ theorem K_strictlyWeakerThan_K4 [DecidableEq α] [Inhabited α] : (𝐊 : Hilber
         . aesop;
         . use 0; aesop;
 
-theorem K_strictlyWeakerThan_K5 [DecidableEq α] [Inhabited α] : (𝐊 : Hilbert α) <ₛ 𝐊𝟓 := by
+theorem K_strictlyWeakerThan_K5 [DecidableEq α] [Inhabited α] : (Hilbert.K α) <ₛ (Hilbert.K5 α)  := by
   constructor;
   . apply K_weakerThan_K5;
   . simp [weakerThan_iff];
@@ -567,14 +569,17 @@ theorem K_strictlyWeakerThan_K5 [DecidableEq α] [Inhabited α] : (𝐊 : Hilber
       use 1;
       simp;
 
+end
+
 
 section
 
 variable {Ax₁ Ax₂ : Theory α} (𝔽₁ 𝔽₂ : FrameClass)
 
 lemma weakerThan_of_subset_FrameClass
-  [sound₁ : Sound 𝜿Ax₁ 𝔽₁#α] [complete₂ : Complete 𝜿Ax₂ 𝔽₂#α]
-  (h𝔽 : 𝔽₂ ⊆ 𝔽₁) : 𝜿Ax₁ ≤ₛ 𝜿Ax₂ := by
+  [sound₁ : Sound (Hilbert.ExtK Ax₁) 𝔽₁#α] [complete₂ : Complete (Hilbert.ExtK Ax₂) 𝔽₂#α]
+  (h𝔽 : 𝔽₂ ⊆ 𝔽₁)
+  : (Hilbert.ExtK Ax₁) ≤ₛ (Hilbert.ExtK Ax₂) := by
   apply System.weakerThan_iff.mpr;
   intro φ hp;
   apply complete₂.complete;
@@ -582,9 +587,9 @@ lemma weakerThan_of_subset_FrameClass
   exact sound₁.sound hp $ h𝔽 hF;
 
 lemma equiv_of_eq_FrameClass
-  [sound₁ : Sound 𝜿Ax₁ 𝔽₁#α] [sound₂ : Sound 𝜿Ax₂ 𝔽₂#α]
-  [complete₁ : Complete 𝜿Ax₁ 𝔽₁#α] [complete₂ : Complete 𝜿Ax₂ 𝔽₂#α]
-  (h𝔽 : 𝔽₁ = 𝔽₂) : 𝜿Ax₁ =ₛ 𝜿Ax₂ := by
+  [sound₁ : Sound (Hilbert.ExtK Ax₁) 𝔽₁#α] [sound₂ : Sound (Hilbert.ExtK Ax₂) 𝔽₂#α]
+  [complete₁ : Complete (Hilbert.ExtK Ax₁) 𝔽₁#α] [complete₂ : Complete (Hilbert.ExtK Ax₂) 𝔽₂#α]
+  (h𝔽 : 𝔽₁ = 𝔽₂) : (Hilbert.ExtK Ax₁) =ₛ (Hilbert.ExtK Ax₂) := by
   apply System.Equiv.antisymm_iff.mpr;
   constructor;
   . apply weakerThan_of_subset_FrameClass 𝔽₁ 𝔽₂; subst_vars; rfl;
@@ -592,9 +597,6 @@ lemma equiv_of_eq_FrameClass
 
 end
 
+end Hilbert
 
-end
-
-end Modal
-
-end LO
+end LO.Modal

--- a/Foundation/Modal/Kripke/Semantics.lean
+++ b/Foundation/Modal/Kripke/Semantics.lean
@@ -289,8 +289,8 @@ def characterizability_union_frameclass_of_theory {T₁ T₂ : Theory α}
     . simpa using char₂.characterize hF₂;
   nonempty := nonempty
 
-abbrev FrameClassOfHilbert (Λ : Hilbert α) : FrameClass.Dep α := 𝔽(Λ.theorems)
-notation "𝔽(" Λ ")"  => FrameClassOfHilbert Λ
+abbrev FrameClassOfHilbert (H : Hilbert α) : FrameClass.Dep α := 𝔽(H.theorems)
+notation "𝔽(" H ")"  => FrameClassOfHilbert H
 
 open Hilbert.Deduction
 
@@ -342,8 +342,8 @@ instance {Ax : Theory α} {𝔽 : FrameClass} [char : 𝔽(Ax).Characteraizable 
   nonempty := char.nonempty
 
 
-abbrev FiniteFrameClassOfHilbert (Λ : Hilbert α) : FiniteFrameClass.Dep α := 𝔽(Λ)ꟳ
-notation "𝔽ꟳ(" Λ ")"  => FiniteFrameClassOfHilbert Λ
+abbrev FiniteFrameClassOfHilbert (H : Hilbert α) : FiniteFrameClass.Dep α := 𝔽(H)ꟳ
+notation "𝔽ꟳ(" H ")"  => FiniteFrameClassOfHilbert H
 
 instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass}  [defi : 𝔽ꟳ(Ax).DefinedBy 𝔽] : 𝔽ꟳ(Hilbert.ExtK Ax).DefinedBy 𝔽 where
   define := by
@@ -395,22 +395,22 @@ instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(Ax).C
 section sound
 
 variable {α : Type u}
-variable {Λ : Hilbert α} {φ : Formula α}
+variable {H : Hilbert α} {φ : Formula α}
 
-lemma sound : Λ ⊢! φ → 𝔽(Λ) ⊧ φ := by
+lemma sound : H ⊢! φ → 𝔽(H) ⊧ φ := by
   intro hp F hF;
   simp [Hilbert.theorems, System.theory] at hF;
   exact hF φ hp;
-instance : Sound Λ 𝔽(Λ) := ⟨sound⟩
+instance : Sound H 𝔽(H) := ⟨sound⟩
 
-lemma sound_finite : Λ ⊢! φ → 𝔽ꟳ(Λ) ⊧ φ := by
+lemma sound_finite : H ⊢! φ → 𝔽ꟳ(H) ⊧ φ := by
   intro hp F hF;
   simp [Hilbert.theorems, System.theory] at hF;
   obtain ⟨FF, hFF₁, rfl⟩ := hF;
   exact hFF₁ φ hp;
-instance : Sound Λ 𝔽ꟳ(Λ) := ⟨sound_finite⟩
+instance : Sound H 𝔽ꟳ(H) := ⟨sound_finite⟩
 
-lemma unprovable_bot (hc : 𝔽(Λ).Nonempty) : Λ ⊬ ⊥ := by
+lemma unprovable_bot (hc : 𝔽(H).Nonempty) : H ⊬ ⊥ := by
   apply (not_imp_not.mpr (sound (α := α)));
   simp [Semantics.Realize];
   obtain ⟨F, hF⟩ := hc;
@@ -418,9 +418,9 @@ lemma unprovable_bot (hc : 𝔽(Λ).Nonempty) : Λ ⊬ ⊥ := by
   constructor;
   . exact hF;
   . exact Semantics.Bot.realize_bot (F := Formula α) (M := Frame.Dep α) F;
-instance (hc : 𝔽(Λ).Nonempty) : System.Consistent Λ := System.Consistent.of_unprovable $ unprovable_bot hc
+instance (hc : 𝔽(H).Nonempty) : System.Consistent H := System.Consistent.of_unprovable $ unprovable_bot hc
 
-lemma unprovable_bot_finite (hc : 𝔽ꟳ(Λ).Nonempty) : Λ ⊬ ⊥ := by
+lemma unprovable_bot_finite (hc : 𝔽ꟳ(H).Nonempty) : H ⊬ ⊥ := by
   apply (not_imp_not.mpr (sound_finite (α := α)));
   simp [Semantics.Realize];
   obtain ⟨F, hF⟩ := hc;
@@ -428,17 +428,17 @@ lemma unprovable_bot_finite (hc : 𝔽ꟳ(Λ).Nonempty) : Λ ⊬ ⊥ := by
   constructor;
   . exact hF;
   . exact Semantics.Bot.realize_bot (F := Formula α) (M := Frame.Dep α) F;
-instance (hc : 𝔽ꟳ(Λ).Nonempty) : System.Consistent Λ := System.Consistent.of_unprovable $ unprovable_bot_finite hc
+instance (hc : 𝔽ꟳ(H).Nonempty) : System.Consistent H := System.Consistent.of_unprovable $ unprovable_bot_finite hc
 
-lemma sound_of_characterizability {𝔽 : FrameClass} [char : 𝔽(Λ).Characteraizable 𝔽]
-  : Λ ⊢! φ → 𝔽#α ⊧ φ := by
+lemma sound_of_characterizability {𝔽 : FrameClass} [char : 𝔽(H).Characteraizable 𝔽]
+  : H ⊢! φ → 𝔽#α ⊧ φ := by
   intro h F hF;
   apply sound h;
   apply char.characterize hF;
-instance {𝔽 : FrameClass} [𝔽(Λ).Characteraizable 𝔽] : Sound Λ 𝔽#α := ⟨sound_of_characterizability⟩
+instance {𝔽 : FrameClass} [𝔽(H).Characteraizable 𝔽] : Sound H 𝔽#α := ⟨sound_of_characterizability⟩
 
-lemma sound_of_finite_characterizability {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(Λ).Characteraizable 𝔽]
-  : Λ ⊢! φ → 𝔽#α ⊧ φ := by
+lemma sound_of_finite_characterizability {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(H).Characteraizable 𝔽]
+  : H ⊢! φ → 𝔽#α ⊧ φ := by
   intro h F hF;
   apply sound_finite h;
   obtain ⟨FF, hFF, rfl⟩ := hF;
@@ -446,22 +446,22 @@ lemma sound_of_finite_characterizability {𝔽 : FiniteFrameClass} [char : 𝔽�
   constructor;
   . exact char.characterize hFF;
   . rfl;
-instance {𝔽 : FiniteFrameClass} [𝔽ꟳ(Λ).Characteraizable 𝔽] : Sound Λ 𝔽#α := ⟨sound_of_finite_characterizability⟩
+instance {𝔽 : FiniteFrameClass} [𝔽ꟳ(H).Characteraizable 𝔽] : Sound H 𝔽#α := ⟨sound_of_finite_characterizability⟩
 
-lemma unprovable_bot_of_characterizability {𝔽 : FrameClass} [char : 𝔽(Λ).Characteraizable 𝔽] : Λ ⊬ ⊥ := by
+lemma unprovable_bot_of_characterizability {𝔽 : FrameClass} [char : 𝔽(H).Characteraizable 𝔽] : H ⊬ ⊥ := by
   apply unprovable_bot;
   obtain ⟨F, hF⟩ := char.nonempty;
   use F;
   apply char.characterize hF;
-instance [FrameClass.Characteraizable.{u} 𝔽(Λ) 𝔽] : System.Consistent Λ
+instance [FrameClass.Characteraizable.{u} 𝔽(H) 𝔽] : System.Consistent H
   := System.Consistent.of_unprovable $ unprovable_bot_of_characterizability
 
-lemma unprovable_bot_of_finite_characterizability {𝔽 : FiniteFrameClass}  [char : 𝔽ꟳ(Λ).Characteraizable 𝔽] : Λ ⊬ ⊥ := by
+lemma unprovable_bot_of_finite_characterizability {𝔽 : FiniteFrameClass}  [char : 𝔽ꟳ(H).Characteraizable 𝔽] : H ⊬ ⊥ := by
   apply unprovable_bot_finite;
   obtain ⟨F, hF⟩ := char.nonempty;
   use F;
   apply char.characterize hF;
-instance {𝔽 : FiniteFrameClass} [FiniteFrameClass.Characteraizable.{u} 𝔽ꟳ(Λ) 𝔽] : System.Consistent Λ
+instance {𝔽 : FiniteFrameClass} [FiniteFrameClass.Characteraizable.{u} 𝔽ꟳ(H) 𝔽] : System.Consistent H
   := System.Consistent.of_unprovable $ unprovable_bot_of_finite_characterizability
 
 end sound
@@ -486,7 +486,7 @@ lemma restrict_finite : 𝔽#α ⊧ φ → 𝔽ꟳ#α ⊧ φ := by
   obtain ⟨FF, hFF₁, rfl⟩ := hF;
   exact h (by simpa)
 
-instance {Λ : Hilbert α} [sound : Sound Λ 𝔽#α] : Sound Λ 𝔽ꟳ#α := ⟨by
+instance {H : Hilbert α} [sound : Sound H 𝔽#α] : Sound H 𝔽ꟳ#α := ⟨by
   intro φ h;
   exact restrict_finite $ sound.sound h;
 ⟩
@@ -495,9 +495,9 @@ instance : Sound (Hilbert.K α) (AllFrameClassꟳ#α) := inferInstance
 
 lemma exists_finite_frame : ¬𝔽ꟳ#α ⊧ φ ↔ ∃ F ∈ 𝔽ꟳ, ¬F#α ⊧ φ := by simp;
 
-class FiniteFrameProperty (Λ : Hilbert α) (𝔽 : FrameClass) where
-  [complete : Complete Λ 𝔽ꟳ#α]
-  [sound : Sound Λ 𝔽ꟳ#α]
+class FiniteFrameProperty (H : Hilbert α) (𝔽 : FrameClass) where
+  [complete : Complete H 𝔽ꟳ#α]
+  [sound : Sound H 𝔽ꟳ#α]
 
 end Kripke
 

--- a/Foundation/Modal/Kripke/Semantics.lean
+++ b/Foundation/Modal/Kripke/Semantics.lean
@@ -292,6 +292,8 @@ def characterizability_union_frameclass_of_theory {T₁ T₂ : Theory α}
 abbrev FrameClassOfHilbert (Λ : Hilbert α) : FrameClass.Dep α := 𝔽(Λ.theorems)
 notation "𝔽(" Λ ")"  => FrameClassOfHilbert Λ
 
+open Hilbert.Deduction
+
 instance {Ax : Theory α} {𝔽 : FrameClass} [defi : 𝔽(Ax).DefinedBy 𝔽] : 𝔽(Hilbert.ExtK Ax).DefinedBy 𝔽 where
   define := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
@@ -301,9 +303,9 @@ instance {Ax : Theory α} {𝔽 : FrameClass} [defi : 𝔽(Ax).DefinedBy 𝔽] :
       apply defi.define.mp;
       constructor;
       intro φ hp;
-      exact h φ $ Deduction.maxm! $ by right; exact hp;
+      exact h φ $ maxm! $ by right; exact hp;
     . intro hF φ hp;
-      induction hp using Deduction.inducition_with_necOnly! with
+      induction hp using inducition_with_necOnly! with
       | hMaxm h =>
         simp at h;
         rcases h with (⟨_, _, rfl⟩ | hR);
@@ -323,7 +325,7 @@ instance {Ax : Theory α} {𝔽 : FrameClass} [char : 𝔽(Ax).Characteraizable 
   characterize := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F hF φ hp;
-    induction hp using Deduction.inducition_with_necOnly! with
+    induction hp using inducition_with_necOnly! with
     | hMaxm h =>
       simp at h;
       rcases h with (⟨_, _, rfl⟩ | hR);
@@ -352,9 +354,9 @@ instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass}  [defi : 𝔽ꟳ(Ax).
       apply defi.define.mp;
       constructor;
       intro φ hp;
-      exact h φ $ Deduction.maxm! $ by right; exact hp;
+      exact h φ $ maxm! $ by right; exact hp;
     . intro hF φ hp;
-      induction hp using Deduction.inducition_with_necOnly! with
+      induction hp using inducition_with_necOnly! with
       | hMaxm h =>
         simp at h;
         rcases h with (⟨_, _, rfl⟩ | hR);
@@ -374,7 +376,7 @@ instance {Ax : Set (Formula α)} {𝔽 : FiniteFrameClass} [char : 𝔽ꟳ(Ax).C
   characterize := by
     simp only [Hilbert.theorems, System.theory, Semantics.RealizeSet.setOf_iff, ValidOnFrame.models_iff, Set.mem_setOf_eq];
     intro F hF φ hp;
-    induction hp using Deduction.inducition_with_necOnly! with
+    induction hp using inducition_with_necOnly! with
     | hMaxm h =>
       simp at h;
       rcases h with (⟨_, _, rfl⟩ | hR);

--- a/Foundation/Modal/Kripke/Ver.lean
+++ b/Foundation/Modal/Kripke/Ver.lean
@@ -30,20 +30,20 @@ instance axiomVer_definability : 𝔽((𝗩𝗲𝗿 : Theory α)).DefinedBy (Iso
     use ⟨PUnit,  λ _ _ => False⟩
     tauto;
 
-instance Ver_definability : 𝔽((𝐕𝐞𝐫 : Hilbert α)).DefinedBy (IsolatedFrameClass) := inferInstance
+instance Ver_definability : 𝔽(Hilbert.Ver α).DefinedBy (IsolatedFrameClass) := inferInstance
 
-instance : Sound 𝐕𝐞𝐫 (IsolatedFrameClass#α) := inferInstance
+instance : Sound (Hilbert.Ver α) (IsolatedFrameClass#α) := inferInstance
 
-instance : System.Consistent (𝐕𝐞𝐫 : Hilbert α) := inferInstance
+instance : System.Consistent (Hilbert.Ver α) := inferInstance
 
 variable [DecidableEq α]
 
-lemma isolated_CanonicalFrame {Ax : Theory α} (h : 𝗩𝗲𝗿 ⊆ Ax) [System.Consistent 𝜿Ax] : Isolated (CanonicalFrame 𝜿Ax) := by
+lemma isolated_CanonicalFrame {Ax : Theory α} (h : 𝗩𝗲𝗿 ⊆ Ax) [System.Consistent (Hilbert.ExtK Ax)] : Isolated (CanonicalFrame (Hilbert.ExtK Ax)) := by
   intro x y rxy;
-  have : (CanonicalModel 𝜿Ax) ⊧ □⊥ := iff_valid_on_canonicalModel_deducible.mpr $ Normal.maxm! (by aesop);
+  have : (CanonicalModel (Hilbert.ExtK Ax)) ⊧ □⊥ := iff_valid_on_canonicalModel_deducible.mpr $ (Hilbert.ExtK.maxm!) (by apply h; simp);
   exact this x _ rxy;
 
-instance : Complete 𝐕𝐞𝐫 (IsolatedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame IsolatedFrameClass $ by
+instance : Complete (Hilbert.Ver α) (IsolatedFrameClass.{u}#α) := instComplete_of_mem_canonicalFrame IsolatedFrameClass $ by
   apply isolated_CanonicalFrame;
   tauto;
 

--- a/Foundation/Modal/Maximal.lean
+++ b/Foundation/Modal/Maximal.lean
@@ -124,7 +124,7 @@ lemma deducible_iff_verTranslation : (Hilbert.Ver α) ⊢! φ ⭤ φⱽ := by
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | _ => apply iff_id!
 
-lemma of_classical {mΛ : Modal.Hilbert α} {φ : IntProp.Formula α} : (𝐂𝐥 ⊢! φ) → (mΛ ⊢! φᴹ) := by
+lemma of_classical {mΛ : Modal.Hilbert α} {φ : IntProp.Formula α} : ((Hilbert.Cl α) ⊢! φ) → (mΛ ⊢! φᴹ) := by
   intro h;
   induction h.some with
   | eaxm ih =>
@@ -137,7 +137,7 @@ lemma of_classical {mΛ : Modal.Hilbert α} {φ : IntProp.Formula α} : (𝐂�
     exact (ih₁ ⟨h₁⟩) ⨀ (ih₂ ⟨h₂⟩);
   | _ => dsimp [IntProp.Formula.toModalFormula]; trivial;
 
-lemma iff_Triv_classical : Hilbert.Triv α ⊢! φ ↔ 𝐂𝐥 ⊢! φᵀᴾ := by
+lemma iff_Triv_classical : Hilbert.Triv α ⊢! φ ↔ (Hilbert.Cl α) ⊢! φᵀᴾ := by
   constructor;
   . intro h;
     induction h using Deduction.inducition_with_necOnly! with
@@ -154,7 +154,7 @@ lemma iff_Triv_classical : Hilbert.Triv α ⊢! φ ↔ 𝐂𝐥 ⊢! φᵀᴾ :=
     have d₂ : Hilbert.Triv α ⊢! φᵀ := by simpa only [TrivTranslation.back] using of_classical h;
     exact d₁ ⨀ d₂;
 
-lemma iff_Ver_classical : (Hilbert.Ver α) ⊢! φ ↔ 𝐂𝐥 ⊢! φⱽᴾ := by
+lemma iff_Ver_classical : (Hilbert.Ver α) ⊢! φ ↔ (Hilbert.Cl α) ⊢! φⱽᴾ := by
   constructor;
   . intro h;
     induction h using Deduction.inducition_with_necOnly! with
@@ -171,13 +171,13 @@ lemma iff_Ver_classical : (Hilbert.Ver α) ⊢! φ ↔ 𝐂𝐥 ⊢! φⱽᴾ :=
     have d₂ : (Hilbert.Ver α) ⊢! φⱽ := by simpa using of_classical h;
     exact d₁ ⨀ d₂;
 
-lemma trivTranslated_of_K4 : (Hilbert.K4 α) ⊢! φ → 𝐂𝐥 ⊢! φᵀᴾ := by
+lemma trivTranslated_of_K4 : (Hilbert.K4 α) ⊢! φ → (Hilbert.Cl α) ⊢! φᵀᴾ := by
   intro h;
   apply iff_Triv_classical.mp;
   exact System.weakerThan_iff.mp Hilbert.K4_weakerThan_Triv h;
 
 
-lemma verTranslated_of_GL : (Hilbert.GL α) ⊢! φ → 𝐂𝐥 ⊢! φⱽᴾ := by
+lemma verTranslated_of_GL : (Hilbert.GL α) ⊢! φ → (Hilbert.Cl α) ⊢! φⱽᴾ := by
   intro h;
   induction h using Deduction.inducition_with_necOnly! with
     | hMaxm a =>

--- a/Foundation/Modal/Maximal.lean
+++ b/Foundation/Modal/Maximal.lean
@@ -124,7 +124,7 @@ lemma deducible_iff_verTranslation : (Hilbert.Ver α) ⊢! φ ⭤ φⱽ := by
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | _ => apply iff_id!
 
-lemma of_classical {mΛ : Modal.Hilbert α} {φ : IntProp.Formula α} : ((Hilbert.Cl α) ⊢! φ) → (mΛ ⊢! φᴹ) := by
+lemma of_classical {mH : Modal.Hilbert α} {φ : IntProp.Formula α} : ((Hilbert.Cl α) ⊢! φ) → (mH ⊢! φᴹ) := by
   intro h;
   induction h.some with
   | eaxm ih =>

--- a/Foundation/Modal/Maximal.lean
+++ b/Foundation/Modal/Maximal.lean
@@ -79,7 +79,7 @@ end VerTranslation
 end Formula
 
 
-open Deduction
+open Hilbert.Deduction
 
 variable {φ : Formula α}
 

--- a/Foundation/Modal/Maximal.lean
+++ b/Foundation/Modal/Maximal.lean
@@ -2,9 +2,9 @@ import Foundation.Modal.Hilbert
 import Foundation.IntProp.Kripke.Semantics
 
 /-!
-  # Maximality of `𝐓𝐫𝐢𝐯` and `𝐕𝐞𝐫`
+  # Maximality of `Hilbert.Triv α` and `𝐕𝐞𝐫`
 
-  `𝐓𝐫𝐢𝐯` and `𝐕𝐞𝐫` are maximal in normal modal Foundation.
+  `Hilbert.Triv α` and `𝐕𝐞𝐫` are maximal in normal modal Foundation.
 -/
 
 namespace LO.IntProp
@@ -85,6 +85,7 @@ variable {φ : Formula α}
 
 open System
 open Formula
+open Hilbert
 
 macro_rules | `(tactic| trivial) => `(tactic|
     first
@@ -104,7 +105,7 @@ macro_rules | `(tactic| trivial) => `(tactic|
     | apply imp_id!;
   )
 
-lemma deducible_iff_trivTranslation : 𝐓𝐫𝐢𝐯 ⊢! φ ⭤ φᵀ := by
+lemma deducible_iff_trivTranslation : (Hilbert.Triv α) ⊢! φ ⭤ φᵀ := by
   induction φ using Formula.rec' with
   | hbox φ ih =>
     simp [TrivTranslation];
@@ -114,7 +115,7 @@ lemma deducible_iff_trivTranslation : 𝐓𝐫𝐢𝐯 ⊢! φ ⭤ φᵀ := by
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | _ => apply iff_id!
 
-lemma deducible_iff_verTranslation : 𝐕𝐞𝐫 ⊢! φ ⭤ φⱽ := by
+lemma deducible_iff_verTranslation : (Hilbert.Ver α) ⊢! φ ⭤ φⱽ := by
   induction φ using Formula.rec' with
   | hbox =>
     apply iff_intro!;
@@ -136,7 +137,7 @@ lemma of_classical {mΛ : Modal.Hilbert α} {φ : IntProp.Formula α} : (𝐂�
     exact (ih₁ ⟨h₁⟩) ⨀ (ih₂ ⟨h₂⟩);
   | _ => dsimp [IntProp.Formula.toModalFormula]; trivial;
 
-lemma iff_Triv_classical : 𝐓𝐫𝐢𝐯 ⊢! φ ↔ 𝐂𝐥 ⊢! φᵀᴾ := by
+lemma iff_Triv_classical : Hilbert.Triv α ⊢! φ ↔ 𝐂𝐥 ⊢! φᵀᴾ := by
   constructor;
   . intro h;
     induction h using Deduction.inducition_with_necOnly! with
@@ -149,11 +150,11 @@ lemma iff_Triv_classical : 𝐓𝐫𝐢𝐯 ⊢! φ ↔ 𝐂𝐥 ⊢! φᵀᴾ :
     | hNec ih => dsimp [TrivTranslation]; trivial;
     | _ => dsimp [TrivTranslation]; trivial;
   . intro h;
-    have d₁ : 𝐓𝐫𝐢𝐯 ⊢! φᵀ ➝ φ := and₂'! deducible_iff_trivTranslation;
-    have d₂ : 𝐓𝐫𝐢𝐯 ⊢! φᵀ := by simpa only [TrivTranslation.back] using of_classical h;
+    have d₁ : Hilbert.Triv α ⊢! φᵀ ➝ φ := and₂'! deducible_iff_trivTranslation;
+    have d₂ : Hilbert.Triv α ⊢! φᵀ := by simpa only [TrivTranslation.back] using of_classical h;
     exact d₁ ⨀ d₂;
 
-lemma iff_Ver_classical : 𝐕𝐞𝐫 ⊢! φ ↔ 𝐂𝐥 ⊢! φⱽᴾ := by
+lemma iff_Ver_classical : (Hilbert.Ver α) ⊢! φ ↔ 𝐂𝐥 ⊢! φⱽᴾ := by
   constructor;
   . intro h;
     induction h using Deduction.inducition_with_necOnly! with
@@ -166,17 +167,17 @@ lemma iff_Ver_classical : 𝐕𝐞𝐫 ⊢! φ ↔ 𝐂𝐥 ⊢! φⱽᴾ := by
     | hNec => dsimp [VerTranslation]; trivial;
     | _ => dsimp [VerTranslation]; trivial;
   . intro h;
-    have d₁ : 𝐕𝐞𝐫 ⊢! φⱽ ➝ φ := and₂'! deducible_iff_verTranslation;
-    have d₂ : 𝐕𝐞𝐫 ⊢! φⱽ := by simpa using of_classical h;
+    have d₁ : (Hilbert.Ver α) ⊢! φⱽ ➝ φ := and₂'! deducible_iff_verTranslation;
+    have d₂ : (Hilbert.Ver α) ⊢! φⱽ := by simpa using of_classical h;
     exact d₁ ⨀ d₂;
 
-lemma trivTranslated_of_K4 : 𝐊𝟒 ⊢! φ → 𝐂𝐥 ⊢! φᵀᴾ := by
+lemma trivTranslated_of_K4 : (Hilbert.K4 α) ⊢! φ → 𝐂𝐥 ⊢! φᵀᴾ := by
   intro h;
   apply iff_Triv_classical.mp;
-  exact System.weakerThan_iff.mp K4_weakerThan_Triv h;
+  exact System.weakerThan_iff.mp Hilbert.K4_weakerThan_Triv h;
 
 
-lemma verTranslated_of_GL : 𝐆𝐋 ⊢! φ → 𝐂𝐥 ⊢! φⱽᴾ := by
+lemma verTranslated_of_GL : (Hilbert.GL α) ⊢! φ → 𝐂𝐥 ⊢! φⱽᴾ := by
   intro h;
   induction h using Deduction.inducition_with_necOnly! with
     | hMaxm a =>
@@ -193,21 +194,21 @@ open IntProp.Kripke (unprovable_classical_of_exists_ClassicalValuation)
 
 variable [Inhabited α]
 
-example : 𝐓𝐫𝐢𝐯 ⊬ Axioms.L (atom default : Formula α) := by
+example : Hilbert.Triv α ⊬ Axioms.L (atom default : Formula α) := by
   apply iff_Triv_classical.not.mpr;
   apply unprovable_classical_of_exists_ClassicalValuation;
   simp [Axioms.L, TrivTranslation, toPropFormula, IntProp.Formula.Kripke.Satisfies];
   use (λ _ => False);
   tauto;
 
-lemma unprovable_AxiomL_K4 : 𝐊𝟒 ⊬ Axioms.L (atom default : Formula α) := by
+lemma unprovable_AxiomL_K4 : Hilbert.K4 α ⊬ Axioms.L (atom default : Formula α) := by
   apply not_imp_not.mpr trivTranslated_of_K4;
   apply unprovable_classical_of_exists_ClassicalValuation;
   simp [Axioms.L, TrivTranslation, toPropFormula, IntProp.Formula.Kripke.Satisfies];
   use (λ _ => False);
   tauto;
 
-theorem K4_strictReducible_GL : (𝐊𝟒 : Hilbert α) <ₛ 𝐆𝐋 := by
+theorem K4_strictReducible_GL : (Hilbert.K4 α) <ₛ (Hilbert.GL α) := by
   dsimp [StrictlyWeakerThan];
   constructor;
   . apply K4_weakerThan_GL;
@@ -217,7 +218,7 @@ theorem K4_strictReducible_GL : (𝐊𝟒 : Hilbert α) <ₛ 𝐆𝐋 := by
     . exact axiomL!;
     . exact unprovable_AxiomL_K4;
 
-lemma unprovable_AxiomT_GL : 𝐆𝐋 ⊬ Axioms.T (atom default : Formula α) := by
+lemma unprovable_AxiomT_GL : (Hilbert.GL α) ⊬ Axioms.T (atom default : Formula α) := by
   apply not_imp_not.mpr verTranslated_of_GL;
   apply unprovable_classical_of_exists_ClassicalValuation;
   simp [Axioms.T, VerTranslation, toPropFormula, IntProp.Formula.Kripke.Satisfies];
@@ -225,13 +226,13 @@ lemma unprovable_AxiomT_GL : 𝐆𝐋 ⊬ Axioms.T (atom default : Formula α) :
   tauto;
 
 
-instance instGLConsistencyViaUnprovableAxiomT : System.Consistent (𝐆𝐋 : Hilbert α) := by
+instance instGLConsistencyViaUnprovableAxiomT : System.Consistent (Hilbert.GL α) := by
   apply consistent_iff_exists_unprovable.mpr;
   existsi (Axioms.T (atom default));
   apply unprovable_AxiomT_GL;
 
 
-theorem not_S4_weakerThan_GL : ¬(𝐒𝟒 : Hilbert α) ≤ₛ 𝐆𝐋 := by
+theorem not_S4_weakerThan_GL : ¬(Hilbert.S4 α) ≤ₛ (Hilbert.GL α) := by
   apply System.not_weakerThan_iff.mpr;
   existsi (Axioms.T (atom default));
   constructor;
@@ -239,7 +240,7 @@ theorem not_S4_weakerThan_GL : ¬(𝐒𝟒 : Hilbert α) ≤ₛ 𝐆𝐋 := by
   . exact unprovable_AxiomT_GL;
 
 
-example : 𝐕𝐞𝐫 ⊬ (∼(□⊥) : Formula α) := by
+example : (Hilbert.Ver α) ⊬ (∼(□⊥) : Formula α) := by
   apply iff_Ver_classical.not.mpr;
   apply unprovable_classical_of_exists_ClassicalValuation;
   dsimp [VerTranslation, toPropFormula, IntProp.Formula.Kripke.Satisfies];

--- a/Foundation/Modal/ModalCompanion/Basic.lean
+++ b/Foundation/Modal/ModalCompanion/Basic.lean
@@ -73,7 +73,7 @@ private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 mΛ] : mΛ �
 instance [System.S4 mΛ] : System.K4 mΛ where
 
 open provable_efq_of_provable_S4 in
-lemma provable_efq_of_provable_S4 [DecidableEq α] (h : 𝐈𝐧𝐭 ⊢! φ) : (Hilbert.S4 α) ⊢! φᵍ := by
+lemma provable_efq_of_provable_S4 [DecidableEq α] (h : (Hilbert.Int α) ⊢! φ) : (Hilbert.S4 α) ⊢! φᵍ := by
   induction h.some with
   | eaxm ih =>
     simp_all only [Set.mem_setOf_eq];

--- a/Foundation/Modal/ModalCompanion/Basic.lean
+++ b/Foundation/Modal/ModalCompanion/Basic.lean
@@ -20,14 +20,14 @@ def GoedelTranslation : IntProp.Formula α → Modal.Formula α
   | φ ➝ ψ => □((GoedelTranslation φ) ➝ (GoedelTranslation ψ))
 postfix:90 "ᵍ" => GoedelTranslation
 
-class ModalCompanion (iΛ : IntProp.Hilbert α) (mΛ : Modal.Hilbert α) where
-  companion : ∀ {φ : IntProp.Formula α}, iΛ ⊢! φ ↔ mΛ ⊢! φᵍ
+class ModalCompanion (iH : IntProp.Hilbert α) (mH : Modal.Hilbert α) where
+  companion : ∀ {φ : IntProp.Formula α}, iH ⊢! φ ↔ mH ⊢! φᵍ
 
 variable {α : Type u}
-variable {iΛ : IntProp.Hilbert α} {mΛ : Hilbert α}
+variable {iH : IntProp.Hilbert α} {mH : Hilbert α}
 variable {φ ψ χ : IntProp.Formula α}
 
-lemma axiomTc_GTranslate! [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! φᵍ ➝ □φᵍ := by
+lemma axiomTc_GTranslate! [DecidableEq α] [System.K4 mH] : mH ⊢! φᵍ ➝ □φᵍ := by
   induction φ using IntProp.Formula.rec' with
   | hverum => exact imply₁'! (nec! verum!);
   | hfalsum => simp only [GoedelTranslation, efq!];
@@ -42,35 +42,35 @@ lemma axiomTc_GTranslate! [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! φᵍ ➝ 
 
 section
 
-private lemma provable_efq_of_provable_S4.case_imply₁ [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! (φ ➝ ψ ➝ φ)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_imply₁ [DecidableEq α] [System.K4 mH] : mH ⊢! (φ ➝ ψ ➝ φ)ᵍ := by
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomTc_GTranslate! $ axiomK'! $ nec! $ imply₁!;
 
-private lemma provable_efq_of_provable_S4.case_imply₂ [DecidableEq α] [System.S4 mΛ] : mΛ ⊢! ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_imply₂ [DecidableEq α] [System.S4 mH] : mH ⊢! ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ)ᵍ := by
   simp only [GoedelTranslation];
   apply nec! $ imp_trans''! (imp_trans''! (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! imply₂!) axiomK!;
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
   apply deduct_iff.mpr;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mΛ]! φᵍ := by_axm!;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mΛ]! (φᵍ ➝ □(ψᵍ ➝ χᵍ)) := by_axm!;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mΛ]! □(ψᵍ ➝ χᵍ) := (by assumption) ⨀ (by assumption);
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mH]! φᵍ := by_axm!;
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mH]! (φᵍ ➝ □(ψᵍ ➝ χᵍ)) := by_axm!;
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[mH]! □(ψᵍ ➝ χᵍ) := (by assumption) ⨀ (by assumption);
   exact axiomT'! this;
-private lemma provable_efq_of_provable_S4.case_and₃ [DecidableEq α] [System.K4 mΛ] : mΛ ⊢! (φ ➝ ψ ➝ φ ⋏ ψ)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_and₃ [DecidableEq α] [System.K4 mH] : mH ⊢! (φ ➝ ψ ➝ φ ⋏ ψ)ᵍ := by
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomTc_GTranslate! $ axiomK'! $ nec! $ and₃!
 
-private lemma provable_efq_of_provable_S4.case_or₃ [System.K4 mΛ] : mΛ ⊢! (((φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ)))ᵍ := by
+private lemma provable_efq_of_provable_S4.case_or₃ [System.K4 mH] : mH ⊢! (((φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ)))ᵍ := by
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomFour! $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! $ or₃!) axiomK!;
 
-private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 mΛ] : mΛ ⊢! (Axioms.NegEquiv φ)ᵍ := by
+private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 mH] : mH ⊢! (Axioms.NegEquiv φ)ᵍ := by
   simp only [GoedelTranslation];
   apply and₃'!;
   . exact nec! $ axiomK'! $ nec! $ and₁'! neg_equiv!;
   . exact nec! $ axiomK'! $ nec! $ and₂'! neg_equiv!;
 
-instance [System.S4 mΛ] : System.K4 mΛ where
+instance [System.S4 mH] : System.K4 mH where
 
 open provable_efq_of_provable_S4 in
 lemma provable_efq_of_provable_S4 [DecidableEq α] (h : (Hilbert.Int α) ⊢! φ) : (Hilbert.S4 α) ⊢! φᵍ := by
@@ -95,13 +95,13 @@ lemma provable_efq_of_provable_S4 [DecidableEq α] (h : (Hilbert.Int α) ⊢! φ
 end
 
 
-lemma dp_of_mdp [DecidableEq α] [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : iΛ ⊢! φ ⋎ ψ → iΛ ⊢! φ ∨ iΛ ⊢! ψ := by
+lemma dp_of_mdp [DecidableEq α] [ModalDisjunctive mH] [ModalCompanion iH mH] [System.S4 mH] : iH ⊢! φ ⋎ ψ → iH ⊢! φ ∨ iH ⊢! ψ := by
     intro hpq;
-    have : mΛ ⊢! □φᵍ ⋎ □ψᵍ := or₃'''! (imply_left_or'! axiomTc_GTranslate!) (imply_right_or'! axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
+    have : mH ⊢! □φᵍ ⋎ □ψᵍ := or₃'''! (imply_left_or'! axiomTc_GTranslate!) (imply_right_or'! axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
     cases ModalDisjunctive.modal_disjunctive this with
     | inl h => left; exact ModalCompanion.companion.mpr h;
     | inr h => right; exact ModalCompanion.companion.mpr h;
 
-theorem disjunctive_of_modalDisjunctive [DecidableEq α] [ModalDisjunctive mΛ] [ModalCompanion iΛ mΛ] [System.S4 mΛ] : Disjunctive iΛ := ⟨dp_of_mdp (iΛ := iΛ) (mΛ := mΛ)⟩
+theorem disjunctive_of_modalDisjunctive [DecidableEq α] [ModalDisjunctive mH] [ModalCompanion iH mH] [System.S4 mH] : Disjunctive iH := ⟨dp_of_mdp (iH := iH) (mH := mH)⟩
 
 end LO.Modal

--- a/Foundation/Modal/ModalCompanion/Basic.lean
+++ b/Foundation/Modal/ModalCompanion/Basic.lean
@@ -73,7 +73,7 @@ private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 mΛ] : mΛ �
 instance [System.S4 mΛ] : System.K4 mΛ where
 
 open provable_efq_of_provable_S4 in
-lemma provable_efq_of_provable_S4 [DecidableEq α] (h : 𝐈𝐧𝐭 ⊢! φ) : 𝐒𝟒 ⊢! φᵍ := by
+lemma provable_efq_of_provable_S4 [DecidableEq α] (h : 𝐈𝐧𝐭 ⊢! φ) : (Hilbert.S4 α) ⊢! φᵍ := by
   induction h.some with
   | eaxm ih =>
     simp_all only [Set.mem_setOf_eq];

--- a/Foundation/Modal/ModalCompanion/GMT.lean
+++ b/Foundation/Modal/ModalCompanion/GMT.lean
@@ -10,7 +10,7 @@ open Modal.Kripke
 
 variable {α : Type u} [DecidableEq α] [Inhabited α] [Encodable α]
 
-variable {iΛ : IntProp.Hilbert α} {mΛ : Modal.Hilbert α}
+variable {iH : IntProp.Hilbert α} {mH : Modal.Hilbert α}
 variable {φ ψ χ : IntProp.Formula α}
 
 lemma provable_S4_of_provable_efq : ((Hilbert.S4 α) ⊢! φᵍ) → ((Hilbert.Int α) ⊢! φ) := by

--- a/Foundation/Modal/ModalCompanion/GMT.lean
+++ b/Foundation/Modal/ModalCompanion/GMT.lean
@@ -12,7 +12,7 @@ variable {α : Type u} [DecidableEq α] [Inhabited α] [Encodable α]
 variable {iΛ : IntProp.Hilbert α} {mΛ : Modal.Hilbert α}
 variable {φ ψ χ : IntProp.Formula α}
 
-lemma provable_S4_of_provable_efq : (𝐒𝟒 ⊢! φᵍ) → (𝐈𝐧𝐭 ⊢! φ) := by
+lemma provable_S4_of_provable_efq : ((Hilbert.S4 α) ⊢! φᵍ) → (𝐈𝐧𝐭 ⊢! φ) := by
   contrapose;
   intro h;
 
@@ -49,7 +49,7 @@ lemma provable_S4_of_provable_efq : (𝐒𝟒 ⊢! φᵍ) → (𝐈𝐧𝐭 ⊢!
   use F;
   exact ⟨⟨F_refl, F_trans⟩, by use V, w⟩;
 
-theorem provable_efq_iff_provable_S4 : 𝐈𝐧𝐭 ⊢! φ ↔ 𝐒𝟒 ⊢! φᵍ := ⟨provable_efq_of_provable_S4, provable_S4_of_provable_efq⟩
-instance : ModalCompanion (α := α) 𝐈𝐧𝐭 𝐒𝟒 := ⟨provable_efq_iff_provable_S4⟩
+theorem provable_efq_iff_provable_S4 : 𝐈𝐧𝐭 ⊢! φ ↔ (Hilbert.S4 α) ⊢! φᵍ := ⟨provable_efq_of_provable_S4, provable_S4_of_provable_efq⟩
+instance : ModalCompanion (α := α) 𝐈𝐧𝐭 (Hilbert.S4 α) := ⟨provable_efq_iff_provable_S4⟩
 
 end LO.Modal

--- a/Foundation/Modal/ModalCompanion/GMT.lean
+++ b/Foundation/Modal/ModalCompanion/GMT.lean
@@ -4,6 +4,7 @@ import Foundation.Modal.ModalCompanion.Basic
 
 namespace LO.Modal
 
+open IntProp
 open LO.Kripke
 open Modal.Kripke
 
@@ -12,7 +13,7 @@ variable {α : Type u} [DecidableEq α] [Inhabited α] [Encodable α]
 variable {iΛ : IntProp.Hilbert α} {mΛ : Modal.Hilbert α}
 variable {φ ψ χ : IntProp.Formula α}
 
-lemma provable_S4_of_provable_efq : ((Hilbert.S4 α) ⊢! φᵍ) → (𝐈𝐧𝐭 ⊢! φ) := by
+lemma provable_S4_of_provable_efq : ((Hilbert.S4 α) ⊢! φᵍ) → ((Hilbert.Int α) ⊢! φ) := by
   contrapose;
   intro h;
 
@@ -49,7 +50,7 @@ lemma provable_S4_of_provable_efq : ((Hilbert.S4 α) ⊢! φᵍ) → (𝐈𝐧�
   use F;
   exact ⟨⟨F_refl, F_trans⟩, by use V, w⟩;
 
-theorem provable_efq_iff_provable_S4 : 𝐈𝐧𝐭 ⊢! φ ↔ (Hilbert.S4 α) ⊢! φᵍ := ⟨provable_efq_of_provable_S4, provable_S4_of_provable_efq⟩
-instance : ModalCompanion (α := α) 𝐈𝐧𝐭 (Hilbert.S4 α) := ⟨provable_efq_iff_provable_S4⟩
+theorem provable_efq_iff_provable_S4 : (Hilbert.Int α) ⊢! φ ↔ (Hilbert.S4 α) ⊢! φᵍ := ⟨provable_efq_of_provable_S4, provable_S4_of_provable_efq⟩
+instance : ModalCompanion (Hilbert.Int α) (Hilbert.S4 α) := ⟨provable_efq_iff_provable_S4⟩
 
 end LO.Modal

--- a/Foundation/Modal/PLoN/Completeness.lean
+++ b/Foundation/Modal/PLoN/Completeness.lean
@@ -6,26 +6,26 @@ namespace LO.Modal
 namespace PLoN
 
 variable {α : Type u} [DecidableEq α]
-variable {Λ : Hilbert α}
+variable {H : Hilbert α}
 
 open Formula
 open Theory
 open MaximalConsistentTheory
 
-abbrev CanonicalFrame (Λ : Hilbert α) [Nonempty (MCT Λ)] : PLoN.Frame α where
-  World := (MCT Λ)
+abbrev CanonicalFrame (H : Hilbert α) [Nonempty (MCT H)] : PLoN.Frame α where
+  World := (MCT H)
   Rel := λ φ Ω₁ Ω₂ => ∼(□φ) ∈ Ω₁.theory ∧ ∼φ ∈ Ω₂.theory
 
-abbrev CanonicalModel (Λ : Hilbert α) [Nonempty (MCT Λ)] : PLoN.Model α where
-  Frame := CanonicalFrame Λ
+abbrev CanonicalModel (H : Hilbert α) [Nonempty (MCT H)] : PLoN.Model α where
+  Frame := CanonicalFrame H
   Valuation Ω a := (atom a) ∈ Ω.theory
 
-instance CanonicalModel.instSatisfies [Nonempty (MCT Λ)] : Semantics (Formula α) ((CanonicalModel Λ).World) := Formula.PLoN.Satisfies.semantics (CanonicalModel Λ)
+instance CanonicalModel.instSatisfies [Nonempty (MCT H)] : Semantics (Formula α) ((CanonicalModel H).World) := Formula.PLoN.Satisfies.semantics (CanonicalModel H)
 
-variable {Λ : Hilbert α} [Nonempty (MCT Λ)] [Λ.HasNecessitation]
+variable {H : Hilbert α} [Nonempty (MCT H)] [H.HasNecessitation]
          {φ : Formula α}
 
-lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ φ ↔ (φ ∈ Ω.theory) := by
+lemma truthlemma : ∀ {Ω : (CanonicalModel H).World}, Ω ⊧ φ ↔ (φ ∈ Ω.theory) := by
   induction φ using Formula.rec' with
   | hbox φ ih =>
     intro Ω;
@@ -36,7 +36,7 @@ lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ φ ↔ (φ ∈ �
       simp [PLoN.Satisfies];
       constructor;
       . assumption;
-      . obtain ⟨Ω', hΩ'⟩ := lindenbaum (Λ := Λ) (T := {∼φ}) (not_singleton_consistent Ω.consistent (iff_mem_neg.mpr hC));
+      . obtain ⟨Ω', hΩ'⟩ := lindenbaum (H := H) (T := {∼φ}) (not_singleton_consistent Ω.consistent (iff_mem_neg.mpr hC));
         use Ω';
         constructor;
         . apply iff_mem_neg.mp;
@@ -50,15 +50,15 @@ lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ φ ↔ (φ ∈ �
       simp_all only [PLoN.Satisfies.iff_models];
   | _ => simp_all [PLoN.Satisfies];
 
-lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFrame Λ ∈ 𝔽) : 𝔽 ⊧ φ → Λ ⊢! φ:= by
+lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFrame H ∈ 𝔽) : 𝔽 ⊧ φ → H ⊢! φ:= by
   simp [PLoN.ValidOnFrameClass, PLoN.ValidOnFrame, PLoN.ValidOnModel];
   contrapose; push_neg;
   intro h;
-  use (CanonicalFrame Λ);
+  use (CanonicalFrame H);
   constructor;
   . exact hFC;
-  . use (CanonicalModel Λ).Valuation;
-    obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := Λ) (T := {∼φ}) (by
+  . use (CanonicalModel H).Valuation;
+    obtain ⟨Ω, hΩ⟩ := lindenbaum (H := H) (T := {∼φ}) (by
       apply unprovable_iff_singleton_neg_consistent.mp;
       exact h;
     );
@@ -67,7 +67,7 @@ lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFram
     apply iff_mem_neg.mp;
     simp_all;
 
-lemma instComplete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFrame Λ ∈ 𝔽) : Complete Λ 𝔽 := ⟨complete_of_mem_canonicalFrame hFC⟩
+lemma instComplete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFrame H ∈ 𝔽) : Complete H 𝔽 := ⟨complete_of_mem_canonicalFrame hFC⟩
 
 instance : Complete (Hilbert.N α) (AllFrameClass.{u, u} α) := instComplete_of_mem_canonicalFrame (by simp)
 

--- a/Foundation/Modal/PLoN/Completeness.lean
+++ b/Foundation/Modal/PLoN/Completeness.lean
@@ -69,7 +69,7 @@ lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFram
 
 lemma instComplete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFrame Λ ∈ 𝔽) : Complete Λ 𝔽 := ⟨complete_of_mem_canonicalFrame hFC⟩
 
-instance : Complete 𝐍 (AllFrameClass.{u, u} α) := instComplete_of_mem_canonicalFrame (by simp)
+instance : Complete (Hilbert.N α) (AllFrameClass.{u, u} α) := instComplete_of_mem_canonicalFrame (by simp)
 
 end PLoN
 

--- a/Foundation/Modal/PLoN/Semantics.lean
+++ b/Foundation/Modal/PLoN/Semantics.lean
@@ -188,7 +188,7 @@ lemma AllFrameClass.nonempty : (AllFrameClass.{_, 0} α).Nonempty := by
 
 open Formula
 
-lemma N_defines : 𝐍.DefinesPLoNFrameClass (AllFrameClass α) := by
+lemma N_defines : (Hilbert.N α).DefinesPLoNFrameClass (AllFrameClass α) := by
   intro F;
   simp [Hilbert.theorems, System.theory, PLoN.ValidOnFrame, PLoN.ValidOnModel];
   intro φ hp;

--- a/Foundation/Modal/PLoN/Semantics.lean
+++ b/Foundation/Modal/PLoN/Semantics.lean
@@ -175,7 +175,7 @@ protected lemma elim_contra : 𝔽 ⊧ (Axioms.ElimContra φ ψ) := by intro _ _
 end Formula.PLoN.ValidOnFrameClass
 
 
-def Hilbert.DefinesPLoNFrameClass (Λ : Hilbert α) (𝔽 : PLoN.FrameClass α) := ∀ {F : Frame α}, F ⊧* Λ.theorems ↔ F ∈ 𝔽
+def Hilbert.DefinesPLoNFrameClass (H : Hilbert α) (𝔽 : PLoN.FrameClass α) := ∀ {F : Frame α}, F ⊧* H.theorems ↔ F ∈ 𝔽
 
 namespace PLoN
 

--- a/Foundation/Modal/PLoN/Semantics.lean
+++ b/Foundation/Modal/PLoN/Semantics.lean
@@ -192,7 +192,7 @@ lemma N_defines : (Hilbert.N α).DefinesPLoNFrameClass (AllFrameClass α) := by
   intro F;
   simp [Hilbert.theorems, System.theory, PLoN.ValidOnFrame, PLoN.ValidOnModel];
   intro φ hp;
-  induction hp using Deduction.inducition_with_necOnly! with
+  induction hp using Hilbert.Deduction.inducition_with_necOnly! with
   | hMaxm h => simp at h;
   | hMdp ihpq ihp =>
     intro V w;

--- a/Foundation/Modal/PLoN/Soundness.lean
+++ b/Foundation/Modal/PLoN/Soundness.lean
@@ -25,9 +25,9 @@ lemma consistent_of_defines (defines : Λ.DefinesPLoNFrameClass 𝔽) (nonempty 
   exact unprovable_bot_of_nonempty_frameclass defines nonempty;
 
 
-instance : Sound 𝐍 (AllFrameClass α) := sound_of_defines N_defines
+instance : Sound (Hilbert.N α) (AllFrameClass α) := sound_of_defines N_defines
 
-instance : System.Consistent (𝐍 : Hilbert α) := consistent_of_defines N_defines AllFrameClass.nonempty
+instance : System.Consistent (Hilbert.N α) := consistent_of_defines N_defines AllFrameClass.nonempty
 
 end PLoN
 

--- a/Foundation/Modal/PLoN/Soundness.lean
+++ b/Foundation/Modal/PLoN/Soundness.lean
@@ -6,21 +6,21 @@ namespace PLoN
 
 open Formula
 
-variable {φ : Formula α} {Λ : Hilbert α}
+variable {φ : Formula α} {H : Hilbert α}
 
-lemma sound (defines : Λ.DefinesPLoNFrameClass 𝔽) (d : Λ ⊢! φ) : 𝔽 ⊧ φ := by
+lemma sound (defines : H.DefinesPLoNFrameClass 𝔽) (d : H ⊢! φ) : 𝔽 ⊧ φ := by
   intro F hF;
   have := defines.mpr hF;
   exact Semantics.RealizeSet.setOf_iff.mp this φ d;
 
-lemma sound_of_defines (defines : Λ.DefinesPLoNFrameClass 𝔽) : Sound Λ 𝔽 := ⟨sound defines⟩
+lemma sound_of_defines (defines : H.DefinesPLoNFrameClass 𝔽) : Sound H 𝔽 := ⟨sound defines⟩
 
-lemma unprovable_bot_of_nonempty_frameclass (defines : Λ.DefinesPLoNFrameClass 𝔽) (nonempty : 𝔽.Nonempty) : Λ ⊬ ⊥ := by
+lemma unprovable_bot_of_nonempty_frameclass (defines : H.DefinesPLoNFrameClass 𝔽) (nonempty : 𝔽.Nonempty) : H ⊬ ⊥ := by
   intro h;
   obtain ⟨⟨_, F⟩, hF⟩ := nonempty;
   simpa using sound defines h hF;
 
-lemma consistent_of_defines (defines : Λ.DefinesPLoNFrameClass 𝔽) (nonempty : 𝔽.Nonempty) : System.Consistent Λ := by
+lemma consistent_of_defines (defines : H.DefinesPLoNFrameClass 𝔽) (nonempty : 𝔽.Nonempty) : System.Consistent H := by
   apply System.Consistent.of_unprovable;
   exact unprovable_bot_of_nonempty_frameclass defines nonempty;
 


### PR DESCRIPTION
`𝐒𝟒`を`Hilbert.S4 α`とちゃんとHilbert流であることを明記するように変更したなど．