### PR TITLE
add(Modal/Neighborhood): Supplementaion of Frame

### DIFF
--- a/Foundation/Modal/Entailment/Basic.lean
+++ b/Foundation/Modal/Entailment/Basic.lean
@@ -724,12 +724,21 @@ instance [Entailment.EMCN 𝓢] : Entailment.ECN 𝓢 where
 
 protected class EK extends Entailment.E 𝓢, HasAxiomK 𝓢
 
+protected class ET extends Entailment.E 𝓢, HasAxiomT 𝓢
+protected class EMT extends Entailment.E 𝓢, HasAxiomM 𝓢, HasAxiomT 𝓢
+instance [Entailment.EMT 𝓢] : Entailment.EM 𝓢 where
+instance [Entailment.EMT 𝓢] : Entailment.ET 𝓢 where
+
 protected class E4 extends Entailment.E 𝓢, HasAxiomFour 𝓢
 
 protected class EMC4 extends Entailment.EMC 𝓢, HasAxiomFour 𝓢
+instance [Entailment.EMC4 𝓢] : Entailment.E4 𝓢 where
+
 protected class EK4 extends Entailment.E4 𝓢, HasAxiomK 𝓢
 
 protected class EMT4 extends Entailment.E4 𝓢, HasAxiomT 𝓢, HasAxiomM 𝓢
+instance [Entailment.EMT4 𝓢] : Entailment.EMT 𝓢 where
+instance [Entailment.EMT4 𝓢] : Entailment.E4 𝓢 where
 
 protected class K extends Entailment.Cl 𝓢, Necessitation 𝓢, HasAxiomK 𝓢, HasDiaDuality 𝓢
 

--- a/Foundation/Modal/Hilbert/Minimal/Basic.lean
+++ b/Foundation/Modal/Hilbert/Minimal/Basic.lean
@@ -364,6 +364,7 @@ protected abbrev EMT : Logic ℕ := Entailment.theory Hilbert.EMT
 notation "𝐄𝐌𝐓" => Modal.EMT
 instance : Hilbert.EMT.HasM where p := 0; q := 1
 instance : Hilbert.EMT.HasT where p := 0
+instance : Entailment.EMT Hilbert.EMT where
 
 
 protected abbrev Hilbert.EMT4 : Hilbert.WithRE ℕ := ⟨{Axioms.M (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.T (.atom 0)}⟩

--- a/Foundation/Modal/Neighborhood/AxiomC.lean
+++ b/Foundation/Modal/Neighborhood/AxiomC.lean
@@ -1,4 +1,5 @@
 import Foundation.Modal.Neighborhood.Basic
+import Foundation.Modal.Neighborhood.Completeness
 
 namespace LO.Modal.Neighborhood
 
@@ -29,5 +30,30 @@ lemma valid_axiomC_of_isRegular [F.IsRegular] : F ⊧ Axioms.C (.atom 0) (.atom 
   constructor;
   . apply h₁;
   . apply h₂;
+
+
+section
+
+variable [Entailment (Formula ℕ) S]
+variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.EC 𝓢]
+
+open Entailment
+open MaximalConsistentSet
+
+instance : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).IsRegular := by
+  constructor;
+  rintro X Y Γ ⟨hX, hY⟩;
+  obtain ⟨φ, rfl, hφ⟩ := minimal_canonical_box.exists_box X Γ hX;
+  obtain ⟨ψ, rfl, hψ⟩ := minimal_canonical_box.exists_box Y Γ hY;
+  rw [(show proofset 𝓢 φ ∩ proofset 𝓢 ψ = proofset 𝓢 (φ ⋏ ψ) by simp)];
+  have : proofset 𝓢 (□φ ⋏ □ψ) ⊆ proofset 𝓢 (□(φ ⋏ ψ)) := proofset.imp_subset |>.mp (by simp);
+  have : Γ ∈ proofset 𝓢 (□(φ ⋏ ψ)) := this $ by
+    simp only [proofset.eq_and, Set.mem_inter_iff];
+    constructor;
+    . apply hφ ▸ hX;
+    . apply hψ ▸ hY;
+  apply minimal_canonical_box 𝓢 |>.canonicity _ ▸ this;
+
+end
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/AxiomC.lean
+++ b/Foundation/Modal/Neighborhood/AxiomC.lean
@@ -40,11 +40,11 @@ variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.EC 𝓢]
 open Entailment
 open MaximalConsistentSet
 
-instance : (CanonicalBox.minimal 𝓢).frame.IsRegular := by
+instance : (minimalCanonicalFrame 𝓢).IsRegular := by
   constructor;
   rintro X Y Γ ⟨hX, hY⟩;
-  obtain ⟨φ, rfl, hφ⟩ := CanonicalBox.minimal.exists_box X Γ hX;
-  obtain ⟨ψ, rfl, hψ⟩ := CanonicalBox.minimal.exists_box Y Γ hY;
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hX;
+  obtain ⟨ψ, rfl, hψ⟩ := minimalCanonicalFrame.exists_box Y Γ hY;
   rw [(show proofset 𝓢 φ ∩ proofset 𝓢 ψ = proofset 𝓢 (φ ⋏ ψ) by simp)];
   have : proofset 𝓢 (□φ ⋏ □ψ) ⊆ proofset 𝓢 (□(φ ⋏ ψ)) := proofset.imp_subset |>.mp (by simp);
   have : Γ ∈ proofset 𝓢 (□(φ ⋏ ψ)) := this $ by
@@ -52,7 +52,8 @@ instance : (CanonicalBox.minimal 𝓢).frame.IsRegular := by
     constructor;
     . apply hφ ▸ hX;
     . apply hψ ▸ hY;
-  apply CanonicalBox.minimal 𝓢 |>.canonicity _ ▸ this;
+  convert this;
+  convert Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) (φ ⋏ ψ);
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomC.lean
+++ b/Foundation/Modal/Neighborhood/AxiomC.lean
@@ -8,9 +8,9 @@ open Formula.Neighborhood
 variable {F : Frame}
 
 class Frame.IsRegular (F : Frame) : Prop where
-  regular : ∀ X Y : Set F, (ℬ X) ∩ (ℬ Y) ⊆ ℬ (X ∩ Y)
+  regular : ∀ X Y, (F.box X) ∩ (F.box Y) ⊆ F.box (X ∩ Y)
 
-lemma Frame.regular [Frame.IsRegular F] {X Y : Set F} : (ℬ X) ∩ (ℬ Y) ⊆ ℬ (X ∩ Y) := by apply IsRegular.regular
+lemma Frame.regular [Frame.IsRegular F] {X Y : Set F} : (F.box X) ∩ (F.box Y) ⊆ F.box (X ∩ Y) := by apply IsRegular.regular
 
 instance : Frame.simple_blackhole.IsRegular := ⟨by
   intro X Y e;
@@ -40,11 +40,11 @@ variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.EC 𝓢]
 open Entailment
 open MaximalConsistentSet
 
-instance : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).IsRegular := by
+instance : (CanonicalBox.minimal 𝓢).frame.IsRegular := by
   constructor;
   rintro X Y Γ ⟨hX, hY⟩;
-  obtain ⟨φ, rfl, hφ⟩ := minimal_canonical_box.exists_box X Γ hX;
-  obtain ⟨ψ, rfl, hψ⟩ := minimal_canonical_box.exists_box Y Γ hY;
+  obtain ⟨φ, rfl, hφ⟩ := CanonicalBox.minimal.exists_box X Γ hX;
+  obtain ⟨ψ, rfl, hψ⟩ := CanonicalBox.minimal.exists_box Y Γ hY;
   rw [(show proofset 𝓢 φ ∩ proofset 𝓢 ψ = proofset 𝓢 (φ ⋏ ψ) by simp)];
   have : proofset 𝓢 (□φ ⋏ □ψ) ⊆ proofset 𝓢 (□(φ ⋏ ψ)) := proofset.imp_subset |>.mp (by simp);
   have : Γ ∈ proofset 𝓢 (□(φ ⋏ ψ)) := this $ by
@@ -52,7 +52,7 @@ instance : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).IsRegular := by
     constructor;
     . apply hφ ▸ hX;
     . apply hψ ▸ hY;
-  apply minimal_canonical_box 𝓢 |>.canonicity _ ▸ this;
+  apply CanonicalBox.minimal 𝓢 |>.canonicity _ ▸ this;
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomGeach.lean
+++ b/Foundation/Modal/Neighborhood/AxiomGeach.lean
@@ -11,16 +11,16 @@ variable {F : Frame} {X Y : Set F.World} {g : Axioms.Geach.Taple}
 namespace Frame
 
 class IsGeachConvergent (g : Axioms.Geach.Taple) (F : Frame) : Prop where
-  gconv : ∀ X : Set F, 𝒟^[g.i] (ℬ^[g.m] X) ⊆ ℬ^[g.j] (𝒟^[g.n] X)
+  gconv : ∀ X : Set F, F.dia^[g.i] (F.box^[g.m] X) ⊆ F.box^[g.j] (F.dia^[g.n] X)
 
 @[simp, grind]
-lemma gconv [F.IsGeachConvergent g] : 𝒟^[g.i] (ℬ^[g.m] X) ⊆ ℬ^[g.j] (𝒟^[g.n] X) := IsGeachConvergent.gconv X
+lemma gconv [F.IsGeachConvergent g] : F.dia^[g.i] (F.box^[g.m] X) ⊆ F.box^[g.j] (F.dia^[g.n] X) := IsGeachConvergent.gconv X
 
 
 class IsReflexive (F : Frame) : Prop where
-  refl : ∀ X : Set F, ℬ X ⊆ X
+  refl : ∀ X : Set F, F.box X ⊆ X
 
-@[simp, grind] lemma refl [F.IsReflexive] : ℬ X ⊆ X := IsReflexive.refl X
+@[simp, grind] lemma refl [F.IsReflexive] : F.box X ⊆ X := IsReflexive.refl X
 
 instance [F.IsReflexive] : F.IsGeachConvergent ⟨0, 0, 1, 0⟩ := ⟨by simp⟩
 
@@ -28,18 +28,18 @@ instance [F.IsGeachConvergent ⟨0, 0, 1, 0⟩] : F.IsReflexive := ⟨λ _ => F.
 
 
 class IsTransitive (F : Frame) : Prop where
-  trans : ∀ X : Set F, ℬ X ⊆ ℬ^[2] X
+  trans : ∀ X : Set F, F.box X ⊆ F.box^[2] X
 
-@[simp, grind] lemma trans [F.IsTransitive] : ℬ X ⊆ ℬ^[2] X := IsTransitive.trans X
+@[simp, grind] lemma trans [F.IsTransitive] : F.box X ⊆ F.box^[2] X := IsTransitive.trans X
 
-instance [F.IsTransitive] : F.IsGeachConvergent ⟨0, 2, 1, 0⟩ := ⟨by simp⟩
+instance [F.IsTransitive] : F.IsGeachConvergent ⟨0, 2, 1, 0⟩ := ⟨fun _ ↦ trans⟩
 
 instance [F.IsGeachConvergent ⟨0, 2, 1, 0⟩] : F.IsTransitive := ⟨λ _ => F.gconv (g := ⟨0, 2, 1, 0⟩)⟩
 
 
 class IsSerial (F : Frame) : Prop where
-  serial : ∀ X : Set F, ℬ X ⊆ 𝒟 X
-@[simp] lemma serial [F.IsSerial] : ℬ X ⊆ 𝒟 X := IsSerial.serial X
+  serial : ∀ X : Set F, F.box X ⊆ F.dia X
+@[simp] lemma serial [F.IsSerial] : F.box X ⊆ F.dia X := IsSerial.serial X
 instance [F.IsSerial] : F.IsGeachConvergent ⟨0, 0, 1, 1⟩ := ⟨by simp⟩
 instance [F.IsGeachConvergent ⟨0, 0, 1, 1⟩] : F.IsSerial := ⟨λ _ => F.gconv (g := ⟨0, 0, 1, 1⟩)⟩
 
@@ -53,7 +53,8 @@ variable {a : ℕ}
 lemma valid_axiomGeach_of_isGeachConvergent [F.IsGeachConvergent g] : F ⊧ Axioms.Geach g (.atom a) := by
   intro V x;
   apply Satisfies.def_imp.mpr;
-  suffices x ∈ 𝒟^[g.i] (ℬ^[g.m] (V a)) → x ∈ ℬ^[g.j] (𝒟^[g.n] (V a)) by simpa [Semantics.Realize, Satisfies];
+  suffices x ∈ F.dia^[g.i] (F.box^[g.m] (V a)) → x ∈ F.box^[g.j] (F.dia^[g.n] (V a)) by
+    simpa [Semantics.Realize, Satisfies];
   apply F.gconv;
 
 @[simp] lemma valid_axiomT_of_isReflexive [F.IsReflexive] : F ⊧ Axioms.T (.atom a) := valid_axiomGeach_of_isGeachConvergent (g := ⟨0, 0, 1, 0⟩)
@@ -64,7 +65,7 @@ lemma valid_axiomGeach_of_isGeachConvergent [F.IsGeachConvergent g] : F ⊧ Axio
 lemma isGeachConvergent_of_valid_axiomGeach (h : F ⊧ Axioms.Geach g (.atom a)) : F.IsGeachConvergent g := by
   constructor;
   intro X x hx;
-  have : x ∈ 𝒟^[g.i] (ℬ^[g.m] X) → x ∈ ℬ^[g.j] (𝒟^[g.n] X) := by
+  have : x ∈ F.dia^[g.i] (F.box^[g.m] X) → x ∈ F.box^[g.j] (F.dia^[g.n] X) := by
     simpa [Semantics.Realize, Satisfies] using Satisfies.def_imp.mp $ @h (λ _ => X) x;
   apply this;
   apply hx;
@@ -93,12 +94,12 @@ variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.E4 𝓢]
 open Entailment
 open MaximalConsistentSet
 
-instance : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).IsTransitive := by
+instance : (CanonicalBox.minimal 𝓢).frame.IsTransitive := by
   constructor;
   intro X Γ hΓ;
-  obtain ⟨φ, rfl, hφ⟩ := minimal_canonical_box.exists_box X Γ hΓ;
+  obtain ⟨φ, rfl, hφ⟩ := CanonicalBox.minimal.exists_box X Γ hΓ;
   have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 (□□φ) := proofset.imp_subset.mp (by simp);
-  apply hφ ▸ (minimal_canonical_box 𝓢 |>.canonicity (□φ) ▸ (this (hφ ▸ hΓ)));
+  apply hφ ▸ (CanonicalBox.minimal 𝓢 |>.canonicity (□φ) ▸ (this (hφ ▸ hΓ)));
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomGeach.lean
+++ b/Foundation/Modal/Neighborhood/AxiomGeach.lean
@@ -94,12 +94,17 @@ variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.E4 𝓢]
 open Entailment
 open MaximalConsistentSet
 
-instance : (CanonicalBox.minimal 𝓢).frame.IsTransitive := by
+instance : (minimalCanonicalFrame 𝓢).IsTransitive := by
   constructor;
   intro X Γ hΓ;
-  obtain ⟨φ, rfl, hφ⟩ := CanonicalBox.minimal.exists_box X Γ hΓ;
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ;
   have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 (□□φ) := proofset.imp_subset.mp (by simp);
-  apply hφ ▸ (CanonicalBox.minimal 𝓢 |>.canonicity (□φ) ▸ (this (hφ ▸ hΓ)));
+  have := Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ);
+  rw [
+    ←(Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) (□φ)),
+    ←(Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) φ)
+  ] at this;
+  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mpr this;
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomGeach.lean
+++ b/Foundation/Modal/Neighborhood/AxiomGeach.lean
@@ -89,12 +89,19 @@ end
 section
 
 variable [Entailment (Formula ℕ) S]
-variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.E4 𝓢]
+variable {𝓢 : S} [Entailment.Consistent 𝓢]
 
 open Entailment
 open MaximalConsistentSet
 
-instance : (minimalCanonicalFrame 𝓢).IsTransitive := by
+instance [Entailment.ET 𝓢] : (minimalCanonicalFrame 𝓢).IsReflexive := by
+  constructor;
+  intro X Γ hΓ;
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ;
+  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 φ := proofset.imp_subset.mp (by simp);
+  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ);
+
+instance [Entailment.E4 𝓢] : (minimalCanonicalFrame 𝓢).IsTransitive := by
   constructor;
   intro X Γ hΓ;
   obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ;

--- a/Foundation/Modal/Neighborhood/AxiomGeach.lean
+++ b/Foundation/Modal/Neighborhood/AxiomGeach.lean
@@ -1,4 +1,4 @@
-import Foundation.Modal.Neighborhood.Basic
+import Foundation.Modal.Neighborhood.Completeness
 
 namespace LO.Modal.Neighborhood
 
@@ -82,5 +82,25 @@ lemma isSerial_of_valid_axiomD (h : F ⊧ Axioms.D (.atom a)) : F.IsSerial := by
   infer_instance;
 
 end
+
+
+
+section
+
+variable [Entailment (Formula ℕ) S]
+variable {𝓢 : S} [Entailment.Consistent 𝓢] [Entailment.E4 𝓢]
+
+open Entailment
+open MaximalConsistentSet
+
+instance : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).IsTransitive := by
+  constructor;
+  intro X Γ hΓ;
+  obtain ⟨φ, rfl, hφ⟩ := minimal_canonical_box.exists_box X Γ hΓ;
+  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 (□□φ) := proofset.imp_subset.mp (by simp);
+  apply hφ ▸ (minimal_canonical_box 𝓢 |>.canonicity (□φ) ▸ (this (hφ ▸ hΓ)));
+
+end
+
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/AxiomM.lean
+++ b/Foundation/Modal/Neighborhood/AxiomM.lean
@@ -11,6 +11,12 @@ class Frame.IsMonotonic (F : Frame) : Prop where
 
 lemma Frame.mono [Frame.IsMonotonic F] {X Y : Set F} : ℬ (X ∩ Y) ⊆ ℬ X ∩ ℬ Y := by apply IsMonotonic.mono
 
+lemma Frame.mono' [Frame.IsMonotonic F] {X Y : Set F} : X ⊆ Y → ℬ X ⊆ ℬ Y := by
+  intro h x hX;
+  apply @F.mono (X := X) (Y := Y) ?_ x ?_ |>.2;
+  . assumption;
+  . sorry;
+
 instance : Frame.simple_blackhole.IsMonotonic := ⟨by
   intro X Y e he;
   constructor <;>

--- a/Foundation/Modal/Neighborhood/AxiomM.lean
+++ b/Foundation/Modal/Neighborhood/AxiomM.lean
@@ -11,12 +11,6 @@ class Frame.IsMonotonic (F : Frame) : Prop where
 
 lemma Frame.mono [Frame.IsMonotonic F] {X Y : Set F} : F.box (X ∩ Y) ⊆ F.box X ∩ F.box Y := by apply IsMonotonic.mono
 
-lemma Frame.mono' [Frame.IsMonotonic F] {X Y : Set F} : X ⊆ Y → F.box X ⊆ F.box Y := by
-  intro h x hX;
-  apply @F.mono (X := X) (Y := Y) ?_ x ?_ |>.2;
-  . assumption;
-  . sorry;
-
 instance : Frame.simple_blackhole.IsMonotonic := ⟨by
   intro X Y e he;
   constructor <;>

--- a/Foundation/Modal/Neighborhood/AxiomM.lean
+++ b/Foundation/Modal/Neighborhood/AxiomM.lean
@@ -7,11 +7,11 @@ open Formula.Neighborhood
 variable {F : Frame}
 
 class Frame.IsMonotonic (F : Frame) : Prop where
-  mono : ∀ X Y : Set F, ℬ (X ∩ Y) ⊆ ℬ X ∩ ℬ Y
+  mono : ∀ X Y : Set F, F.box (X ∩ Y) ⊆ F.box X ∩ F.box Y
 
-lemma Frame.mono [Frame.IsMonotonic F] {X Y : Set F} : ℬ (X ∩ Y) ⊆ ℬ X ∩ ℬ Y := by apply IsMonotonic.mono
+lemma Frame.mono [Frame.IsMonotonic F] {X Y : Set F} : F.box (X ∩ Y) ⊆ F.box X ∩ F.box Y := by apply IsMonotonic.mono
 
-lemma Frame.mono' [Frame.IsMonotonic F] {X Y : Set F} : X ⊆ Y → ℬ X ⊆ ℬ Y := by
+lemma Frame.mono' [Frame.IsMonotonic F] {X Y : Set F} : X ⊆ Y → F.box X ⊆ F.box Y := by
   intro h x hX;
   apply @F.mono (X := X) (Y := Y) ?_ x ?_ |>.2;
   . assumption;

--- a/Foundation/Modal/Neighborhood/AxiomN.lean
+++ b/Foundation/Modal/Neighborhood/AxiomN.lean
@@ -1,4 +1,5 @@
 import Foundation.Modal.Neighborhood.Basic
+import Foundation.Modal.Neighborhood.Completeness
 
 namespace LO.Modal.Neighborhood
 
@@ -23,5 +24,8 @@ lemma containsUnit_of_valid_axiomN (h : F ⊧ Axioms.N) : F.ContainsUnit := by
   constructor;
   intro x;
   simpa [Satisfies] using @h (λ _ => Set.univ) x;
+
+
+
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/Basic.lean
+++ b/Foundation/Modal/Neighborhood/Basic.lean
@@ -22,28 +22,10 @@ variable {F : Frame} {X Y : Set F.World}
 instance : CoeSort Frame Type := ⟨Frame.World⟩
 instance {F : Frame} : Nonempty F.World := F.world_nonempty
 
-@[reducible] def box {F : Frame} : Set F.World → Set F.World := λ X => { w | X ∈ F.𝒩 w }
-@[reducible] def dia {F : Frame} := λ X => (F.box Xᶜ)ᶜ
+@[reducible] def box (F : Frame) : Set F.World → Set F.World := λ X => { w | X ∈ F.𝒩 w }
+@[reducible] def dia (F : Frame) := λ X => (F.box Xᶜ)ᶜ
 
-prefix:max "ℬ" => Frame.box
-prefix:max "𝒟" => Frame.dia
-
-def box_iterate {F : Frame} : ℕ → Set F.World → Set F.World
-| 0     => id
-| n + 1 => λ X => ℬ (F.box_iterate n X)
-notation:max "ℬ^[" n:80 "]" => Frame.box_iterate n
-
-def dia_iterate {F : Frame} : ℕ → Set F.World → Set F.World
-| 0     => id
-| n + 1 => λ X => 𝒟 (F.dia_iterate n X)
-notation:max "𝒟^[" n:80 "]" => Frame.dia_iterate n
-
-@[simp] lemma box_iterate_zero : ℬ^[0] X = X := rfl
-@[simp] lemma dia_iterate_zero : 𝒟^[0] X = X := rfl
-@[simp] lemma box_iterate_one : ℬ^[1] X = ℬ X := rfl
-@[simp] lemma dia_iterate_one : 𝒟^[1] X = 𝒟 X := rfl
-
-lemma eq_ℬ_𝒩 {F : Frame} {X Y : Set F.World} : (ℬ X) = Y ↔ (∀ x, X ∈ F.𝒩 x ↔ x ∈ Y) := by
+lemma eq_ℬ_𝒩 {F : Frame} {X Y : Set F.World} : (F.box X) = Y ↔ (∀ x, X ∈ F.𝒩 x ↔ x ∈ Y) := by
   constructor;
   . rintro rfl;
     tauto;
@@ -84,7 +66,7 @@ def Model.truthset (M : Model) : Formula ℕ → Set M.World
 | .atom n => M.Val n
 | ⊥       => ∅
 | φ ➝ ψ  => (truthset M φ)ᶜ ∪ truthset M ψ
-| □φ      => ℬ (truthset M φ)
+| □φ      => M.box (truthset M φ)
 
 namespace Model.truthset
 
@@ -105,20 +87,20 @@ instance : CoeFun Model (λ M => Formula ℕ → Set M.World) := ⟨λ M => trut
   _         = (M φ ∩ M ψ) ∪ ((M φ)ᶜ ∩ (M ψ)ᶜ)     := by tauto_set;
 
 @[simp, grind]
-lemma eq_multibox {n : ℕ} : M (□^[n] φ) = ℬ^[n] (M φ) := by
+lemma eq_multibox {n : ℕ} : M (□^[n] φ) = M.box^[n] (M φ) := by
   induction n with
   | zero => simp
-  | succ n ih => simp [ih, truthset, Frame.box_iterate]
+  | succ n ih => rw [Function.iterate_succ']; simp [ih, truthset]
 
-@[simp, grind] lemma eq_box : M (□φ) = ℬ (M φ) := eq_multibox (n := 1)
+@[simp, grind] lemma eq_box : M (□φ) = M.box (M φ) := eq_multibox (n := 1)
 
 @[simp, grind]
-lemma eq_multidia {n : ℕ} : M (◇^[n] φ) = 𝒟^[n] (M φ) := by
+lemma eq_multidia {n : ℕ} : M (◇^[n] φ) = M.dia^[n] (M φ) := by
   induction n with
   | zero => simp
-  | succ n ih => simp [ih, truthset, Frame.dia_iterate]
+  | succ n ih => rw [Function.iterate_succ']; simp [ih, truthset]
 
-@[simp, grind] lemma eq_dia : M (◇φ) = 𝒟 (M φ) := eq_multidia (n := 1)
+@[simp, grind] lemma eq_dia : M (◇φ) = M.dia (M φ) := eq_multidia (n := 1)
 
 
 @[grind]
@@ -155,10 +137,10 @@ variable {M : Model} {x : M.World} {φ ψ ξ : Formula ℕ}
 @[grind] lemma def_box : x ⊧ □φ ↔ M φ ∈ (M.𝒩 x) := by simp [Semantics.Realize, Satisfies];
 @[grind] lemma def_dia : x ⊧ ◇φ ↔ (M φ)ᶜ ∈ (M.𝒩 x)ᶜ := by simp [Semantics.Realize, Satisfies];
 
-@[grind] lemma def_multibox' : x ⊧ □^[n]φ ↔ x ∈ ℬ^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
-@[grind] lemma def_mutlidia' : x ⊧ ◇^[n]φ ↔ x ∈ 𝒟^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
-@[grind] lemma def_box' : x ⊧ □φ ↔ x ∈ ℬ (M φ) := def_multibox' (n := 1)
-@[grind] lemma def_dia' : x ⊧ ◇φ ↔ x ∈ 𝒟 (M φ) := def_mutlidia' (n := 1)
+@[grind] lemma def_multibox' : x ⊧ □^[n]φ ↔ x ∈ M.box^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_mutlidia' : x ⊧ ◇^[n]φ ↔ x ∈ M.dia^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_box' : x ⊧ □φ ↔ x ∈ M.box (M φ) := def_multibox' (n := 1)
+@[grind] lemma def_dia' : x ⊧ ◇φ ↔ x ∈ M.dia (M φ) := def_mutlidia' (n := 1)
 
 protected instance : Semantics.Tarski (M.World) where
   realize_top := by grind

--- a/Foundation/Modal/Neighborhood/Completeness.lean
+++ b/Foundation/Modal/Neighborhood/Completeness.lean
@@ -150,6 +150,61 @@ def minimal_canonical_box (𝓢 : S) [Entailment.E 𝓢] : CanonicalBox 𝓢 whe
       apply h.choose_spec.symm;
     . tauto;
 
+namespace minimal_canonical_box
+
+variable {𝓢 : S} [Entailment.E 𝓢] [Consistent 𝓢]
+
+lemma exists_box (X) (Γ : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).World) (hΓ : Γ ∈ ℬ X)
+  : ∃ φ, X = proofset 𝓢 φ ∧ ℬ X = proofset 𝓢 (□φ)
+  := by
+    simp [mkCanonicalFrame, Frame.mk_ℬ, minimal_canonical_box] at hΓ;
+    split at hΓ;
+    . rename_i h;
+      obtain ⟨φ, hφ⟩ := h;
+      use φ;
+      constructor;
+      . assumption;
+      . convert minimal_canonical_box 𝓢 |>.canonicity φ;
+    . contradiction;
+
+lemma exists_dia (X) (Γ : (mkCanonicalFrame 𝓢 (minimal_canonical_box 𝓢)).World) (hΓ : Γ ∈ ℬ X)
+  : ∃ φ, X = proofset 𝓢 φ ∧ 𝒟 X = proofset 𝓢 (◇φ)
+  := by
+    obtain ⟨φ, hφ, hΓ⟩ := exists_box X Γ hΓ;
+    use φ;
+    constructor;
+    . assumption;
+    . ext Γ;
+      rw [(show ◇φ = ∼□(∼φ) by rfl)];
+      simp only [
+        minimal_canonical_box, mkCanonicalFrame, Frame.mk_ℬ, Set.mem_compl_iff,
+        Set.mem_setOf_eq, proofset.eq_neg
+      ];
+      constructor;
+      . intro h;
+        split at h;
+        . rename_i h₂;
+          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [this] at h; simpa;
+          apply proofset.eq_boxed_of_eq;
+          rw [←h₂.choose_spec, hφ];
+          simp;
+        . exfalso;
+          rename_i h₂;
+          push_neg at h₂;
+          apply @h₂ (∼φ);
+          simpa;
+      . intro h;
+        split;
+        . rename_i h₂;
+          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [←this] at h; simpa;
+          apply proofset.eq_boxed_of_eq;
+          rw [←h₂.choose_spec, hφ];
+          simp;
+        . tauto;
+
+end minimal_canonical_box
+
+
 end Neighborhood
 
 end

--- a/Foundation/Modal/Neighborhood/Completeness.lean
+++ b/Foundation/Modal/Neighborhood/Completeness.lean
@@ -1,5 +1,6 @@
 import Foundation.Modal.MaximalConsistentSet
 import Foundation.Modal.Neighborhood.Basic
+import Foundation.Modal.Entailment.EM
 
 namespace LO.Modal
 
@@ -71,6 +72,12 @@ lemma eq_boxed_of_eq [Entailment.E 𝓢] : ‖φ‖ = ‖ψ‖ → ‖□φ‖ =
   apply re!;
   apply iff_subset.mpr;
   assumption;
+
+@[grind]
+lemma box_subset_of_subset [Entailment.EM 𝓢] : ‖φ‖ ⊆ ‖ψ‖ → ‖□φ‖ ⊆ ‖□ψ‖ := by
+  intro h;
+  apply imp_subset.mp;
+  exact Entailment.rm! $ imp_subset.mpr h;
 
 end MaximalConsistentSet.proofset
 

--- a/Foundation/Modal/Neighborhood/Logic/E.lean
+++ b/Foundation/Modal/Neighborhood/Logic/E.lean
@@ -22,7 +22,7 @@ instance : Entailment.Consistent Hilbert.E := consistent_of_sound_frameclass Fra
   use ⟨Unit, λ _ => {}⟩;
   simp;
 
-instance : Complete Hilbert.E FrameClass.E := complete_of_canonical_frame FrameClass.E (minimal_canonical_box (Hilbert.E)) (by tauto)
+instance : Complete Hilbert.E FrameClass.E := complete_of_canonical_frame FrameClass.E (minimalCanonicalFrame (Hilbert.E)) (by tauto)
 
 instance : Hilbert.E ⪱ Hilbert.EK := by
   constructor;

--- a/Foundation/Modal/Neighborhood/Logic/E4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/E4.lean
@@ -18,7 +18,7 @@ namespace Neighborhood
 
 instance : Frame.simple_blackhole.IsTransitive := by
   constructor;
-  simp [Frame.box, Frame.box_iterate];
+  simp [Frame.box];
 
 @[reducible] protected alias Frame.IsE4 := Frame.IsTransitive
 protected abbrev FrameClass.E4 : FrameClass := { F | F.IsE4 }
@@ -80,6 +80,10 @@ instance : Sound Hilbert.E4 FrameClass.E4 := instSound_of_validates_axioms $ by
 instance : Entailment.Consistent Hilbert.E4 := consistent_of_sound_frameclass FrameClass.E4 $ by
   use Frame.simple_blackhole;
   simp only [Set.mem_setOf_eq];
+  infer_instance;
+
+instance : Complete Hilbert.E4 FrameClass.E4 := complete_of_canonical_frame FrameClass.E4 (minimalCanonicalFrame (Hilbert.E4)) $ by
+  apply Set.mem_setOf_eq.mpr;
   infer_instance;
 
 end E4.Neighborhood

--- a/Foundation/Modal/Neighborhood/Logic/EC.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EC.lean
@@ -1,6 +1,7 @@
 import Foundation.Modal.Neighborhood.Hilbert
 import Foundation.Modal.Neighborhood.AxiomC
 import Foundation.Modal.Neighborhood.Logic.E
+import Foundation.Modal.Neighborhood.Supplementation
 
 namespace LO.Modal
 

--- a/Foundation/Modal/Neighborhood/Logic/EM.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EM.lean
@@ -1,7 +1,5 @@
-import Foundation.Modal.Neighborhood.Hilbert
-import Foundation.Modal.Neighborhood.AxiomM
 import Foundation.Modal.Neighborhood.Logic.E
-import Foundation.Vorspiel.Set.Fin
+import Foundation.Modal.Neighborhood.Supplementation
 
 namespace LO.Modal
 
@@ -29,6 +27,10 @@ instance : Sound Hilbert.EM FrameClass.EM := instSound_of_validates_axioms $ by
 instance : Entailment.Consistent Hilbert.EM := consistent_of_sound_frameclass FrameClass.EM $ by
   use Frame.simple_blackhole;
   simp only [Set.mem_setOf_eq];
+  infer_instance;
+
+instance : Complete Hilbert.EM FrameClass.EM := complete_of_canonical_frame FrameClass.EM (supplementalMinimalCanonicalFrame (Hilbert.EM)) $ by
+  apply Set.mem_setOf_eq.mpr;
   infer_instance;
 
 end EM.Neighborhood

--- a/Foundation/Modal/Neighborhood/Logic/EMC.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMC.lean
@@ -1,6 +1,7 @@
 import Foundation.Modal.Neighborhood.Hilbert
 import Foundation.Modal.Neighborhood.Logic.EM
 import Foundation.Modal.Neighborhood.Logic.EC
+import Foundation.Vorspiel.Set.Fin
 
 
 namespace LO.Modal
@@ -78,6 +79,10 @@ instance : Entailment.Consistent Hilbert.EMC := consistent_of_sound_frameclass F
   simp;
   constructor;
 
+instance : Complete Hilbert.EMC FrameClass.EMC := complete_of_canonical_frame FrameClass.EMC (supplementalMinimalCanonicalFrame (Hilbert.EMC)) $ by
+  apply Set.mem_setOf_eq.mpr;
+  constructor;
+
 end EMC.Neighborhood
 
 instance : Hilbert.EC ⪱ Hilbert.EMC := by
@@ -149,6 +154,7 @@ instance : Hilbert.EM ⪱ Hilbert.EMC := by
       use M, 0;
       constructor;
       . exact {
+          -- TODO: need golf!
           mono := by
             rintro X Y w hw;
             constructor;

--- a/Foundation/Modal/Neighborhood/Logic/EMC4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMC4.lean
@@ -11,7 +11,7 @@ open Formula.Neighborhood
 
 namespace Neighborhood
 
-protected class Frame.IsEMC4 (F : Frame) extends F.IsMonotonic, F.IsRegular, F.IsTransitive
+protected class Frame.IsEMC4 (F : Frame) extends F.IsMonotonic, F.IsRegular, F.IsTransitive where
 protected abbrev FrameClass.EMC4 : FrameClass := { F | F.IsEMC4 }
 
 end Neighborhood
@@ -28,6 +28,10 @@ instance : Sound Hilbert.EMC4 FrameClass.EMC4 := instSound_of_validates_axioms $
 instance : Entailment.Consistent Hilbert.EMC4 := consistent_of_sound_frameclass FrameClass.EMC4 $ by
   use Frame.simple_blackhole;
   simp only [Set.mem_setOf_eq];
+  constructor;
+
+instance : Complete Hilbert.EMC4 FrameClass.EMC4 := complete_of_canonical_frame FrameClass.EMC4 (supplementalMinimalCanonicalFrame (Hilbert.EMC4)) $ by
+  apply Set.mem_setOf_eq.mpr;
   constructor;
 
 end E4.Neighborhood

--- a/Foundation/Modal/Neighborhood/Logic/EMT.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMT.lean
@@ -14,7 +14,7 @@ instance : Frame.simple_blackhole.IsReflexive := by
   intro X x;
   simp_all;
 
-protected class Frame.IsEMT (F : Frame) extends F.IsMonotonic, F.IsReflexive
+protected class Frame.IsEMT (F : Frame) extends F.IsMonotonic, F.IsReflexive where
 protected abbrev FrameClass.EMT : FrameClass := { F | F.IsEMT }
 
 end Neighborhood
@@ -30,6 +30,10 @@ instance : Sound Hilbert.EMT FrameClass.EMT := instSound_of_validates_axioms $ b
 
 instance : Entailment.Consistent Hilbert.EMT := consistent_of_sound_frameclass FrameClass.EMT $ by
   use Frame.simple_blackhole;
+  apply Set.mem_setOf_eq.mpr;
+  constructor;
+
+instance : Complete Hilbert.EMT FrameClass.EMT := complete_of_canonical_frame FrameClass.EMT (supplementalMinimalCanonicalFrame (Hilbert.EMT)) $ by
   apply Set.mem_setOf_eq.mpr;
   constructor;
 

--- a/Foundation/Modal/Neighborhood/Logic/EMT4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMT4.lean
@@ -9,7 +9,7 @@ open Formula.Neighborhood
 
 namespace Neighborhood
 
-protected class Frame.IsEMT4 (F : Frame) extends F.IsMonotonic, F.IsReflexive, F.IsTransitive
+protected class Frame.IsEMT4 (F : Frame) extends F.IsMonotonic, F.IsReflexive, F.IsTransitive where
 protected abbrev FrameClass.EMT4 : FrameClass := { F | F.IsEMT4 }
 
 end Neighborhood
@@ -25,6 +25,10 @@ instance : Sound Hilbert.EMT4 FrameClass.EMT4 := instSound_of_validates_axioms $
 
 instance : Entailment.Consistent Hilbert.EMT4 := consistent_of_sound_frameclass FrameClass.EMT4 $ by
   use Frame.simple_blackhole;
+  apply Set.mem_setOf_eq.mpr;
+  constructor;
+
+instance : Complete Hilbert.EMT4 FrameClass.EMT4 := complete_of_canonical_frame FrameClass.EMT4 (supplementalMinimalCanonicalFrame (Hilbert.EMT4)) $ by
   apply Set.mem_setOf_eq.mpr;
   constructor;
 

--- a/Foundation/Modal/Neighborhood/Supplementation.lean
+++ b/Foundation/Modal/Neighborhood/Supplementation.lean
@@ -1,24 +1,60 @@
 import Foundation.Modal.Neighborhood.Basic
 import Foundation.Modal.Neighborhood.AxiomM
+import Foundation.Modal.Neighborhood.AxiomC
 import Foundation.Modal.Neighborhood.AxiomGeach
 
 namespace LO.Modal.Neighborhood
 
 variable {F : Frame}
 
-def Frame.Supplementation (F : Frame) : Frame := Frame.mk_ℬ F.World (λ X => (Set.sUnion { ℬ Y | Y ⊆ X }))
+def Frame.Supplementation (F : Frame) : Frame := Frame.mk_ℬ F.World (λ X => (Set.sUnion { F.box Y | Y ⊆ X }))
 
 local postfix:80 "♯" => Frame.Supplementation
 
-lemma wow {w : F♯.World} : w ∈ ℬ X ↔ ∃ Y ⊆ X, w ∈ F.box Y := by
-  simp only [Frame.Supplementation, Frame.box, Frame.mk_ℬ, Set.mem_sUnion, Set.mem_setOf_eq, exists_exists_and_eq_and]
+namespace Frame.Supplementation
+
+lemma iff_exists_subset {X : Set (F.World)} {w : F.World} : w ∈ F♯.box X ↔ ∃ Y ⊆ X, w ∈ F.box Y := by
+  simp [Frame.Supplementation, Frame.box, Frame.mk_ℬ, Set.mem_sUnion, Set.mem_setOf_eq, exists_exists_and_eq_and]
+
+lemma subset (X : Set (F.World)) : F.box X ⊆ F♯.box X := by
+  intro x;
+  simp [Frame.Supplementation, Frame.box, Frame.mk_ℬ];
+  tauto;
+
+lemma monotonic {X Y : Set (F.World)} (h : X ⊆ Y) : F♯.box X ⊆ F♯.box Y := by
+  intro x hX;
+  obtain ⟨X', hX', hX⟩ := iff_exists_subset.mp hX;
+  apply iff_exists_subset.mpr;
+  use X';
+  constructor;
+  . apply Set.Subset.trans hX' h;
+  . assumption;
+
+lemma monotonic_iterated {X Y : Set (F.World)} (h : X ⊆ Y) (n) : F♯.box^[n] X ⊆ F♯.box^[n] Y := by
+  induction n with
+  | zero => simpa;
+  | succ n ih =>
+    rw [Function.iterate_succ'];
+    apply monotonic;
+    apply ih;
+
+lemma itl_reduce : F♯♯.box X = F♯.box X := by
+  ext x;
+  simp only [Supplementation, mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion, exists_exists_and_eq_and]
+  constructor;
+  . rintro ⟨Y, RYX, Z, RZY, hZ⟩;
+    use Z;
+    constructor;
+    . tauto_set;
+    . assumption;
+  . tauto;
 
 instance : F♯.IsMonotonic := by
   constructor;
   rintro X Y x hx;
-  obtain ⟨W, hW₁, hW₂⟩ := wow.mp hx;
+  obtain ⟨W, hW₁, hW₂⟩ := iff_exists_subset.mp hx;
   constructor <;>
-  . apply wow.mpr;
+  . apply iff_exists_subset.mpr;
     use W;
     constructor;
     . tauto_set;
@@ -27,7 +63,7 @@ instance : F♯.IsMonotonic := by
 instance [F.IsReflexive] : F♯.IsReflexive := by
   constructor;
   intro X w hw;
-  replace ⟨Y, hY₁, hY₂⟩ := wow.mp hw;
+  replace ⟨Y, hY₁, hY₂⟩ := iff_exists_subset.mp hw;
   apply hY₁;
   apply F.refl;
   exact hY₂;
@@ -35,8 +71,23 @@ instance [F.IsReflexive] : F♯.IsReflexive := by
 instance [F.IsTransitive] : F♯.IsTransitive := by
   constructor;
   intro X w hw;
-  obtain ⟨Y, hY₁, hY₂⟩ := wow.mp hw;
-  have := F.trans hY₂;
-  sorry;
+  obtain ⟨Y, hYX, hY⟩ := iff_exists_subset.mp hw;
+  apply monotonic_iterated hYX 2
+  apply monotonic $ subset Y;
+  apply subset (F.box Y) $ F.trans hY;
+
+instance [F.IsRegular] : F♯.IsRegular := by
+  constructor;
+  rintro X Y w ⟨hX, hY⟩;
+  apply iff_exists_subset.mpr;
+  obtain ⟨X', _⟩ := iff_exists_subset.mp hX;
+  obtain ⟨Y', _⟩ := iff_exists_subset.mp hY;
+  use X' ∩ Y';
+  constructor;
+  . tauto_set;
+  . apply @Frame.regular F _ X' Y';
+    tauto;
+
+end Frame.Supplementation
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/Supplementation.lean
+++ b/Foundation/Modal/Neighborhood/Supplementation.lean
@@ -1,0 +1,42 @@
+import Foundation.Modal.Neighborhood.Basic
+import Foundation.Modal.Neighborhood.AxiomM
+import Foundation.Modal.Neighborhood.AxiomGeach
+
+namespace LO.Modal.Neighborhood
+
+variable {F : Frame}
+
+def Frame.Supplementation (F : Frame) : Frame := Frame.mk_ℬ F.World (λ X => (Set.sUnion { ℬ Y | Y ⊆ X }))
+
+local postfix:80 "♯" => Frame.Supplementation
+
+lemma wow {w : F♯.World} : w ∈ ℬ X ↔ ∃ Y ⊆ X, w ∈ F.box Y := by
+  simp only [Frame.Supplementation, Frame.box, Frame.mk_ℬ, Set.mem_sUnion, Set.mem_setOf_eq, exists_exists_and_eq_and]
+
+instance : F♯.IsMonotonic := by
+  constructor;
+  rintro X Y x hx;
+  obtain ⟨W, hW₁, hW₂⟩ := wow.mp hx;
+  constructor <;>
+  . apply wow.mpr;
+    use W;
+    constructor;
+    . tauto_set;
+    . assumption;
+
+instance [F.IsReflexive] : F♯.IsReflexive := by
+  constructor;
+  intro X w hw;
+  replace ⟨Y, hY₁, hY₂⟩ := wow.mp hw;
+  apply hY₁;
+  apply F.refl;
+  exact hY₂;
+
+instance [F.IsTransitive] : F♯.IsTransitive := by
+  constructor;
+  intro X w hw;
+  obtain ⟨Y, hY₁, hY₂⟩ := wow.mp hw;
+  have := F.trans hY₂;
+  sorry;
+
+end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/Supplementation.lean
+++ b/Foundation/Modal/Neighborhood/Supplementation.lean
@@ -90,4 +90,51 @@ instance [F.IsRegular] : F♯.IsRegular := by
 
 end Frame.Supplementation
 
+
+section
+
+open MaximalConsistentSet (proofset)
+open MaximalConsistentSet.proofset
+
+variable {S} [Entailment (Formula ℕ) S]
+variable {𝓢 : S} [Entailment.Consistent 𝓢]
+
+abbrev supplementalMinimalCanonicalFrame (𝓢 : S) [Entailment.E 𝓢] [Entailment.Consistent 𝓢] : Frame := (minimalCanonicalFrame 𝓢)♯
+
+variable [Entailment.EM 𝓢]
+
+instance : (supplementalMinimalCanonicalFrame 𝓢).IsCanonical 𝓢 where
+  box_proofset := by
+    intro φ;
+    apply Set.eq_of_subset_of_subset;
+    . intro Γ;
+      simp only [
+        Frame.Supplementation, Frame.mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion,
+        exists_exists_and_eq_and, forall_exists_index, and_imp
+      ];
+      intro X hX h;
+      split at h;
+      . rename_i hψ;
+        rw [hψ.choose_spec] at hX;
+        apply box_subset_of_subset hX;
+        apply h;
+      . contradiction;
+    . intro Γ;
+      simp only [
+        Frame.Supplementation, Frame.mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion,
+        exists_exists_and_eq_and
+      ];
+      intro hΓ;
+      use proofset 𝓢 φ;
+      constructor
+      . rfl;
+      . split;
+        . rename_i hψ;
+          rw [←eq_boxed_of_eq hψ.choose_spec];
+          apply hΓ;
+        . simp_all;
+
+end
+
+
 end LO.Modal.Neighborhood


### PR DESCRIPTION
現在の実装で近傍フレームがカノニカルである `Frame.IsCanonical` ということを考えると素朴には下のようになる．

```
class Frame.IsCanonical (F : Frame) : Prop where
  eq_world : F.World = MaximalConsistentSet 𝓢
  box_proofset : ∀ φ, F.box (eq_world ▸ (proofset 𝓢 φ)) = eq_world ▸ (proofset 𝓢 (□φ))
```

しかしこの方法ではtruthlemmaを示すためには `Frame.IsCanonical.eq_world ▸ (∅ : Set (MaximalConsistentSet 𝓢)) = (∅ : Set F.World)` みたいな当たり前に成り立ってほしい集合に関しての演算に閉じなくなってしまう．

いま取っている方法は `(Set (MaximalConsistentSet 𝓢)) → (Set (MaximalConsistentSet 𝓢))` がカノニカルであるみたいな方針を取っているが，かなり微妙で教科書的な定義ではないし，「フレームがreflexiveである」という命題と「↑の関数がカノニカルである」といった性質の定義されるレベルがゴチャゴチャになってしまう．