### PR TITLE
refactor(Modal/Kripke, Prop/Kripke): `CoeSort` on `Model.World`

### DIFF
--- a/Foundation/Modal/Kripke/Basic.lean
+++ b/Foundation/Modal/Kripke/Basic.lean
@@ -82,6 +82,7 @@ abbrev Valuation (F : Frame) := F.World → ℕ → Prop
 
 structure Model extends Frame where
   Val : Valuation toFrame
+instance : CoeSort Model Type := ⟨λ M => M.toFrame.World⟩
 instance : CoeFun (Model) (λ M => M.World → ℕ → Prop) := ⟨fun m => m.Val⟩
 
 end Kripke

--- a/Foundation/Propositional/Kripke/Basic.lean
+++ b/Foundation/Propositional/Kripke/Basic.lean
@@ -59,6 +59,7 @@ instance {F : Frame} : CoeFun (Valuation F) (λ _ => F.World → ℕ → Prop) :
 
 structure Model extends Frame where
   Val : Valuation toFrame
+instance : CoeSort (Model) (Type) := ⟨λ M => M.World⟩
 instance : CoeFun (Model) (λ M => M.World → ℕ → Prop) := ⟨fun m => m.Val⟩
 
 end Kripke


### PR DESCRIPTION
既存のコードの修正はしていないが，今後は使えるようにした．

Fixes #313