### PR TITLE
add(Meta): `cl_prover [...]` for hypotheses of weak entailment

### DIFF
--- a/Foundation/Meta/Test.lean
+++ b/Foundation/Meta/Test.lean
@@ -29,11 +29,11 @@ open LO.Modal.Entailment
 
 variable {S F : Type*} [DecidableEq F] [BasicModalLogicalConnective F] [Entailment F S]
 
-variable {𝓢 : S} [Modal.Entailment.K 𝓢] {φ ψ ξ χ : F}
+variable {𝓢 𝓣 𝓤 : S} [𝓣 ⪯ 𝓢] [𝓤 ⪯ 𝓢] [Modal.Entailment.K 𝓢] {φ ψ ξ χ : F}
 
 example : 𝓢 ⊢! ((□φ ➝ □□φ) ➝ □φ) ➝ □φ := by cl_prover 6
 
-example (h : 𝓢 ⊢! □φ ⭤ φ) : 𝓢 ⊢! φ ⭤ □φ ⋏ φ := by cl_prover [h]
+example (h₁ : 𝓣 ⊢! □φ ⭤ φ) (h₂ : 𝓤 ⊢! □ψ ⭤ ψ) : 𝓢 ⊢! φ ⋎ □ψ ⭤ □φ ⋏ φ ⋎ ψ := by cl_prover [h₁, h₂]
 
 end
 


### PR DESCRIPTION
`𝓣 ⪯ 𝓢` が示された Entailment についての証明 `𝓣 ⊢! ...` も仮定に使用できるようにした．

```lean
variable {S F : Type*} [DecidableEq F] [BasicModalLogicalConnective F] [Entailment F S]

variable {𝓢 𝓣 𝓤 : S} [𝓣 ⪯ 𝓢] [𝓤 ⪯ 𝓢] [Modal.Entailment.K 𝓢] {φ ψ ξ χ : F}

example (h₁ : 𝓣 ⊢! □φ ⭤ φ) (h₂ : 𝓤 ⊢! □ψ ⭤ ψ) : 𝓢 ⊢! φ ⋎ □ψ ⭤ □φ ⋏ φ ⋎ ψ := by cl_prover [h₁, h₂]
```