### PR TITLE
docs: Fix `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,13 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
+title: "Formalized Formal Logic"
+abstract: A mechanized proof library for mathematical logic.
 authors:
 - family-names: "Saito"
   given-names: "Shogo"
 - family-names: "Noguchi"
   given-names: "Mashu"
-title: "A Mechanized proof library for mathematical logic"
-version: 0.0.1
-date-released: 2023-01-30
-url: "https://github.com/FormalizedFormalLogic/Foundation"
+type: software
+repository-code: "https://github.com/FormalizedFormalLogic/Foundation"
+license: Apache-2.0
+date-released: "2023-01-30"


### PR DESCRIPTION
`CITATION.cff`の修正．
- `title`としては`Formalized Formal Logic`のほうが適切な気がするため修正し，元の文は`abstract`に移動．
- `version`は消した．

今後のこのリポジトリのバージョンという概念だが，論文を書く（書いた）タイミングでgitの機能でtagを打ち（リリースでもいいですが），論文側から参照する際はそのタグのバージョンのコードを参照する，という方針が一番良いように思える．