### PR TITLE
refactor(Prop): Use notation for Logics

### DIFF
--- a/Foundation/Modal/ModalCompanion/Cl.lean
+++ b/Foundation/Modal/ModalCompanion/Cl.lean
@@ -5,18 +5,18 @@ import Foundation.Propositional.Kripke.Logic.Cl
 
 namespace LO
 
-namespace Propositional
-
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
-open Formula.Kripke
+open Propositional
+open Propositional.Formula (atom goedelTranslate)
+open Propositional.Logic (smallestMC largestMC)
 open Modal
 open Modal.Kripke
-open Propositional
-open Propositional.Formula (atom)
-open Propositional.Formula (goedelTranslate)
+open Modal.Formula.Kripke
 
-lemma Logic.Cl.smallestMC.mem_diabox_box : 𝐂𝐥.smallestMC ⊢! (◇□(.atom 0) ➝ □(.atom 0)) := by
-  have : 𝐂𝐥.smallestMC ⊢! □(.atom 0) ⋎ □(∼□(.atom 0)) := by
+namespace Propositional
+
+lemma Logic.Cl.smallestMC.mem_diabox_box : (smallestMC 𝐂𝐥) ⊢! (◇□(.atom 0) ➝ □(.atom 0)) := by
+  have : (smallestMC 𝐂𝐥) ⊢! □(.atom 0) ⋎ □(∼□(.atom 0)) := by
     apply Logic.sumNormal.mem₂!;
     use Axioms.LEM (.atom 0);
     constructor;
@@ -30,11 +30,11 @@ lemma Logic.Cl.smallestMC.mem_diabox_box : 𝐂𝐥.smallestMC ⊢! (◇□(.ato
   . apply CN!_of_CN!_right;
     exact diaDuality_mp!;
 
-instance : Entailment.HasAxiomFive 𝐂𝐥.smallestMC where
+instance : Entailment.HasAxiomFive (smallestMC 𝐂𝐥) where
   Five φ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := 𝐂𝐥.smallestMC) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ);
+    apply Modal.Logic.subst! (L := (smallestMC 𝐂𝐥)) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ);
     have := Modal.Logic.subst! (s := λ _ => ∼(.atom 0)) $ Logic.Cl.smallestMC.mem_diabox_box;
     apply _ ⨀ this;
     apply C!_trans ?_ CANC!;
@@ -62,7 +62,7 @@ section S5
 
 namespace Logic
 
-lemma S5.is_smallestMC_of_Cl : Logic.S5 = 𝐂𝐥.smallestMC := by
+lemma S5.is_smallestMC_of_Cl : Logic.S5 = (smallestMC 𝐂𝐥) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -87,7 +87,7 @@ lemma S5.is_smallestMC_of_Cl : Logic.S5 = 𝐂𝐥.smallestMC := by
       apply rm_diabox'!;
       apply WeakerThan.pbl this;
 
-instance : Sound 𝐂𝐥.smallestMC FrameClass.S5 := by
+instance : Sound (smallestMC 𝐂𝐥) FrameClass.S5 := by
   rw [←Logic.S5.is_smallestMC_of_Cl];
   infer_instance;
 
@@ -109,7 +109,7 @@ lemma Logic.gS5Grz_of_Cl : 𝐂𝐥 ⊢! φ → Logic.S5Grz ⊢! φᵍ := by
   intro h;
   apply WeakerThan.pbl $ modalCompanion_Cl_S5.companion.mp h;
 
-lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = 𝐂𝐥.largestMC := by
+lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = (Logic.largestMC 𝐂𝐥) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -120,7 +120,7 @@ lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = 𝐂𝐥.largestMC := by
       rcases (by simpa using h) with (⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := 𝐂𝐥.smallestMC);
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐂𝐥));
         simp;
       . simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
@@ -135,7 +135,7 @@ lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = 𝐂𝐥.largestMC := by
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound 𝐂𝐥.largestMC FrameClass.finite_Triv := by
+instance : Sound (Logic.largestMC 𝐂𝐥) FrameClass.finite_Triv := by
   suffices Sound Logic.Triv FrameClass.finite_Triv by
     simpa [←Logic.S5Grz.is_largestMC_of_Cl];
   infer_instance;

--- a/Foundation/Modal/ModalCompanion/Cl.lean
+++ b/Foundation/Modal/ModalCompanion/Cl.lean
@@ -15,8 +15,8 @@ open Propositional
 open Propositional.Formula (atom)
 open Propositional.Formula (goedelTranslate)
 
-lemma Logic.Cl.smallestMC.mem_diabox_box : Logic.Cl.smallestMC ⊢! (◇□(.atom 0) ➝ □(.atom 0)) := by
-  have : Logic.Cl.smallestMC ⊢! □(.atom 0) ⋎ □(∼□(.atom 0)) := by
+lemma Logic.Cl.smallestMC.mem_diabox_box : 𝐂𝐥.smallestMC ⊢! (◇□(.atom 0) ➝ □(.atom 0)) := by
+  have : 𝐂𝐥.smallestMC ⊢! □(.atom 0) ⋎ □(∼□(.atom 0)) := by
     apply Logic.sumNormal.mem₂!;
     use Axioms.LEM (.atom 0);
     constructor;
@@ -30,11 +30,11 @@ lemma Logic.Cl.smallestMC.mem_diabox_box : Logic.Cl.smallestMC ⊢! (◇□(.ato
   . apply CN!_of_CN!_right;
     exact diaDuality_mp!;
 
-instance : Entailment.HasAxiomFive Logic.Cl.smallestMC where
+instance : Entailment.HasAxiomFive 𝐂𝐥.smallestMC where
   Five φ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := Logic.Cl.smallestMC) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ);
+    apply Modal.Logic.subst! (L := 𝐂𝐥.smallestMC) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ);
     have := Modal.Logic.subst! (s := λ _ => ∼(.atom 0)) $ Logic.Cl.smallestMC.mem_diabox_box;
     apply _ ⨀ this;
     apply C!_trans ?_ CANC!;
@@ -62,7 +62,7 @@ section S5
 
 namespace Logic
 
-lemma S5.is_smallestMC_of_Cl : Logic.S5 = Logic.Cl.smallestMC := by
+lemma S5.is_smallestMC_of_Cl : Logic.S5 = 𝐂𝐥.smallestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -87,11 +87,11 @@ lemma S5.is_smallestMC_of_Cl : Logic.S5 = Logic.Cl.smallestMC := by
       apply rm_diabox'!;
       apply WeakerThan.pbl this;
 
-instance : Sound Logic.Cl.smallestMC FrameClass.S5 := by
+instance : Sound 𝐂𝐥.smallestMC FrameClass.S5 := by
   rw [←Logic.S5.is_smallestMC_of_Cl];
   infer_instance;
 
-instance modalCompanion_Cl_S5 : ModalCompanion Logic.Cl Logic.S5 := by
+instance modalCompanion_Cl_S5 : ModalCompanion 𝐂𝐥 Logic.S5 := by
   rw [Logic.S5.is_smallestMC_of_Cl];
   exact Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.Cl)
@@ -105,11 +105,11 @@ end S5
 
 section S5Grz
 
-lemma Logic.gS5Grz_of_Cl : Logic.Cl ⊢! φ → Logic.S5Grz ⊢! φᵍ := by
+lemma Logic.gS5Grz_of_Cl : 𝐂𝐥 ⊢! φ → Logic.S5Grz ⊢! φᵍ := by
   intro h;
   apply WeakerThan.pbl $ modalCompanion_Cl_S5.companion.mp h;
 
-lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = Logic.Cl.largestMC := by
+lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = 𝐂𝐥.largestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -120,7 +120,7 @@ lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = Logic.Cl.largestMC := by
       rcases (by simpa using h) with (⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := Logic.Cl.smallestMC);
+      . apply WeakerThan.pbl (𝓢 := 𝐂𝐥.smallestMC);
         simp;
       . simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
@@ -135,19 +135,19 @@ lemma Logic.S5Grz.is_largestMC_of_Cl : Logic.S5Grz = Logic.Cl.largestMC := by
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound Logic.Cl.largestMC FrameClass.finite_Triv := by
+instance : Sound 𝐂𝐥.largestMC FrameClass.finite_Triv := by
   suffices Sound Logic.Triv FrameClass.finite_Triv by
     simpa [←Logic.S5Grz.is_largestMC_of_Cl];
   infer_instance;
 
-instance modalCompanion_Cl_S5Grz : ModalCompanion Logic.Cl Logic.S5Grz := by
+instance modalCompanion_Cl_S5Grz : ModalCompanion 𝐂𝐥 Logic.S5Grz := by
   rw [Logic.S5Grz.is_largestMC_of_Cl];
   apply Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.finite_Cl)
     (MC := Modal.Kripke.FrameClass.finite_Triv);
   . intro F hF; simp_all only [Set.mem_setOf_eq]; exact {};
 
-instance modalCompanion_Cl_Triv : ModalCompanion Logic.Cl Logic.Triv := by
+instance modalCompanion_Cl_Triv : ModalCompanion 𝐂𝐥 Logic.Triv := by
   convert modalCompanion_Cl_S5Grz;
   simp;
 
@@ -156,7 +156,7 @@ end S5Grz
 
 section boxdot
 
-theorem embedding_Cl_Ver {φ : Propositional.Formula ℕ} : Logic.Cl ⊢! φ ↔ Logic.Ver ⊢! φᵍᵇ := by
+theorem embedding_Cl_Ver {φ : Propositional.Formula ℕ} : 𝐂𝐥 ⊢! φ ↔ Logic.Ver ⊢! φᵍᵇ := by
   exact Iff.trans modalCompanion_Cl_Triv.companion Logic.iff_boxdotTranslated_Ver_Triv.symm
 
 end boxdot

--- a/Foundation/Modal/ModalCompanion/Int.lean
+++ b/Foundation/Modal/ModalCompanion/Int.lean
@@ -19,7 +19,7 @@ lemma Logic.gS4_of_Int : Hilbert.Int ⊢! φ → Logic.S4 ⊢! φᵍ := by
   rintro _ ⟨φ, ⟨_⟩, ⟨s, rfl⟩⟩;
   apply nec! $ efq!;
 
-lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = Logic.Int.smallestMC := by
+lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = 𝐈𝐧𝐭.smallestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -44,11 +44,11 @@ lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = Logic.Int.smallestMC := by
       simp only [theory, Propositional.Logic.iff_provable, Set.mem_setOf_eq] at hφ;
       apply Logic.gS4_of_Int hφ;
 
-instance : Sound Logic.Int.smallestMC FrameClass.S4 := by
+instance : Sound 𝐈𝐧𝐭.smallestMC FrameClass.S4 := by
   rw [←Logic.S4.is_smallestMC_of_Int];
   infer_instance;
 
-instance modalCompanion_Int_S4 : ModalCompanion Logic.Int Logic.S4 := by
+instance modalCompanion_Int_S4 : ModalCompanion 𝐈𝐧𝐭 Logic.S4 := by
   rw [Logic.S4.is_smallestMC_of_Int];
   apply Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.all
@@ -63,7 +63,7 @@ section Grz
 
 lemma Logic.gGrz_of_Int : Hilbert.Int ⊢! φ → Logic.Grz ⊢! φᵍ := λ h ↦ WeakerThan.pbl $ gS4_of_Int h
 
-lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = Logic.Int.largestMC := by
+lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = 𝐈𝐧𝐭.largestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -83,11 +83,11 @@ lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = Logic.Int.largestMC := by
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound Logic.Int.largestMC FrameClass.finite_Grz := by
+instance : Sound 𝐈𝐧𝐭.largestMC FrameClass.finite_Grz := by
   rw [←Logic.Grz.is_largestMC_of_Int];
   infer_instance;
 
-instance modalCompanion_Int_Grz : ModalCompanion Logic.Int Logic.Grz := by
+instance modalCompanion_Int_Grz : ModalCompanion 𝐈𝐧𝐭 Logic.Grz := by
   rw [Logic.Grz.is_largestMC_of_Int];
   apply Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.finite_all
@@ -99,7 +99,7 @@ end Grz
 
 section glivenko
 
-lemma Logic.iff_provable_Cl_provable_dia_gS4 : Logic.Cl ⊢! φ ↔ Logic.S4 ⊢! ◇φᵍ := by
+lemma Logic.iff_provable_Cl_provable_dia_gS4 : 𝐂𝐥 ⊢! φ ↔ Logic.S4 ⊢! ◇φᵍ := by
   constructor;
   . intro h;
     suffices Logic.S4 ⊢! □◇φᵍ by exact axiomT'! this;
@@ -119,7 +119,7 @@ section boxdot
 /--
   Chagrov & Zakharyaschev 1997, Theorem 3.89
 -/
-theorem embedding_Int_GL {φ : Propositional.Formula ℕ} : Logic.Int ⊢! φ ↔ Logic.GL ⊢! φᵍᵇ:= by
+theorem embedding_Int_GL {φ : Propositional.Formula ℕ} : 𝐈𝐧𝐭 ⊢! φ ↔ Logic.GL ⊢! φᵍᵇ:= by
   exact Iff.trans modalCompanion_Int_Grz.companion Logic.iff_provable_boxdot_GL_provable_Grz.symm
 
 end boxdot

--- a/Foundation/Modal/ModalCompanion/Int.lean
+++ b/Foundation/Modal/ModalCompanion/Int.lean
@@ -9,6 +9,7 @@ namespace LO.Modal
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 open Propositional
 open Propositional.Formula (goedelTranslate)
+open Propositional.Logic (smallestMC largestMC)
 open Modal
 open Modal.Kripke
 
@@ -19,7 +20,7 @@ lemma Logic.gS4_of_Int : Hilbert.Int ⊢! φ → Logic.S4 ⊢! φᵍ := by
   rintro _ ⟨φ, ⟨_⟩, ⟨s, rfl⟩⟩;
   apply nec! $ efq!;
 
-lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = 𝐈𝐧𝐭.smallestMC := by
+lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = (smallestMC 𝐈𝐧𝐭) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -44,7 +45,7 @@ lemma Logic.S4.is_smallestMC_of_Int : Logic.S4 = 𝐈𝐧𝐭.smallestMC := by
       simp only [theory, Propositional.Logic.iff_provable, Set.mem_setOf_eq] at hφ;
       apply Logic.gS4_of_Int hφ;
 
-instance : Sound 𝐈𝐧𝐭.smallestMC FrameClass.S4 := by
+instance : Sound (smallestMC 𝐈𝐧𝐭) FrameClass.S4 := by
   rw [←Logic.S4.is_smallestMC_of_Int];
   infer_instance;
 
@@ -63,7 +64,7 @@ section Grz
 
 lemma Logic.gGrz_of_Int : Hilbert.Int ⊢! φ → Logic.Grz ⊢! φᵍ := λ h ↦ WeakerThan.pbl $ gS4_of_Int h
 
-lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = 𝐈𝐧𝐭.largestMC := by
+lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = (Logic.largestMC 𝐈𝐧𝐭) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -83,7 +84,7 @@ lemma Logic.Grz.is_largestMC_of_Int : Logic.Grz = 𝐈𝐧𝐭.largestMC := by
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound 𝐈𝐧𝐭.largestMC FrameClass.finite_Grz := by
+instance : Sound (Logic.largestMC 𝐈𝐧𝐭) FrameClass.finite_Grz := by
   rw [←Logic.Grz.is_largestMC_of_Int];
   infer_instance;
 

--- a/Foundation/Modal/ModalCompanion/KC.lean
+++ b/Foundation/Modal/ModalCompanion/KC.lean
@@ -62,12 +62,12 @@ lemma Logic.S4Point2.goedelTranslated_axiomWLEM : Logic.S4Point2 ⊢! □(∼φ�
 
 namespace Logic
 
-instance : Entailment.HasAxiomPoint2 Logic.KC.smallestMC where
+instance : Entailment.HasAxiomPoint2 𝐊𝐂.smallestMC where
   Point2 φ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := Logic.KC.smallestMC) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ);
-    have : Logic.KC.smallestMC ⊢! □(∼□(.atom 0)) ⋎ □(∼□(∼□(.atom 0))) := by
+    apply Modal.Logic.subst! (L := 𝐊𝐂.smallestMC) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ);
+    have : 𝐊𝐂.smallestMC ⊢! □(∼□(.atom 0)) ⋎ □(∼□(∼□(.atom 0))) := by
       apply Logic.sumNormal.mem₂!;
       use Axioms.WeakLEM (.atom 0);
       constructor;
@@ -94,7 +94,7 @@ instance : Entailment.HasAxiomPoint2 Logic.KC.smallestMC where
       . apply Satisfies.negneg_def.mp h u
         apply IsRefl.refl;
 
-lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = Logic.KC.smallestMC := by
+lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = 𝐊𝐂.smallestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -122,14 +122,14 @@ lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = Logic.KC.smallestMC := by
           exact Logic.S4Point2.goedelTranslated_axiomWLEM;
       . simpa [theory] using hφ;
 
-instance : Sound Logic.KC.smallestMC FrameClass.S4Point2 := by
+instance : Sound 𝐊𝐂.smallestMC FrameClass.S4Point2 := by
   rw [←Logic.S4Point2.is_smallestMC_of_KC];
   infer_instance;
 
-instance modalCompanion_KC_S4Point2 : ModalCompanion Logic.KC Logic.S4Point2 := by
+instance modalCompanion_KC_S4Point2 : ModalCompanion 𝐊𝐂 Logic.S4Point2 := by
   rw [Logic.S4Point2.is_smallestMC_of_KC];
   exact Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
-    (IL := Logic.KC)
+    (IL := 𝐊𝐂)
     (IC := Propositional.Kripke.FrameClass.KC)
     (MC := Modal.Kripke.FrameClass.S4Point2)
     $ by rintro F hF; simp_all only [Set.mem_setOf_eq]; exact {};
@@ -141,11 +141,11 @@ end S4Point2
 
 section GrzPoint2
 
-lemma Logic.gGrzPoint2_of_KC : Logic.KC ⊢! φ → Logic.GrzPoint2 ⊢! φᵍ := by
+lemma Logic.gGrzPoint2_of_KC : 𝐊𝐂 ⊢! φ → Logic.GrzPoint2 ⊢! φᵍ := by
   intro h;
   apply WeakerThan.pbl $ modalCompanion_KC_S4Point2.companion.mp h;
 
-lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = Logic.KC.largestMC := by
+lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = 𝐊𝐂.largestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -156,7 +156,7 @@ lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = Logic.KC.largestMC 
       rcases (by simpa using h) with (⟨s, rfl⟩ | ⟨s, rfl⟩ | ⟨s, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := Logic.KC.smallestMC); simp;
+      . apply WeakerThan.pbl (𝓢 := 𝐊𝐂.smallestMC); simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
     | nec ihφ => exact nec! ihφ;
     | _ => simp;
@@ -169,11 +169,11 @@ lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = Logic.KC.largestMC 
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound Logic.KC.largestMC FrameClass.finite_GrzPoint2 := by
+instance : Sound 𝐊𝐂.largestMC FrameClass.finite_GrzPoint2 := by
   rw [←Logic.GrzPoint2.is_largestMC_of_KC];
   infer_instance;
 
-instance modalCompanion_KC_GrzPoint2 : ModalCompanion Logic.KC Logic.GrzPoint2 := by
+instance modalCompanion_KC_GrzPoint2 : ModalCompanion 𝐊𝐂 Logic.GrzPoint2 := by
   rw [Logic.GrzPoint2.is_largestMC_of_KC];
   exact Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.finite_KC

--- a/Foundation/Modal/ModalCompanion/KC.lean
+++ b/Foundation/Modal/ModalCompanion/KC.lean
@@ -14,11 +14,10 @@ namespace LO.Modal
 
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 open Propositional
-open Propositional.Formula (goedelTranslate)
-open Propositional.Formula (atom)
+open Propositional.Formula (atom goedelTranslate)
+open Propositional.Logic (smallestMC largestMC)
 open Modal
 open Modal.Kripke
-open Modal.Formula (atom)
 open Modal.Formula.Kripke
 
 section S4Point2
@@ -62,12 +61,12 @@ lemma Logic.S4Point2.goedelTranslated_axiomWLEM : Logic.S4Point2 ⊢! □(∼φ�
 
 namespace Logic
 
-instance : Entailment.HasAxiomPoint2 𝐊𝐂.smallestMC where
+instance : Entailment.HasAxiomPoint2 (smallestMC 𝐊𝐂) where
   Point2 φ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := 𝐊𝐂.smallestMC) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ);
-    have : 𝐊𝐂.smallestMC ⊢! □(∼□(.atom 0)) ⋎ □(∼□(∼□(.atom 0))) := by
+    apply Modal.Logic.subst! (L := (smallestMC 𝐊𝐂)) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ);
+    have : (smallestMC 𝐊𝐂) ⊢! □(∼□(.atom 0)) ⋎ □(∼□(∼□(.atom 0))) := by
       apply Logic.sumNormal.mem₂!;
       use Axioms.WeakLEM (.atom 0);
       constructor;
@@ -94,7 +93,7 @@ instance : Entailment.HasAxiomPoint2 𝐊𝐂.smallestMC where
       . apply Satisfies.negneg_def.mp h u
         apply IsRefl.refl;
 
-lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = 𝐊𝐂.smallestMC := by
+lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = (smallestMC 𝐊𝐂) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -122,7 +121,7 @@ lemma S4Point2.is_smallestMC_of_KC : Logic.S4Point2 = 𝐊𝐂.smallestMC := by
           exact Logic.S4Point2.goedelTranslated_axiomWLEM;
       . simpa [theory] using hφ;
 
-instance : Sound 𝐊𝐂.smallestMC FrameClass.S4Point2 := by
+instance : Sound (smallestMC 𝐊𝐂) FrameClass.S4Point2 := by
   rw [←Logic.S4Point2.is_smallestMC_of_KC];
   infer_instance;
 
@@ -145,7 +144,7 @@ lemma Logic.gGrzPoint2_of_KC : 𝐊𝐂 ⊢! φ → Logic.GrzPoint2 ⊢! φᵍ :
   intro h;
   apply WeakerThan.pbl $ modalCompanion_KC_S4Point2.companion.mp h;
 
-lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = 𝐊𝐂.largestMC := by
+lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = (Logic.largestMC 𝐊𝐂) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -156,7 +155,7 @@ lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = 𝐊𝐂.largestMC 
       rcases (by simpa using h) with (⟨s, rfl⟩ | ⟨s, rfl⟩ | ⟨s, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := 𝐊𝐂.smallestMC); simp;
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐊𝐂)); simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
     | nec ihφ => exact nec! ihφ;
     | _ => simp;
@@ -169,7 +168,7 @@ lemma Logic.GrzPoint2.is_largestMC_of_KC : Logic.GrzPoint2 = 𝐊𝐂.largestMC 
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound 𝐊𝐂.largestMC FrameClass.finite_GrzPoint2 := by
+instance : Sound (Logic.largestMC 𝐊𝐂) FrameClass.finite_GrzPoint2 := by
   rw [←Logic.GrzPoint2.is_largestMC_of_KC];
   infer_instance;
 

--- a/Foundation/Modal/ModalCompanion/LC.lean
+++ b/Foundation/Modal/ModalCompanion/LC.lean
@@ -7,11 +7,11 @@ namespace LO.Modal
 
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 open Propositional
-open Propositional.Formula (goedelTranslate)
-open Propositional.Formula (atom)
+open Propositional.Formula (atom goedelTranslate)
+open Propositional.Logic (smallestMC largestMC)
 open Modal
-open Modal.Formula (atom)
 open Modal.Kripke
+open Modal.Formula.Kripke
 
 section S4Point3
 
@@ -36,12 +36,12 @@ private lemma Logic.S4Point.lemma₁ : Logic.S4 ⊢! □(□φ ➝ □ψ) ➝ �
 namespace Logic
 
 
-instance : Entailment.HasAxiomPoint3 𝐋𝐂.smallestMC where
+instance : Entailment.HasAxiomPoint3 (smallestMC 𝐋𝐂) where
   Point3 φ ψ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := 𝐋𝐂.smallestMC) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a);
-    have : 𝐋𝐂.smallestMC ⊢! □(□.atom 0 ➝ □.atom 1) ⋎ □(□.atom 1 ➝ □.atom 0) := by
+    apply Modal.Logic.subst! (L := (smallestMC 𝐋𝐂)) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a);
+    have : (smallestMC 𝐋𝐂) ⊢! □(□.atom 0 ➝ □.atom 1) ⋎ □(□.atom 1 ➝ □.atom 0) := by
       apply Logic.sumNormal.mem₂!;
       use Axioms.Dummett (.atom 0) (.atom 1);
       constructor;
@@ -52,7 +52,7 @@ instance : Entailment.HasAxiomPoint3 𝐋𝐂.smallestMC where
     . apply Entailment.WeakerThan.pbl (𝓢 := Logic.S4)
       simp;
 
-lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = 𝐋𝐂.smallestMC := by
+lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = (smallestMC 𝐋𝐂) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -80,7 +80,7 @@ lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = 𝐋𝐂.smallestMC := by
           repeat exact Logic.S4Point3.goedelTranslated_axiomDummett;
       . simpa [theory] using hφ;
 
-instance : Sound 𝐋𝐂.smallestMC FrameClass.S4Point3 := by
+instance : Sound (smallestMC 𝐋𝐂) FrameClass.S4Point3 := by
   rw [←Logic.S4Point3.is_smallestMC_of_LC];
   infer_instance;
 
@@ -102,7 +102,7 @@ lemma Logic.gGrzPoint3_of_LC : 𝐋𝐂 ⊢! φ → Logic.GrzPoint3 ⊢! φᵍ :
   intro h;
   apply WeakerThan.pbl $ modalCompanion_LC_S4Point3.companion.mp h;
 
-lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = 𝐋𝐂.largestMC := by
+lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = (Logic.largestMC 𝐋𝐂) := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -113,7 +113,7 @@ lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = 𝐋𝐂.largestMC 
       rcases (by simpa using h) with (⟨s, rfl⟩ | ⟨s, rfl⟩ | ⟨s, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := 𝐋𝐂.smallestMC);
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐋𝐂));
         simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
     | nec ihφ => exact nec! ihφ;
@@ -127,7 +127,7 @@ lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = 𝐋𝐂.largestMC 
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound 𝐋𝐂.largestMC FrameClass.finite_connected_partial_order := by
+instance : Sound (Logic.largestMC 𝐋𝐂) FrameClass.finite_connected_partial_order := by
   rw [←Logic.GrzPoint3.is_largestMC_of_LC];
   infer_instance;
 

--- a/Foundation/Modal/ModalCompanion/LC.lean
+++ b/Foundation/Modal/ModalCompanion/LC.lean
@@ -36,12 +36,12 @@ private lemma Logic.S4Point.lemma₁ : Logic.S4 ⊢! □(□φ ➝ □ψ) ➝ �
 namespace Logic
 
 
-instance : Entailment.HasAxiomPoint3 Logic.LC.smallestMC where
+instance : Entailment.HasAxiomPoint3 𝐋𝐂.smallestMC where
   Point3 φ ψ := by
     constructor;
     apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := Logic.LC.smallestMC) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a);
-    have : Logic.LC.smallestMC ⊢! □(□.atom 0 ➝ □.atom 1) ⋎ □(□.atom 1 ➝ □.atom 0) := by
+    apply Modal.Logic.subst! (L := 𝐋𝐂.smallestMC) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a);
+    have : 𝐋𝐂.smallestMC ⊢! □(□.atom 0 ➝ □.atom 1) ⋎ □(□.atom 1 ➝ □.atom 0) := by
       apply Logic.sumNormal.mem₂!;
       use Axioms.Dummett (.atom 0) (.atom 1);
       constructor;
@@ -52,7 +52,7 @@ instance : Entailment.HasAxiomPoint3 Logic.LC.smallestMC where
     . apply Entailment.WeakerThan.pbl (𝓢 := Logic.S4)
       simp;
 
-lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = Logic.LC.smallestMC := by
+lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = 𝐋𝐂.smallestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -80,11 +80,11 @@ lemma S4Point3.is_smallestMC_of_LC : Logic.S4Point3 = Logic.LC.smallestMC := by
           repeat exact Logic.S4Point3.goedelTranslated_axiomDummett;
       . simpa [theory] using hφ;
 
-instance : Sound Logic.LC.smallestMC FrameClass.S4Point3 := by
+instance : Sound 𝐋𝐂.smallestMC FrameClass.S4Point3 := by
   rw [←Logic.S4Point3.is_smallestMC_of_LC];
   infer_instance;
 
-instance modalCompanion_LC_S4Point3 : ModalCompanion Logic.LC Logic.S4Point3 := by
+instance modalCompanion_LC_S4Point3 : ModalCompanion 𝐋𝐂 Logic.S4Point3 := by
   rw [Logic.S4Point3.is_smallestMC_of_LC];
   exact Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.LC)
@@ -98,11 +98,11 @@ end S4Point3
 
 section GrzPoint3
 
-lemma Logic.gGrzPoint3_of_LC : Logic.LC ⊢! φ → Logic.GrzPoint3 ⊢! φᵍ := by
+lemma Logic.gGrzPoint3_of_LC : 𝐋𝐂 ⊢! φ → Logic.GrzPoint3 ⊢! φᵍ := by
   intro h;
   apply WeakerThan.pbl $ modalCompanion_LC_S4Point3.companion.mp h;
 
-lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = Logic.LC.largestMC := by
+lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = 𝐋𝐂.largestMC := by
   apply Logic.iff_equal_provable_equiv.mpr;
   apply Entailment.Equiv.antisymm_iff.mpr;
   constructor;
@@ -113,7 +113,7 @@ lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = Logic.LC.largestMC 
       rcases (by simpa using h) with (⟨s, rfl⟩ | ⟨s, rfl⟩ | ⟨s, rfl⟩);
       . simp;
       . simp;
-      . apply WeakerThan.pbl (𝓢 := Logic.LC.smallestMC);
+      . apply WeakerThan.pbl (𝓢 := 𝐋𝐂.smallestMC);
         simp;
     | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
     | nec ihφ => exact nec! ihφ;
@@ -127,11 +127,11 @@ lemma Logic.GrzPoint3.is_largestMC_of_LC : Logic.GrzPoint3 = Logic.LC.largestMC 
     | nec ih => apply nec! ih;
     | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
 
-instance : Sound Logic.LC.largestMC FrameClass.finite_connected_partial_order := by
+instance : Sound 𝐋𝐂.largestMC FrameClass.finite_connected_partial_order := by
   rw [←Logic.GrzPoint3.is_largestMC_of_LC];
   infer_instance;
 
-instance modalCompanion_LC_GrzPoint3 : ModalCompanion Logic.LC Logic.GrzPoint3 := by
+instance modalCompanion_LC_GrzPoint3 : ModalCompanion 𝐋𝐂 Logic.GrzPoint3 := by
   rw [Logic.GrzPoint3.is_largestMC_of_LC];
   exact Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.finite_LC)
@@ -143,7 +143,7 @@ end GrzPoint3
 
 section boxdot
 
-theorem embedding_LC_GLPoint3 {φ : Propositional.Formula ℕ} : Logic.LC ⊢! φ ↔ Logic.GLPoint3 ⊢! φᵍᵇ := by
+theorem embedding_LC_GLPoint3 {φ : Propositional.Formula ℕ} : 𝐋𝐂 ⊢! φ ↔ Logic.GLPoint3 ⊢! φᵍᵇ := by
   exact Iff.trans modalCompanion_LC_GrzPoint3.companion Logic.iff_boxdotTranslatedGLPoint3_GrzPoint3.symm
 
 end boxdot

--- a/Foundation/Propositional/ClassicalSemantics/Hilbert.lean
+++ b/Foundation/Propositional/ClassicalSemantics/Hilbert.lean
@@ -119,15 +119,15 @@ namespace Logic.Cl
 
 variable {φ : Formula ℕ}
 
-theorem tautologies : Logic.Cl = { φ | φ.isTautology } := by
+theorem tautologies : 𝐂𝐥 = { φ | φ.isTautology } := by
   ext φ;
   simp [Hilbert.Cl.iff_isTautology_provable, Entailment.theory];
 
-lemma exists_valuation_of_not (h : Logic.Cl ⊬ φ) : ∃ v : Valuation _, ¬(v ⊧ φ) := by
+lemma exists_valuation_of_not (h : 𝐂𝐥 ⊬ φ) : ∃ v : Valuation _, ¬(v ⊧ φ) := by
   apply Hilbert.Cl.exists_valuation_of_not_provable;
   tauto;
 
-lemma iff_isTautology : Logic.Cl ⊢! φ ↔ φ.isTautology := by simp [tautologies];
+lemma iff_isTautology : 𝐂𝐥 ⊢! φ ↔ φ.isTautology := by simp [tautologies];
 
 end Logic.Cl
 

--- a/Foundation/Propositional/Hilbert/Glivenko.lean
+++ b/Foundation/Propositional/Hilbert/Glivenko.lean
@@ -38,10 +38,10 @@ theorem iff_provable_neg_efq_provable_neg_efq : Hilbert.Int ⊢! ∼φ ↔ Hilbe
 
 end Hilbert
 
-lemma iff_negneg_Int_Cl : Logic.Int ⊢! ∼∼φ ↔ Logic.Cl ⊢! φ := by
+lemma iff_negneg_Int_Cl : 𝐈𝐧𝐭 ⊢! ∼∼φ ↔ 𝐂𝐥 ⊢! φ := by
   simpa [Entailment.theory] using Hilbert.iff_provable_dn_efq_dne_provable;
 
-lemma iff_neg_Int_neg_Cl : Logic.Int ⊢! ∼φ ↔ Logic.Cl ⊢! ∼φ := by
+lemma iff_neg_Int_neg_Cl : 𝐈𝐧𝐭 ⊢! ∼φ ↔ 𝐂𝐥 ⊢! ∼φ := by
   simpa [Entailment.theory] using Hilbert.iff_provable_neg_efq_provable_neg_efq;
 
 end LO.Propositional

--- a/Foundation/Propositional/Hilbert/WellKnown.lean
+++ b/Foundation/Propositional/Hilbert/WellKnown.lean
@@ -104,12 +104,12 @@ end Hilbert
 
 
 protected abbrev Hilbert.Int : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0)}⟩
-protected abbrev Logic.Int := Hilbert.Int.logic
+notation "𝐈𝐧𝐭" => Hilbert.Int.logic
 instance : Hilbert.Int.HasEFQ where p := 0;
 instance : Entailment.Int (Hilbert.Int) where
 
 protected abbrev Hilbert.Cl : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.LEM (.atom 0)}⟩
-protected abbrev Logic.Cl := Hilbert.Cl.logic
+notation "𝐂𝐥" => Hilbert.Cl.logic
 instance : Hilbert.Cl.HasEFQ where p := 0;
 instance : Hilbert.Cl.HasLEM where p := 0;
 instance : Entailment.Cl (Hilbert.Cl) where
@@ -118,21 +118,21 @@ lemma Hilbert.Int_weakerThan_Cl : (Hilbert.Int) ⪯ (Hilbert.Cl) := by apply wea
 
 
 protected abbrev Hilbert.KC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.WeakLEM (.atom 0)}⟩
-protected abbrev Logic.KC := Hilbert.KC.logic
+notation "𝐊𝐂" => Hilbert.KC.logic
 instance : Hilbert.KC.HasEFQ where p := 0;
 instance : Hilbert.KC.HasWeakLEM where p := 0;
 instance : Entailment.KC (Hilbert.KC) where
 
 
 protected abbrev Hilbert.LC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.Dummett (.atom 0) (.atom 1)}⟩
-protected abbrev Logic.LC := Hilbert.LC.logic
+notation "𝐋𝐂" => Hilbert.LC.logic
 instance : Hilbert.LC.HasEFQ where p := 0;
 instance : Hilbert.LC.HasDummett where p := 0; q := 1;
 instance : Entailment.LC (Hilbert.LC) where
 
 
 protected abbrev Hilbert.KP : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2)}⟩
-protected abbrev Logic.KP := Hilbert.KP.logic
+notation "𝐊𝐏" => Hilbert.KP.logic
 instance : Hilbert.KP.HasEFQ where p := 0;
 instance : Hilbert.KP.HasKrieselPutnam where p := 0; q := 1; r := 2;
 instance : Entailment.KP (Hilbert.KP) where

--- a/Foundation/Propositional/Hilbert/WellKnown.lean
+++ b/Foundation/Propositional/Hilbert/WellKnown.lean
@@ -104,12 +104,14 @@ end Hilbert
 
 
 protected abbrev Hilbert.Int : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0)}⟩
-notation "𝐈𝐧𝐭" => Hilbert.Int.logic
+protected abbrev Int := Hilbert.Int.logic
+notation "𝐈𝐧𝐭" => Propositional.Int
 instance : Hilbert.Int.HasEFQ where p := 0;
 instance : Entailment.Int (Hilbert.Int) where
 
 protected abbrev Hilbert.Cl : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.LEM (.atom 0)}⟩
-notation "𝐂𝐥" => Hilbert.Cl.logic
+protected abbrev Cl := Hilbert.Cl.logic
+notation "𝐂𝐥" => Propositional.Cl
 instance : Hilbert.Cl.HasEFQ where p := 0;
 instance : Hilbert.Cl.HasLEM where p := 0;
 instance : Entailment.Cl (Hilbert.Cl) where
@@ -118,24 +120,26 @@ lemma Hilbert.Int_weakerThan_Cl : (Hilbert.Int) ⪯ (Hilbert.Cl) := by apply wea
 
 
 protected abbrev Hilbert.KC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.WeakLEM (.atom 0)}⟩
-notation "𝐊𝐂" => Hilbert.KC.logic
+protected abbrev KC := Hilbert.KC.logic
+notation "𝐊𝐂" => Propositional.KC
 instance : Hilbert.KC.HasEFQ where p := 0;
 instance : Hilbert.KC.HasWeakLEM where p := 0;
 instance : Entailment.KC (Hilbert.KC) where
 
 
 protected abbrev Hilbert.LC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.Dummett (.atom 0) (.atom 1)}⟩
-notation "𝐋𝐂" => Hilbert.LC.logic
+protected abbrev LC := Hilbert.LC.logic
+notation "𝐋𝐂" => Propositional.LC
 instance : Hilbert.LC.HasEFQ where p := 0;
 instance : Hilbert.LC.HasDummett where p := 0; q := 1;
 instance : Entailment.LC (Hilbert.LC) where
 
 
 protected abbrev Hilbert.KP : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2)}⟩
-notation "𝐊𝐏" => Hilbert.KP.logic
+protected abbrev KP := Hilbert.KP.logic
+notation "𝐊𝐏" => Propositional.KP
 instance : Hilbert.KP.HasEFQ where p := 0;
 instance : Hilbert.KP.HasKrieselPutnam where p := 0; q := 1; r := 2;
 instance : Entailment.KP (Hilbert.KP) where
-
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/Logic/Cl.lean
+++ b/Foundation/Propositional/Kripke/Logic/Cl.lean
@@ -150,10 +150,10 @@ instance : Hilbert.Int ⪱ Hilbert.Cl := calc
 
 end Hilbert
 
-propositional_kripke Logic.Cl FrameClass.Cl
-propositional_kripke Logic.Cl FrameClass.finite_Cl
+propositional_kripke 𝐂𝐥 FrameClass.Cl
+propositional_kripke 𝐂𝐥 FrameClass.finite_Cl
 
-instance : Logic.LC ⪱ Logic.Cl := inferInstance
-instance : Logic.Int ⪱ Logic.Cl := inferInstance
+instance : 𝐋𝐂 ⪱ 𝐂𝐥 := inferInstance
+instance : 𝐈𝐧𝐭 ⪱ 𝐂𝐥 := inferInstance
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/Logic/Int.lean
+++ b/Foundation/Propositional/Kripke/Logic/Int.lean
@@ -158,8 +158,8 @@ end DP
 end Hilbert.Int.Kripke
 
 
-propositional_kripke Logic.Int FrameClass.Int
-propositional_kripke Logic.Int FrameClass.finite_Int
+propositional_kripke 𝐈𝐧𝐭 FrameClass.Int
+propositional_kripke 𝐈𝐧𝐭 FrameClass.finite_Int
 
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/Logic/KC.lean
+++ b/Foundation/Propositional/Kripke/Logic/KC.lean
@@ -190,9 +190,9 @@ instance : Hilbert.Int ⪱ Hilbert.KC := calc
 
 end Hilbert
 
-propositional_kripke Logic.KC FrameClass.KC
-propositional_kripke Logic.KC FrameClass.finite_KC
+propositional_kripke 𝐊𝐂 FrameClass.KC
+propositional_kripke 𝐊𝐂 FrameClass.finite_KC
 
-instance : Logic.KP ⪱ Logic.KC := inferInstance
+instance : 𝐊𝐏 ⪱ 𝐊𝐂 := inferInstance
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/Logic/KP.lean
+++ b/Foundation/Propositional/Kripke/Logic/KP.lean
@@ -107,9 +107,9 @@ instance : Hilbert.Int ⪱ Hilbert.KP := by
 end Hilbert
 
 
-propositional_kripke Logic.KP FrameClass.KP
+propositional_kripke 𝐊𝐏 FrameClass.KP
 
-instance : Logic.Int ⪱ Logic.KP := inferInstance
+instance : 𝐈𝐧𝐭 ⪱ 𝐊𝐏 := inferInstance
 
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/Logic/LC.lean
+++ b/Foundation/Propositional/Kripke/Logic/LC.lean
@@ -136,10 +136,10 @@ instance : Hilbert.KC ⪱ Hilbert.LC := by
 end Hilbert
 
 
-propositional_kripke Logic.LC FrameClass.LC
-propositional_kripke Logic.LC FrameClass.finite_LC
+propositional_kripke 𝐋𝐂 FrameClass.LC
+propositional_kripke 𝐋𝐂 FrameClass.finite_LC
 
-instance : Logic.KC ⪱ Logic.LC := inferInstance
+instance : 𝐊𝐂 ⪱ 𝐋𝐂 := inferInstance
 
 
 end LO.Propositional

--- a/Foundation/Propositional/Logic/Letterless_Int_Cl.lean
+++ b/Foundation/Propositional/Logic/Letterless_Int_Cl.lean
@@ -14,7 +14,7 @@ namespace Logic
 
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 
-theorem iff_letterless_Int_Cl {φ : Formula ℕ} (hφ : φ.letterless) : Logic.Int ⊢! φ ↔ Logic.Cl ⊢! φ := by
+theorem iff_letterless_Int_Cl {φ : Formula ℕ} (hφ : φ.letterless) : 𝐈𝐧𝐭 ⊢! φ ↔ 𝐂𝐥 ⊢! φ := by
   constructor;
   . apply WeakerThan.wk;
     infer_instance;

--- a/Foundation/Propositional/Logic/PostComplete.lean
+++ b/Foundation/Propositional/Logic/PostComplete.lean
@@ -22,7 +22,7 @@ open Formula.ClassicalSemantics
 open Propositional.Hilbert.Cl
 open ClassicalSemantics
 
-theorem Cl.post_complete : ¬∃ L : Logic _, Entailment.Consistent L ∧ Nonempty (L.IsSuperintuitionistic) ∧ Logic.Cl ⪱ L := by
+theorem Cl.post_complete : ¬∃ L : Logic _, Entailment.Consistent L ∧ Nonempty (L.IsSuperintuitionistic) ∧ 𝐂𝐥 ⪱ L := by
   by_contra! hC;
   obtain ⟨L, L_consis, ⟨L_ne⟩, L_Cl⟩ := hC;
   apply Logic.no_bot (L := L);

--- a/Kite/Propositional.lean
+++ b/Kite/Propositional.lean
@@ -1,7 +1,7 @@
 import Foundation.Propositional.Logic.Basic
 import Kite.Basic
 
-open Lean Meta Qq Elab Command
+open Lean Meta Qq Elab Command PrettyPrinter
 open LO.Propositional
 
 namespace Kite
@@ -9,11 +9,9 @@ namespace Kite
 def isMatch (ci : ConstantInfo) : MetaM (Option Edge) := withNewMCtxDepth do
   match ← inferTypeQ ci.type with
   | ⟨1, ~q(Prop), ~q(LO.Entailment.StrictlyWeakerThan (S := Logic ℕ) (T := Logic ℕ) $a $b)⟩ =>
-    return some ⟨toString (←Lean.PrettyPrinter.ppExpr a), toString (←Lean.PrettyPrinter.ppExpr b), .ssub⟩
+    return some ⟨s!"{←PrettyPrinter.ppExpr a}", s!"{←PrettyPrinter.ppExpr b}", .ssub⟩
   | ⟨1, ~q(Prop), ~q(LO.Entailment.WeakerThan (S := Logic ℕ) (T := Logic ℕ) $a $b)⟩ =>
-    return some ⟨toString (←Lean.PrettyPrinter.ppExpr a), toString (←Lean.PrettyPrinter.ppExpr b), .sub⟩
-  -- | ⟨1, ~q(Prop), ~q(@HasSubset.Subset Logic _ $a $b)⟩ => return some (.ext, a, b)
-  -- | ⟨1, ~q(Prop), ~q(($a : Logic) = $b)⟩ => return some (.ext, a, b)
+    return some ⟨s!"{←PrettyPrinter.ppExpr a}", s!"{←PrettyPrinter.ppExpr b}", .sub⟩
   | _ => return none
 
 def findMatches : MetaM Json := do

--- a/Kite/propositional.typ
+++ b/Kite/propositional.typ
@@ -38,11 +38,11 @@
         + "}",
     ),
     labels: (
-      "LO.Propositional.Logic.Cl": $Logic("Cl")$,
-      "LO.Propositional.Logic.Int": $Logic("Int")$,
-      "LO.Propositional.Logic.KC": $Logic("KC")$,
-      "LO.Propositional.Logic.KP": $Logic("KP")$,
-      "LO.Propositional.Logic.LC": $Logic("LC")$,
+      "𝐂𝐥": $Logic("Cl")$,
+      "𝐈𝐧𝐭": $Logic("Int")$,
+      "𝐊𝐂": $Logic("KC")$,
+      "𝐊𝐏": $Logic("KP")$,
+      "𝐋𝐂": $Logic("LC")$,
     ),
     width: 90pt,
   )


### PR DESCRIPTION
そもそも`Logic.Int`として定義しなくとも良いような気がした．

```lean
notation "𝐈𝐧𝐭" => Hilbert.Int.logic
```

様相論理で`𝐊𝐏`が被るが，型から上手く推論されるような気もする．ダメだったら置き換えればよいだけなのでとりあえずこれで試す．

close #422