### PR TITLE
refactor(ProvabilityLogic): refactor & rename

### DIFF
--- a/Foundation.lean
+++ b/Foundation.lean
@@ -63,7 +63,6 @@ import Foundation.FirstOrder.Omega1.Nuon
 
 import Foundation.FirstOrder.Incompleteness.FixedPoint
 import Foundation.FirstOrder.Incompleteness.StandardProvability
-import Foundation.FirstOrder.Incompleteness.DerivabilityCondition.Basic
 import Foundation.FirstOrder.Incompleteness.First
 import Foundation.FirstOrder.Incompleteness.Second
 import Foundation.FirstOrder.Incompleteness.ConsistencyPredicate
@@ -137,6 +136,8 @@ import Foundation.Modal.Logic.Dz.Basic
 import Foundation.Modal.Maximal.Makinson
 
 -- Provability Logic
+import Foundation.ProvabilityLogic.Conditions
+
 import Foundation.ProvabilityLogic.N.Soundness
 
 import Foundation.ProvabilityLogic.GL.Completeness

--- a/Foundation.lean
+++ b/Foundation.lean
@@ -136,7 +136,7 @@ import Foundation.Modal.Logic.Dz.Basic
 import Foundation.Modal.Maximal.Makinson
 
 -- Provability Logic
-import Foundation.ProvabilityLogic.Conditions
+import Foundation.ProvabilityLogic.Incompleteness
 
 import Foundation.ProvabilityLogic.N.Soundness
 

--- a/Foundation/FirstOrder/Arith/Basic/Hierarchy.lean
+++ b/Foundation/FirstOrder/Arith/Basic/Hierarchy.lean
@@ -1,4 +1,4 @@
-import Foundation.FirstOrder.Arith.Basic.ORingStruc
+import Foundation.FirstOrder.Arith.Basic.Model
 
 namespace LO
 
@@ -421,17 +421,6 @@ lemma remove_exists {φ : Semiformula L ξ (n + 1)} : Hierarchy b s (∃' φ) �
 
 end Hierarchy
 
-section
-
-variable {L : Language} [L.LT] [Structure L ℕ]
-
-abbrev Sigma1Sound (T : Theory L) := SoundOn T (Hierarchy 𝚺 1)
-
-lemma consistent_of_sigma1Sound (T : Theory L) [Sigma1Sound T] :
-    Entailment.Consistent T := consistent_of_sound T (Hierarchy 𝚺 1) (by simp [Set.mem_def])
-
-end
-
 section LOR
 
 lemma sigma₁_induction {P : (n : ℕ) → Semiformula ℒₒᵣ ξ n → Prop}
@@ -491,6 +480,11 @@ lemma sigma₁_induction' {n φ} (hp : Hierarchy 𝚺 1 φ)
 end LOR
 
 end Arith
+
+abbrev ArithmeticTheory.Sigma1Sound (T : ArithmeticTheory) := T.SoundOn (Arith.Hierarchy 𝚺 1)
+
+instance (T : ArithmeticTheory) [T.Sigma1Sound] : Entailment.Consistent T :=
+  T.consistent_of_sound (Arith.Hierarchy 𝚺 1) (by simp)
 
 end FirstOrder
 

--- a/Foundation/FirstOrder/Arith/Basic/Model.lean
+++ b/Foundation/FirstOrder/Arith/Basic/Model.lean
@@ -134,53 +134,9 @@ variable {M : Type*} [ORingStruc M]
   · simp only [Theory.lMap, Set.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
     intro H φ hp f; exact eval_lMap_oringEmb.mpr (H hp f)
 
-/-
-instance [M ⊧ₘ* 𝐈Open] : M ⊧ₘ* 𝐏𝐀⁻ := ModelsTheory.of_add_left M 𝐏𝐀⁻ (Theory.InductionScheme _ Semiformula.Open)
-
-instance [M ⊧ₘ* 𝐈Open] : M ⊧ₘ* Theory.InductionScheme ℒₒᵣ Semiformula.Open :=
-  ModelsTheory.of_add_right M 𝐏𝐀⁻ (Theory.InductionScheme _ Semiformula.Open)
-
-def models_PeanoMinus_of_models_InductionOnHierarchy (Γ n) [M ⊧ₘ* 𝐈𝐍𝐃 Γ n] : M ⊧ₘ* 𝐏𝐀⁻ := ModelsTheory.of_add_left M 𝐏𝐀⁻ (Theory.InductionScheme _ (Arith.Hierarchy Γ n))
-
-def models_InductionScheme_of_models_InductionOnHierarchy (Γ n) [M ⊧ₘ* 𝐈𝐍𝐃 Γ n] : M ⊧ₘ* Theory.InductionScheme ℒₒᵣ (Arith.Hierarchy Γ n) :=
-  ModelsTheory.of_add_right M 𝐏𝐀⁻ (Theory.InductionScheme _ (Arith.Hierarchy Γ n))
-
-instance models_PeanoMinus_of_models_Peano [M ⊧ₘ* 𝐏𝐀] : M ⊧ₘ* 𝐏𝐀⁻ := ModelsTheory.of_add_left M 𝐏𝐀⁻ (Theory.InductionScheme _ Set.univ)
-
--/
-
 end
 
 end model
-
-/-
-namespace Standard
-
-variable {ξ : Type v} (e : Fin n → ℕ) (ε : ξ → ℕ)
-
-set_option linter.flexible false in
-lemma models_succInd (φ : Semiformula ℒₒᵣ ℕ 1) : ℕ ⊧ₘ succInd φ := by
-  simp [Empty.eq_elim, succInd, models_iff, Matrix.constant_eq_singleton, Matrix.comp_vecCons',
-    Semiformula.eval_substs, Semiformula.eval_rew_q Rew.toS, Function.comp]
-  intro e hzero hsucc x; induction' x with x ih
-  · exact hzero
-  · exact hsucc x ih
-
-set_option linter.flexible false in
-instance models_ISigma (Γ k) : ℕ ⊧ₘ* 𝐈𝐍𝐃Γ k := by
-  simp [Theory.InductionScheme, models_PeanoMinus]; rintro _ φ _ rfl; simp [models_succInd]
-
-instance models_ISigmaZero : ℕ ⊧ₘ* 𝐈𝚺₀ := inferInstance
-
-instance models_ISigmaOne : ℕ ⊧ₘ* 𝐈𝚺₁ := inferInstance
-
-set_option linter.flexible false in
-instance models_Peano : ℕ ⊧ₘ* 𝐏𝐀 := by
-  simp [Theory.Peano, Theory.InductionScheme, models_PeanoMinus]; rintro _ φ _ rfl; simp [models_succInd]
-
-end Standard
-
--/
 
 section
 
@@ -216,21 +172,20 @@ lemma oRing_weakerThan_of (T S : Theory ℒₒᵣ) [𝐄𝐐 ⪯ S]
 
 end Arith
 
-namespace Theory
+class ArithmeticTheory.SoundOn (T : ArithmeticTheory) (F : Sentence ℒₒᵣ → Prop) where
+  sound : ∀ {σ}, T ⊢!. σ → F σ → ℕ ⊧ₘ₀ σ
 
-open Arith
+namespace ArithmeticTheory
 
-/-
+variable (T : ArithmeticTheory) (F : Sentence ℒₒᵣ → Prop)
 
-instance Peano.consistent : Entailment.Consistent 𝐏𝐀 :=
-  Sound.consistent_of_satisfiable ⟨_, inferInstanceAs (ℕ ⊧ₘ* 𝐏𝐀)⟩
+instance [ℕ ⊧ₘ* T] : T.SoundOn F := ⟨fun b _ ↦ consequence_iff.mp (sound!₀ b) ℕ inferInstance⟩
 
-instance TrueArith.consistent : Entailment.Consistent 𝐓𝐀 :=
-  Sound.consistent_of_satisfiable ⟨_, inferInstanceAs (ℕ ⊧ₘ* 𝐓𝐀)⟩
+lemma consistent_of_sound [SoundOn T F] (hF : F ⊥) : Entailment.Consistent T :=
+  Entailment.consistent_iff_unprovable_bot.mpr fun b ↦ by
+    simpa [Models₀] using SoundOn.sound (T := T) (F := F) (by simpa [Axiom.provable_iff]) hF
 
--/
-
-end Theory
+end ArithmeticTheory
 
 end FirstOrder
 

--- a/Foundation/FirstOrder/Arith/Basic/ORingStruc.lean
+++ b/Foundation/FirstOrder/Arith/Basic/ORingStruc.lean
@@ -111,10 +111,6 @@ end Semiterm
 
 namespace Semiformula
 
-instance : Coe (Semiformula ℒₒᵣ ξ n) (Semiformula L ξ n) := ⟨Semiformula.lMap Language.oringEmb⟩
-
-instance : Coe (Theory ℒₒᵣ) (Theory L) := ⟨(Semiformula.lMap Language.oringEmb '' ·)⟩
-
 @[simp] lemma oringEmb_eq (v : Fin 2 → Semiterm ℒₒᵣ ξ n) :
     Semiformula.lMap (Language.oringEmb : ℒₒᵣ →ᵥ L) (op(=).operator v) = op(=).operator ![(v 0 : Semiterm L ξ n), (v 1 : Semiterm L ξ n)] := by
   simpa [lMap_rel, rew_rel, Operator.operator, Operator.Eq.sentence_eq] using Matrix.fun_eq_vec_two
@@ -216,22 +212,6 @@ macro_rules
 end BinderNotation
 
 namespace Arith
-
-class SoundOn {L : Language} [Structure L ℕ]
-    (T : Theory L) (F : Sentence L → Prop) where
-  sound : ∀ {σ}, F σ → T ⊢! ↑σ → ℕ ⊧ₘ₀ σ
-
-instance {L : Language} [Structure L ℕ] (T : Theory L) (F : Sentence L → Prop) [ℕ ⊧ₘ* T] : SoundOn T F :=
-  ⟨fun _ b ↦ consequence_iff.mp (sound! (T := T) b) ℕ inferInstance⟩
-
-section
-
-variable {L : Language} [Structure L ℕ] (T : Theory L) (F : Set (Sentence L))
-
-lemma consistent_of_sound [SoundOn T F] (hF : ⊥ ∈ F) : Entailment.Consistent T :=
-  Entailment.consistent_iff_unprovable_bot.mpr fun b ↦ by simpa [Models₀] using SoundOn.sound (F := F) hF b
-
-end
 
 section
 

--- a/Foundation/FirstOrder/Arith/Basic/ORingStruc.lean
+++ b/Foundation/FirstOrder/Arith/Basic/ORingStruc.lean
@@ -255,17 +255,26 @@ section
 
 open Encodable Semiterm.Operator.GoedelNumber
 
-instance {α} [Encodable α] : Semiterm.Operator.GoedelNumber ℒₒᵣ α :=
+variable {α} [Encodable α]
+
+instance : Semiterm.Operator.GoedelNumber ℒₒᵣ α :=
   Semiterm.Operator.GoedelNumber.ofEncodable
 
-lemma goedelNumber_def {α} [Encodable α] (a : α) :
+lemma goedelNumber_def (a : α) :
   goedelNumber a = Semiterm.Operator.encode ℒₒᵣ a := rfl
 
-lemma goedelNumber'_def {α} [Encodable α] (a : α) :
+lemma goedelNumber'_def (a : α) :
   (⌜a⌝ : Semiterm ℒₒᵣ ξ n) = Semiterm.Operator.encode ℒₒᵣ a := rfl
 
-@[simp] lemma encode_encode_eq {α} [Encodable α] (a : α) :
+lemma goedelNumber'_eq_coe_encode (a : α) :
+  (⌜a⌝ : Semiterm ℒₒᵣ ξ n) = ↑(Encodable.encode a) := rfl
+
+@[simp] lemma encode_encode_eq (a : α) :
     (goedelNumber (encode a) : Semiterm.Const ℒₒᵣ) = goedelNumber a := by simp [Semiterm.Operator.encode, goedelNumber_def]
+
+@[simp] lemma rew_goedelNumber' (ω : Rew ℒₒᵣ ξ₁ n₁ ξ₂ n₂) (a : α) :
+    ω ⌜a⌝ = ⌜a⌝ := by
+  simp [goedelNumber'_def]
 
 end
 

--- a/Foundation/FirstOrder/Arith/Definability/Absoluteness.lean
+++ b/Foundation/FirstOrder/Arith/Definability/Absoluteness.lean
@@ -78,7 +78,7 @@ lemma models_iff_of_Delta1 {σ : 𝚫₁.Semisentence n} (hσ : σ.ProperOn ℕ)
     have : V ⊧/(e ·) (∼σ.pi.val) := by simpa [numeral_eq_natCast] using R0.bold_sigma_one_completeness' (M := V) (by simp) this
     simpa [hσV.iff'] using this
 
-variable {T : Theory ℒₒᵣ} [𝐏𝐀⁻ ⪯ T] [Sigma1Sound T]
+variable {T : ArithmeticTheory} [𝐏𝐀⁻ ⪯ T] [T.Sigma1Sound]
 
 noncomputable instance : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐏𝐀⁻) inferInstance inferInstance
 

--- a/Foundation/FirstOrder/Arith/Definability/Hierarchy.lean
+++ b/Foundation/FirstOrder/Arith/Definability/Hierarchy.lean
@@ -64,7 +64,7 @@ variable {ξ n}
 
 namespace Semiformula
 
-def val {Γ : HierarchySymbol} : Γ.Semiformula ξ n → Semiformula ℒₒᵣ ξ n
+@[coe] def val {Γ : HierarchySymbol} : Γ.Semiformula ξ n → Semiformula ℒₒᵣ ξ n
   | mkSigma φ _ => φ
   | mkPi    φ _ => φ
   | mkDelta φ _ => φ.val

--- a/Foundation/FirstOrder/Arith/Induction.lean
+++ b/Foundation/FirstOrder/Arith/Induction.lean
@@ -28,21 +28,21 @@ variable (L)
 def InductionScheme (Γ : Semiformula L ℕ 1 → Prop) : Theory L :=
   { ψ | ∃ φ : Semiformula L ℕ 1, Γ φ ∧ ψ = succInd φ }
 
-abbrev IOpen : Theory ℒₒᵣ := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ Semiformula.Open
+abbrev IOpen : ArithmeticTheory := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ Semiformula.Open
 
 notation "𝐈Open" => IOpen
 
-abbrev InductionOnHierarchy (Γ : Polarity) (k : ℕ) : Theory ℒₒᵣ := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ (Arith.Hierarchy Γ k)
+abbrev InductionOnHierarchy (Γ : Polarity) (k : ℕ) : ArithmeticTheory := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ (Arith.Hierarchy Γ k)
 
 prefix:max "𝐈𝐍𝐃 " => InductionOnHierarchy
 
-abbrev ISigma (k : ℕ) : Theory ℒₒᵣ := 𝐈𝐍𝐃 𝚺 k
+abbrev ISigma (k : ℕ) : ArithmeticTheory := 𝐈𝐍𝐃 𝚺 k
 
 prefix:max "𝐈𝚺" => ISigma
 
 notation "𝐈𝚺₀" => ISigma 0
 
-abbrev IPi (k : ℕ) : Theory ℒₒᵣ := 𝐈𝐍𝐃 𝚷 k
+abbrev IPi (k : ℕ) : ArithmeticTheory := 𝐈𝐍𝐃 𝚷 k
 
 prefix:max "𝐈𝚷" => IPi
 
@@ -52,20 +52,13 @@ notation "𝐈𝚺₁" => ISigma 1
 
 notation "𝐈𝚷₁" => IPi 1
 
-abbrev Peano : Theory ℒₒᵣ := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ Set.univ
+abbrev Peano : ArithmeticTheory := 𝐏𝐀⁻ + InductionScheme ℒₒᵣ Set.univ
 
 notation "𝐏𝐀" => Peano
 
 variable {L}
 
 variable {C C' : Semiformula ℒₒᵣ ℕ 1 → Prop}
-
-lemma coe_InductionOnHierarchy_subset_InductionOnHierarchy :
-    (InductionScheme ℒₒᵣ (Arith.Hierarchy Γ ν) : Theory L) ⊆ InductionScheme L (Arith.Hierarchy Γ ν) := by
-  simp only [InductionScheme, Set.image_subset_iff, Set.preimage_setOf_eq, Set.setOf_subset_setOf, forall_exists_index, and_imp]
-  rintro _ φ Hp rfl
-  exact ⟨Semiformula.lMap (Language.oringEmb : ℒₒᵣ →ᵥ L) φ, Arith.Hierarchy.oringEmb Hp,
-    by simp [succInd, Semiformula.lMap_substs]⟩
 
 lemma InductionScheme_subset (h : ∀ {φ : Semiformula ℒₒᵣ ℕ 1},  C φ → C' φ) : InductionScheme ℒₒᵣ C ⊆ InductionScheme ℒₒᵣ C' := by
   intro _; simp only [InductionScheme, Set.mem_setOf_eq, forall_exists_index, and_imp]; rintro φ hp rfl; exact ⟨φ, h hp, rfl⟩
@@ -388,9 +381,9 @@ instance models_Peano : ℕ ⊧ₘ* 𝐏𝐀 := by
     Semantics.RealizeSet.setOf_iff, forall_exists_index, and_imp, true_and]
   rintro _ φ _ rfl; simp [models_succInd]
 
-instance : Entailment.Consistent (𝐈𝐍𝐃 Γ k) := consistent_of_sound (𝐈𝐍𝐃 Γ k) (Eq ⊥) rfl
+instance : Entailment.Consistent (𝐈𝐍𝐃 Γ k) := (𝐈𝐍𝐃 Γ k).consistent_of_sound (Eq ⊥) rfl
 
-instance : Entailment.Consistent 𝐏𝐀 := consistent_of_sound 𝐏𝐀 (Eq ⊥) rfl
+instance : Entailment.Consistent 𝐏𝐀 := 𝐏𝐀.consistent_of_sound (Eq ⊥) rfl
 
 instance : 𝐏𝐀 ⪯ 𝐓𝐀 := inferInstance
 

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -509,7 +509,9 @@ instance [L.DecidableEq] : Entailment.Deduction (Axiom L) where
     have : cons σ A ⊢ σ ➝ τ := Axiomatized.weakening (by simp) b
     this ⨀ (Axiomatized.cons _ _)
 
-def provable_iff [L.DecidableEq] {T : Theory L} {σ : Sentence L} :
+variable [L.DecidableEq] {T : Theory L}
+
+def provable_iff {σ : Sentence L} :
     (T : Axiom L) ⊢! σ ↔ T ⊢! ↑σ := by
   constructor
   · intro b
@@ -527,14 +529,23 @@ def provable_iff [L.DecidableEq] {T : Theory L} {σ : Sentence L} :
       by_axm _ <| by simpa [Theory.toAxiom, Axiom.toTheory] using ⟨φ, by simpa, rfl⟩
     exact Theory.close!_iff.mp this
 
-def unprovable_iff [L.DecidableEq] {T : Theory L} {σ} :
+def unprovable_iff {σ} :
     (T : Axiom L) ⊬ σ ↔ T ⊬ ↑σ := provable_iff.not
 
-def provable_close₀_iff [L.DecidableEq] {T : Theory L} {φ : SyntacticFormula L} :
+def provable_close₀_iff {φ : SyntacticFormula L} :
     (T : Axiom L) ⊢! ∀∀₀ φ ↔ T ⊢! φ := Iff.trans provable_iff (by simp [Theory.close!_iff])
 
-instance [L.DecidableEq] (T U : Theory L) [T ⪯ U] : T.toAxiom ⪯ U.toAxiom :=
+def unprovable_close₀_iff {φ : SyntacticFormula L} :
+    (T : Axiom L) ⊬ ∀∀₀ φ ↔ T ⊬ φ := provable_close₀_iff.not
+
+instance (T U : Theory L) [T ⪯ U] : T.toAxiom ⪯ U.toAxiom :=
   ⟨fun _ b ↦ Axiom.provable_iff.mpr <| (inferInstanceAs (T ⪯ U)).pbl (Axiom.provable_iff.mp b)⟩
+
+@[simp] lemma consistent_iff {T : Theory L} :
+    Consistent (T : Axiom L) ↔ Consistent T := calc
+  Consistent (T : Axiom L) ↔ (T : Axiom L) ⊬ ⊥ := consistent_iff_unprovable_bot
+  _                        ↔ T ⊬ ⊥             := by simp [unprovable_iff]
+  _                        ↔ Consistent T      := consistent_iff_unprovable_bot.symm
 
 end Axiom
 

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -543,11 +543,13 @@ def unprovable_close₀_iff {φ : SyntacticFormula L} :
 instance (T U : Theory L) [T ⪯ U] : T.toAxiom ⪯ U.toAxiom :=
   ⟨fun _ b ↦ Axiom.provable_iff.mpr <| (inferInstanceAs (T ⪯ U)).pbl (Axiom.provable_iff.mp b)⟩
 
-@[simp] lemma consistent_iff {T : Theory L} :
+@[simp] lemma consistent_iff :
     Consistent (T : Axiom L) ↔ Consistent T := calc
   Consistent (T : Axiom L) ↔ (T : Axiom L) ⊬ ⊥ := consistent_iff_unprovable_bot
   _                        ↔ T ⊬ ⊥             := by simp [unprovable_iff]
   _                        ↔ Consistent T      := consistent_iff_unprovable_bot.symm
+
+instance [Consistent T] : Consistent (T : Axiom L) := by simp_all
 
 end Axiom
 

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -451,6 +451,8 @@ abbrev Axiom := Set (Sentence L)
 
 variable {L}
 
+abbrev ArithmeticAxiom := Axiom ℒₒᵣ
+
 @[coe] def Theory.toAxiom (T : Theory L) : Axiom L := Semiformula.close₀ '' T
 
 @[coe] def Axiom.toTheory (A : Axiom L) : Theory L := Rewriting.embedding '' A

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -533,6 +533,9 @@ def unprovable_iff [L.DecidableEq] {T : Theory L} {σ} :
 def provable_close₀_iff [L.DecidableEq] {T : Theory L} {φ : SyntacticFormula L} :
     (T : Axiom L) ⊢! ∀∀₀ φ ↔ T ⊢! φ := Iff.trans provable_iff (by simp [Theory.close!_iff])
 
+instance [L.DecidableEq] (T U : Theory L) [T ⪯ U] : T.toAxiom ⪯ U.toAxiom :=
+  ⟨fun _ b ↦ Axiom.provable_iff.mpr <| (inferInstanceAs (T ⪯ U)).pbl (Axiom.provable_iff.mp b)⟩
+
 end Axiom
 
 end FirstOrder

--- a/Foundation/FirstOrder/Basic/Coding.lean
+++ b/Foundation/FirstOrder/Basic/Coding.lean
@@ -11,12 +11,12 @@ open Encodable
 namespace Semiterm
 
 def toNat {n : ℕ} : Semiterm L ξ n → ℕ
-  | #z                        => Nat.pair 0 z + 1
-  | &x                        => Nat.pair 1 (encode x) + 1
+  |                        #z => Nat.pair 0 z + 1
+  |                        &x => Nat.pair 1 (encode x) + 1
   | func (arity := arity) f v => (Nat.pair 2 <| Nat.pair arity <| Nat.pair (encode f) <| Matrix.vecToNat fun i ↦ toNat (v i)) + 1
 
 def ofNat (n : ℕ) : ℕ → Option (Semiterm L ξ n)
-  | 0 => none
+  |     0 => none
   | e + 1 =>
     match e.unpair.1 with
     | 0 => if h : e.unpair.2 < n then some #⟨e.unpair.2, h⟩ else none
@@ -41,20 +41,32 @@ def ofNat (n : ℕ) : ℕ → Option (Semiterm L ξ n)
     | _ => none
 
 lemma ofNat_toNat {n : ℕ} : ∀ t : Semiterm L ξ n, ofNat n (toNat t) = some t
-  | #z => by simp [toNat, ofNat]
-  | &x => by simp [toNat, ofNat]
+  |       #z => by simp [toNat, ofNat]
+  |       &x => by simp [toNat, ofNat]
   | func f v => by
-      simp only [toNat, ofNat, Nat.unpair_pair, Option.pure_def, Option.bind_eq_bind]
-      rw [Nat.unpair_pair, Nat.unpair_pair, Nat.unpair_pair, Nat.natToVec_vecToNat]
-      simp
+      suffices (Matrix.getM fun i ↦ ofNat n (v i).toNat) = some v by
+        simp only [toNat, ofNat, Nat.unpair_pair, Option.pure_def, Option.bind_eq_bind]
+        rw [Nat.unpair_pair, Nat.unpair_pair, Nat.unpair_pair, Nat.natToVec_vecToNat]
+        simpa
       have : (fun i ↦ ofNat n (toNat (v i))) = (fun i ↦ pure (v i)) := funext <| fun i ↦ ofNat_toNat (v i)
-      rw [this, Matrix.getM_pure]
-      simp
+      simp [this, Matrix.getM_pure]
 
 instance encodable : Encodable (Semiterm L ξ n) where
   encode := toNat
   decode := ofNat n
   encodek := ofNat_toNat
+
+lemma encode_eq_toNat (t : Semiterm L ξ n) : encode t = toNat t := rfl
+
+lemma toNat_func {k} (f : L.Func k) (v : Fin k → Semiterm L ξ n) :
+    toNat (func f v) = (Nat.pair 2 <| Nat.pair k <| Nat.pair (encode f) <| Matrix.vecToNat fun i ↦ toNat (v i)) + 1 := rfl
+
+@[simp] lemma encode_emb (t : Semiterm L Empty n) : encode (Rew.emb t : Semiterm L ξ n) = encode t := by
+  simp only [encode_eq_toNat]
+  induction t
+  · simp [toNat]
+  · contradiction
+  · simp [Rew.func, toNat_func, *]
 
 end Semiterm
 
@@ -62,18 +74,18 @@ namespace Semiformula
 
 variable [(k : ℕ) → Encodable (L.Rel k)]
 
-def toNat : {n : ℕ} → Semiformula L ξ n → ℕ
-  | _, rel (arity := arity) R v  => (Nat.pair 0 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1
-  | _, nrel (arity := arity) R v => (Nat.pair 1 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1
-  | _, ⊤                         => (Nat.pair 2 0) + 1
-  | _, ⊥                         => (Nat.pair 3 0) + 1
-  | _, φ ⋏ ψ                     => (Nat.pair 4 <| φ.toNat.pair ψ.toNat) + 1
-  | _, φ ⋎ ψ                     => (Nat.pair 5 <| φ.toNat.pair ψ.toNat) + 1
-  | _, ∀' φ                      => (Nat.pair 6 <| φ.toNat) + 1
-  | _, ∃' φ                      => (Nat.pair 7 <| φ.toNat) + 1
+def toNat {n : ℕ} : Semiformula L ξ n → ℕ
+  |  rel (arity := arity) R v => (Nat.pair 0 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1
+  | nrel (arity := arity) R v => (Nat.pair 1 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1
+  |                         ⊤ => (Nat.pair 2 0) + 1
+  |                         ⊥ => (Nat.pair 3 0) + 1
+  |                     φ ⋏ ψ => (Nat.pair 4 <| φ.toNat.pair ψ.toNat) + 1
+  |                     φ ⋎ ψ => (Nat.pair 5 <| φ.toNat.pair ψ.toNat) + 1
+  |                      ∀' φ => (Nat.pair 6 <| φ.toNat) + 1
+  |                      ∃' φ => (Nat.pair 7 <| φ.toNat) + 1
 
 def ofNat : (n : ℕ) → ℕ → Option (Semiformula L ξ n)
-  | _, 0 => none
+  | _,     0 => none
   | n, e + 1 =>
     let idx := e.unpair.1
     let c := e.unpair.2
@@ -126,26 +138,65 @@ def ofNat : (n : ℕ) → ℕ → Option (Semiformula L ξ n)
         return ∃' φ
     | _ => none
 
-lemma ofNat_toNat : {n : ℕ} → ∀ φ : Semiformula L ξ n, ofNat n (toNat φ) = some φ
-  | _, rel R v  => by
+lemma ofNat_toNat {n : ℕ} : ∀ φ : Semiformula L ξ n, ofNat n (toNat φ) = some φ
+  |  rel R v => by
     simp only [toNat, ofNat, Nat.unpair_pair, Option.pure_def, Option.bind_eq_bind]
     rw [Nat.unpair_pair, Nat.unpair_pair]
     simp [Matrix.getM_pure]
-  | _, nrel R v => by
+  | nrel R v => by
     simp only [toNat, ofNat, Nat.unpair_pair, Option.pure_def, Option.bind_eq_bind]
     rw [Nat.unpair_pair, Nat.unpair_pair]
     simp [Matrix.getM_pure]
-  | _, ⊤        => by simp [toNat, ofNat]
-  | _, ⊥        => by simp [toNat, ofNat]
-  | _, φ ⋎ ψ    => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
-  | _, φ ⋏ ψ    => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
-  | _, ∀' φ     => by simp [toNat, ofNat, ofNat_toNat φ]
-  | _, ∃' φ     => by simp [toNat, ofNat, ofNat_toNat φ]
+  |        ⊤ => by simp [toNat, ofNat]
+  |        ⊥ => by simp [toNat, ofNat]
+  |    φ ⋎ ψ => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
+  |    φ ⋏ ψ => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
+  |     ∀' φ => by simp [toNat, ofNat, ofNat_toNat φ]
+  |     ∃' φ => by simp [toNat, ofNat, ofNat_toNat φ]
 
 instance encodable : Encodable (Semiformula L ξ n) where
   encode := toNat
   decode := ofNat n
   encodek := ofNat_toNat
+
+open Encodable
+
+lemma encode_eq_toNat
+    (φ : Semiformula L ξ n) : encode φ = toNat φ := rfl
+
+lemma encode_rel {arity : ℕ} (R : L.Rel arity) (v : Fin arity → Semiterm L ξ n) :
+    encode (Semiformula.rel R v) = (Nat.pair 0 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1 := rfl
+
+lemma encode_nrel {arity : ℕ} (R : L.Rel arity) (v : Fin arity → Semiterm L ξ n) :
+    encode (Semiformula.nrel R v) = (Nat.pair 1 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1 := rfl
+
+lemma encode_verum : encode (⊤ : Semiformula L ξ n) = (Nat.pair 2 0) + 1 := rfl
+
+lemma encode_falsum : encode (⊥ : Semiformula L ξ n) = (Nat.pair 3 0) + 1 := rfl
+
+lemma encode_and (φ ψ : Semiformula L ξ n) : encode (φ ⋏ ψ) = (Nat.pair 4 <| φ.toNat.pair ψ.toNat) + 1 := rfl
+
+lemma encode_or (φ ψ : Semiformula L ξ n) : encode (φ ⋎ ψ) = (Nat.pair 5 <| φ.toNat.pair ψ.toNat) + 1 := rfl
+
+lemma encode_all (φ : Semiformula L ξ (n + 1)) : encode (∀' φ) = (Nat.pair 6 <| φ.toNat) + 1 := rfl
+
+lemma encode_ex (φ : Semiformula L ξ (n + 1)) : encode (∃' φ) = (Nat.pair 7 <| φ.toNat) + 1 := rfl
+
+@[simp] lemma encode_emb (σ : Semisentence L n) :
+    encode (Rewriting.embedding σ : Semiformula L ξ n) = encode σ := by
+  induction σ using rec' <;>
+    simp [coe_rel, coe_nrel,
+      encode_rel, encode_nrel, encode_verum, encode_falsum, encode_and, encode_or, encode_all, encode_ex,
+      ← encode_eq_toNat, *]
+
+@[simp] lemma encode_inj_sentence {σ : Semisentence L n} {φ : Semiformula L ξ n} :
+    encode φ = encode σ ↔ φ = Rewriting.embedding σ := by
+  constructor
+  · intro h; apply encode_inj.mp; simpa
+  · rintro rfl; simp
+
+@[simp] lemma encode_inj_sentence' {σ : Semisentence L n} {φ : Semiformula L ξ n} :
+    encode σ = encode φ ↔ φ = Rewriting.embedding σ := by rw [←encode_inj_sentence, eq_comm]
 
 end Semiformula
 

--- a/Foundation/FirstOrder/Basic/Syntax/Formula.lean
+++ b/Foundation/FirstOrder/Basic/Syntax/Formula.lean
@@ -11,9 +11,7 @@ The quantification is represented by de Bruijn index.
 
 -/
 
-namespace LO
-
-namespace FirstOrder
+namespace LO.FirstOrder
 
 inductive Semiformula (L : Language) (ξ : Type*) : ℕ → Type _ where
   |  verum {n} : Semiformula L ξ n
@@ -34,6 +32,18 @@ abbrev Semisentence (L : Language) (n : ℕ) := Semiformula L Empty n
 abbrev SyntacticSemiformula (L : Language) (n : ℕ) := Semiformula L ℕ n
 
 abbrev SyntacticFormula (L : Language) := SyntacticSemiformula L 0
+
+abbrev ArithmeticSemiformula (ξ : Type*) (n : ℕ) := Semiformula ℒₒᵣ ξ n
+
+abbrev ArithmeticFormula (ξ : Type*) := Formula ℒₒᵣ ξ
+
+abbrev ArithmeticSemisentence (n : ℕ) := Semisentence ℒₒᵣ n
+
+abbrev ArithmeticSentence := Sentence ℒₒᵣ
+
+abbrev ArithmeticSyntacticSemiformula (n : ℕ) := SyntacticSemiformula ℒₒᵣ n
+
+abbrev ArithmeticSyntacticFormula := SyntacticFormula ℒₒᵣ
 
 namespace Semiformula
 
@@ -680,6 +690,6 @@ lemma add_def : T + U = T ∪ U := rfl
 
 end Theory
 
-end FirstOrder
+abbrev ArithmeticTheory := Theory ℒₒᵣ
 
-end LO
+end LO.FirstOrder

--- a/Foundation/FirstOrder/Basic/Syntax/Rew.lean
+++ b/Foundation/FirstOrder/Basic/Syntax/Rew.lean
@@ -230,6 +230,12 @@ instance : Coe (Semisentence L n) (SyntacticSemiformula L n) := ⟨Rewriting.emb
 
 @[simp] lemma coe_inj (σ π : Semisentence L n) : (σ : SyntacticSemiformula L n) = π ↔ σ = π := Rewriting.embedding_injective.eq_iff
 
+lemma coe_rel [IsEmpty ο] {k : ℕ} (R : L.Rel k) (v : Fin k → Semiterm L ο n) :
+    (Rewriting.embedding (rel R v) : Semiformula L ξ n) = (rel R fun i ↦ Rew.emb (v i)) := by rfl
+
+lemma coe_nrel [IsEmpty ο] {k : ℕ} (R : L.Rel k) (v : Fin k → Semiterm L ο n) :
+    (Rewriting.embedding (nrel R v) : Semiformula L ξ n) = (nrel R fun i ↦ Rew.emb (v i)) := by rfl
+
 lemma coe_substitute_eq_substitute_coe (φ : Semisentence L k) (v : Fin k → Semiterm L Empty n) :
     (↑(φ ⇜ v) : SyntacticSemiformula L n) = (↑φ : SyntacticSemiformula L k)⇜(fun i ↦ (↑(v i) : Semiterm L ℕ n)) :=
   Rewriting.embedding_substitute_eq_substitute_embedding φ v

--- a/Foundation/FirstOrder/ISigma1/Metamath/Coding.lean
+++ b/Foundation/FirstOrder/ISigma1/Metamath/Coding.lean
@@ -1,83 +1,7 @@
 import Foundation.FirstOrder.ISigma1.Metamath.Formula.Typed
 import Mathlib.Combinatorics.Colex
 
-
 open Encodable LO FirstOrder Arith PeanoMinus IOpen ISigma0 ISigma1 Metamath
-
-namespace LO.FirstOrder
-
-variable {L : Language} {ξ : Type*}
-
-
-namespace Semiterm
-
-variable [Encodable ξ] [(k : ℕ) → Encodable (L.Func k)]
-
-lemma encode_eq_toNat (t : Semiterm L ξ n) : Encodable.encode t = toNat t := rfl
-
-lemma toNat_func {k} (f : L.Func k) (v : Fin k → Semiterm L ξ n) :
-    toNat (func f v) = (Nat.pair 2 <| Nat.pair k <| Nat.pair (encode f) <| Matrix.vecToNat fun i ↦ toNat (v i)) + 1 := rfl
-
-@[simp] lemma encode_emb (t : Semiterm L Empty n) : Encodable.encode (Rew.emb t : Semiterm L ξ n) = Encodable.encode t := by
-  simp only [encode_eq_toNat]
-  induction t
-  · simp [toNat]
-  · contradiction
-  · simp [Rew.func, toNat_func, *]
-
-end Semiterm
-
-namespace  Semiformula
-
-/-! TODO: move to Foundation-/
-lemma embedding_rel [IsEmpty ο] {k : ℕ} (R : L.Rel k) (v : Fin k → Semiterm L ο n) :
-    (Rewriting.embedding (rel R v) : Semiformula L ξ n) = (rel R fun i ↦ Rew.emb (v i)) := by rfl
-
-lemma embedding_nrel [IsEmpty ο] {k : ℕ} (R : L.Rel k) (v : Fin k → Semiterm L ο n) :
-    (Rewriting.embedding (nrel R v) : Semiformula L ξ n) = (nrel R fun i ↦ Rew.emb (v i)) := by rfl
-
-open Encodable
-
-variable [Encodable ξ] [(k : ℕ) → Encodable (L.Func k)] [(k : ℕ) → Encodable (L.Rel k)]
-
-lemma encode_eq_toNat
-    (φ : Semiformula L ξ n) : Encodable.encode φ = toNat φ := rfl
-
-lemma encode_rel {arity : ℕ} (R : L.Rel arity) (v : Fin arity → Semiterm L ξ n) :
-    encode (Semiformula.rel R v) = (Nat.pair 0 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1 := rfl
-
-lemma encode_nrel {arity : ℕ} (R : L.Rel arity) (v : Fin arity → Semiterm L ξ n) :
-    encode (Semiformula.nrel R v) = (Nat.pair 1 <| arity.pair <| (encode R).pair <| Matrix.vecToNat fun i ↦ encode (v i)) + 1 := rfl
-
-lemma encode_verum : encode (⊤ : Semiformula L ξ n) = (Nat.pair 2 0) + 1 := rfl
-
-lemma encode_falsum : encode (⊥ : Semiformula L ξ n) = (Nat.pair 3 0) + 1 := rfl
-
-lemma encode_and (φ ψ : Semiformula L ξ n) : encode (φ ⋏ ψ) = (Nat.pair 4 <| φ.toNat.pair ψ.toNat) + 1 := rfl
-
-lemma encode_or (φ ψ : Semiformula L ξ n) : encode (φ ⋎ ψ) = (Nat.pair 5 <| φ.toNat.pair ψ.toNat) + 1 := rfl
-
-lemma encode_all (φ : Semiformula L ξ (n + 1)) : encode (∀' φ) = (Nat.pair 6 <| φ.toNat) + 1 := rfl
-
-lemma encode_ex (φ : Semiformula L ξ (n + 1)) : encode (∃' φ) = (Nat.pair 7 <| φ.toNat) + 1 := rfl
-
-@[simp] lemma encode_emb
-    (φ : Semisentence L n) : Encodable.encode (Rewriting.embedding φ : Semiformula L ξ n) = Encodable.encode φ := by
-  induction φ using rec' <;>
-    simp [embedding_rel, embedding_nrel,
-      encode_rel, encode_nrel, encode_verum, encode_falsum, encode_and, encode_or, encode_all, encode_ex,
-      ← encode_eq_toNat, *]
-
-end Semiformula
-
-namespace Semiformula.Operator
-
-lemma lt_eq [L.LT] (t u : Semiterm L ξ n) :
-    LT.lt.operator ![t, u] = Semiformula.rel Language.LT.lt ![t, u] := by simp [operator, LT.sentence_eq, rew_rel]
-
-end Semiformula.Operator
-
-end LO.FirstOrder
 
 namespace LO.ISigma1.Metamath
 
@@ -649,11 +573,11 @@ open FirstOrder Arith PeanoMinus IOpen ISigma0 ISigma1 Metamath
 @[simp] lemma codeIn'_ball (t : SyntacticSemiterm ℒₒᵣ n) (φ : SyntacticSemiformula ℒₒᵣ (n + 1)) :
     (⌜∀[“#0 < !!(Rew.bShift t)”] φ⌝ : (Language.codeIn ℒₒᵣ V).Semiformula n) = Language.Semiformula.ball ⌜t⌝ (.cast (n := ↑(n + 1)) ⌜φ⌝) := by
   ext; simp [LO.ball, imp_eq, Language.Semiformula.cast,
-    Language.Semiformula.ball, Semiformula.Operator.lt_eq]
+    Language.Semiformula.ball, Semiformula.Operator.lt_def]
 @[simp] lemma codeIn'_bex (t : SyntacticSemiterm ℒₒᵣ n) (φ : SyntacticSemiformula ℒₒᵣ (n + 1)) :
     (⌜∃[“#0 < !!(Rew.bShift t)”] φ⌝ : (Language.codeIn ℒₒᵣ V).Semiformula n) = Language.Semiformula.bex ⌜t⌝ (.cast (n := ↑(n + 1)) ⌜φ⌝) := by
   ext; simp [LO.bex, imp_eq, Language.Semiformula.cast,
-    Language.Semiformula.ball, Semiformula.Operator.lt_eq]
+    Language.Semiformula.ball, Semiformula.Operator.lt_def]
 
 instance : GoedelQuote (Sentence L) ((L.codeIn V).Formula) := ⟨fun σ ↦ (⌜Rew.embs ▹ σ⌝ : (Language.codeIn L V).Semiformula (0 : ℕ))⟩
 

--- a/Foundation/FirstOrder/Incompleteness/ConsistencyPredicate.lean
+++ b/Foundation/FirstOrder/Incompleteness/ConsistencyPredicate.lean
@@ -16,29 +16,44 @@ variable {V : Type*} [ORingStruc V] [V ⊧ₘ* 𝐈𝚺₁]
 
 section WitnessComparisons
 
-variable (T : Theory ℒₒᵣ) [T.Delta1Definable]
+variable (T : ArithmeticTheory) [T.Delta1Definable] (V)
 
-def _root_.LO.FirstOrder.Theory.Consistencyₐ (φ : V) : Prop := ¬T.Provableₐ (⌜ℒₒᵣ⌝.neg φ)
+def _root_.LO.FirstOrder.ArithmeticTheory.IsConsistent : Prop := ¬T.Provable (⌜(⊥ : ArithmeticSentence)⌝ : V)
 
-lemma _root_.LO.FirstOrder.Theory.Consistencyₐ.quote_iff {φ : Sentence ℒₒᵣ} :
-    T.Consistencyₐ (⌜φ⌝ : V) ↔ ¬T.Provableₐ (⌜∼φ⌝ : V) := by
-  simp [LO.FirstOrder.Theory.Consistencyₐ, quote_sentence_eq_quote_emb (∼φ)]
+variable {V}
+
+def _root_.LO.FirstOrder.ArithmeticTheory.Consistency (φ : V) : Prop := ¬T.Provable (⌜ℒₒᵣ⌝.neg φ)
+
+lemma _root_.LO.FirstOrder.Theory.Consistency.quote_iff {φ : Sentence ℒₒᵣ} :
+    T.Consistency (⌜φ⌝ : V) ↔ ¬T.Provable (⌜∼φ⌝ : V) := by
+  simp [ArithmeticTheory.Consistency, quote_sentence_eq_quote_emb (∼φ)]
 
 section
 
-noncomputable def _root_.LO.FirstOrder.Theory.consistencyₐ : 𝚷₁.Semisentence 1 := .mkPi
-  “φ. ∀ nφ, !(ℒₒᵣ).lDef.negDef nφ φ → ¬!T.provableₐ nφ” (by simp)
+noncomputable def _root_.LO.FirstOrder.ArithmeticTheory.isConsistent : 𝚷₁.Sentence :=
+  .mkPi (∼T.provabilityPred ⊥) (by simp)
 
-lemma consistencyₐ_defined : 𝚷₁-Predicate (T.Consistencyₐ : V → Prop) via T.consistencyₐ := by
+@[simp] lemma isConsistent_defined : Semiformula.Evalbm V ![] (T.isConsistent : Sentence ℒₒᵣ) ↔ T.IsConsistent V := by
+  simp [models₀_iff, ArithmeticTheory.isConsistent, ArithmeticTheory.IsConsistent]
+
+noncomputable def _root_.LO.FirstOrder.ArithmeticTheory.consistency : 𝚷₁.Semisentence 1 := .mkPi
+  “φ. ∀ nφ, !(ℒₒᵣ).lDef.negDef nφ φ → ¬!T.provable nφ” (by simp)
+
+lemma consistency_defined : 𝚷₁-Predicate (T.Consistency : V → Prop) via T.consistency := by
   intro v
-  simp [Theory.Consistencyₐ, Theory.consistencyₐ, ((ℒₒᵣ).codeIn V).neg_defined.df.iff]
+  simp [ArithmeticTheory.Consistency, ArithmeticTheory.consistency, ((ℒₒᵣ).codeIn V).neg_defined.df.iff]
 
-@[simp] lemma eval_consistencyₐ (v) :
-    Semiformula.Evalbm V v T.consistencyₐ.val ↔ T.Consistencyₐ (v 0) := (consistencyₐ_defined T).df.iff v
+@[simp] lemma eval_consistency (v) :
+    Semiformula.Evalbm V v T.consistency.val ↔ T.Consistency (v 0) := (consistency_defined T).df.iff v
 
-instance consistencyₐ_definable : 𝚷₁-Predicate (T.Consistencyₐ : V → Prop) := (consistencyₐ_defined T).to_definable
+instance consistency_definable : 𝚷₁-Predicate (T.Consistency : V → Prop) := (consistency_defined T).to_definable
 
 end
+
+def isConsistent_eq : T.isConsistent = T.standardPr.con := rfl
+
+@[simp] lemma standard_isConsistent [𝐑₀ ⪯ T] : T.IsConsistent ℕ ↔ Entailment.Consistent T := by
+  simp [ArithmeticTheory.IsConsistent, Entailment.consistent_iff_unprovable_bot, Axiom.provable_iff]
 
 end WitnessComparisons
 

--- a/Foundation/FirstOrder/Incompleteness/Delta1.lean
+++ b/Foundation/FirstOrder/Incompleteness/Delta1.lean
@@ -15,16 +15,16 @@ axiom PA_delta1Definable : 𝐏𝐀.Delta1Definable
 
 attribute [instance] ISigma1_delta1Definable PA_delta1Definable
 
-instance : 𝐈𝚺₁ ⪱ 𝐈𝚺₁ + 𝐂𝐨𝐧[𝐈𝚺₁] := inferInstance
+instance : 𝐈𝚺₁ ⪱ 𝐈𝚺₁.AddSelfConsistency := inferInstance
 
-instance : 𝐈𝚺₁ + 𝐂𝐨𝐧[𝐈𝚺₁] ⪯ 𝐓𝐀 := inferInstance
+instance : 𝐈𝚺₁.AddSelfConsistency ⪯ 𝐓𝐀 := inferInstance
 
-instance : 𝐈𝚺₁ ⪱ 𝐈𝚺₁ + ¬𝐂𝐨𝐧[𝐈𝚺₁] := inferInstance
+instance : 𝐈𝚺₁ ⪱ 𝐈𝚺₁.AddSelfInconsistency := inferInstance
 
-instance : 𝐏𝐀 ⪱ 𝐏𝐀 + 𝐂𝐨𝐧[𝐏𝐀] := inferInstance
+instance : 𝐏𝐀 ⪱ 𝐏𝐀.AddSelfConsistency := inferInstance
 
-instance : 𝐏𝐀 + 𝐂𝐨𝐧[𝐏𝐀] ⪯ 𝐓𝐀 := inferInstance
+instance : 𝐏𝐀.AddSelfConsistency ⪯ 𝐓𝐀 := inferInstance
 
-instance : 𝐏𝐀 ⪱ 𝐏𝐀 + ¬𝐂𝐨𝐧[𝐏𝐀] := inferInstance
+instance : 𝐏𝐀 ⪱ 𝐏𝐀.AddSelfInconsistency := inferInstance
 
 end LO.FirstOrder

--- a/Foundation/FirstOrder/Incompleteness/DerivabilityCondition/Basic.lean
+++ b/Foundation/FirstOrder/Incompleteness/DerivabilityCondition/Basic.lean
@@ -1,23 +1,12 @@
 import Foundation.FirstOrder.Arith.Basic
 import Foundation.Logic.HilbertStyle.Supplemental
+import Foundation.Meta.ClProver
 
-namespace LO.FirstOrder
+namespace LO.ProvabilityLogic
 
-namespace Theory.Alt
+open FirstOrder
 
-variable {L : Language} [L.DecidableEq] {T U : Theory L}
-
---instance [s : T ⪯ U] : T ⪯ U.toAxiom.thy := s
-
-instance [s : T ⪯ U] : T.toAxiom ⪯ U.toAxiom :=
-  ⟨fun _ b ↦ Axiom.provable_iff.mpr (s.pbl (Axiom.provable_iff.mp b))⟩
-
-end Theory.Alt
-
-
-namespace DerivabilityCondition
-
-variable [Semiterm.Operator.GoedelNumber L (Sentence L)]
+variable {L : Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
 
 structure ProvabilityPredicate (T₀ : Theory L) (T : Theory L) where
   prov : Semisentence L 1
@@ -29,9 +18,9 @@ variable {T₀ T : Theory L}
 
 @[coe] def pr (𝔅 : ProvabilityPredicate T₀ T) (σ : Sentence L) : Sentence L := 𝔅.prov/[⌜σ⌝]
 
-instance : CoeFun (ProvabilityPredicate T₀ T) (fun _ => Sentence L → Sentence L) := ⟨pr⟩
+instance : CoeFun (ProvabilityPredicate T₀ T) (fun _ ↦ Sentence L → Sentence L) := ⟨pr⟩
 
-def con (𝔅 : ProvabilityPredicate T₀ T) : Sentence L := ∼(𝔅 ⊥)
+def con (𝔅 : ProvabilityPredicate T₀ T) : Sentence L := ∼𝔅 ⊥
 
 end ProvabilityPredicate
 
@@ -44,24 +33,24 @@ namespace ProvabilityPredicate
 variable {T₀ T : Theory L}
 
 class HBL2 (𝔅 : ProvabilityPredicate T₀ T) where
-  protected D2 {σ τ : Sentence L} : T₀ ⊢!. 𝔅 (σ ➝ τ) ➝ (𝔅 σ) ➝ (𝔅 τ)
+  protected D2 (σ τ : Sentence L) : T₀ ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ
 
 class HBL3 (𝔅 : ProvabilityPredicate T₀ T) where
-  protected D3 {σ : Sentence L} : T₀ ⊢!. (𝔅 σ) ➝ 𝔅 (𝔅 σ)
+  protected D3 (σ : Sentence L) : T₀ ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ)
 
 class HBL (𝔅 : ProvabilityPredicate T₀ T) extends 𝔅.HBL2, 𝔅.HBL3
 
 class Loeb (𝔅 : ProvabilityPredicate T₀ T) where
-  protected LT {σ : Sentence L} : T ⊢!. (𝔅 σ) ➝ σ → T ⊢!. σ
+  protected LT (σ : Sentence L) : T ⊢!. 𝔅 σ ➝ σ → T ⊢!. σ
 
 class FormalizedLoeb (𝔅 : ProvabilityPredicate T₀ T) where
-  protected FLT {σ : Sentence L} : T₀ ⊢!. 𝔅 ((𝔅 σ) ➝ σ) ➝ (𝔅 σ)
+  protected FLT (σ : Sentence L) : T₀ ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ
 
 class Rosser (𝔅 : ProvabilityPredicate T₀ T) where
-  protected Ro {σ : Sentence L} : T ⊢!. ∼σ → T₀ ⊢!. ∼(𝔅 σ)
+  protected Ro (σ : Sentence L) : T ⊢!. ∼σ → T₀ ⊢!. ∼𝔅 σ
 
 class Sound (𝔅 : ProvabilityPredicate T₀ T) (N : outParam Type*) [Nonempty N] [Structure L N] where
-  protected sound {σ : Sentence L} : N ⊧ₘ₀ 𝔅 σ ↔ T ⊢!. σ
+  protected sound (σ : Sentence L) : N ⊧ₘ₀ 𝔅 σ ↔ T ⊢!. σ
 
 protected alias sound := Sound.sound
 
@@ -81,52 +70,50 @@ protected alias LT := Loeb.LT
 protected alias FLT := FormalizedLoeb.FLT
 protected alias Ro := Rosser.Ro
 
-lemma D1_shift [L.DecidableEq] [T₀ ⪯ T] : T ⊢!. σ → T ⊢!. (𝔅 σ) := by
+lemma D1_shift [L.DecidableEq] [T₀ ⪯ T] : T ⊢!. σ → T ⊢!. 𝔅 σ := by
   intro h;
   apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
   apply 𝔅.D1 h;
 
-lemma D2_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] : T ⊢!. 𝔅 (σ ➝ τ) ➝ (𝔅 σ) ➝ (𝔅 τ) := by
+lemma D2_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] : T ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ := by
   apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
   apply 𝔅.D2;
 
-lemma D3_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL3] : T ⊢!. (𝔅 σ) ➝ 𝔅 (𝔅 σ) := by
+lemma D3_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL3] : T ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ) := by
   apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
   apply 𝔅.D3;
 
-lemma FLT_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.FormalizedLoeb] : T ⊢!. 𝔅 ((𝔅 σ) ➝ σ) ➝ (𝔅 σ) := by
+lemma FLT_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.FormalizedLoeb] : T ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
   apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
   apply 𝔅.FLT;
 
-lemma D2' [𝔅.HBL2] [Entailment.ModusPonens T] : T₀ ⊢!. 𝔅 (σ ➝ τ) → T₀ ⊢!. (𝔅 σ) ➝ (𝔅 τ) := by
+lemma D2' [𝔅.HBL2] (σ τ) : T₀ ⊢!. 𝔅 (σ ➝ τ) → T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := by
   intro h;
-  exact 𝔅.D2 ⨀ h;
+  exact 𝔅.D2 σ τ ⨀ h;
 
-lemma prov_distribute_imply [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) : T₀ ⊢!. (𝔅 σ) ➝ (𝔅 τ) := 𝔅.D2' $ 𝔅.D1 h
+lemma prov_distribute_imply [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) : T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := 𝔅.D2' σ τ <| 𝔅.D1 h
 
 lemma prov_distribute_imply' [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] (h : T₀ ⊢!. σ ➝ τ) :
-    T₀ ⊢!. (𝔅 σ) ➝ (𝔅 τ) := prov_distribute_imply $ WeakerThan.pbl h
+    T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := prov_distribute_imply $ WeakerThan.pbl h
 
 lemma prov_distribute_imply'' [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) :
-    T ⊢!. (𝔅 σ) ➝ (𝔅 τ) := WeakerThan.pbl $ prov_distribute_imply h
+    T ⊢!. 𝔅 σ ➝ 𝔅 τ := WeakerThan.pbl $ prov_distribute_imply h
 
-lemma prov_distribute_iff [𝔅.HBL2] (h : T ⊢!. σ ⭤ τ) : T₀ ⊢!. (𝔅 σ) ⭤ (𝔅 τ) := by
+lemma prov_distribute_iff [𝔅.HBL2] (h : T ⊢!. σ ⭤ τ) : T₀ ⊢!. 𝔅 σ ⭤ 𝔅 τ := by
   apply E!_intro;
   . exact prov_distribute_imply $ K!_left h;
   . exact prov_distribute_imply $ K!_right h;
 
-lemma prov_distribute_and  [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ (𝔅 σ) ⋏ (𝔅 τ) := by
-  have h₁ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ (𝔅 σ) := 𝔅.D2' <| 𝔅.D1 and₁!;
-  have h₂ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ (𝔅 τ) := 𝔅.D2' <| 𝔅.D1 and₂!;
+lemma prov_distribute_and  [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ ⋏ 𝔅 τ := by
+  have h₁ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ := 𝔅.D2' _ _ <| 𝔅.D1 and₁!;
+  have h₂ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 τ := 𝔅.D2' _ _ <| 𝔅.D1 and₂!;
   exact right_K!_intro h₁ h₂;
 
-def prov_distribute_and' [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) → T₀ ⊢!. (𝔅 σ) ⋏ (𝔅 τ) := λ h => prov_distribute_and ⨀ h
+def prov_distribute_and' [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) → T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ := λ h => prov_distribute_and ⨀ h
 
-def prov_collect_and [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. (𝔅 σ) ⋏ (𝔅 τ) ➝ 𝔅 (σ ⋏ τ) := by
-  have h₁ : T₀ ⊢!. (𝔅 σ) ➝ 𝔅 (τ ➝ σ ⋏ τ) := prov_distribute_imply $ and₃!;
-  have h₂ : T₀ ⊢!. 𝔅 (τ ➝ σ ⋏ τ) ➝ (𝔅 τ) ➝ 𝔅 (σ ⋏ τ) := 𝔅.D2;
-  apply CK!_iff_CC!.mpr;
-  exact C!_trans h₁ h₂;
+def prov_collect_and [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ ➝ 𝔅 (σ ⋏ τ) := by
+  have : T₀ ⊢!. 𝔅 σ ➝ 𝔅 (τ ➝ σ ⋏ τ) := prov_distribute_imply (by cl_prover)
+  cl_prover [this, 𝔅.D2 τ (σ ⋏ τ)]
 
 end
 
@@ -145,18 +132,25 @@ section GoedelSentence
 
 variable [Diagonalization T₀]
 
-local notation "γ" => 𝔅.goedel
+local notation "𝗚" => 𝔅.goedel
 
-lemma goedel_spec : T₀ ⊢!. γ ⭤ ∼𝔅 γ := by
+variable (𝔅)
+
+lemma ProvabilityPredicate.goedel_spec : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := by
   convert (diag (T := T₀) “x. ¬!𝔅.prov x”);
   simp [goedel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs];
   rfl;
 
+lemma ProvabilityPredicate.goedel_spec_self [L.DecidableEq] [T₀ ⪯ T] :
+    T ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := WeakerThan.pbl 𝔅.goedel_spec
+
+variable {𝔅}
+
 variable [T₀ ⪯ T]
 
-private lemma goedel_specAux₁ [L.DecidableEq] : T ⊢!. γ ⭤ ∼𝔅 γ := WeakerThan.pbl (𝓢 := T₀.toAxiom) goedel_spec
+private lemma goedel_specAux₁ [L.DecidableEq] : T ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := WeakerThan.pbl (𝓢 := T₀.toAxiom) 𝔅.goedel_spec
 
-private lemma goedel_specAux₂ [L.DecidableEq] : T ⊢!. ∼γ ➝ 𝔅 γ := CN!_of_CN!_left $ K!_right goedel_specAux₁
+private lemma goedel_specAux₂ [L.DecidableEq] : T ⊢!. ∼𝗚 ➝ 𝔅 𝗚 := CN!_of_CN!_left $ K!_right goedel_specAux₁
 
 end GoedelSentence
 
@@ -169,35 +163,36 @@ section First
 
 variable [T₀ ⪯ T] [Diagonalization T₀]
 
-local notation "γ" => 𝔅.goedel
+local notation "𝗚" => 𝔅.goedel
 
-variable [Entailment.Consistent T]
+variable [L.DecidableEq] [Entailment.Consistent T]
 
-theorem unprovable_goedel [L.DecidableEq] : T ⊬. γ := by
+theorem unprovable_goedel : T ⊬. 𝗚 := by
   intro h;
-  have h₁ : T ⊢!. 𝔅 γ := D1_shift h;
-  have h₂ : T ⊢!. ∼𝔅 γ := (K!_left goedel_specAux₁) ⨀ h;
-  have : T ⊢!. ⊥ := (N!_iff_CO!.mp h₂) ⨀ h₁;
+  have h₁ : T ⊢!. 𝔅 𝗚 := D1_shift h
+  have h₂ : T ⊢!. ∼𝔅 𝗚 := K!_left goedel_specAux₁ ⨀ h
+  have : T ⊢!. ⊥ := by cl_prover [h₁, h₂]
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this)
-  contradiction;
+  contradiction
 
-theorem unrefutable_goedel [(k : ℕ) → DecidableEq (L.Func k)] [(k : ℕ) → DecidableEq (L.Rel k)] [𝔅.GoedelSound] : T ⊬. ∼γ := by
+theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
   intro h₂;
-  have h₁ : T ⊢!. γ := γ_sound $ goedel_specAux₂ ⨀ h₂;
+  have h₁ : T ⊢!. 𝗚 := γ_sound $ goedel_specAux₂ ⨀ h₂;
   have : T ⊢!. ⊥ := (N!_iff_CO!.mp h₂) ⨀ h₁;
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
   contradiction;
 
-theorem goedel_independent [L.DecidableEq] [𝔅.GoedelSound] : Entailment.Undecidable T ↑γ := by
-  suffices T ⊬. γ ∧ T ⊬. ∼γ by simpa [Entailment.Undecidable, not_or, Axiom.unprovable_iff] using this
+theorem goedel_independent [𝔅.GoedelSound] : Entailment.Undecidable T ↑𝗚 := by
+  suffices T ⊬. 𝗚 ∧ T ⊬. ∼𝗚 by simpa [Entailment.Undecidable, not_or, Axiom.unprovable_iff] using this
   constructor
   . apply unprovable_goedel
   . apply unrefutable_goedel
 
-theorem first_incompleteness [L.DecidableEq] [𝔅.GoedelSound]
-  : ¬Entailment.Complete T := Entailment.incomplete_iff_exists_undecidable.mpr ⟨γ, goedel_independent⟩
+theorem first_incompleteness [𝔅.GoedelSound] :
+    ¬Entailment.Complete T :=
+  Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝗚, goedel_independent⟩
 
 end First
 
@@ -205,49 +200,38 @@ section Second
 
 variable [L.DecidableEq] [𝔅.HBL]
 
-local notation "γ" => 𝔅.goedel
+local notation "𝗚" => 𝔅.goedel
 
-lemma formalized_consistent_of_existance_unprovable : T₀ ⊢!. ∼(𝔅 σ) ➝ 𝔅.con := contra! $ 𝔅.D2 ⨀ (𝔅.D1 efq!)
+lemma formalized_consistent_of_existance_unprovable (σ) : T₀ ⊢!. ∼𝔅 σ ➝ 𝔅.con := contra! $ 𝔅.D2 _ _ ⨀ (𝔅.D1 efq!)
 
-private lemma consistency_lemma_1 [T₀ ⪯ U] : (U ⊢!. 𝔅.con ➝ ∼(𝔅 σ)) ↔ (U ⊢!. (𝔅 σ) ➝ 𝔅 (∼σ)) := by
-  constructor;
-  . intro H;
-    exact C!_of_CNN! $ C!_trans (WeakerThan.pbl (𝓢 := T₀.toAxiom) formalized_consistent_of_existance_unprovable) H;
-  . intro H
-    apply contra!
-    have : T₀ ⊢!. (𝔅 σ) ⋏ 𝔅 (∼σ) ➝ 𝔅 ⊥ := C!_trans prov_collect_and $ prov_distribute_imply lac!;
-    have : U ⊢!. (𝔅 σ) ➝ 𝔅 (∼σ) ➝ 𝔅 ⊥ := WeakerThan.pbl $ CK!_iff_CC!.mp $ this;
-    exact this ⨀₁ H;
-
-private lemma consistency_lemma_2 : T₀ ⊢!. ((𝔅 σ) ➝ 𝔅 (∼σ)) ➝ (𝔅 σ) ➝ 𝔅 ⊥ := by
-  have : T ⊢!. σ ➝ ∼σ ➝ ⊥ := CK!_iff_CC!.mp lac!
-  have : T₀ ⊢!. (𝔅 σ) ➝ 𝔅 (∼σ ➝ ⊥)  := prov_distribute_imply this;
-  have : T₀ ⊢!. (𝔅 σ) ➝ (𝔅 (∼σ) ➝ 𝔅 ⊥) := C!_trans this 𝔅.D2;
-  -- TODO: more simple proof
-  apply FiniteContext.deduct'!;
-  apply FiniteContext.deduct!;
-  have d₁ : [(𝔅 σ), (𝔅 σ) ➝ 𝔅 (∼σ)] ⊢[T₀.toAxiom]! (𝔅 σ) := FiniteContext.by_axm!;
-  have d₂ : [(𝔅 σ), (𝔅 σ) ➝ 𝔅 (∼σ)] ⊢[T₀.toAxiom]! (𝔅 σ) ➝ 𝔅 (∼σ) := FiniteContext.by_axm!;
-  have d₃ : [(𝔅 σ), (𝔅 σ) ➝ 𝔅 (∼σ)] ⊢[T₀.toAxiom]! 𝔅 (∼σ) := d₂ ⨀ d₁;
-  exact ((FiniteContext.of'! this) ⨀ d₁) ⨀ d₃;
+private lemma consistency_lemma_2 : T₀ ⊢!. (𝔅 σ ➝ 𝔅 (∼σ)) ➝ 𝔅 σ ➝ 𝔅 ⊥ := by
+  have : T₀ ⊢!. 𝔅 σ ➝ 𝔅 (∼σ ➝ ⊥) := prov_distribute_imply <| by cl_prover
+  cl_prover [this, 𝔅.D2 (∼σ) ⊥]
 
 variable [T₀ ⪯ T] [Diagonalization T₀]
 
 /-- Formalized First Incompleteness Theorem -/
-theorem formalized_unprovable_goedel : T ⊢!. 𝔅.con ➝ ∼𝔅 γ := by
-  have h₁ : T₀ ⊢!. 𝔅 γ ➝ 𝔅 (𝔅 γ) := 𝔅.D3;
-  have h₂ : T ⊢!. 𝔅 γ ➝ ∼γ := WeakerThan.pbl $ CN!_of_CN!_right $ K!_left goedel_spec;
-  have h₃ : T₀ ⊢!. 𝔅 (𝔅 γ) ➝ 𝔅 (∼γ) := prov_distribute_imply h₂;
-  exact WeakerThan.pbl $ contra! $ consistency_lemma_2 ⨀ (C!_trans h₁ h₃);
+theorem formalized_unprovable_goedel : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := by
+  suffices T₀ ⊢!. ∼𝔅 ⊥ ➝ ∼𝔅 𝗚 from this
+  have h₁ : T₀ ⊢!. 𝔅 𝗚 ➝ 𝔅 (𝔅 𝗚) := 𝔅.D3 𝗚
+  have h₂ : T₀ ⊢!. 𝔅 𝗚 ➝ 𝔅 (𝔅 𝗚 ➝ ⊥) := prov_distribute_imply <| by cl_prover [𝔅.goedel_spec_self]
+  have h₃ : T₀ ⊢!. 𝔅 (𝔅 𝗚 ➝ ⊥) ➝ 𝔅 (𝔅 𝗚) ➝ 𝔅 ⊥ := 𝔅.D2 (𝔅 𝗚) ⊥
+  cl_prover [h₁, h₂, h₃]
 
-theorem iff_goedel_consistency : T ⊢!. γ ⭤ 𝔅.con :=
-  E!_trans goedel_specAux₁ $ E!_intro (WeakerThan.pbl (𝓢 := T₀.toAxiom) formalized_consistent_of_existance_unprovable) formalized_unprovable_goedel
+theorem goedel_iff_consistency : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := by
+  have h₁ : T₀ ⊢!. ∼𝔅 𝗚 ➝ 𝔅.con := formalized_consistent_of_existance_unprovable 𝗚
+  have h₂ : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := formalized_unprovable_goedel
+  have h₃ : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := 𝔅.goedel_spec
+  cl_prover [h₁, h₂, h₃]
 
-theorem unprovable_consistency [Entailment.Consistent T] : T ⊬. 𝔅.con :=
-  uniff_of_E! iff_goedel_consistency |>.mp $ unprovable_goedel
+theorem unprovable_consistency [Entailment.Consistent T] : T₀ ⊬. 𝔅.con := by
+  intro h
+  have h₁ : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := goedel_iff_consistency
+  have : T₀ ⊢!. 𝗚 := by cl_prover [h, h₁]
+
 
 theorem unrefutable_consistency [Entailment.Consistent T] [𝔅.GoedelSound] : T ⊬. ∼𝔅.con :=
-  uniff_of_E! (ENN!_of_E! $ iff_goedel_consistency) |>.mp $ unrefutable_goedel
+  uniff_of_E! (ENN!_of_E! $ goedel_iff_consistency) |>.mp $ unrefutable_goedel
 
 end Second
 
@@ -283,17 +267,17 @@ variable [T₀ ⪯ T] [Diagonalization T₀] [𝔅.HBL]
 
 local notation "κ(" σ ")" => 𝔅.kreisel σ
 
-theorem loeb_theorm [L.DecidableEq] (H : T ⊢!. (𝔅 σ) ➝ σ) : T ⊢!. σ := by
+theorem loeb_theorm [L.DecidableEq] (H : T ⊢!. 𝔅 σ ➝ σ) : T ⊢!. σ := by
   have d₁ : T ⊢!. 𝔅 (𝔅.kreisel σ) ➝ σ := C!_trans (WeakerThan.pbl (kreisel_specAux₁ σ)) H;
   have d₂ : T ⊢!. 𝔅 (𝔅.kreisel σ)     := WeakerThan.pbl (𝓢 := T₀.toAxiom) (𝔅.D1 $ WeakerThan.pbl (kreisel_specAux₂ σ) ⨀ d₁);
   exact d₁ ⨀ d₂;
 
 instance [L.DecidableEq] : 𝔅.Loeb := ⟨loeb_theorm (T := T)⟩
 
-theorem formalized_loeb_theorem [L.DecidableEq] : T₀ ⊢!. 𝔅 ((𝔅 σ) ➝ σ) ➝ (𝔅 σ) := by
-  have hκ₁ : T₀ ⊢!. 𝔅 (κ(σ)) ➝ (𝔅 σ) := kreisel_specAux₁ σ;
-  have : T₀ ⊢!. ((𝔅 σ) ➝ σ) ➝ (𝔅 κ(σ) ➝ σ) := CCC!_of_C!_left hκ₁;
-  have : T ⊢!. ((𝔅 σ) ➝ σ) ➝ κ(σ) := WeakerThan.pbl (𝓢 := T₀.toAxiom) $ C!_trans this (kreisel_specAux₂ σ);
+theorem formalized_loeb_theorem [L.DecidableEq] : T₀ ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
+  have hκ₁ : T₀ ⊢!. 𝔅 (κ(σ)) ➝ 𝔅 σ := kreisel_specAux₁ σ;
+  have : T₀ ⊢!. (𝔅 σ ➝ σ) ➝ (𝔅 κ(σ) ➝ σ) := CCC!_of_C!_left hκ₁;
+  have : T ⊢!. (𝔅 σ ➝ σ) ➝ κ(σ) := WeakerThan.pbl (𝓢 := T₀.toAxiom) $ C!_trans this (kreisel_specAux₂ σ);
   exact C!_trans (𝔅.D2 ⨀ (𝔅.D1 this)) hκ₁;
 
 instance [L.DecidableEq] : 𝔅.FormalizedLoeb := ⟨formalized_loeb_theorem (T := T)⟩
@@ -323,7 +307,7 @@ lemma formalized_unrefutable_goedel
   : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.goedel) := by
   by_contra hC;
   have : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con)  := formalized_unprovable_not_consistency;
-  have : T ⊢!. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := C!_trans hC $ WeakerThan.pbl $ K!_left $ ENN!_of_E! $ prov_distribute_iff $ ENN!_of_E! iff_goedel_consistency;
+  have : T ⊢!. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := C!_trans hC $ WeakerThan.pbl $ K!_left $ ENN!_of_E! $ prov_distribute_iff $ ENN!_of_E! goedel_iff_consistency;
   contradiction;
 
 end Loeb
@@ -377,6 +361,4 @@ theorem kriesel_remark : T ⊢!. 𝔅.con := by
 
 end
 
-end DerivabilityCondition
-
-end LO.FirstOrder
+end LO.ProvabilityLogic

--- a/Foundation/FirstOrder/Incompleteness/First.lean
+++ b/Foundation/FirstOrder/Incompleteness/First.lean
@@ -14,17 +14,18 @@ lemma FirstOrder.Arith.re_iff_sigma1 {P : ℕ → Prop} : REPred P ↔ 𝚺₁-P
     exact ⟨.mkSigma (codeOfREPred P) (by simp [codeOfREPred, codeOfPartrec']), by
       intro v; symm; simp; simpa [←Matrix.fun_eq_vec_one] using codeOfREPred_spec h (x := v 0)⟩
   · rintro ⟨φ, hφ⟩
-    have := (sigma1_re id (φ.sigma_prop)).comp
-      (f := fun x : ℕ ↦ x ::ᵥ List.Vector.nil) (Primrec.to_comp <| Primrec.vector_cons.comp .id (.const _))
+    have : REPred fun x ↦ (Semiformula.Evalm ℕ (x ::ᵥ List.Vector.nil).get id) _ :=
+      (sigma1_re id (φ.sigma_prop)).comp
+        (f := fun x : ℕ ↦ x ::ᵥ List.Vector.nil) (Primrec.to_comp <| Primrec.vector_cons.comp .id (.const _))
     exact this.of_eq <| by intro x; symm; simpa [List.Vector.cons_get, Matrix.empty_eq] using hφ ![x]
 
 open Entailment FirstOrder Arith R0 PeanoMinus IOpen ISigma0 ISigma1 Metamath
 
 /-- Gödel's first incompleteness theorem-/
 theorem R0.goedel_first_incompleteness
-    (T : Theory ℒₒᵣ) [𝐑₀ ⪯ T] [Sigma1Sound T] [T.Delta1Definable] :
+    (T : ArithmeticTheory) [𝐑₀ ⪯ T] [T.Sigma1Sound] [T.Delta1Definable] :
     ¬Entailment.Complete (T : Axiom ℒₒᵣ) := by
-  have con : Consistent (T : Axiom ℒₒᵣ) := by simpa using consistent_of_sigma1Sound T
+  have con : Consistent (T : Axiom ℒₒᵣ) := inferInstance
   let D : ℕ → Prop := fun n : ℕ ↦ ∃ φ : SyntacticSemiformula ℒₒᵣ 1, n = ⌜φ⌝ ∧ T ⊢! ∼φ/[⌜φ⌝]
   have D_re : REPred D := by
     have : 𝚺₁-Predicate fun φ : ℕ ↦

--- a/Foundation/FirstOrder/Incompleteness/First.lean
+++ b/Foundation/FirstOrder/Incompleteness/First.lean
@@ -18,11 +18,13 @@ lemma FirstOrder.Arith.re_iff_sigma1 {P : ℕ → Prop} : REPred P ↔ 𝚺₁-P
       (f := fun x : ℕ ↦ x ::ᵥ List.Vector.nil) (Primrec.to_comp <| Primrec.vector_cons.comp .id (.const _))
     exact this.of_eq <| by intro x; symm; simpa [List.Vector.cons_get, Matrix.empty_eq] using hφ ![x]
 
-open FirstOrder Arith R0 PeanoMinus IOpen ISigma0 ISigma1 Metamath
+open Entailment FirstOrder Arith R0 PeanoMinus IOpen ISigma0 ISigma1 Metamath
 
-/-- Gödel's First Incompleteness Theorem-/
+/-- Gödel's first incompleteness theorem-/
 theorem R0.goedel_first_incompleteness
-    (T : Theory ℒₒᵣ) [𝐑₀ ⪯ T] [Sigma1Sound T] [T.Delta1Definable] : ¬Entailment.Complete T := by
+    (T : Theory ℒₒᵣ) [𝐑₀ ⪯ T] [Sigma1Sound T] [T.Delta1Definable] :
+    ¬Entailment.Complete (T : Axiom ℒₒᵣ) := by
+  have con : Consistent (T : Axiom ℒₒᵣ) := by simpa using consistent_of_sigma1Sound T
   let D : ℕ → Prop := fun n : ℕ ↦ ∃ φ : SyntacticSemiformula ℒₒᵣ 1, n = ⌜φ⌝ ∧ T ⊢! ∼φ/[⌜φ⌝]
   have D_re : REPred D := by
     have : 𝚺₁-Predicate fun φ : ℕ ↦
@@ -36,21 +38,20 @@ theorem R0.goedel_first_incompleteness
         refine ⟨φ, rfl, Language.Theory.Provable.sound (by simpa)⟩
       · rintro ⟨φ, rfl, b⟩
         exact ⟨by simp, by simpa using provable_of_provable (V := ℕ) b⟩
-  let σ : SyntacticSemiformula ℒₒᵣ 1 := codeOfREPred (D)
-  let ρ : SyntacticFormula ℒₒᵣ := σ/[⌜σ⌝]
-  have : ∀ n : ℕ, D n ↔ T ⊢! σ/[‘↑n’] := fun n ↦ by
-    simpa [Semiformula.coe_substs_eq_substs_coe₁, Axiom.provable_iff] using re_complete (T := T) (D_re) (x := n)
-  have : T ⊢! ∼ρ ↔ T ⊢! ρ := by
-    simpa [D, goedelNumber'_def, quote_eq_encode] using this ⌜σ⌝
-  have con : Entailment.Consistent T := consistent_of_sigma1Sound T
-  refine LO.Entailment.incomplete_iff_exists_undecidable.mpr ⟨↑ρ, ?_, ?_⟩
-  · intro h
-    have : T ⊢! ∼↑ρ := by simpa [Axiom.provable_iff] using this.mpr h
-    exact LO.Entailment.not_consistent_iff_inconsistent.mpr
-      (Entailment.inconsistent_of_provable_of_unprovable h this) inferInstance
-  · intro h
-    have : T ⊢! ↑ρ := this.mp (by simpa [Axiom.provable_iff] using h)
-    exact LO.Entailment.not_consistent_iff_inconsistent.mpr
-      (Entailment.inconsistent_of_provable_of_unprovable this h) inferInstance
+  let σ : Semisentence ℒₒᵣ 1 := codeOfREPred D
+  let ρ : Sentence ℒₒᵣ := σ/[⌜σ⌝]
+  have : ∀ n : ℕ, D n ↔ T ⊢!. σ/[↑n] := fun n ↦ by
+    simpa [Semiformula.coe_substs_eq_substs_coe₁, Axiom.provable_iff] using re_complete (T := T) D_re (x := n)
+  have : T ⊢!. ∼ρ ↔ T ⊢!. ρ := by
+    have : T ⊢! ∼↑σ/[↑(Encodable.encode σ)] ↔ T ⊢! ↑σ/[↑(Encodable.encode σ)] := by
+      simpa [Axiom.provable_iff, quote_eq_encode,
+        goedelNumber'_eq_coe_encode, D, Rewriting.embedding_substs_eq_substs_coe₁] using this ⌜σ⌝
+    simpa [Axiom.provable_iff, ρ, Rewriting.embedding_substs_eq_substs_coe₁]
+  refine incomplete_iff_exists_undecidable.mpr
+    ⟨ ρ
+    , fun h ↦ not_consistent_iff_inconsistent.mpr
+        (inconsistent_of_provable_of_unprovable h (this.mpr h)) inferInstance
+    , fun h ↦ not_consistent_iff_inconsistent.mpr
+      (inconsistent_of_provable_of_unprovable (this.mp h) h) inferInstance ⟩
 
 end LO

--- a/Foundation/FirstOrder/Incompleteness/First.lean
+++ b/Foundation/FirstOrder/Incompleteness/First.lean
@@ -2,8 +2,7 @@ import Foundation.FirstOrder.Incompleteness.StandardProvability
 import Foundation.FirstOrder.R0.Representation
 
 /-!
-# Gödel's first incompleteness theorem over $\mathsf{R_0}$
-
+# Gödel's first incompleteness theorem for arithmetic theories stronger than $\mathsf{R_0}$
 -/
 
 namespace LO

--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -1,88 +1,48 @@
 import Foundation.FirstOrder.Incompleteness.StandardProvability
+import Foundation.FirstOrder.Incompleteness.ConsistencyPredicate
 
 /-!
-# Gödel's second incompleteness theorem over $\mathsf{I}\Sigma_1$
-
+# Gödel's second incompleteness theorem for arithmetic theories stronger than $\mathsf{I}\Sigma_1$
 -/
 
 namespace LO.ISigma1
 
-open FirstOrder Arith PeanoMinus IOpen ISigma0 Metamath Arithmetization
-  Entailment FiniteContext
+open FirstOrder Entailment ProvabilityLogic
 
-variable (T : Theory ℒₒᵣ) [𝐈𝚺₁ ⪯ T] [T.Delta1Definable]
-
-local notation "𝗚" => T.goedelₐ
-
-local notation "𝗖𝗼𝗻" => T.consistentₐ
-
-local prefix:max "□" => T.bewₐ
-
-lemma goedel_iff_unprovable_goedel' : T ⊢! ↑𝗚 ⭤ ∼↑□𝗚 := by
-  simpa [Axiom.provable_iff] using goedel_iff_unprovable_goedel
-
-lemma goedel_unprovable [Entailment.Consistent T] : T ⊬ ↑𝗚 := by
-  intro h
-  have hp : T ⊢! ↑□𝗚 := (Axiom.provable_iff (T := T)).mp <| provableₐ_D1 <| (Axiom.provable_iff (T := T)).mpr h
-  have hn : T ⊢! ∼↑□𝗚 := by simpa [Axiom.provable_iff] using K!_left (goedel_iff_unprovable_goedel' T) ⨀ h
-  exact not_consistent_iff_inconsistent.mpr (inconsistent_of_provable_of_unprovable hp hn) inferInstance
-
-lemma not_goedel_unprovable [ℕ ⊧ₘ* T] : T ⊬ ∼↑𝗚 := fun h ↦ by
-  haveI : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
-  have : T ⊢!. □𝗚 := Entailment.CN!_of_CN!_left (K!_right goedel_iff_unprovable_goedel) ⨀ (by simpa [Axiom.provable_iff] using h)
-  have : T ⊢! ↑𝗚 := (Axiom.provable_iff (T := T)).mp <| provableₐ_sound this
-  exact not_consistent_iff_inconsistent.mpr (inconsistent_of_provable_of_unprovable this h)
-    (Sound.consistent_of_satisfiable ⟨_, (inferInstance : ℕ ⊧ₘ* T)⟩)
-
-lemma consistent_iff_goedel : T ⊢! ↑𝗖𝗼𝗻 ⭤ ↑𝗚 := by
-  apply E!_intro
-  · have bew_G : [∼𝗚] ⊢[T.toAxiom]! □𝗚 := deductInv'! <| CN!_of_CN!_left <| K!_right goedel_iff_unprovable_goedel
-    have bew_not_bew_G : [∼𝗚] ⊢[T.toAxiom]! □(∼□𝗚) := by
-      have : T ⊢!. □(𝗚 ➝ ∼□𝗚) := provableₐ_D1 <| K!_left goedel_iff_unprovable_goedel
-      exact provableₐ_D2_context (of'! this) bew_G
-    have bew_bew_G : [∼𝗚] ⊢[T.toAxiom]! □□𝗚 := provableₐ_D3_context bew_G
-    have : [∼𝗚] ⊢[T.toAxiom]! □⊥ :=
-      provableₐ_D2_context (provableₐ_D2_context (of'! <| provableₐ_D1 <| CNC!) bew_not_bew_G) bew_bew_G
-    simpa [Axiom.provable_iff] using CN!_of_CN!_left (deduct'! this)
-  · have : [□⊥] ⊢[T.toAxiom]! □𝗚 := by
-      have : T ⊢!. □(⊥ ➝ 𝗚) := provableₐ_D1 efq!
-      exact provableₐ_D2_context (of'! this) (by simp)
-    have : [□⊥] ⊢[T.toAxiom]! ∼𝗚 :=
-      of'! (CN!_of_CN!_right <| K!_left <| goedel_iff_unprovable_goedel) ⨀ this
-    simpa [Axiom.provable_iff] using  CN!_of_CN!_right (deduct'! this)
+variable (T : ArithmeticTheory) [𝐈𝚺₁ ⪯ T] [T.Delta1Definable]
 
 /-- Gödel's Second Incompleteness Theorem-/
-theorem goedel_second_incompleteness [Entailment.Consistent T] : T ⊬ ↑𝗖𝗼𝗻 := fun h ↦
-  goedel_unprovable T <| K!_left (consistent_iff_goedel T) ⨀ h
+theorem goedel_second_incompleteness [Entailment.Consistent T] :
+    T ⊬. T.isConsistent :=
+  T.standardPr.unprovable_consistency
 
-theorem inconsistent_unprovable [ℕ ⊧ₘ* T] : T ⊬ ∼↑𝗖𝗼𝗻 := fun h ↦
-  not_goedel_unprovable T <| contra! (K!_right (consistent_iff_goedel T)) ⨀ h
+theorem inconsistent_unprovable [T.Sigma1Sound] :
+    T ⊬. ∼T.isConsistent :=
+  have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
+  T.standardPr.unrefutable_consistency
 
-theorem inconsistent_undecidable [ℕ ⊧ₘ* T] : Entailment.Undecidable T ↑𝗖𝗼𝗻 := by
-  haveI : Consistent T := Sound.consistent_of_satisfiable ⟨_, (inferInstance : ℕ ⊧ₘ* T)⟩
-  constructor
-  · exact goedel_second_incompleteness T
-  · exact inconsistent_unprovable T
+theorem inconsistent_independent [T.Sigma1Sound] :
+    Entailment.Undecidable (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ) :=
+  have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
+  T.standardPr.consistency_independent
 
-instance [Entailment.Consistent T] : T ⪱ T + 𝐂𝐨𝐧[T] :=
-  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ↑𝗖𝗼𝗻)
-    (goedel_second_incompleteness T) (Entailment.by_axm _ (by simp))
+abbrev _root_.LO.FirstOrder.ArithmeticTheory.AddSelfConsistency : ArithmeticTheory := T + {↑T.isConsistent}
 
-instance [Entailment.Consistent T] : ℕ ⊧ₘ* 𝐂𝐨𝐧[T] := by
-  suffices ℕ ⊧ₘ₀ T.consistentₐ by simpa [Models₀] using this
-  suffices ¬T.Provableₐ ⌜⊥⌝ by simpa [models₀_iff] using  this
-  intro H
-  haveI : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
-  have : T ⊢! ⊥ := (Axiom.provable_iff (T := T)).mp <| provableₐ_iff_provable₀.mp H
-  have : Entailment.Inconsistent T := inconsistent_iff_provable_bot.mpr this
-  exact Consistent.not_inconsistent this
+abbrev _root_.LO.FirstOrder.ArithmeticTheory.AddSelfInconsistency : ArithmeticTheory := T + {∼↑T.isConsistent}
 
-instance [ℕ ⊧ₘ* T] : ℕ ⊧ₘ* T + 𝐂𝐨𝐧[T] :=
-  haveI : Entailment.Consistent T := Sound.consistent_of_satisfiable ⟨_, inferInstanceAs (ℕ ⊧ₘ* T)⟩
-  ModelsTheory.add_iff.mpr ⟨inferInstance, inferInstance⟩
+instance [Consistent T] : T ⪱ T.AddSelfConsistency :=
+  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ↑T.isConsistent)
+    ((Axiom.unprovable_iff (T := T)).mp (goedel_second_incompleteness T))
+    (Entailment.by_axm _ (by simp))
 
-instance [ℕ ⊧ₘ* T] : T ⪱ T + ¬𝐂𝐨𝐧[T] :=
-  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑𝗖𝗼𝗻)
-    (inconsistent_unprovable T) (Entailment.by_axm _ (by simp))
+instance [ℕ ⊧ₘ* T] : ℕ ⊧ₘ* T.AddSelfConsistency := by
+  have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
+  have : Consistent T := ArithmeticTheory.consistent_of_sound T (Eq ⊥) rfl
+  simp [models_iff, *]
+
+instance [T.Sigma1Sound] : T ⪱ T.AddSelfInconsistency :=
+  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑T.isConsistent)
+    (by simpa using (Axiom.unprovable_iff (T := T)).mp (inconsistent_unprovable T))
+    (Entailment.by_axm _ (by simp))
 
 end LO.ISigma1

--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -22,7 +22,7 @@ theorem inconsistent_unprovable [T.Sigma1Sound] :
   T.standardPr.unrefutable_consistency
 
 theorem inconsistent_independent [T.Sigma1Sound] :
-    Entailment.Undecidable (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ) :=
+    Entailment.Independent (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ) :=
   have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
   T.standardPr.consistency_independent
 

--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -11,8 +11,8 @@ open FirstOrder Entailment ProvabilityLogic
 
 variable (T : ArithmeticTheory) [𝐈𝚺₁ ⪯ T] [T.Delta1Definable]
 
-/-- Gödel's Second Incompleteness Theorem-/
-theorem goedel_second_incompleteness [Entailment.Consistent T] :
+/-- Gödel's second incompleteness theorem-/
+theorem goedel_second_incompleteness [Consistent T] :
     T ⊬. T.isConsistent :=
   T.standardPr.unprovable_consistency
 
@@ -22,7 +22,7 @@ theorem inconsistent_unprovable [T.Sigma1Sound] :
   T.standardPr.unrefutable_consistency
 
 theorem inconsistent_independent [T.Sigma1Sound] :
-    Entailment.Independent (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ) :=
+    Independent (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ) :=
   have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
   T.standardPr.consistency_independent
 
@@ -31,7 +31,7 @@ abbrev _root_.LO.FirstOrder.ArithmeticTheory.AddSelfConsistency : ArithmeticTheo
 abbrev _root_.LO.FirstOrder.ArithmeticTheory.AddSelfInconsistency : ArithmeticTheory := T + {∼↑T.isConsistent}
 
 instance [Consistent T] : T ⪱ T.AddSelfConsistency :=
-  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ↑T.isConsistent)
+  StrictlyWeakerThan.of_unprovable_provable (φ := ↑T.isConsistent)
     ((Axiom.unprovable_iff (T := T)).mp (goedel_second_incompleteness T))
     (Entailment.by_axm _ (by simp))
 
@@ -41,7 +41,7 @@ instance [ℕ ⊧ₘ* T] : ℕ ⊧ₘ* T.AddSelfConsistency := by
   simp [models_iff, *]
 
 instance [T.Sigma1Sound] : T ⪱ T.AddSelfInconsistency :=
-  Entailment.StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑T.isConsistent)
+  StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑T.isConsistent)
     (by simpa using (Axiom.unprovable_iff (T := T)).mp (inconsistent_unprovable T))
     (Entailment.by_axm _ (by simp))
 

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/D1.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/D1.lean
@@ -213,20 +213,20 @@ end
 
 section
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
 
 /-- Hilbert–Bernays provability condition D1 -/
-theorem provableₐ_of_provable {φ} : T ⊢! φ → T.Provableₐ (⌜φ⌝ : V) := fun h ↦
+theorem provable_of_provable_arith {φ} : T ⊢! φ → T.Provable (⌜φ⌝ : V) := fun h ↦
   Language.Theory.Derivable.of_ss Arithmetization.theory_subset_AddR₀ (provable_of_provable h)
 
-theorem provableₐ_of_provable₀ {σ} : T ⊢!. σ → T.Provableₐ (⌜σ⌝ : V) := fun h ↦ by
-  simpa using provableₐ_of_provable (T := T) (V := V) <| Axiom.provable_iff.mp h
+theorem provable_of_provable_arith₀ {σ} : T ⊢!. σ → T.Provable (⌜σ⌝ : V) := fun h ↦ by
+  simpa using provable_of_provable_arith (T := T) (V := V) <| Axiom.provable_iff.mp h
 
-theorem provableₐ_of_provable' {φ} : T ⊢! φ → T†V ⊢! ⌜φ⌝ := fun h ↦ by
-  simpa [provableₐ_iff'] using provableₐ_of_provable (V := V) h
+theorem provable_of_provable_arith' {φ} : T ⊢! φ → T†V ⊢! ⌜φ⌝ := fun h ↦ by
+  simpa [provable_iff'] using provable_of_provable_arith (V := V) h
 
-theorem provableₐ_of_provable'₀ {σ} : T ⊢!. σ → T†V ⊢! ⌜σ⌝ := fun h ↦ by
-  simpa [provableₐ_iff] using provableₐ_of_provable₀ (V := V) h
+theorem provable_of_provable_arith'₀ {σ} : T ⊢!. σ → T†V ⊢! ⌜σ⌝ := fun h ↦ by
+  simpa [provable_iff] using provable_of_provable_arith₀ (V := V) h
 
 end
 
@@ -403,9 +403,9 @@ lemma Language.Theory.Provable.complete₀ {σ : Sentence L} :
     T.tCodeIn ℕ ⊢! ⌜σ⌝ ↔ T ⊢! ↑σ :=
   ⟨by simpa [Language.Theory.TProvable.iff_provable] using Language.Theory.Provable.smallSound, tprovable_of_provable⟩
 
-@[simp] lemma provableₐ_iff_provable₀ {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐑₀ ⪯ T] {σ : Sentence ℒₒᵣ} :
-    T.Provableₐ (⌜σ⌝ : ℕ) ↔ T ⊢!. σ := by
-  simpa [provableₐ_iff, Language.Theory.Provable.complete₀, Axiom.provable_iff] using
+@[simp] lemma provable_iff_provable₀ {T : ArithmeticTheory} [T.Delta1Definable] [𝐑₀ ⪯ T] {σ : Sentence ℒₒᵣ} :
+    T.Provable (⌜σ⌝ : ℕ) ↔ T ⊢!. σ := by
+  simpa [provable_iff, Language.Theory.Provable.complete₀, Axiom.provable_iff] using
     FirstOrder.Arith.add_cobhamR0'.symm
 
 end LO.ISigma1.Metamath

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/D3.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/D3.lean
@@ -177,28 +177,28 @@ end Arithmetization
 
 section
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
 
 theorem sigma₁_complete {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
-    V ⊧ₘ₀ σ → T.Provableₐ (⌜σ⌝ : V) := fun h ↦ by
-  simpa [provableₐ_iff] using Arithmetization.TProof.sigma₁_complete _ hσ h
+    V ⊧ₘ₀ σ → T.Provable (⌜σ⌝ : V) := fun h ↦ by
+  simpa [provable_iff] using Arithmetization.TProof.sigma₁_complete _ hσ h
 
 theorem sigma₁_complete_provable {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
     V ⊧ₘ₀ σ → T†V ⊢! ⌜σ⌝ := fun h ↦ by
-  simpa [provableₐ_iff] using Arithmetization.TProof.sigma₁_complete _ hσ h
+  simpa [provable_iff] using Arithmetization.TProof.sigma₁_complete _ hσ h
 
 end
 
 section D2
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
 
 /-- Hilbert–Bernays provability condition D2 -/
-theorem modus_ponens {φ ψ : SyntacticFormula ℒₒᵣ} (hφψ : T.Provableₐ (⌜φ ➝ ψ⌝ : V)) (hφ : T.Provableₐ (⌜φ⌝ : V)) :
-    T.Provableₐ (⌜ψ⌝ : V) := provableₐ_iff'.mpr <| (by simpa using provableₐ_iff'.mp hφψ) ⨀ provableₐ_iff'.mp hφ
+theorem modus_ponens {φ ψ : SyntacticFormula ℒₒᵣ} (hφψ : T.Provable (⌜φ ➝ ψ⌝ : V)) (hφ : T.Provable (⌜φ⌝ : V)) :
+    T.Provable (⌜ψ⌝ : V) := provable_iff'.mpr <| (by simpa using provable_iff'.mp hφψ) ⨀ provable_iff'.mp hφ
 
-theorem modus_ponens₀ {σ τ : Sentence ℒₒᵣ} (hστ : T.Provableₐ (⌜σ ➝ τ⌝ : V)) (hσ : T.Provableₐ (⌜σ⌝ : V)) :
-    T.Provableₐ (⌜τ⌝ : V) := provableₐ_iff.mpr <| (by simpa using provableₐ_iff.mp hστ) ⨀ provableₐ_iff.mp hσ
+theorem modus_ponens₀ {σ τ : Sentence ℒₒᵣ} (hστ : T.Provable (⌜σ ➝ τ⌝ : V)) (hσ : T.Provable (⌜σ⌝ : V)) :
+    T.Provable (⌜τ⌝ : V) := provable_iff.mpr <| (by simpa using provable_iff.mp hστ) ⨀ provable_iff.mp hσ
 
 end D2
 

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
@@ -12,74 +12,69 @@ namespace LO.ISigma1
 
 open FirstOrder Arith PeanoMinus IOpen ISigma0 Metamath Arithmetization
 
-variable {T : Theory ℒₒᵣ} [𝐈𝚺₁ ⪯ T]
+variable {T : ArithmeticTheory} [𝐈𝚺₁ ⪯ T]
 
 section
 
-variable (U : Theory ℒₒᵣ) [U.Delta1Definable]
+variable (U : ArithmeticTheory) [U.Delta1Definable]
 
-noncomputable abbrev _root_.LO.FirstOrder.Theory.bewₐ (σ : Sentence ℒₒᵣ) : Sentence ℒₒᵣ := U.provableₐ/[⌜σ⌝]
+noncomputable abbrev _root_.LO.FirstOrder.ArithmeticTheory.provabilityPred (σ : Sentence ℒₒᵣ) : Sentence ℒₒᵣ := U.provable/[⌜σ⌝]
 
-noncomputable abbrev _root_.LO.FirstOrder.Theory.consistentₐ : Sentence ℒₒᵣ := ∼U.bewₐ ⊥
+/-
+noncomputable abbrev _root_.LO.FirstOrder.ArithmeticTheory.consistent : Sentence ℒₒᵣ := ∼U.provabilityPred ⊥
 
-abbrev _root_.LO.FirstOrder.Theory.Consistentₐ : Theory ℒₒᵣ := {↑U.consistentₐ}
+abbrev _root_.LO.FirstOrder.ArithmeticTheory.Consistent : ArithmeticTheory := {↑U.consistent}
 
-notation "𝐂𝐨𝐧[" U "]" => LO.FirstOrder.Theory.Consistentₐ U
-
-abbrev _root_.LO.FirstOrder.Theory.Inconsistentₐ : Theory ℒₒᵣ := {∼↑U.consistentₐ}
-
-notation "¬𝐂𝐨𝐧[" U "]" => LO.FirstOrder.Theory.Inconsistentₐ U
-
-noncomputable def _root_.LO.FirstOrder.Theory.goedelₐ : Sentence ℒₒᵣ := fixpoint (∼U.provableₐ)
+abbrev _root_.LO.FirstOrder.ArithmeticTheory.Inconsistent : ArithmeticTheory := {∼↑U.consistent}
+-/
 
 end
 
 section
 
-variable {U : Theory ℒₒᵣ} [U.Delta1Definable]
+variable {U : ArithmeticTheory} [U.Delta1Definable]
 
-theorem provableₐ_D1 {σ} : U ⊢!. σ → T ⊢!. U.bewₐ σ := by
+local prefix:90 "□" => U.provabilityPred
+
+theorem provable_D1 {σ} : U ⊢!. σ → T ⊢!. □σ := by
   intro h
   haveI : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
   apply complete₀ <| oRing_consequence_of _ _ fun (V : Type) _ _ ↦ by
     haveI : V ⊧ₘ* 𝐈𝚺₁ := ModelsTheory.of_provably_subtheory V _ T inferInstance
-    simpa [models_iff] using provableₐ_of_provable₀ (T := U) (V := V) h
+    simpa [models_iff] using provable_of_provable_arith₀ (T := U) (V := V) h
 
-theorem provableₐ_D2 {σ π} : T ⊢!. U.bewₐ (σ ➝ π) ➝ U.bewₐ σ ➝ U.bewₐ π :=
+theorem provable_D2 {σ π} : T ⊢!. □(σ ➝ π) ➝ □σ ➝ □π :=
   haveI : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
   complete₀ <| oRing_consequence_of _ _ fun (V : Type) _ _ ↦ by
     haveI : V ⊧ₘ* 𝐈𝚺₁ := ModelsTheory.of_provably_subtheory V _ T inferInstance
     simpa [models_iff] using modus_ponens₀
 
-lemma provableₐ_sigma₁_complete {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
-    T ⊢!. σ ➝ U.bewₐ σ :=
+lemma provable_sigma₁_complete {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
+    T ⊢!. σ ➝ □σ :=
   haveI : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
   complete₀ <| oRing_consequence_of _ _ fun (V : Type) _ _ ↦ by
     haveI : V ⊧ₘ* 𝐈𝚺₁ := ModelsTheory.of_provably_subtheory V _ T inferInstance
     simpa [models_iff] using sigma₁_complete (T := U) (V := V) hσ
 
-theorem provableₐ_D3 {σ : Sentence ℒₒᵣ} :
-    T ⊢!. U.bewₐ σ ➝ U.bewₐ (U.bewₐ σ) := provableₐ_sigma₁_complete (by simp)
-
-lemma goedel_iff_unprovable_goedel : T ⊢!. U.goedelₐ ⭤ ∼U.bewₐ U.goedelₐ := by
-  simpa [Theory.goedelₐ, Theory.bewₐ] using diagonal (∼U.provableₐ)
+theorem provable_D3 {σ : Sentence ℒₒᵣ} :
+    T ⊢!. □σ ➝ □□σ := provable_sigma₁_complete (by simp)
 
 open LO.Entailment LO.Entailment.FiniteContext
 
-lemma provableₐ_D2_context {Γ σ π} (hσπ : Γ ⊢[T.toAxiom]! (U.bewₐ (σ ➝ π))) (hσ : Γ ⊢[T.toAxiom]! U.bewₐ σ) :
-    Γ ⊢[T.toAxiom]! U.bewₐ π := of'! provableₐ_D2 ⨀ hσπ ⨀ hσ
+lemma provable_D2_context {Γ σ π} (hσπ : Γ ⊢[T.toAxiom]! (□(σ ➝ π))) (hσ : Γ ⊢[T.toAxiom]! □σ) :
+    Γ ⊢[T.toAxiom]! □π := of'! provable_D2 ⨀ hσπ ⨀ hσ
 
-lemma provableₐ_D3_context {Γ σ} (hσπ : Γ ⊢[T.toAxiom]! U.bewₐ σ) : Γ ⊢[T.toAxiom]! U.bewₐ (U.bewₐ σ) := of'! provableₐ_D3 ⨀ hσπ
+lemma provable_D3_context {Γ σ} (hσπ : Γ ⊢[T.toAxiom]! □σ) : Γ ⊢[T.toAxiom]! □(□σ) := of'! provable_D3 ⨀ hσπ
 
-variable [ℕ ⊧ₘ* T] [𝐑₀ ⪯ U]
+variable [T.Sigma1Sound] [𝐑₀ ⪯ U]
 
 omit [𝐈𝚺₁ ⪯ T] in
-lemma provableₐ_sound {σ} : T ⊢!. U.bewₐ σ → U ⊢!. σ := by
+lemma provable_sound {σ} : T ⊢!. □σ → U ⊢!. σ := by
   intro h
-  have : U.Provableₐ (⌜σ⌝ : ℕ) := by simpa [models₀_iff] using consequence_iff.mp (sound!₀ h) ℕ inferInstance
-  simpa using this
+  have : ℕ ⊧ₘ₀ U.provabilityPred σ := ArithmeticTheory.SoundOn.sound (F := Arith.Hierarchy 𝚺 1) h (by simp)
+  simpa [models₀_iff] using this
 
-lemma provableₐ_complete {σ} : U ⊢!. σ ↔ T ⊢!. U.bewₐ σ := ⟨provableₐ_D1, provableₐ_sound⟩
+lemma provable_complete {σ} : U ⊢!. σ ↔ T ⊢!. □σ := ⟨provable_D1, provable_sound⟩
 
 end
 
@@ -91,23 +86,25 @@ open ProvabilityLogic
 
 open PeanoMinus IOpen ISigma0 ISigma1 Metamath Arithmetization
 
-variable (T : Theory ℒₒᵣ) [T.Delta1Definable]
+variable (T : ArithmeticTheory) [T.Delta1Definable]
 
 noncomputable instance : Diagonalization 𝐈𝚺₁ where
   fixpoint := fixpoint
   diag θ := diagonal θ
 
-/-- TODO: rename to `standardPP`-/
 noncomputable abbrev _root_.LO.FirstOrder.Theory.standardPr : ProvabilityPredicate 𝐈𝚺₁ T where
-  prov := T.provableₐ
-  D1 := provableₐ_D1
+  prov := T.provable
+  D1 := provable_D1
 
-instance : T.standardPr.HBL2 := ⟨fun _ _ ↦ provableₐ_D2⟩
-instance : T.standardPr.HBL3 := ⟨fun _ ↦ provableₐ_D3⟩
-instance : T.standardPr.HBL := ⟨⟩
-instance [ℕ ⊧ₘ* T] [𝐑₀ ⪯ T] : T.standardPr.GoedelSound := ⟨fun h ↦ by simpa using provableₐ_sound h⟩
+instance : T.standardPr.HBL2 := ⟨fun _ _ ↦ provable_D2⟩
 
-lemma standardPr_def (σ : Sentence ℒₒᵣ) : (T.standardPr) σ = T.provableₐ.val/[⌜σ⌝] := rfl
+instance : T.standardPr.HBL3 := ⟨fun _ ↦ provable_D3⟩
+
+instance : T.standardPr.HBL where
+
+instance [T.Sigma1Sound] [𝐑₀ ⪯ T] : T.standardPr.GoedelSound := ⟨fun h ↦ by simpa using provable_sound h⟩
+
+lemma standardPr_def (σ : Sentence ℒₒᵣ) : T.standardPr σ = T.provabilityPred σ := rfl
 
 instance [𝐑₀ ⪯ T] [T.Delta1Definable] : T.standardPr.Sound ℕ := ⟨fun {σ} ↦ by simp [Arith.standardPr_def, models₀_iff]⟩
 

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
@@ -1,6 +1,6 @@
 import Foundation.FirstOrder.Incompleteness.StandardProvability.D1
 import Foundation.FirstOrder.Incompleteness.StandardProvability.D3
-import Foundation.FirstOrder.Incompleteness.DerivabilityCondition.Basic
+import Foundation.ProvabilityLogic.Conditions
 import Foundation.FirstOrder.Incompleteness.FixedPoint
 
 /-!
@@ -87,28 +87,28 @@ end LO.ISigma1
 
 namespace LO.FirstOrder.Arith
 
-open DerivabilityCondition
+open ProvabilityLogic
 
 open PeanoMinus IOpen ISigma0 ISigma1 Metamath Arithmetization
 
-variable (T : Theory ℒₒᵣ) [𝐈𝚺₁ ⪯ T]
+variable (T : Theory ℒₒᵣ) [T.Delta1Definable]
 
-variable (U : Theory ℒₒᵣ) [U.Delta1Definable]
-
-noncomputable instance : Diagonalization T where
+noncomputable instance : Diagonalization 𝐈𝚺₁ where
   fixpoint := fixpoint
   diag θ := diagonal θ
 
 /-- TODO: rename to `standardPP`-/
-noncomputable abbrev _root_.LO.FirstOrder.Theory.standardDP : ProvabilityPredicate T U where
-  prov := U.provableₐ
+noncomputable abbrev _root_.LO.FirstOrder.Theory.standardPr : ProvabilityPredicate 𝐈𝚺₁ T where
+  prov := T.provableₐ
   D1 := provableₐ_D1
 
-instance : (Theory.standardDP T U).HBL2 := ⟨provableₐ_D2⟩
-instance : (Theory.standardDP T U).HBL3 := ⟨provableₐ_D3⟩
-instance : (Theory.standardDP T U).HBL := ⟨⟩
-instance [ℕ ⊧ₘ* U] [𝐑₀ ⪯ U] : (Theory.standardDP T U).GoedelSound := ⟨fun h ↦ by simpa using provableₐ_sound h⟩
+instance : T.standardPr.HBL2 := ⟨fun _ _ ↦ provableₐ_D2⟩
+instance : T.standardPr.HBL3 := ⟨fun _ ↦ provableₐ_D3⟩
+instance : T.standardPr.HBL := ⟨⟩
+instance [ℕ ⊧ₘ* T] [𝐑₀ ⪯ T] : T.standardPr.GoedelSound := ⟨fun h ↦ by simpa using provableₐ_sound h⟩
 
-lemma standardDP_def (σ : Sentence ℒₒᵣ) : (T.standardDP U) σ = U.provableₐ.val/[⌜σ⌝] := rfl
+lemma standardPr_def (σ : Sentence ℒₒᵣ) : (T.standardPr) σ = T.provableₐ.val/[⌜σ⌝] := rfl
+
+instance [𝐑₀ ⪯ T] [T.Delta1Definable] : T.standardPr.Sound ℕ := ⟨fun {σ} ↦ by simp [Arith.standardPr_def, models₀_iff]⟩
 
 end LO.FirstOrder.Arith

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.lean
@@ -1,6 +1,6 @@
 import Foundation.FirstOrder.Incompleteness.StandardProvability.D1
 import Foundation.FirstOrder.Incompleteness.StandardProvability.D3
-import Foundation.ProvabilityLogic.Conditions
+import Foundation.ProvabilityLogic.Incompleteness
 import Foundation.FirstOrder.Incompleteness.FixedPoint
 
 /-!

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability/FormalizedR0.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability/FormalizedR0.lean
@@ -27,7 +27,7 @@ end
 
 namespace Theory
 
-inductive R0' : Theory ℒₒᵣ
+inductive R0' : ArithmeticTheory
   | eq_refl : R0' “∀ x, x = x”
   | replace (φ : SyntacticSemiformula ℒₒᵣ 1) : R0' “∀ x y, x = y → !φ x → !φ y”
   | Ω₁ (n m : ℕ)  : R0' “↑n + ↑m = ↑(n + m)”
@@ -37,7 +37,7 @@ inductive R0' : Theory ℒₒᵣ
 
 notation "𝐑₀'" => R0'
 
-abbrev addR0' (T : Theory ℒₒᵣ) : Theory ℒₒᵣ := T + 𝐑₀'
+abbrev addR0' (T : ArithmeticTheory) : ArithmeticTheory := T + 𝐑₀'
 
 end Theory
 
@@ -151,7 +151,7 @@ noncomputable instance R0'.subtheoryOfR0 : 𝐑₀' ⪯ 𝐑₀ := Entailment.We
   case Ω₃ n m h => exact Entailment.by_axm _ (R0.Ω₃ n m h)
   case Ω₄ n => exact Entailment.by_axm _ (R0.Ω₄ n)
 
-variable {T : Theory ℒₒᵣ} [𝐑₀ ⪯ T]
+variable {T : ArithmeticTheory} [𝐑₀ ⪯ T]
 
 lemma add_cobhamR0' {φ} : T ⊢! φ ↔ T + 𝐑₀' ⊢! φ := by
   constructor
@@ -681,16 +681,16 @@ def Ω₄.proof (n : V): ⌜𝐑₀'⌝[V] ⊢ (#'0 <' ↑n ⭤ (tSubstItr (#'0)
 
 end Theory.R0'
 
-instance Theory.addR0'Delta1Definable (T : Theory ℒₒᵣ) [d : T.Delta1Definable] : (T + 𝐑₀').Delta1Definable :=
+instance Theory.addR0'Delta1Definable (T : ArithmeticTheory) [d : T.Delta1Definable] : (T + 𝐑₀').Delta1Definable :=
   d.add Theory.R0'Delta1Definable
 section
 
-abbrev _root_.LO.FirstOrder.Theory.AddR₀TTheory
-    (T : Theory ℒₒᵣ) [T.Delta1Definable] (V) [ORingStruc V] [V ⊧ₘ* 𝐈𝚺₁] : ⌜ℒₒᵣ⌝[V].TTheory := (T + 𝐑₀').tCodeIn V
+abbrev _root_.LO.FirstOrder.ArithmeticTheory.AddR₀TTheory
+    (T : ArithmeticTheory) [T.Delta1Definable] (V) [ORingStruc V] [V ⊧ₘ* 𝐈𝚺₁] : ⌜ℒₒᵣ⌝[V].TTheory := (T + 𝐑₀').tCodeIn V
 
-scoped [LO.ISigma1.Metamath] infix:100 "†" => LO.FirstOrder.Theory.AddR₀TTheory
+scoped [LO.ISigma1.Metamath] infix:100 "†" => LO.FirstOrder.ArithmeticTheory.AddR₀TTheory
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
 
 @[simp] lemma R₀'_subset_AddR₀ : ⌜𝐑₀'⌝[V] ⊆ T†V := Set.subset_union_right
 
@@ -712,37 +712,37 @@ open Arithmetization
 
 section
 
-variable (T : Theory ℒₒᵣ) [T.Delta1Definable]
+variable (T : ArithmeticTheory) [T.Delta1Definable]
 
 /-- Provability predicate for arithmetic stronger than $\mathbf{R_0}$. -/
-def _root_.LO.FirstOrder.Theory.Provableₐ (φ : V) : Prop := ((T + 𝐑₀').codeIn V).Provable φ
+def _root_.LO.FirstOrder.ArithmeticTheory.Provable (φ : V) : Prop := ((T + 𝐑₀').codeIn V).Provable φ
 
 variable {T}
 
-lemma provableₐ_iff {σ : Sentence ℒₒᵣ} : T.Provableₐ (⌜σ⌝ : V) ↔ T†V ⊢! ⌜σ⌝ := by
+lemma provable_iff {σ : Sentence ℒₒᵣ} : T.Provable (⌜σ⌝ : V) ↔ T†V ⊢! ⌜σ⌝ := by
   simp [Language.Theory.TProvable.iff_provable]; rfl
 
 /-- TODO: refactor name-/
-lemma provableₐ_iff' {φ : SyntacticFormula ℒₒᵣ} : T.Provableₐ (⌜φ⌝ : V) ↔ T†V ⊢! ⌜φ⌝ := by
+lemma provable_iff' {φ : SyntacticFormula ℒₒᵣ} : T.Provable (⌜φ⌝ : V) ↔ T†V ⊢! ⌜φ⌝ := by
   simp [Language.Theory.TProvable.iff_provable]; rfl
 
 section
 
 variable (T)
 
-def _root_.LO.FirstOrder.Theory.provableₐ : 𝚺₁.Semisentence 1 := .mkSigma
+def _root_.LO.FirstOrder.ArithmeticTheory.provable : 𝚺₁.Semisentence 1 := .mkSigma
   “p. !(T + 𝐑₀').tDef.prv p” (by simp)
 
-lemma provableₐ_defined : 𝚺₁-Predicate (T.Provableₐ : V → Prop) via T.provableₐ := by
-  intro v; simp [FirstOrder.Theory.provableₐ, FirstOrder.Theory.Provableₐ, ((T + 𝐑₀').codeIn V).provable_defined.df.iff]
+lemma provable_defined : 𝚺₁-Predicate (T.Provable : V → Prop) via T.provable := by
+  intro v; simp [ArithmeticTheory.provable, ArithmeticTheory.Provable, ((T + 𝐑₀').codeIn V).provable_defined.df.iff]
 
-@[simp] lemma eval_provableₐ (v) :
-    Semiformula.Evalbm V v T.provableₐ.val ↔ T.Provableₐ (v 0) := (provableₐ_defined T).df.iff v
+@[simp] lemma eval_provable (v) :
+    Semiformula.Evalbm V v T.provable.val ↔ T.Provable (v 0) := (provable_defined T).df.iff v
 
-instance provableₐ_definable : 𝚺₁-Predicate (T.Provableₐ : V → Prop) := (provableₐ_defined T).to_definable
+instance provable_definable : 𝚺₁-Predicate (T.Provable : V → Prop) := (provable_defined T).to_definable
 
 /-- instance for definability tactic-/
-instance provableₐ_definable' : 𝚺-[0 + 1]-Predicate (T.Provableₐ : V → Prop) := provableₐ_definable T
+instance provable_definable' : 𝚺-[0 + 1]-Predicate (T.Provable : V → Prop) := provable_definable T
 
 end
 

--- a/Foundation/FirstOrder/Incompleteness/WitnessComparison.lean
+++ b/Foundation/FirstOrder/Incompleteness/WitnessComparison.lean
@@ -109,7 +109,7 @@ end WitnessComparisons
 
 section ProvabilityComparisonOnArithmetic
 
-variable (T : Theory ℒₒᵣ) [T.Delta1Definable]
+variable (T : ArithmeticTheory) [T.Delta1Definable]
 
 /-- Provability predicate for arithmetic stronger than $\mathbf{R_0}$. -/
 def _root_.LO.FirstOrder.Theory.ProvabilityComparisonₐ (φ ψ : V) : Prop := ((T + 𝐑₀').codeIn V).ProvabilityComparison φ ψ
@@ -136,11 +136,11 @@ namespace ProvabilityComparisonₐ
 
 variable {T} {φ ψ : V}
 
-lemma refl_iff_provable : T.ProvabilityComparisonₐ φ φ ↔ T.Provableₐ φ := Language.Theory.ProvabilityComparison.refl_iff_provable
+lemma refl_iff_provable : T.ProvabilityComparisonₐ φ φ ↔ T.Provable φ := Language.Theory.ProvabilityComparison.refl_iff_provable
 
 lemma antisymm : T.ProvabilityComparisonₐ φ ψ → T.ProvabilityComparisonₐ ψ φ → φ = ψ := Language.Theory.ProvabilityComparison.antisymm
 
-lemma find_minimal_proof_fintype [Fintype ι] (φ : ι → V) (H : T.Provableₐ (φ i)) :
+lemma find_minimal_proof_fintype [Fintype ι] (φ : ι → V) (H : T.Provable (φ i)) :
     ∃ j, ∀ k, T.ProvabilityComparisonₐ (φ j) (φ k) := Language.Theory.ProvabilityComparison.find_minimal_proof_fintype _ H
 
 end ProvabilityComparisonₐ

--- a/Foundation/FirstOrder/PeanoMinus/Basic.lean
+++ b/Foundation/FirstOrder/PeanoMinus/Basic.lean
@@ -35,7 +35,7 @@ abbrev         ltTri : SyntacticFormula ℒₒᵣ := “x y | x < y ∨ x = y �
 
 end PeanoMinus.Axiom
 
-inductive PeanoMinus : Theory ℒₒᵣ
+inductive PeanoMinus : ArithmeticTheory
   | equal         : ∀ φ ∈ 𝐄𝐐, PeanoMinus φ
   | addZero       : PeanoMinus PeanoMinus.Axiom.addZero
   | addAssoc      : PeanoMinus PeanoMinus.Axiom.addAssoc
@@ -154,7 +154,7 @@ set_option linter.flexible false in
   case ltTrans => intro f; exact Nat.lt_trans
   case ltTri => intro f; exact Nat.lt_trichotomy _ _
   case equal h =>
-    have : ℕ ⊧ₘ* (𝐄𝐐 : Theory ℒₒᵣ) := inferInstance
+    have : ℕ ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h⟩
 
 instance : 𝐄𝐐 ⪯ 𝐏𝐀⁻ := Entailment.WeakerThan.ofSubset <| fun φ hp ↦ PeanoMinus.equal φ hp
@@ -323,7 +323,7 @@ instance qq : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
   intro φ h
   rcases h
   case equal h =>
-    have : M ⊧ₘ* (𝐄𝐐 : Theory ℒₒᵣ) := inferInstance
+    have : M ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h
   case Ω₁ n m =>
     simp [models_iff, numeral_eq_natCast]
@@ -530,7 +530,7 @@ variable {M}
   · rfl
   · unfold natCast; rw [coe_add_one]; simp [*]
 
-variable {T : Theory ℒₒᵣ} [𝐏𝐀⁻ ⪯ T]
+variable {T : ArithmeticTheory} [𝐏𝐀⁻ ⪯ T]
 
 instance : 𝐑₀ ⪯ 𝐏𝐀⁻ := oRing_weakerThan_of.{0} _ _ fun _ _ _ ↦ inferInstance
 

--- a/Foundation/FirstOrder/R0/Basic.lean
+++ b/Foundation/FirstOrder/R0/Basic.lean
@@ -14,7 +14,7 @@ namespace LO
 
 open FirstOrder FirstOrder.Arith
 
-inductive R0 : Theory ℒₒᵣ
+inductive R0 : ArithmeticTheory
   | equal : ∀ φ ∈ 𝐄𝐐, R0 φ
   | Ω₁ (n m : ℕ) : R0 “↑n + ↑m = ↑(n + m)”
   | Ω₂ (n m : ℕ) : R0 “↑n * ↑m = ↑(n * m)”
@@ -31,7 +31,7 @@ instance : ℕ ⊧ₘ* 𝐑₀ := ⟨by
   intro σ h
   rcases h <;> try { simp [models_def, ←le_iff_eq_or_lt]; done }
   case equal h =>
-    have : ℕ ⊧ₘ* (𝐄𝐐 : Theory ℒₒᵣ) := inferInstance
+    have : ℕ ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     simpa [models_def] using modelsTheory_iff.mp this h
   case Ω₃ h =>
     simpa [models_def, ←le_iff_eq_or_lt] using h⟩
@@ -140,7 +140,7 @@ end R0
 
 namespace FirstOrder.Arith
 
-variable {T : Theory ℒₒᵣ} [𝐑₀ ⪯ T]
+variable {T : ArithmeticTheory} [𝐑₀ ⪯ T]
 
 theorem sigma_one_completeness {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
     ℕ ⊧ₘ₀ σ → T ⊢!. σ := fun H =>
@@ -150,10 +150,10 @@ theorem sigma_one_completeness {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1
     exact R0.sigma_one_completeness hσ H
 
 open Classical in
-theorem sigma_one_completeness_iff [ss : Sigma1Sound T] {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
+theorem sigma_one_completeness_iff [ss : T.Sigma1Sound] {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
     ℕ ⊧ₘ₀ σ ↔ T ⊢!. σ :=
   haveI : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans (𝓣 := T) inferInstance inferInstance
-  ⟨fun h ↦ sigma_one_completeness (T := T) hσ h, fun h ↦ ss.sound (by simp [hσ]) <| Axiom.provable_iff.mp h⟩
+  ⟨fun h ↦ sigma_one_completeness hσ h, fun h ↦ ss.sound h (by simp [hσ])⟩
 
 end FirstOrder.Arith
 
@@ -228,7 +228,7 @@ instance : OmegaAddOne ⊧ₘ* 𝐑₀ := ⟨by
   intro σ h
   rcases h <;> simp [models_def, ←le_iff_eq_or_lt]
   case equal h =>
-    have : OmegaAddOne ⊧ₘ* (𝐄𝐐 : Theory ℒₒᵣ) := inferInstance
+    have : OmegaAddOne ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h
   case Ω₃ h => exact h
   case Ω₄ n =>

--- a/Foundation/FirstOrder/R0/Representation.lean
+++ b/Foundation/FirstOrder/R0/Representation.lean
@@ -252,7 +252,7 @@ lemma codeOfREPred_spec {A : ℕ → Prop} (hp : REPred A) {x : ℕ} :
   simpa [Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfPartrec'_spec (Nat.Partrec'.of_part this) (v := ![x]) (y := 0)).trans (by simp [f])
 
-variable {T : Theory ℒₒᵣ} [𝐑₀ ⪯ T] [Sigma1Sound T]
+variable {T : ArithmeticTheory} [𝐑₀ ⪯ T] [T.Sigma1Sound]
 
 lemma re_complete {A : ℕ → Prop} (hp : REPred A) {x : ℕ} :
     A x ↔ T ⊢!. (codeOfREPred A)/[‘↑x’] := Iff.trans

--- a/Foundation/Logic/Entailment.lean
+++ b/Foundation/Logic/Entailment.lean
@@ -338,12 +338,12 @@ variable (𝓢 : S)
 
 def Complete : Prop := ∀ f, 𝓢 ⊢! f ∨ 𝓢 ⊢! ∼f
 
-def Undecidable (f : F) : Prop := 𝓢 ⊬ f ∧ 𝓢 ⊬ ∼f
+def Independent (f : F) : Prop := 𝓢 ⊬ f ∧ 𝓢 ⊬ ∼f
 
 end
 
 lemma incomplete_iff_exists_undecidable [LogicalConnective F] {𝓢 : S} :
-    ¬Entailment.Complete 𝓢 ↔ ∃ f, Undecidable 𝓢 f := by simp [Complete, Undecidable, not_or]
+    ¬Entailment.Complete 𝓢 ↔ ∃ f, Independent 𝓢 f := by simp [Complete, Independent, not_or]
 
 variable (S T)
 

--- a/Foundation/Modal/Logic/GL/Independency.lean
+++ b/Foundation/Modal/Logic/GL/Independency.lean
@@ -41,7 +41,7 @@ lemma unprovable_not_independency_of_consistency : Logic.GL ⊬ ∼(independency
     simpa;
 
 /-
-theorem undecidable_independency_of_consistency : Undecidable Hilbert.GL (independency (∼□⊥)) := by
+theorem undecidable_independency_of_consistency : Independent Hilbert.GL (independency (∼□⊥)) := by
   constructor;
   . exact unprovable_independency;
   . exact unprovable_not_independency_of_consistency;
@@ -65,7 +65,7 @@ lemma unprovable_not_higherIndependency_of_consistency : Logic.GL ⊬ ∼(higher
     . exact ih h;
 
 /-
-theorem undecidable_higherIndependency_of_consistency : Undecidable Hilbert.GL (higherIndependency (∼□⊥) n) := by
+theorem undecidable_higherIndependency_of_consistency : Independent Hilbert.GL (higherIndependency (∼□⊥) n) := by
   constructor;
   . exact unprovable_higherIndependency_of_consistency;
   . exact unprovable_not_higherIndependency_of_consistency;

--- a/Foundation/Modal/Logic/S/Consistent.lean
+++ b/Foundation/Modal/Logic/S/Consistent.lean
@@ -17,7 +17,7 @@ lemma iff_provable_GL_provable_box_S {A : Modal.Formula _} : Logic.GL ⊢! A ↔
   . intro h;
     apply GL.arithmetical_completeness (T := 𝐈𝚺₁);
     intro f;
-    exact Iff.mp ((𝐈𝚺₁).standardDP 𝐈𝚺₁).sound (S.arithmetical_soundness h f)
+    exact Iff.mp 𝐈𝚺₁.standardPr.sound (S.arithmetical_soundness h f)
 
 theorem S.no_boxbot : Logic.S ⊬ □⊥ := iff_provable_GL_provable_box_S.not.mp $ by simp;
 

--- a/Foundation/ProvabilityLogic/Basic.lean
+++ b/Foundation/ProvabilityLogic/Basic.lean
@@ -1,4 +1,4 @@
-import Foundation.FirstOrder.Incompleteness.DerivabilityCondition.Basic
+import Foundation.ProvabilityLogic.Conditions
 import Foundation.FirstOrder.Incompleteness.StandardProvability
 import Foundation.FirstOrder.Incompleteness.Delta1
 import Foundation.Logic.HilbertStyle.Cl
@@ -7,24 +7,10 @@ import Foundation.Modal.Hilbert.WellKnown
 namespace LO
 
 open Entailment FiniteContext
-open FirstOrder LO.FirstOrder.DerivabilityCondition
+open FirstOrder ProvabilityLogic
 open Modal Modal.Hilbert
 
-
-namespace FirstOrder
-
-variable {T : Theory ℒₒᵣ}
-
-instance [𝐈𝚺₁ ⪯ T] [T.Delta1Definable] : ((𝐈𝚺₁).standardDP T).Sound ℕ := ⟨fun {σ} ↦ by
-  have : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
-  simp [Arith.standardDP_def, models₀_iff]⟩
-
-end FirstOrder
-
-
-
-variable {L : Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
-         {T₀ T : Theory L}
+variable {L : Language} [Semiterm.Operator.GoedelNumber L (Sentence L)] {T₀ T : Theory L}
 
 namespace ProvabilityLogic
 
@@ -93,7 +79,6 @@ lemma iff_interpret_and' : T ⊢!. f.interpret 𝔅 (A ⋏ B) ↔ T ⊢!. (f.int
     apply K!_intro <;> assumption;
 
 end
-
 
 lemma letterless_interpret
   {f₁ f₂ : Realization L} (A_letterless : A.letterless)

--- a/Foundation/ProvabilityLogic/Conditions.lean
+++ b/Foundation/ProvabilityLogic/Conditions.lean
@@ -50,7 +50,7 @@ class Rosser (𝔅 : ProvabilityPredicate T₀ T) where
   protected Ro {σ : Sentence L} : T ⊢!. ∼σ → T₀ ⊢!. ∼𝔅 σ
 
 class Sound (𝔅 : ProvabilityPredicate T₀ T) (N : outParam Type*) [Nonempty N] [Structure L N] where
-  protected sound (σ : Sentence L) : N ⊧ₘ₀ 𝔅 σ ↔ T ⊢!. σ
+  protected sound {σ : Sentence L} : N ⊧ₘ₀ 𝔅 σ ↔ T ⊢!. σ
 
 protected alias sound := Sound.sound
 

--- a/Foundation/ProvabilityLogic/GL/Completeness.lean
+++ b/Foundation/ProvabilityLogic/GL/Completeness.lean
@@ -20,7 +20,7 @@ namespace LO
 namespace ProvabilityLogic
 
 open Entailment Entailment.FiniteContext
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open Modal
 open Modal.Kripke
 open Modal.Formula.Kripke
@@ -487,7 +487,7 @@ lemma solovay_unprovable [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] {i :
 variable (T F r)
 
 instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
-    [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : SolovaySentences ((𝐈𝚺₁).standardDP T) F r where
+    [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : SolovaySentences T.standardPr F r where
   σ := T.solovay
   SC1 i j ne :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
@@ -496,11 +496,11 @@ instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
   SC2 i j h :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
     oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
-      simpa [models_iff, standardDP_def] using Solovay.consistent h
+      simpa [models_iff, standardPr_def] using Solovay.consistent h
   SC3 i h :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
     oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
-    simpa [models_iff, standardDP_def] using Solovay.box_disjunction h
+    simpa [models_iff, standardPr_def] using Solovay.box_disjunction h
   SC4 i ne := solovay_unprovable ne
 
 lemma _root_.LO.ProvabilityLogic.SolovaySentences.standard_σ_def [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] :
@@ -513,7 +513,7 @@ end LO.ISigma1.Metamath
 namespace LO.ProvabilityLogic
 
 open Entailment Entailment.FiniteContext
-open FirstOrder Arith FirstOrder.DerivabilityCondition
+open FirstOrder Arith
 open Modal
 open Modal.Kripke
 
@@ -521,28 +521,28 @@ variable {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [SoundOn
 
 /-- Arithmetical completeness of GL-/
 theorem GL.arithmetical_completeness :
-    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret ((𝐈𝚺₁).standardDP T) A) → Logic.GL ⊢! A := by
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr A) → Logic.GL ⊢! A := by
   contrapose;
   intro hA;
   push_neg;
   obtain ⟨M₁, r₁, _, hA₁⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp hA;
   have : Fintype (M₁.extendRoot r₁ 1).World := Fintype.ofFinite _
-  let σ : SolovaySentences ((𝐈𝚺₁).standardDP T) (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root :=
+  let σ : SolovaySentences T.standardPr (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root :=
     SolovaySentences.standard (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root T
   use σ.realization;
-  have : 𝐈𝚺₁ ⊢!. σ r₁ ➝ σ.realization.interpret ((𝐈𝚺₁).standardDP T) (∼A) :=
+  have : 𝐈𝚺₁ ⊢!. σ r₁ ➝ σ.realization.interpret T.standardPr (∼A) :=
     σ.mainlemma (A := ∼A) (i := r₁) (by trivial) |>.1 $ Model.extendRoot.inr_satisfies_iff |>.not.mpr hA₁;
-  replace : 𝐈𝚺₁ ⊢!. σ.realization.interpret ((𝐈𝚺₁).standardDP T) A ➝ ∼(σ r₁) := by
+  replace : 𝐈𝚺₁ ⊢!. σ.realization.interpret T.standardPr A ➝ ∼(σ r₁) := by
     apply CN!_of_CN!_right;
     apply C!_trans this;
     apply K!_right neg_equiv!;
-  replace : T ⊢!. σ.realization.interpret ((𝐈𝚺₁).standardDP T) A ➝ ∼(σ r₁) := WeakerThan.pbl this;
+  replace : T ⊢!. σ.realization.interpret T.standardPr A ➝ ∼(σ r₁) := WeakerThan.pbl this;
   by_contra hC;
   have : T ⊢!. ∼(σ r₁) := this ⨀ hC;
   exact σ.SC4 _ (by rintro ⟨⟩) this;
 
 theorem GL.arithmetical_completeness_iff :
-    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret ((𝐈𝚺₁).standardDP T) A) ↔ Logic.GL ⊢! A :=
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr A) ↔ Logic.GL ⊢! A :=
   ⟨GL.arithmetical_completeness, GL.arithmetical_soundness⟩
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/GL/Completeness.lean
+++ b/Foundation/ProvabilityLogic/GL/Completeness.lean
@@ -110,7 +110,7 @@ open Modal ProvabilityLogic Kripke
 
 variable {F : Kripke.Frame} {r : F} [F.IsFiniteTree r] [Fintype F]
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
 
 section model
 
@@ -187,7 +187,7 @@ lemma rew_θAux (w : Fin N → Semiterm ℒₒᵣ Empty N') (t : F → Semiterm 
 def _root_.LO.FirstOrder.Theory.solovay (i : F) : Sentence ℒₒᵣ := exclusiveMultifixpoint
   (fun j ↦
     let jj := (Fintype.equivFin F).symm j
-    θAux T (fun i ↦ #(Fintype.equivFin F i)) jj ⋏ ⩕ k ∈ { k : F | jj ≺ k }, T.consistencyₐ/[#(Fintype.equivFin F k)])
+    θAux T (fun i ↦ #(Fintype.equivFin F i)) jj ⋏ ⩕ k ∈ { k : F | jj ≺ k }, T.consistency/[#(Fintype.equivFin F k)])
   (Fintype.equivFin F i)
 
 def twoPoint (i j : F) : Sentence ℒₒᵣ := twoPointAux T (fun i ↦ ⌜T.solovay i⌝) i j
@@ -197,15 +197,15 @@ def θChain (ε : List F) : Sentence ℒₒᵣ := θChainAux T (fun i ↦ ⌜T.s
 def θ (i : F) : Sentence ℒₒᵣ := θAux T (fun i ↦ ⌜T.solovay i⌝) i
 
 lemma solovay_diag (i : F) :
-    𝐈𝚺₁ ⊢!. T.solovay i ⭤ θ T i ⋏ ⩕ j ∈ { j : F | i ≺ j }, T.consistencyₐ/[⌜T.solovay j⌝] := by
+    𝐈𝚺₁ ⊢!. T.solovay i ⭤ θ T i ⋏ ⩕ j ∈ { j : F | i ≺ j }, T.consistency/[⌜T.solovay j⌝] := by
   have : 𝐈𝚺₁ ⊢!. T.solovay i ⭤
       (Rew.substs fun j ↦ ⌜T.solovay ((Fintype.equivFin F).symm j)⌝) ▹
-        (θAux T (fun i ↦ #(Fintype.equivFin F i)) i ⋏ ⩕ k ∈ { k : F | i ≺ k }, T.consistencyₐ/[#(Fintype.equivFin F k)]) := by
+        (θAux T (fun i ↦ #(Fintype.equivFin F i)) i ⋏ ⩕ k ∈ { k : F | i ≺ k }, T.consistency/[#(Fintype.equivFin F k)]) := by
     simpa [Theory.solovay, Matrix.comp_vecCons', Matrix.constant_eq_singleton] using
       exclusiveMultidiagonal (T := 𝐈𝚺₁) (i := Fintype.equivFin F i)
         (fun j ↦
           let jj := (Fintype.equivFin F).symm j
-          θAux T (fun i ↦ #(Fintype.equivFin F i)) jj ⋏ ⩕ k ∈ { k : F | jj ≺ k }, T.consistencyₐ/[#(Fintype.equivFin F k)])
+          θAux T (fun i ↦ #(Fintype.equivFin F i)) jj ⋏ ⩕ k ∈ { k : F | jj ≺ k }, T.consistency/[#(Fintype.equivFin F k)])
   simpa [θ, Finset.map_conj', Function.comp_def, rew_θAux, ←TransitiveRewriting.comp_app,
     Rew.substs_comp_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton] using this
 
@@ -244,7 +244,7 @@ inductive ΘChain : List F → Prop where
 
 def Θ (i : F) : Prop := ∃ ε : List F, ε.ChainI (· ≻ ·) i r ∧ ΘChain T V ε
 
-def _root_.LO.FirstOrder.Theory.Solovay (i : F) := Θ T V i ∧ ∀ j, i ≺ j → T.Consistencyₐ (⌜T.solovay j⌝ : V)
+def _root_.LO.FirstOrder.Theory.Solovay (i : F) := Θ T V i ∧ ∀ j, i ≺ j → T.Consistency (⌜T.solovay j⌝ : V)
 
 variable {T V}
 
@@ -317,7 +317,7 @@ lemma ΘChain.append_iff {ε₁ ε₂ : List F} : ΘChain T V (ε₁ ++ i :: ε�
 private lemma Solovay.exclusive.comparable {i₁ i₂ : F} {ε₁ ε₂ : List F}
     (ne : i₁ ≠ i₂)
     (h : ε₁ <:+ ε₂)
-    (Hi₁ : ∀ j, i₁ ≺ j → T.Consistencyₐ (⌜T.solovay j⌝ : V))
+    (Hi₁ : ∀ j, i₁ ≺ j → T.Consistency (⌜T.solovay j⌝ : V))
     (cε₁ : List.ChainI (· ≻ ·) i₁ r ε₁)
     (cε₂ : List.ChainI (· ≻ ·) i₂ r ε₂)
     (Θε₂ : ΘChain T V ε₂) : False := by
@@ -334,8 +334,8 @@ private lemma Solovay.exclusive.comparable {i₁ i₂ : F} {ε₁ ε₂ : List F
     rcases cε₁.tail_exists with ⟨ε₁', rfl⟩
     exact List.infix_iff_prefix_suffix.mpr ⟨j :: i₁ :: ε₁', by simp, hj⟩
   have hij₁ : i₁ ≺ j := cε₂.rel_of_infix j i₁ hji₁ε₂
-  have : ¬T.Provableₐ (⌜∼T.solovay j⌝ : V) := by simpa [Theory.Consistencyₐ.quote_iff] using Hi₁ j hij₁
-  have : T.Provableₐ (⌜∼T.solovay j⌝ : V) := by
+  have : ¬T.Provable (⌜∼T.solovay j⌝ : V) := by simpa [Theory.Consistency.quote_iff] using Hi₁ j hij₁
+  have : T.Provable (⌜∼T.solovay j⌝ : V) := by
     have : ΘChain T V [j, i₁] := by
       rcases hji₁ε₂ with ⟨η₁, η₂, rfl⟩
       have Θε₂ : ΘChain T V (η₁ ++ j :: i₁ :: η₂) := by simpa using Θε₂
@@ -384,10 +384,10 @@ lemma Solovay.exclusive {i₁ i₂ : F} (ne : i₁ ≠ i₂) : T.Solovay V i₁ 
   contradiction
 
 /-- Condition 2.-/
-lemma Solovay.consistent {i j : F} (hij : i ≺ j) : T.Solovay V i → ¬T.Provableₐ (⌜∼T.solovay j⌝ : V) := fun h ↦
-  (Theory.Consistencyₐ.quote_iff _).mp (h.2 j hij)
+lemma Solovay.consistent {i j : F} (hij : i ≺ j) : T.Solovay V i → ¬T.Provable (⌜∼T.solovay j⌝ : V) := fun h ↦
+  (Theory.Consistency.quote_iff _).mp (h.2 j hij)
 
-lemma Solovay.refute (ne : r ≠ i) : T.Solovay V i → T.Provableₐ (⌜∼T.solovay i⌝ : V) := by
+lemma Solovay.refute (ne : r ≠ i) : T.Solovay V i → T.Provable (⌜∼T.solovay i⌝ : V) := by
   intro h
   rcases show Θ T V i from h.1 with ⟨ε, hε, cε⟩
   rcases List.ChainI.prec_exists_of_ne hε (Ne.symm ne) with ⟨ε', i', hii', rfl, hε'⟩
@@ -404,9 +404,9 @@ lemma Θ.disjunction (i : F) : Θ T V i → T.Solovay V i ∨ ∃ j, i ≺ j ∧
   · left; exact hS
   · right
     have : ∃ j, i ≺ j ∧ ∀ k, i ≺ k → T.ProvabilityComparisonₐ (V := V) ⌜∼T.solovay j⌝ ⌜∼T.solovay k⌝ := by
-      have : ∃ j, i ≺ j ∧ T.Provableₐ (⌜∼T.solovay j⌝ : V) := by
-        have : Θ T V i → ∃ x, i ≺ x ∧ T.Provableₐ (⌜∼T.solovay x⌝ : V) := by
-          simpa [Theory.Consistencyₐ.quote_iff, Theory.Solovay] using hS
+      have : ∃ j, i ≺ j ∧ T.Provable (⌜∼T.solovay j⌝ : V) := by
+        have : Θ T V i → ∃ x, i ≺ x ∧ T.Provable (⌜∼T.solovay x⌝ : V) := by
+          simpa [Theory.Consistency.quote_iff, Theory.Solovay] using hS
         exact this hΘ
       rcases this with ⟨j', hij', hj'⟩
       have := ProvabilityComparisonₐ.find_minimal_proof_fintype (T := T) (ι := {j : F // i ≺ j}) (i := ⟨j', hij'⟩)
@@ -433,9 +433,9 @@ lemma solovay_disjunction : ∃ i : F, T.Solovay V i := by
 
 /-- Condition 3.-/
 lemma Solovay.box_disjunction [𝐈𝚺₁ ⪯ T] {i : F} (ne : r ≠ i) :
-    T.Solovay V i → T.Provableₐ (⌜⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ : V) := by
+    T.Solovay V i → T.Provable (⌜⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ : V) := by
   intro hS
-  have TP : T†V ⊢! ⌜θ T i ➝ T.solovay i ⋎ ⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ := provableₐ_of_provable'₀ <| by
+  have TP : T†V ⊢! ⌜θ T i ➝ T.solovay i ⋎ ⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ := provable_of_provable_arith'₀ <| by
     have : 𝐈𝚺₁ ⊢!. θ T i ➝ T.solovay i ⋎ ⩖ j ∈ {j : F | i ≺ j}, T.solovay j :=
       oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
         simpa [models_iff] using Θ.disjunction i
@@ -443,30 +443,31 @@ lemma Solovay.box_disjunction [𝐈𝚺₁ ⪯ T] {i : F} (ne : r ≠ i) :
   have Tθ : T†V ⊢! ⌜θ T i⌝ :=
     sigma₁_complete_provable (show Hierarchy 𝚺 1 (θ T i) by simp) (by simpa [models_iff] using hS.1)
   have hP : T†V ⊢! ⌜T.solovay i⌝ ⋎ ⌜⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ := (by simpa using TP) ⨀ Tθ
-  have : T†V ⊢! ∼⌜T.solovay i⌝ := by simpa using provableₐ_iff.mp (Solovay.refute ne hS)
+  have : T†V ⊢! ∼⌜T.solovay i⌝ := by simpa using provable_iff.mp (Solovay.refute ne hS)
   have : T†V ⊢! ⌜⩖ j ∈ {j : F | i ≺ j}, T.solovay j⌝ := Entailment.of_a!_of_n! hP this
-  exact provableₐ_iff.mpr this
+  exact provable_iff.mpr this
 
 end model
 
-lemma solovay_root_sound [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T.Solovay ℕ r := by
+lemma solovay_root_sound [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : T.Solovay ℕ r := by
   haveI : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans inferInstance (inferInstanceAs (𝐈𝚺₁ ⪯ T))
   have NS : ∀ i, r ≠ i → ¬T.Solovay ℕ i := by
     intro i hi H
-    have Bi : T ⊢!. ∼T.solovay i := (provableₐ_iff_provable₀ (T := T)).mp (Solovay.refute hi H)
+    have Bi : T ⊢!. ∼T.solovay i := (provable_iff_provable₀ (T := T)).mp (Solovay.refute hi H)
     have : ¬T.Solovay ℕ i := by
-      set π := θ T i ⋏ ⩕ j ∈ { j : F | i ≺ j }, T.consistencyₐ/[⌜T.solovay j⌝]
+      set π := θ T i ⋏ ⩕ j ∈ { j : F | i ≺ j }, T.consistency/[⌜T.solovay j⌝]
       have sπ : 𝐈𝚺₁ ⊢!. T.solovay i ⭤ π := solovay_diag T i
       have : T ⊢!. ∼π := by
         have : T ⊢!. T.solovay i ⭤ π := Entailment.WeakerThan.wk (inferInstanceAs (𝐈𝚺₁.toAxiom ⪯ T.toAxiom)) sπ
         exact Entailment.K!_left (Entailment.ENN!_of_E! this) ⨀ Bi
       have : ¬ℕ ⊧/![] π := by
         simpa [models_iff] using
-          (inferInstanceAs (SoundOn T (Hierarchy 𝚷 2))).sound
+          (inferInstanceAs (T.SoundOn (Hierarchy 𝚷 2))).sound
             (σ := ∼π)
+            this
             (by simp [π,
-              (show Hierarchy 𝚷 1 T.consistencyₐ.val by simp).strict_mono 𝚺 (show 1 < 2 by simp),
-              (show Hierarchy 𝚺 1 (θ T i) by simp).mono (show 1 ≤ 2 by simp)]) <| Axiom.provable_iff.mp this
+              (show Hierarchy 𝚷 1 T.consistency.val by simp).strict_mono 𝚺 (show 1 < 2 by simp),
+              (show Hierarchy 𝚺 1 (θ T i) by simp).mono (show 1 ≤ 2 by simp)])
       have : T.Solovay ℕ i ↔ ℕ ⊧/![] π := by
         simpa [models_iff] using consequence_iff.mp (sound!₀ sπ) ℕ inferInstance
       simpa [this]
@@ -478,16 +479,16 @@ lemma solovay_root_sound [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T.
     contradiction
 
 /-- Condition 4.-/
-lemma solovay_unprovable [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] {i : F} (h : r ≠ i) : T ⊬. ∼T.solovay i := by
+lemma solovay_unprovable [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] {i : F} (h : r ≠ i) : T ⊬. ∼T.solovay i := by
   haveI : 𝐑₀ ⪯ T := Entailment.WeakerThan.trans inferInstance (inferInstanceAs (𝐈𝚺₁ ⪯ T))
-  have : ∼T.Provableₐ ⌜∼T.solovay i⌝ :=
+  have : ∼T.Provable ⌜∼T.solovay i⌝ :=
     Solovay.consistent (V := ℕ) (T := T) (Frame.root_genaretes'! i (Ne.symm h)) solovay_root_sound
-  simpa [Theory.Consistencyₐ.quote_iff, provableₐ_iff_provable₀, Axiom.unprovable_iff] using this
+  simpa [Theory.Consistency.quote_iff, provable_iff_provable₀, Axiom.unprovable_iff] using this
 
 variable (T F r)
 
 instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
-    [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : SolovaySentences T.standardPr F r where
+    [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : SolovaySentences T.standardPr F r where
   σ := T.solovay
   SC1 i j ne :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
@@ -503,7 +504,7 @@ instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
     simpa [models_iff, standardPr_def] using Solovay.box_disjunction h
   SC4 i ne := solovay_unprovable ne
 
-lemma _root_.LO.ProvabilityLogic.SolovaySentences.standard_σ_def [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] :
+lemma _root_.LO.ProvabilityLogic.SolovaySentences.standard_σ_def [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] :
     (SolovaySentences.standard F r T).σ = T.solovay := rfl
 
 end SolovaySentences
@@ -517,7 +518,7 @@ open FirstOrder Arith
 open Modal
 open Modal.Kripke
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] {A : Modal.Formula _}
+variable {T : ArithmeticTheory} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] {A : Modal.Formula _}
 
 /-- Arithmetical completeness of GL-/
 theorem GL.arithmetical_completeness :

--- a/Foundation/ProvabilityLogic/GL/Completeness.lean
+++ b/Foundation/ProvabilityLogic/GL/Completeness.lean
@@ -1,4 +1,4 @@
-import Foundation.ProvabilityLogic.Basic
+import Foundation.ProvabilityLogic.Interpretation
 import Foundation.Modal.Kripke.Logic.GL.Tree
 import Foundation.Modal.Kripke.ExtendRoot
 import Foundation.FirstOrder.Incompleteness.WitnessComparison

--- a/Foundation/ProvabilityLogic/GL/Soundness.lean
+++ b/Foundation/ProvabilityLogic/GL/Soundness.lean
@@ -5,7 +5,7 @@ namespace LO.ProvabilityLogic
 open Entailment
 open Modal
 open Modal.Hilbert
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open ProvabilityPredicate
 
 variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
@@ -13,8 +13,7 @@ variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L
          {T U : FirstOrder.Theory L} [Diagonalization T]  [T ⪯ U]
          {𝔅 : ProvabilityPredicate T U} [𝔅.HBL]
 
-lemma GL.arithmetical_soundness (h : Logic.GL ⊢! A) : ∀ {f : Realization L}, U ⊢!. (f.interpret 𝔅 A) := by
-  intro f;
+lemma GL.arithmetical_soundness (h : Logic.GL ⊢! A) {f : Realization L} : U ⊢!. f.interpret 𝔅 A := by
   induction h with
   | maxm hp =>
     rcases (by simpa using hp) with (⟨_, rfl⟩ | ⟨_, rfl⟩)

--- a/Foundation/ProvabilityLogic/GL/Soundness.lean
+++ b/Foundation/ProvabilityLogic/GL/Soundness.lean
@@ -1,4 +1,4 @@
-import Foundation.ProvabilityLogic.Basic
+import Foundation.ProvabilityLogic.Interpretation
 
 namespace LO.ProvabilityLogic
 

--- a/Foundation/ProvabilityLogic/GL/Unprovability.lean
+++ b/Foundation/ProvabilityLogic/GL/Unprovability.lean
@@ -163,7 +163,7 @@ lemma unrefutable_independency_of_consistency :
   congr;
 
 theorem undecidable_independency_of_consistency :
-    Undecidable T.toAxiom (T.standardPr.indep (T.standardPr.con)) := by
+    Independent T.toAxiom (T.standardPr.indep (T.standardPr.con)) := by
   constructor;
   . exact unprovable_independency_of_consistency;
   . exact unrefutable_independency_of_consistency;

--- a/Foundation/ProvabilityLogic/GL/Unprovability.lean
+++ b/Foundation/ProvabilityLogic/GL/Unprovability.lean
@@ -53,7 +53,7 @@ open FirstOrder FirstOrder.Arith
 open Modal Logic
 open Entailment
 
-variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
+variable {T : ArithmeticTheory} [T.Delta1Definable]
          {f : Realization ℒₒᵣ}
          {A B : Modal.Formula _}
 
@@ -61,7 +61,7 @@ variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
 section Corollary
 
 /-- Gödel's Second Incompleteness Theorem -/
-example [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T ⊬. T.standardPr.con := by
+example [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : T ⊬. T.standardPr.con := by
   have h := GL.arithmetical_completeness_iff (T := T) |>.not.mpr $ GL.unprovable_notbox (φ := ⊥);
   push_neg at h;
   obtain ⟨f, h⟩ := h;
@@ -119,7 +119,7 @@ lemma iff_not_modalIndep_not_bewIndep :
   . intro h; exact (K!_left iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
   . intro h; exact (K!_right iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
 
-variable [SoundOn T (Hierarchy 𝚷 2)]
+variable [T.SoundOn (Hierarchy 𝚷 2)]
 
 lemma unprovable_independency_of_consistency :
     T ⊬. T.standardPr.indep (T.standardPr.con) := by

--- a/Foundation/ProvabilityLogic/GL/Unprovability.lean
+++ b/Foundation/ProvabilityLogic/GL/Unprovability.lean
@@ -1,11 +1,9 @@
 import Foundation.Modal.Logic.GL.Independency
 import Foundation.ProvabilityLogic.GL.Completeness
 
-namespace LO
+namespace LO.ProvabilityLogic
 
-open Modal.Logic
-
-namespace FirstOrder.DerivabilityCondition
+open Modal.Logic FirstOrder
 
 namespace ProvabilityPredicate
 
@@ -19,7 +17,7 @@ variable {L : Language} [L.DecidableEq] [Semiterm.Operator.GoedelNumber L (Sente
 def indep (𝔅 : ProvabilityPredicate T₀ T) (σ : Sentence L) : Sentence L := ∼(𝔅 σ) ⋏ ∼(𝔅 (∼σ))
 
 lemma indep_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
-  T ⊢!. 𝔅.indep σ ➝ 𝔅.indep π := by
+    T ⊢!. 𝔅.indep σ ➝ 𝔅.indep π := by
   apply CKK!_of_C!_of_C!;
   . apply contra!;
     apply WeakerThan.pbl (𝓢 := T₀.toAxiom);
@@ -32,26 +30,27 @@ lemma indep_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
     exact K!_left h;
 
 lemma indep_iff_distribute_inside [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
-  T ⊢!. 𝔅.indep σ ⭤ 𝔅.indep π := by
+    T ⊢!. 𝔅.indep σ ⭤ 𝔅.indep π := by
   apply K!_intro
   . exact indep_distribute $ h;
   . apply indep_distribute;
     exact E!_symm h;
 
 lemma indep_iff_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
-  T ⊢!. 𝔅.indep σ ↔ T ⊢!. 𝔅.indep π := by
+    T ⊢!. 𝔅.indep σ ↔ T ⊢!. 𝔅.indep π := by
   constructor;
   . intro H; exact K!_left (indep_iff_distribute_inside h) ⨀ H;
   . intro H; exact K!_right (indep_iff_distribute_inside h) ⨀ H;
 
 end ProvabilityPredicate
 
-end FirstOrder.DerivabilityCondition
+end ProvabilityLogic
 
 
 namespace ProvabilityLogic
 
-open FirstOrder FirstOrder.Arith FirstOrder.DerivabilityCondition
+open FirstOrder FirstOrder.Arith
+open Modal Logic
 open Entailment
 
 variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
@@ -62,7 +61,7 @@ variable {T : Theory ℒₒᵣ} [T.Delta1Definable]
 section Corollary
 
 /-- Gödel's Second Incompleteness Theorem -/
-example [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T ⊬. ((𝐈𝚺₁).standardDP T).con := by
+example [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T ⊬. T.standardPr.con := by
   have h := GL.arithmetical_completeness_iff (T := T) |>.not.mpr $ GL.unprovable_notbox (φ := ⊥);
   push_neg at h;
   obtain ⟨f, h⟩ := h;
@@ -70,11 +69,10 @@ example [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)] : T ⊬. ((𝐈𝚺�
 
 end Corollary
 
-
 section Independency
 
-lemma iff_modalConsis_bewConsis_inside
-  : T ⊢!. f.interpret (𝐈𝚺₁.standardDP T) (∼□⊥) ⭤ (𝐈𝚺₁.standardDP T).con := by
+lemma iff_modalConsis_bewConsis_inside :
+    T ⊢!. f.interpret T.standardPr (∼□⊥) ⭤ T.standardPr.con := by
   apply K!_intro;
   . refine C!_trans (K!_left Realization.iff_interpret_neg_inside) ?_;
     apply contra!;
@@ -86,8 +84,7 @@ lemma iff_modalConsis_bewConsis_inside
 variable [𝐈𝚺₁ ⪯ T]
 
 lemma iff_modalIndep_bewIndep_inside :
-  T ⊢!. f.interpret ((𝐈𝚺₁).standardDP T) (Modal.independency A) ⭤ ((𝐈𝚺₁).standardDP T).indep (f.interpret ((𝐈𝚺₁).standardDP T) A)
-  := by
+    T ⊢!. f.interpret T.standardPr (Modal.independency A) ⭤ T.standardPr.indep (f.interpret T.standardPr A) := by
   apply K!_intro;
   . refine C!_trans (K!_left $ Realization.iff_interpret_and_inside) ?_;
     apply CKK!_of_C!_of_C!;
@@ -95,7 +92,7 @@ lemma iff_modalIndep_bewIndep_inside :
     . apply C!_trans (K!_left $ Realization.iff_interpret_neg_inside (A := □(∼A))) ?_;
       apply contra!;
       apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply ((𝐈𝚺₁).standardDP T).prov_distribute_imply;
+      apply T.standardPr.prov_distribute_imply;
       apply K!_right $ Realization.iff_interpret_neg_inside;
   . refine C!_trans ?_ (K!_right $ Realization.iff_interpret_and_inside);
     apply CKK!_of_C!_of_C!;
@@ -103,23 +100,21 @@ lemma iff_modalIndep_bewIndep_inside :
     . apply C!_trans ?_ (K!_right $ Realization.iff_interpret_neg_inside (A := □(∼A)));
       apply contra!;
       apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply ((𝐈𝚺₁).standardDP T).prov_distribute_imply;
+      apply T.standardPr.prov_distribute_imply;
       apply K!_left $ Realization.iff_interpret_neg_inside;
 
 lemma iff_modalIndep_bewIndep :
-  T ⊢!. f.interpret ((𝐈𝚺₁).standardDP T) (Modal.independency A) ↔ T ⊢!. ((𝐈𝚺₁).standardDP T).indep (f.interpret ((𝐈𝚺₁).standardDP T) A)
-  := by
+    T ⊢!. f.interpret T.standardPr (Modal.independency A) ↔ T ⊢!. T.standardPr.indep (f.interpret T.standardPr A) := by
   constructor;
   . intro h; exact (K!_left iff_modalIndep_bewIndep_inside) ⨀ h;
   . intro h; exact (K!_right iff_modalIndep_bewIndep_inside) ⨀ h;
 
 lemma iff_not_modalIndep_not_bewIndep_inside :
-  T ⊢!. ∼f.interpret ((𝐈𝚺₁).standardDP T) (Modal.independency A) ⭤ ∼((𝐈𝚺₁).standardDP T).indep (f.interpret ((𝐈𝚺₁).standardDP T) A)
-  := ENN!_of_E! iff_modalIndep_bewIndep_inside
+    T ⊢!. ∼f.interpret T.standardPr (Modal.independency A) ⭤ ∼T.standardPr.indep (f.interpret T.standardPr A) :=
+  ENN!_of_E! iff_modalIndep_bewIndep_inside
 
 lemma iff_not_modalIndep_not_bewIndep :
-  T ⊢!. ∼f.interpret ((𝐈𝚺₁).standardDP T) (Modal.independency A) ↔ T ⊢!. ∼((𝐈𝚺₁).standardDP T).indep (f.interpret ((𝐈𝚺₁).standardDP T) A)
-  := by
+    T ⊢!. ∼f.interpret T.standardPr (Modal.independency A) ↔ T ⊢!. ∼T.standardPr.indep (f.interpret T.standardPr A) := by
   constructor;
   . intro h; exact (K!_left iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
   . intro h; exact (K!_right iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
@@ -127,13 +122,13 @@ lemma iff_not_modalIndep_not_bewIndep :
 variable [SoundOn T (Hierarchy 𝚷 2)]
 
 lemma unprovable_independency_of_consistency :
-  T ⊬. ((𝐈𝚺₁).standardDP T).indep (((𝐈𝚺₁).standardDP T).con) := by
+    T ⊬. T.standardPr.indep (T.standardPr.con) := by
   let g : Realization ℒₒᵣ := λ _ => ⊥;
-  suffices T ⊬. g.interpret (𝐈𝚺₁.standardDP T) (Modal.independency (∼□⊥)) by
+  suffices T ⊬. g.interpret T.standardPr (Modal.independency (∼□⊥)) by
     have H₁ := iff_modalIndep_bewIndep (f := g) (T := T) (A := ∼□⊥);
-    have H₂ := ((𝐈𝚺₁).standardDP T).indep_iff_distribute (T := T)
-      (σ := g.interpret (𝐈𝚺₁.standardDP T) (∼□⊥))
-      (π := (𝐈𝚺₁.standardDP T).con)
+    have H₂ := T.standardPr.indep_iff_distribute (T := T)
+      (σ := g.interpret T.standardPr (∼□⊥))
+      (π := T.standardPr.con)
       iff_modalConsis_bewConsis_inside;
     exact Iff.trans H₁ H₂ |>.not.mp this;
   have h := GL.arithmetical_completeness_iff (T := T) |>.not.mpr $ GL.unprovable_independency (φ := ∼□⊥);
@@ -142,20 +137,20 @@ lemma unprovable_independency_of_consistency :
   congr;
 
 lemma unrefutable_independency_of_consistency :
-  T ⊬. ∼((𝐈𝚺₁).standardDP T).indep (((𝐈𝚺₁).standardDP T).con) := by
+    T ⊬. ∼T.standardPr.indep (T.standardPr.con) := by
   let g : Realization ℒₒᵣ := λ _ => ⊥;
-  suffices T ⊬. ∼g.interpret (𝐈𝚺₁.standardDP T) (Modal.independency (∼□⊥)) by
+  suffices T ⊬. ∼g.interpret T.standardPr (Modal.independency (∼□⊥)) by
     have H₁ := iff_not_modalIndep_not_bewIndep (f := g) (T := T) (A := ∼□⊥);
     have H₂ : T ⊢!.
-      ∼(𝐈𝚺₁.standardDP T).indep (g.interpret (𝐈𝚺₁.standardDP T) (∼□⊥)) ⭤
-      ∼(𝐈𝚺₁.standardDP T).indep (𝐈𝚺₁.standardDP T).con
-      := ENN!_of_E! $ ((𝐈𝚺₁).standardDP T).indep_iff_distribute_inside (T := T)
-      (σ := g.interpret (𝐈𝚺₁.standardDP T) (∼□⊥))
-      (π := (𝐈𝚺₁.standardDP T).con)
+      ∼T.standardPr.indep (g.interpret T.standardPr (∼□⊥)) ⭤
+      ∼T.standardPr.indep T.standardPr.con
+      := ENN!_of_E! $ T.standardPr.indep_iff_distribute_inside (T := T)
+      (σ := g.interpret T.standardPr (∼□⊥))
+      (π := T.standardPr.con)
       iff_modalConsis_bewConsis_inside;
     replace H₂ :
-      T ⊢!. ∼(𝐈𝚺₁.standardDP T).indep (g.interpret (𝐈𝚺₁.standardDP T) (∼□⊥)) ↔
-      T ⊢!. ∼(𝐈𝚺₁.standardDP T).indep (𝐈𝚺₁.standardDP T).con
+      T ⊢!. ∼T.standardPr.indep (g.interpret T.standardPr (∼□⊥)) ↔
+      T ⊢!. ∼T.standardPr.indep T.standardPr.con
       := by
       constructor;
       . intro H; exact K!_left H₂ ⨀ H;
@@ -168,7 +163,7 @@ lemma unrefutable_independency_of_consistency :
   congr;
 
 theorem undecidable_independency_of_consistency :
-  Undecidable T.toAxiom (((𝐈𝚺₁).standardDP T).indep (((𝐈𝚺₁).standardDP T).con)) := by
+    Undecidable T.toAxiom (T.standardPr.indep (T.standardPr.con)) := by
   constructor;
   . exact unprovable_independency_of_consistency;
   . exact unrefutable_independency_of_consistency;

--- a/Foundation/ProvabilityLogic/Grz/Completeness.lean
+++ b/Foundation/ProvabilityLogic/Grz/Completeness.lean
@@ -2,7 +2,7 @@ import Foundation.Modal.Boxdot.Grz_S
 
 namespace LO
 
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open Modal
 open Modal.Hilbert
 open FirstOrder
@@ -81,7 +81,7 @@ lemma iff_models_interpret_boxdot_strongInterpret
 end Realization
 
 theorem Grz.arithmetical_completeness_iff {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [Arith.SoundOn T (Arith.Hierarchy 𝚷 2)] :
-  (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret ((𝐈𝚺₁).standardDP T) A) ↔ Logic.Grz ⊢! A := by
+  (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
   constructor;
   . intro h;
     suffices Logic.GL ⊢! Aᵇ by apply Modal.Logic.iff_provable_boxdot_GL_provable_Grz.mp this;
@@ -91,14 +91,15 @@ theorem Grz.arithmetical_completeness_iff {T : Theory ℒₒᵣ} [T.Delta1Defina
     apply h;
   . intro h f;
     replace h := Modal.Logic.iff_provable_boxdot_GL_provable_Grz.mpr h;
-    have : (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret ((𝐈𝚺₁).standardDP T) (Aᵇ)) := GL.arithmetical_completeness_iff.mpr h;
+    have : (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr (Aᵇ)) := GL.arithmetical_completeness_iff.mpr h;
     exact Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ this;
 
 theorem Grz.arithmetical_completeness_model_iff
   {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [Arith.SoundOn T (Arith.Hierarchy 𝚷 2)] [ℕ ⊧ₘ* T] :
-  (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret ((𝐈𝚺₁).standardDP T) A) ↔ Logic.Grz ⊢! A := by
+  (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
   apply Iff.trans ?_ Modal.Logic.iff_provable_Grz_provable_boxdot_S;
   apply Iff.trans ?_ (S.arithmetical_completeness_iff (T := T)).symm;
+  have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
   constructor;
   . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mpr $ h;
   . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ h f;

--- a/Foundation/ProvabilityLogic/Grz/Completeness.lean
+++ b/Foundation/ProvabilityLogic/Grz/Completeness.lean
@@ -23,7 +23,8 @@ def strongInterpret (f : Realization L) (𝔅 : ProvabilityPredicate T₀ T) : F
   | φ ➝ ψ => (f.strongInterpret 𝔅 φ) ➝ (f.strongInterpret 𝔅 ψ)
   | □φ => (f.strongInterpret 𝔅 φ) ⋏ 𝔅 (f.strongInterpret 𝔅 φ)
 
-lemma iff_interpret_boxdot_strongInterpret_inside [L.DecidableEq] [𝔅.HBL2] : T ⊢!. f.interpret 𝔅 (Aᵇ) ⭤ f.strongInterpret 𝔅 A := by
+lemma iff_interpret_boxdot_strongInterpret_inside [L.DecidableEq] [𝔅.HBL2] :
+    T ⊢!. f.interpret 𝔅 (Aᵇ) ⭤ f.strongInterpret 𝔅 A := by
   induction A with
   | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
   | hfalsum => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
@@ -39,7 +40,8 @@ lemma iff_interpret_boxdot_strongInterpret_inside [L.DecidableEq] [𝔅.HBL2] : 
       . exact K!_right ih;
       . exact 𝔅.prov_distribute_imply'' $ K!_right ih;
 
-lemma iff_interpret_boxdot_strongInterpret [L.DecidableEq] [𝔅.HBL2] : T ⊢!. f.interpret 𝔅 (Aᵇ) ↔ T ⊢!. f.strongInterpret 𝔅 A := by
+lemma iff_interpret_boxdot_strongInterpret [L.DecidableEq] [𝔅.HBL2] :
+    T ⊢!. f.interpret 𝔅 (Aᵇ) ↔ T ⊢!. f.strongInterpret 𝔅 A := by
   constructor;
   . intro h; exact (K!_left iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
   . intro h; exact (K!_right iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
@@ -80,8 +82,8 @@ lemma iff_models_interpret_boxdot_strongInterpret
 
 end Realization
 
-theorem Grz.arithmetical_completeness_iff {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [Arith.SoundOn T (Arith.Hierarchy 𝚷 2)] :
-  (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
+theorem Grz.arithmetical_completeness_iff {T : ArithmeticTheory} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [T.SoundOn (Arith.Hierarchy 𝚷 2)] :
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
   constructor;
   . intro h;
     suffices Logic.GL ⊢! Aᵇ by apply Modal.Logic.iff_provable_boxdot_GL_provable_Grz.mp this;
@@ -95,8 +97,8 @@ theorem Grz.arithmetical_completeness_iff {T : Theory ℒₒᵣ} [T.Delta1Defina
     exact Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ this;
 
 theorem Grz.arithmetical_completeness_model_iff
-  {T : Theory ℒₒᵣ} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [Arith.SoundOn T (Arith.Hierarchy 𝚷 2)] [ℕ ⊧ₘ* T] :
-  (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
+    {T : ArithmeticTheory} [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [ℕ ⊧ₘ* T] :
+    (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret T.standardPr A) ↔ Logic.Grz ⊢! A := by
   apply Iff.trans ?_ Modal.Logic.iff_provable_Grz_provable_boxdot_S;
   apply Iff.trans ?_ (S.arithmetical_completeness_iff (T := T)).symm;
   have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -172,7 +172,7 @@ theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
   contradiction;
 
-theorem goedel_independent [𝔅.GoedelSound] : Entailment.Undecidable (T : Axiom L) 𝗚 := by
+theorem goedel_independent [𝔅.GoedelSound] : Entailment.Independent (T : Axiom L) 𝗚 := by
   constructor
   . apply unprovable_goedel
   . apply unrefutable_goedel
@@ -219,7 +219,7 @@ theorem unrefutable_consistency [Consistent T] [𝔅.GoedelSound] : T ⊬. ∼�
   have : T ⊢!. ∼𝗚 := by cl_prover [h, this]
   exact unrefutable_goedel this
 
-theorem consistency_independent [Consistent T] [𝔅.GoedelSound] : Undecidable (T : Axiom L) 𝔅.con := by
+theorem consistency_independent [Consistent T] [𝔅.GoedelSound] : Independent (T : Axiom L) 𝔅.con := by
   constructor
   . apply unprovable_consistency
   . apply unrefutable_consistency
@@ -323,8 +323,8 @@ theorem unrefutable_rosser : T ⊬. ∼𝗥 := by
     by simpa [Axiom.provable_iff] using (N!_iff_CO!.mp hnρ) ⨀ hρ;
   contradiction
 
-theorem rosser_independent : Entailment.Undecidable T ↑𝗥 := by
-  suffices T ⊬. 𝗥 ∧ T ⊬. ∼𝗥 by simpa [Entailment.Undecidable, not_or, Axiom.unprovable_iff] using this;
+theorem rosser_independent : Entailment.Independent T ↑𝗥 := by
+  suffices T ⊬. 𝗥 ∧ T ⊬. ∼𝗥 by simpa [Entailment.Independent, not_or, Axiom.unprovable_iff] using this;
   constructor
   . apply unprovable_rosser
   . apply unrefutable_rosser

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -2,6 +2,10 @@ import Foundation.FirstOrder.Arith.Basic
 import Foundation.Logic.HilbertStyle.Supplemental
 import Foundation.Meta.ClProver
 
+/-!
+# Abstract incompleteness theorems and related results
+-/
+
 namespace LO.ProvabilityLogic
 
 open FirstOrder
@@ -141,58 +145,43 @@ lemma ProvabilityPredicate.goedel_spec : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := by
   simp [goedel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs];
   rfl;
 
-lemma ProvabilityPredicate.goedel_spec_self [L.DecidableEq] [T₀ ⪯ T] :
-    T ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := WeakerThan.pbl 𝔅.goedel_spec
-
 variable {𝔅}
-
-variable [T₀ ⪯ T]
-
-private lemma goedel_specAux₁ [L.DecidableEq] : T ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := WeakerThan.pbl (𝓢 := T₀.toAxiom) 𝔅.goedel_spec
-
-private lemma goedel_specAux₂ [L.DecidableEq] : T ⊢!. ∼𝗚 ➝ 𝔅 𝗚 := CN!_of_CN!_left $ K!_right goedel_specAux₁
 
 end GoedelSentence
 
 class ProvabilityPredicate.GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] where
-  γ_sound : T ⊢!. 𝔅 𝔅.goedel → T ⊢!. 𝔅.goedel
-
-open GoedelSound
+  goedel_sound : T ⊢!. 𝔅 𝔅.goedel → T ⊢!. 𝔅.goedel
 
 section First
 
-variable [T₀ ⪯ T] [Diagonalization T₀]
+variable [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Entailment.Consistent T]
 
 local notation "𝗚" => 𝔅.goedel
-
-variable [L.DecidableEq] [Entailment.Consistent T]
 
 theorem unprovable_goedel : T ⊬. 𝗚 := by
   intro h;
   have h₁ : T ⊢!. 𝔅 𝗚 := D1_shift h
-  have h₂ : T ⊢!. ∼𝔅 𝗚 := K!_left goedel_specAux₁ ⨀ h
-  have : T ⊢!. ⊥ := by cl_prover [h₁, h₂]
+  have : T ⊢!. ⊥ := by cl_prover [h₁, 𝔅.goedel_spec, h]
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this)
   contradiction
 
 theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
   intro h₂;
-  have h₁ : T ⊢!. 𝗚 := γ_sound $ goedel_specAux₂ ⨀ h₂;
+  have h₁ : T ⊢!. 𝗚 := GoedelSound.goedel_sound <| by cl_prover [𝔅.goedel_spec, h₂]
   have : T ⊢!. ⊥ := (N!_iff_CO!.mp h₂) ⨀ h₁;
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
   contradiction;
 
-theorem goedel_independent [𝔅.GoedelSound] : Entailment.Undecidable T ↑𝗚 := by
-  suffices T ⊬. 𝗚 ∧ T ⊬. ∼𝗚 by simpa [Entailment.Undecidable, not_or, Axiom.unprovable_iff] using this
+theorem goedel_independent [𝔅.GoedelSound] : Entailment.Undecidable (T : Axiom L) 𝗚 := by
   constructor
   . apply unprovable_goedel
   . apply unrefutable_goedel
 
 theorem first_incompleteness [𝔅.GoedelSound] :
-    ¬Entailment.Complete T :=
-  Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝗚, goedel_independent⟩
+    ¬Entailment.Complete (T : Axiom L) :=
+  incomplete_iff_exists_undecidable.mpr ⟨𝗚, goedel_independent⟩
 
 end First
 
@@ -200,17 +189,17 @@ section Second
 
 variable [L.DecidableEq] [𝔅.HBL]
 
-local notation "𝗚" => 𝔅.goedel
-
 lemma formalized_consistent_of_existance_unprovable (σ) : T₀ ⊢!. ∼𝔅 σ ➝ 𝔅.con := contra! $ 𝔅.D2 _ _ ⨀ (𝔅.D1 efq!)
 
 variable [T₀ ⪯ T] [Diagonalization T₀]
+
+local notation "𝗚" => 𝔅.goedel
 
 /-- Formalized First Incompleteness Theorem -/
 theorem formalized_unprovable_goedel : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := by
   suffices T₀ ⊢!. ∼𝔅 ⊥ ➝ ∼𝔅 𝗚 from this
   have h₁ : T₀ ⊢!. 𝔅 𝗚 ➝ 𝔅 (𝔅 𝗚) := 𝔅.D3 𝗚
-  have h₂ : T₀ ⊢!. 𝔅 𝗚 ➝ 𝔅 (𝔅 𝗚 ➝ ⊥) := prov_distribute_imply <| by cl_prover [𝔅.goedel_spec_self]
+  have h₂ : T₀ ⊢!. 𝔅 𝗚 ➝ 𝔅 (𝔅 𝗚 ➝ ⊥) := prov_distribute_imply <| by cl_prover [𝔅.goedel_spec]
   have h₃ : T₀ ⊢!. 𝔅 (𝔅 𝗚 ➝ ⊥) ➝ 𝔅 (𝔅 𝗚) ➝ 𝔅 ⊥ := 𝔅.D2 (𝔅 𝗚) ⊥
   cl_prover [h₁, h₂, h₃]
 
@@ -231,6 +220,11 @@ theorem unrefutable_consistency [Consistent T] [𝔅.GoedelSound] : T ⊬. ∼�
   have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := goedel_iff_consistency
   have : T ⊢!. ∼𝗚 := by cl_prover [h, this]
   exact unrefutable_goedel this
+
+theorem consistency_independent [Consistent T] [𝔅.GoedelSound] : Undecidable (T : Axiom L) 𝔅.con := by
+  constructor
+  . apply unprovable_consistency
+  . apply unrefutable_consistency
 
 end Second
 
@@ -287,7 +281,6 @@ instance [L.DecidableEq] : 𝔅.FormalizedLoeb := ⟨formalized_loeb_theorem (T 
 
 end LoebTheorem
 
-
 variable [Entailment.Consistent T]
 
 lemma unprovable_consistency_via_loeb [L.DecidableEq] [𝔅.Loeb] : T ⊬. 𝔅.con := by
@@ -299,8 +292,8 @@ lemma unprovable_consistency_via_loeb [L.DecidableEq] [𝔅.Loeb] : T ⊬. 𝔅.
 
 variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [𝔅.HBL] [𝔅.GoedelSound]
 
-lemma formalized_unprovable_not_consistency
-  : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := by
+lemma formalized_unprovable_not_consistency :
+    T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := by
   by_contra hC;
   have : T ⊢!. ∼𝔅.con := Loeb.LT $ CN!_of_CN!_right hC;
   have : T ⊬. ∼𝔅.con := unrefutable_consistency;
@@ -316,34 +309,19 @@ lemma formalized_unrefutable_goedel : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.goede
 
 end Loeb
 
-abbrev ProvabilityPredicate.rosser
-    [Diagonalization T₀]
-    (𝔅 : ProvabilityPredicate T₀ T) [𝔅.Rosser] : Sentence L :=
-  fixpoint T₀ “x. ¬!𝔅.prov x”
+section Rosser
 
-section RosserSentence
+variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [Entailment.Consistent T]
 
-local notation "𝗥" => 𝔅.rosser
-
-variable [Diagonalization T₀] [𝔅.Rosser] (𝔅)
-
-lemma ProvabilityPredicate.rosser_spec : T₀ ⊢!. 𝗥 ⭤ ∼(𝔅 𝗥) := 𝔅.goedel_spec
-
-variable {𝔅}
-
-end RosserSentence
-
-section
-
-variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [Entailment.Consistent T] [𝔅.Rosser]
-
-local notation "𝗥" => 𝔅.rosser
+local notation "𝗥" => 𝔅.goedel
 
 lemma unprovable_rosser : T ⊬. 𝗥 := unprovable_goedel
 
+variable [𝔅.Rosser]
+
 theorem unrefutable_rosser : T ⊬. ∼𝗥 := by
   intro hnρ;
-  have hρ : T ⊢!. 𝗥 := WeakerThan.pbl $ (K!_right 𝔅.rosser_spec) ⨀ (𝔅.Ro hnρ);
+  have hρ : T ⊢!. 𝗥 := WeakerThan.pbl $ (K!_right 𝔅.goedel_spec) ⨀ (𝔅.Ro hnρ);
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr $ inconsistent_iff_provable_bot.mpr <|
     by simpa [Axiom.provable_iff] using (N!_iff_CO!.mp hnρ) ⨀ hρ;
   contradiction
@@ -355,14 +333,14 @@ theorem rosser_independent : Entailment.Undecidable T ↑𝗥 := by
   . apply unrefutable_rosser
 
 theorem rosser_first_incompleteness (𝔅 : ProvabilityPredicate T₀ T) [𝔅.Rosser] : ¬Entailment.Complete T :=
-  Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝔅.rosser, rosser_independent  ⟩
+  Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝔅.goedel, rosser_independent⟩
 
 omit [Diagonalization T₀] [Consistent T] in
-/-- If `𝔅` satisfies Rosser provability condition, then `𝔅.con` is provable in `T`. -/
+/-- If `𝔅` satisfies Rosser provability condition, then `𝔅.con` is provable from `T`. -/
 theorem kriesel_remark : T ⊢!. 𝔅.con := by
   have : T₀ ⊢!. ∼𝔅 ⊥ := 𝔅.Ro (N!_iff_CO!.mpr (by simp));
   exact WeakerThan.pbl $ this;
 
-end
+end Rosser
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -152,7 +152,7 @@ class GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] wh
 
 section First
 
-variable [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Entailment.Consistent T]
+variable [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Consistent T]
 
 local notation "𝗚" => 𝔅.goedel
 
@@ -172,7 +172,9 @@ theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
   contradiction;
 
-theorem goedel_independent [𝔅.GoedelSound] : Entailment.Independent (T : Axiom L) 𝗚 := by
+#check unrefutable_goedel
+
+theorem goedel_independent [𝔅.GoedelSound] : Independent (T : Axiom L) 𝗚 := by
   constructor
   . apply unprovable_goedel
   . apply unrefutable_goedel

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -152,7 +152,7 @@ class GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] wh
 
 section First
 
-variable [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Consistent T]
+variable (𝔅) [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Consistent T]
 
 local notation "𝗚" => 𝔅.goedel
 
@@ -172,8 +172,6 @@ theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
     inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
   contradiction;
 
-#check unrefutable_goedel
-
 theorem goedel_independent [𝔅.GoedelSound] : Independent (T : Axiom L) 𝗚 := by
   constructor
   . apply unprovable_goedel
@@ -181,7 +179,7 @@ theorem goedel_independent [𝔅.GoedelSound] : Independent (T : Axiom L) 𝗚 :
 
 theorem first_incompleteness [𝔅.GoedelSound] :
     ¬Entailment.Complete (T : Axiom L) :=
-  incomplete_iff_exists_undecidable.mpr ⟨𝗚, goedel_independent⟩
+  incomplete_iff_exists_undecidable.mpr ⟨𝗚, 𝔅.goedel_independent⟩
 
 end First
 
@@ -213,13 +211,13 @@ theorem unprovable_consistency [Consistent T] : T ⊬. 𝔅.con := by
   intro h
   have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := 𝔅.goedel_iff_consistency
   have : T ⊢!. 𝗚 := by cl_prover [h, this]
-  exact unprovable_goedel this
+  exact 𝔅.unprovable_goedel this
 
 theorem unrefutable_consistency [Consistent T] [𝔅.GoedelSound] : T ⊬. ∼𝔅.con := by
   intro h
   have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := 𝔅.goedel_iff_consistency
   have : T ⊢!. ∼𝗚 := by cl_prover [h, this]
-  exact unrefutable_goedel this
+  exact 𝔅.unrefutable_goedel this
 
 theorem consistency_independent [Consistent T] [𝔅.GoedelSound] : Independent (T : Axiom L) 𝔅.con := by
   constructor
@@ -280,7 +278,7 @@ instance [L.DecidableEq] : 𝔅.FormalizedLoeb := ⟨formalized_loeb_theorem (T 
 
 end LoebTheorem
 
-variable [Entailment.Consistent T]
+variable [Consistent T]
 
 lemma unprovable_consistency_via_loeb [L.DecidableEq] [𝔅.Loeb] : T ⊬. 𝔅.con := by
   by_contra hC;
@@ -310,11 +308,9 @@ end Loeb
 
 section Rosser
 
-variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [Entailment.Consistent T]
+variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [Consistent T]
 
 local notation "𝗥" => 𝔅.goedel
-
-lemma unprovable_rosser : T ⊬. 𝗥 := unprovable_goedel
 
 variable [𝔅.Rosser]
 
@@ -325,13 +321,12 @@ theorem unrefutable_rosser : T ⊬. ∼𝗥 := by
     by simpa [Axiom.provable_iff] using (N!_iff_CO!.mp hnρ) ⨀ hρ;
   contradiction
 
-theorem rosser_independent : Entailment.Independent T ↑𝗥 := by
-  suffices T ⊬. 𝗥 ∧ T ⊬. ∼𝗥 by simpa [Entailment.Independent, not_or, Axiom.unprovable_iff] using this;
+theorem rosser_independent : Independent (T : Axiom L) 𝗥 := by
   constructor
-  . apply unprovable_rosser
+  . apply unprovable_goedel
   . apply unrefutable_rosser
 
-theorem rosser_first_incompleteness (𝔅 : ProvabilityPredicate T₀ T) [𝔅.Rosser] : ¬Entailment.Complete T :=
+theorem rosser_first_incompleteness (𝔅 : ProvabilityPredicate T₀ T) [𝔅.Rosser] : ¬Entailment.Complete (T : Axiom L) :=
   Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝔅.goedel, rosser_independent⟩
 
 omit [Diagonalization T₀] [Consistent T] in

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -121,15 +121,13 @@ def prov_collect_and [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 σ
 
 end
 
-end ProvabilityPredicate
-
 variable {T₀ T : Theory L} {𝔅 : ProvabilityPredicate T₀ T}
 
 open LO.Entailment
 open Diagonalization
 open ProvabilityPredicate
 
-def ProvabilityPredicate.goedel [Diagonalization T₀] (𝔅 : ProvabilityPredicate T₀ T) : Sentence L :=
+def goedel [Diagonalization T₀] (𝔅 : ProvabilityPredicate T₀ T) : Sentence L :=
   fixpoint T₀ “x. ¬!𝔅.prov x”
 
 section GoedelSentence
@@ -140,7 +138,7 @@ local notation "𝗚" => 𝔅.goedel
 
 variable (𝔅)
 
-lemma ProvabilityPredicate.goedel_spec : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := by
+lemma goedel_spec : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := by
   convert (diag (T := T₀) “x. ¬!𝔅.prov x”);
   simp [goedel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs];
   rfl;
@@ -149,7 +147,7 @@ variable {𝔅}
 
 end GoedelSentence
 
-class ProvabilityPredicate.GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] where
+class GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] where
   goedel_sound : T ⊢!. 𝔅 𝔅.goedel → T ⊢!. 𝔅.goedel
 
 section First
@@ -191,7 +189,7 @@ variable [L.DecidableEq] [𝔅.HBL]
 
 lemma formalized_consistent_of_existance_unprovable (σ) : T₀ ⊢!. ∼𝔅 σ ➝ 𝔅.con := contra! $ 𝔅.D2 _ _ ⨀ (𝔅.D1 efq!)
 
-variable [T₀ ⪯ T] [Diagonalization T₀]
+variable [T₀ ⪯ T] [Diagonalization T₀] (𝔅)
 
 local notation "𝗚" => 𝔅.goedel
 
@@ -205,19 +203,19 @@ theorem formalized_unprovable_goedel : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := b
 
 theorem goedel_iff_consistency : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := by
   have h₁ : T₀ ⊢!. ∼𝔅 𝗚 ➝ 𝔅.con := formalized_consistent_of_existance_unprovable 𝗚
-  have h₂ : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := formalized_unprovable_goedel
+  have h₂ : T₀ ⊢!. 𝔅.con ➝ ∼𝔅 𝗚 := 𝔅.formalized_unprovable_goedel
   have h₃ : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := 𝔅.goedel_spec
   cl_prover [h₁, h₂, h₃]
 
 theorem unprovable_consistency [Consistent T] : T ⊬. 𝔅.con := by
   intro h
-  have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := goedel_iff_consistency
+  have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := 𝔅.goedel_iff_consistency
   have : T ⊢!. 𝗚 := by cl_prover [h, this]
   exact unprovable_goedel this
 
 theorem unrefutable_consistency [Consistent T] [𝔅.GoedelSound] : T ⊬. ∼𝔅.con := by
   intro h
-  have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := goedel_iff_consistency
+  have : T₀ ⊢!. 𝗚 ⭤ 𝔅.con := 𝔅.goedel_iff_consistency
   have : T ⊢!. ∼𝗚 := by cl_prover [h, this]
   exact unrefutable_goedel this
 
@@ -230,7 +228,7 @@ end Second
 
 section Loeb
 
-def ProvabilityPredicate.kreisel [Diagonalization T₀]
+def kreisel [Diagonalization T₀]
     (𝔅 : ProvabilityPredicate T₀ T) [𝔅.HBL]
     (σ : Sentence L) : Sentence L := fixpoint T₀ “x. !𝔅.prov x → !σ”
 
@@ -242,7 +240,7 @@ local prefix:80 "𝗞" => 𝔅.kreisel
 
 variable (𝔅)
 
-lemma ProvabilityPredicate.kreisel_spec (σ : Sentence L) : T₀ ⊢!. 𝗞 σ ⭤ (𝔅 (𝗞 σ) ➝ σ) := by
+lemma kreisel_spec (σ : Sentence L) : T₀ ⊢!. 𝗞 σ ⭤ (𝔅 (𝗞 σ) ➝ σ) := by
   convert (diag (T := T₀) “x. !𝔅.prov x → !σ”);
   simp [kreisel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs];
   rfl;
@@ -256,7 +254,6 @@ private lemma kreisel_specAux₁ [L.DecidableEq] [T₀ ⪯ T] (σ : Sentence L) 
 private lemma kreisel_specAux₂ (σ : Sentence L) : T₀ ⊢!. (𝔅 (𝗞 σ) ➝ σ) ➝ 𝗞 σ := K!_right (𝔅.kreisel_spec σ)
 
 end KrieselSentence
-
 
 section LoebTheorem
 
@@ -296,7 +293,7 @@ lemma formalized_unprovable_not_consistency :
     T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := by
   by_contra hC;
   have : T ⊢!. ∼𝔅.con := Loeb.LT $ CN!_of_CN!_right hC;
-  have : T ⊬. ∼𝔅.con := unrefutable_consistency;
+  have : T ⊬. ∼𝔅.con := unrefutable_consistency 𝔅;
   contradiction;
 
 lemma formalized_unrefutable_goedel : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.goedel) := by
@@ -304,7 +301,7 @@ lemma formalized_unrefutable_goedel : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.goede
   have : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con)  := formalized_unprovable_not_consistency;
   have : T ⊢!. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) :=
     C!_trans hC $ WeakerThan.pbl <| K!_left <| ENN!_of_E!
-      <| prov_distribute_iff <| ENN!_of_E! <| WeakerThan.pbl goedel_iff_consistency;
+      <| prov_distribute_iff <| ENN!_of_E! <| WeakerThan.pbl (𝔅.goedel_iff_consistency);
   contradiction;
 
 end Loeb
@@ -343,4 +340,4 @@ theorem kriesel_remark : T ⊢!. 𝔅.con := by
 
 end Rosser
 
-end LO.ProvabilityLogic
+end LO.ProvabilityLogic.ProvabilityPredicate

--- a/Foundation/ProvabilityLogic/Interpretation.lean
+++ b/Foundation/ProvabilityLogic/Interpretation.lean
@@ -1,4 +1,4 @@
-import Foundation.ProvabilityLogic.Conditions
+import Foundation.ProvabilityLogic.Incompleteness
 import Foundation.FirstOrder.Incompleteness.StandardProvability
 import Foundation.FirstOrder.Incompleteness.Delta1
 import Foundation.Logic.HilbertStyle.Cl

--- a/Foundation/ProvabilityLogic/N/Soundness.lean
+++ b/Foundation/ProvabilityLogic/N/Soundness.lean
@@ -5,7 +5,7 @@ namespace LO.ProvabilityLogic
 open Entailment
 open Modal
 open Modal.Hilbert
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open ProvabilityPredicate
 
 variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
@@ -13,8 +13,7 @@ variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L
          {T U : FirstOrder.Theory L} [T ⪯ U]
          {𝔅 : ProvabilityPredicate T U}
 
-lemma N.arithmetical_soundness (h : Logic.N ⊢! A) : ∀ {f : Realization L}, U ⊢!. (f.interpret 𝔅 A) := by
-  intro f;
+lemma N.arithmetical_soundness (h : Logic.N ⊢! A) {f : Realization L} : U ⊢!. f.interpret 𝔅 A := by
   induction h with
   | maxm hp => simp at hp;
   | nec ihp => exact D1_shift ihp;

--- a/Foundation/ProvabilityLogic/N/Soundness.lean
+++ b/Foundation/ProvabilityLogic/N/Soundness.lean
@@ -1,4 +1,4 @@
-import Foundation.ProvabilityLogic.Basic
+import Foundation.ProvabilityLogic.Interpretation
 
 namespace LO.ProvabilityLogic
 

--- a/Foundation/ProvabilityLogic/S/Completeness.lean
+++ b/Foundation/ProvabilityLogic/S/Completeness.lean
@@ -14,7 +14,7 @@ namespace LO.ProvabilityLogic
 
 open Entailment
 open Modal
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open ProvabilityPredicate
 
 variable {T₀ T : FirstOrder.Theory ℒₒᵣ} [T₀ ⪯ T] [Diagonalization T₀]
@@ -30,11 +30,11 @@ open Arith
 variable [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)]
 
 lemma GL_S_TFAE :
-  [
-    Logic.GL ⊢! (A.rflSubformula.conj ➝ A),
-    Logic.S ⊢! A,
-    ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret ((𝐈𝚺₁).standardDP T) A)
-  ].TFAE := by
+    [
+      Logic.GL ⊢! (A.rflSubformula.conj ➝ A),
+      Logic.S ⊢! A,
+      ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardPr A)
+    ].TFAE := by
   tfae_have 1 → 2 := by
     intro h;
     have h : Logic.S ⊢! Finset.conj A.rflSubformula ➝ A := WeakerThan.pbl h;
@@ -43,6 +43,7 @@ lemma GL_S_TFAE :
     simp [-Logic.iff_provable];
   tfae_have 2 → 3 := by
     intro h f;
+    have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
     apply S.arithmetical_soundness;
     exact h;
   tfae_have 3 → 1 := by
@@ -61,13 +62,13 @@ lemma GL_S_TFAE :
         $ (Satisfies.fconj_def.mp
         $ Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr hA₁) φ hφ;
     have : Fintype M₀.World := Fintype.ofFinite _
-    let σ : SolovaySentences ((𝐈𝚺₁).standardDP T) (M₀.toFrame) r₀ :=
+    let σ : SolovaySentences T.standardPr (M₀.toFrame) r₀ :=
       SolovaySentences.standard M₀.toFrame Frame.extendRoot.root T
     use σ.realization;
     have H :
       ∀ B ∈ A.subformulas,
-      (r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ (σ.realization.interpret ((𝐈𝚺₁).standardDP T) B)) ∧
-      (¬r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ ∼(σ.realization.interpret ((𝐈𝚺₁).standardDP T) B)) := by
+      (r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ (σ.realization.interpret T.standardPr B)) ∧
+      (¬r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ ∼(σ.realization.interpret T.standardPr B)) := by
       intro B B_sub;
       induction B with
       | hfalsum => simp [Satisfies, Realization.interpret];
@@ -104,16 +105,16 @@ lemma GL_S_TFAE :
         constructor;
         . intro h;
           apply C!_of_conseq!;
-          apply ((𝐈𝚺₁).standardDP T).D1;
+          apply T.standardPr.D1;
           apply Entailment.WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-          have : 𝐈𝚺₁ ⊢!. ((⩖ j, σ j)) ➝ σ.realization.interpret ((𝐈𝚺₁).standardDP T) B := by
+          have : 𝐈𝚺₁ ⊢!. ((⩖ j, σ j)) ➝ σ.realization.interpret T.standardPr B := by
             apply left_Fdisj'!_intro;
             have hrfl : r₁ ⊧ □B ➝ B := by
               apply hA₁;
               simpa [Formula.rflSubformula];
             rintro (i | i) _;
             . rw [(show (Sum.inl i) = r₀ by simp [r₀]; omega)]
-              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization.interpret ((𝐈𝚺₁).standardDP T) B by convert this;
+              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization.interpret T.standardPr B by convert this;
               apply ihB (Formula.subformulas.mem_box B_sub) |>.1;
               exact hrfl h;
             . by_cases e : i = r₁;
@@ -132,24 +133,24 @@ lemma GL_S_TFAE :
           have := Satisfies.box_def.not.mp h;
           push_neg at this;
           obtain ⟨i, Rij, hA⟩ := this;
-          have : 𝐈𝚺₁ ⊢!. σ.σ (Sum.inr i) ➝ ∼σ.realization.interpret ((𝐈𝚺₁).standardDP T) B :=
+          have : 𝐈𝚺₁ ⊢!. σ.σ (Sum.inr i) ➝ ∼σ.realization.interpret T.standardPr B :=
             σ.mainlemma (A := B) (i := i) (by trivial) |>.2
             <| Model.extendRoot.inr_satisfies_iff (n := 1) |>.not.mpr hA;
-          have : 𝐈𝚺₁ ⊢!. ∼((𝐈𝚺₁).standardDP T) (∼σ (Sum.inr i)) ➝ ∼((𝐈𝚺₁).standardDP T) (σ.realization.interpret ((𝐈𝚺₁).standardDP T) B) :=
+          have : 𝐈𝚺₁ ⊢!. ∼T.standardPr (∼σ (Sum.inr i)) ➝ ∼T.standardPr (σ.realization.interpret T.standardPr B) :=
             contra!
-            $ ((𝐈𝚺₁).standardDP T).prov_distribute_imply'
+            $ T.standardPr.prov_distribute_imply'
             $ CN!_of_CN!_right $ this;
           refine C!_trans ?_ this;
           apply σ.SC2;
           tauto;
     have : ℕ ⊧ₘ* 𝐈𝚺₁ := models_of_subtheory (U := 𝐈𝚺₁) (T := T) (M := ℕ) inferInstance;
-    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization.interpret ((𝐈𝚺₁).standardDP T) A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂;
+    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization.interpret T.standardPr A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂;
     simp only [models₀_imply_iff, models₀_not_iff] at this;
     exact this <| by
       simpa [models₀_iff, σ, SolovaySentences.standard_σ_def] using ISigma1.Metamath.SolovaySentences.solovay_root_sound
   tfae_finish;
 
-theorem S.arithmetical_completeness_iff : Logic.S ⊢! A ↔ ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret ((𝐈𝚺₁).standardDP T) A) := GL_S_TFAE.out 1 2
+theorem S.arithmetical_completeness_iff : Logic.S ⊢! A ↔ ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardPr A) := GL_S_TFAE.out 1 2
 
 end ProvabilityLogic
 

--- a/Foundation/ProvabilityLogic/S/Completeness.lean
+++ b/Foundation/ProvabilityLogic/S/Completeness.lean
@@ -17,7 +17,7 @@ open Modal
 open FirstOrder
 open ProvabilityPredicate
 
-variable {T₀ T : FirstOrder.Theory ℒₒᵣ} [T₀ ⪯ T] [Diagonalization T₀]
+variable {T₀ T : ArithmeticTheory} [T₀ ⪯ T] [Diagonalization T₀]
          {𝔅 : ProvabilityPredicate T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.Sound ℕ]
          {A B : Formula ℕ}
 
@@ -27,7 +27,7 @@ open Modal.Kripke
 open Modal.Formula.Kripke
 open Arith
 
-variable [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [SoundOn T (Hierarchy 𝚷 2)]
+variable [T.Delta1Definable] [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)]
 
 lemma GL_S_TFAE :
     [

--- a/Foundation/ProvabilityLogic/S/Soundness.lean
+++ b/Foundation/ProvabilityLogic/S/Soundness.lean
@@ -5,7 +5,7 @@ namespace LO.ProvabilityLogic
 
 open Entailment
 open Modal
-open FirstOrder FirstOrder.DerivabilityCondition
+open FirstOrder
 open ProvabilityPredicate
 
 variable {T₀ T : FirstOrder.Theory ℒₒᵣ} [T₀ ⪯ T] [Diagonalization T₀]

--- a/pages/src/first_order/arithmetics.md
+++ b/pages/src/first_order/arithmetics.md
@@ -80,7 +80,7 @@ Since `Exponential` and `Exponential.total` are defined in all the model of $\ma
 |                  $t [\vec{w}]$                  | [`L.termSubst w t`]     |           $\mathsf{I}\Sigma_1$           |           $\mathsf{I}\Sigma_1$           | $\Delta_1$ |       none       |
 |           $\mathrm{Semiformula}_x(y)$           | [`L.Semiformula x y`]   |           $\mathsf{I}\Sigma_1$           |                    -                     | $\Delta_1$ |        -         |
 |                  $φ [\vec{w}]$                  | [`L.substs w φ`]        |           $\mathsf{I}\Sigma_1$           |           $\mathsf{I}\Sigma_1$           | $\Delta_1$ |       none       |
-|            $\mathrm{Pr}_T(\varphi)$             | [`T.Provableₐ φ`]       |           $\mathsf{I}\Sigma_1$           |                    -                     | $\Sigma_1$ |        -         |
+|            $\mathrm{Pr}_T(\varphi)$             | [`T.Provable φ`]       |           $\mathsf{I}\Sigma_1$           |                    -                     | $\Sigma_1$ |        -         |
  
 [`x ≤ y`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/PeanoMinus/Basic.html#LO.PeanoMinus.instLE
 [`x - y`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/PeanoMinus/Functions.html#LO.PeanoMinus.sub
@@ -113,5 +113,5 @@ Since `Exponential` and `Exponential.total` are defined in all the model of $\ma
 [`L.termSubst w t`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/ISigma1/Metamath/Term/Functions.html#LO.ISigma1.Metamath.Language.termSubst
 [`L.Semiformula x y`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/ISigma1/Metamath/Formula/Basic.html#LO.ISigma1.Metamath.Language.IsSemiformula
 [`L.substs w φ`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/ISigma1/Metamath/Formula/Functions.html#LO.ISigma1.Metamath.Language.substs
-[`T.Provableₐ φ`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/FormalizedR0.html#LO.FirstOrder.Theory.Provable%E2%82%90
+[`T.Provable φ`]: https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/FormalizedR0.html#LO.FirstOrder.Theory.Provable%E2%82%90
 

--- a/pages/src/first_order/goedel1.md
+++ b/pages/src/first_order/goedel1.md
@@ -47,7 +47,7 @@ lemma re_complete
 
 ```lean
 theorem goedel_first_incompleteness
-  (T : Theory ℒₒᵣ) [𝐑₀ ≼ T] [Sigma1Sound T] [T.Delta1Definable] :
+  (T : ArithmeticTheory) [𝐑₀ ≼ T] [Sigma1Sound T] [T.Delta1Definable] :
   ¬System.Complete T
 ```
 - [goedel_first_incompleteness](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/First.html#LO.R0.goedel_first_incompleteness)

--- a/pages/src/first_order/goedel2.md
+++ b/pages/src/first_order/goedel2.md
@@ -241,16 +241,16 @@ $$
 #### Lemma: Gödel sentence is undecidable, i.e., $T \nvdash \mathrm{G}$ if $T$ is consistent, and $T \nvdash \lnot\mathrm{G}$ if $\mathbb{N} \models T$.
 
 ```lean
-lemma LO.ISigma1.goedel_unprovable
-    (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [System.Consistent T] :
-    T ⊬ ↑𝗚
+theorem unprovable_goedel
+    (𝔅 : ProvabilityPredicate T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] :
+    T ⊬. 𝔅.goedel
 
-lemma LO.ISigma1.not_goedel_unprovable
-    (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [ℕ ⊧ₘ* T] :
-    T ⊬ ∼↑𝗚
+theorem unrefutable_goedel
+    (𝔅 : ProvabilityPredicate T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] [𝔅.GoedelSound] :
+    T ⊬. ∼𝔅.goedel
 ```
-- [LO.ISigma1.goedel_unprovable](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.goedel_unprovable)
-- [LO.ISigma1.not_goedel_unprovable](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.not_goedel_unprovable)
+- [LO.ProvabilityLogic.ProvabilityPredicate.unprovable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.unprovable_goedel)
+- [LO.ProvabilityLogic.ProvabilityPredicate.unrefutable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.unrefutable_goedel)
 
 Define formalized incompleteness sentence $\mathrm{Con}_T$:
 $$
@@ -259,22 +259,22 @@ $$
 
 #### Lemma: $T \vdash \mathrm{Con}_T \leftrightarrow G_T$
 ```lean
-lemma LO.ISigma1.consistent_iff_goedel
-    (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] :
-    T ⊢! ↑𝗖𝗼𝗻 ⭤ ↑𝗚
+theorem goedel_iff_consistency
+    (𝔅 : ProvabilityPredicate T₀ T) [𝔅.HBL] [T₀ ⪯ T] [Diagonalization T₀] :
+    T₀ ⊢!. 𝔅.goedel ⭤ 𝔅.con
 ```
-- [LO.ISigma1.consistent_iff_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.consistent_iff_goedel)
+- [LO.ProvabilityLogic.ProvabilityPredicate.goedel_iff_consistency](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.goedel_iff_consistency)
 
 #### Theorem: $T$ cannot prove its own consistency, i.e., $T \nvdash \mathrm{Con}_T$ if $T$ is consistent. Moreover, $\mathrm{Con}_T$ is undecidable from $T$ if $\mathbb{N} \models T$.
 
 ```lean
 theorem LO.ISigma1.goedel_second_incompleteness
-    (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [System.Consistent T] :
-    T ⊬ ↑𝗖𝗼𝗻 
+    (T : ArithmeticTheory) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [System.Consistent T] :
+    T ⊬. T.isConsistent 
 
 theorem LO.ISigma1.inconsistent_undecidable
-    (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [ℕ ⊧ₘ* T] :
-    System.Independent T ↑𝗖𝗼𝗻
+    (T : ArithmeticTheory) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [T.Sigma1Sound] :
+    Independent (T : Axiom ℒₒᵣ) (T.isConsistent : Sentence ℒₒᵣ)
 ```
 - [LO.ISigma1.goedel_second_incompleteness](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.goedel_second_incompleteness)
 - [LO.ISigma1.inconsistent_undecidable](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.inconsistent_undecidable)

--- a/pages/src/first_order/goedel2.md
+++ b/pages/src/first_order/goedel2.md
@@ -162,7 +162,7 @@ Following holds for all formula (not coded one) $\varphi$ and finite set $\Gamma
     V \models \mathrm{Provable}_{T + \mathsf{R_0}} (\ulcorner \sigma \urcorner)$
   ```lean
   theorem LO.ISigma1.Metamath.sigma1_complete (hσ : Hierarchy 𝚺 1 σ) :
-      V ⊧ₘ₀ σ → T.Provableₐ ⌜σ⌝
+      V ⊧ₘ₀ σ → T.Provable ⌜σ⌝
   ```
   - [LO.ISigma1.Metamath.sigma1_complete](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/D3.html#LO.ISigma1.Metamath.sigma1_complete)
 
@@ -170,11 +170,11 @@ Now assume that $U$ is a theory of arithmetic stronger than $\mathsf{R_0}$ and
 $T$ be a theory  of arithmetic stronger than $\mathsf{I}\Sigma_1$.
 The following holds, thanks to the completeness theorem.
 - $U \vdash \sigma \iff T \vdash \mathrm{Provable}_U(\ulcorner \sigma \urcorner)$
-  - [LO.ISigma1.provableₐ_complete](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_complete)
+  - [LO.ISigma1.provable_complete](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_complete)
 - $T \vdash \mathrm{Provable}_U(\ulcorner \sigma \to \pi \urcorner) \to \mathrm{Provable}_U(\ulcorner \sigma \urcorner) \to \mathrm{Provable}_U(\ulcorner \pi \urcorner)$
-  - [LO.ISigma1.provableₐ_D2](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_D2)
+  - [LO.ISigma1.provable_D2](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_D2)
 - $T \vdash \mathrm{Provable}_U(\ulcorner \sigma \urcorner) \to \mathrm{Provable}_U(\ulcorner \mathrm{Provable}_U(\ulcorner \sigma \urcorner) \urcorner)$
-  - [LO.ISigma1.provableₐ_D3](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_D3)
+  - [LO.ISigma1.provable_D3](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/StandardProvability/DerivabilityCondition.html#LO.ISigma1.provable%E2%82%90_D3)
 
 ## Second Incompleteness Theorem
 

--- a/pages/src/first_order/goedel2.md
+++ b/pages/src/first_order/goedel2.md
@@ -274,7 +274,7 @@ theorem LO.ISigma1.goedel_second_incompleteness
 
 theorem LO.ISigma1.inconsistent_undecidable
     (T : Theory ℒₒᵣ) [𝐈𝚺₁ ≼ T] [T.Delta1Definable] [ℕ ⊧ₘ* T] :
-    System.Undecidable T ↑𝗖𝗼𝗻
+    System.Independent T ↑𝗖𝗼𝗻
 ```
 - [LO.ISigma1.goedel_second_incompleteness](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.goedel_second_incompleteness)
 - [LO.ISigma1.inconsistent_undecidable](https://formalizedformallogic.github.io/Foundation/doc/Foundation/FirstOrder/Incompleteness/Second.html#LO.ISigma1.inconsistent_undecidable)


### PR DESCRIPTION
- `standardDP` のベース理論を `𝐈𝚺₁` に固定する．
- `cl_prover` で証明を簡略化する．
-  FirstOrder/Incompleteness/DerivabilityCondition/Basic.lean を ProvabilityLogic/Incompleteness.lean に改名．
-  ProvabilityLogic/Basic.lean を ProvabilityLogic/Interpretation.lean に改名．
- Rosser 文 `ProvabilityPredicate.rosser` を削除し `ProvabilityPredicate.goedel` で置き換える．
- G2 の証明を可証性論理のそれを利用して示す．
- `Entailment.Undecidable` を`Entailment.Independent` に改名．
- G2 の仮定 `ℕ ⊧ₘ* T` を `T.Sigma1Sound` に弱める．