### PR TITLE
refactor(FirstOrder & ProvabilityLogic): generalize provability notion

### DIFF
--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -10,33 +10,33 @@ namespace LO.FirstOrder.Arithmetic
 
 open LO.Entailment ProvabilityLogic
 
-variable (T : ArithmeticTheory) [T.Δ₁] [𝐈𝚺₁ ⪯ T]
+variable (T : Theory ℒₒᵣ) [T.Δ₁] [𝐈𝚺₁ ⪯ T]
 
 /-- Gödel's second incompleteness theorem -/
 theorem consistent_unprovable [Consistent T] :
     T ⊬. T.consistent :=
-  T.standardPr.con_unprovable
+  T.standardProvability.con_unprovable
 
-theorem inconsistent_unprovable [T.SoundOnHierarchy 𝚺 1] :
+theorem inconsistent_unprovable [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] :
     T ⊬. ∼T.consistent :=
-  T.standardPr.con_unrefutable
+  T.standardProvability.con_unrefutable
 
-theorem inconsistent_independent [T.SoundOnHierarchy 𝚺 1] :
+theorem inconsistent_independent [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] :
     Independent (T : Axiom ℒₒᵣ) (T.consistent : Sentence ℒₒᵣ) :=
-  T.standardPr.con_independent
+  T.standardProvability.con_independent
 
 instance [Consistent T] : T ⪱ T + T.Con :=
   StrictlyWeakerThan.of_unprovable_provable (φ := ↑T.consistent)
     ((Axiom.unprovable_iff (T := T)).mp (consistent_unprovable T))
     (Entailment.by_axm _ (by simp [Theory.add_def]))
 
-instance [T.SoundOnHierarchy 𝚺 1] : T ⪱ T + T.Incon :=
+instance [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T ⪱ T + T.Incon :=
   StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑T.consistent)
     (by simpa using (Axiom.unprovable_iff (T := T)).mp (inconsistent_unprovable T))
     (Entailment.by_axm _ (by simp [Theory.add_def]))
 
 /-- Gödel-Rosser incompleteness theorem -/
 theorem incomplete' [Consistent T] : ¬Entailment.Complete (T : Axiom ℒₒᵣ) :=
-  T.rosserPr.rosser_first_incompleteness
+  T.rosserProvability.rosser_first_incompleteness
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Internal/Consistency.lean
+++ b/Foundation/FirstOrder/Internal/Consistency.lean
@@ -64,7 +64,7 @@ end
 
 variable (T : ArithmeticTheory) [T.Δ₁] (V)
 
-def consistent_eq : T.consistent = T.standardPr.con := rfl
+def consistent_eq : T.consistent = T.standardProvability.con := rfl
 
 @[simp] lemma standard_consistent [𝐑₀ ⪯ T] : T.Consistent ℕ ↔ Entailment.Consistent T := by
   simp [Theory.Consistent, Entailment.consistent_iff_unprovable_bot, Axiom.provable_iff]

--- a/Foundation/FirstOrder/Internal/DerivabilityCondition.lean
+++ b/Foundation/FirstOrder/Internal/DerivabilityCondition.lean
@@ -11,11 +11,15 @@ import Foundation.FirstOrder.Internal.FixedPoint
 
 namespace LO.FirstOrder.Arithmetic
 
-open ISigma1 Metamath
+open ISigma1 Metamath ProvabilityLogic
+
+instance : Diagonalization 𝐈𝚺₁ where
+  fixpoint := fixpoint
+  diag θ := diagonal θ
 
 section
 
-variable {T : ArithmeticTheory} [T.Δ₁]
+variable {L : Language} [L.Encodable] [L.LORDefinable] {T : Theory L} [T.Δ₁]
 
 local prefix:90 "□" => T.provabilityPred
 
@@ -26,6 +30,28 @@ theorem provable_D1 {σ} : T ⊢!. σ → 𝐈𝚺₁ ⊢!. □σ := fun h ↦
 theorem provable_D2 {σ π} : 𝐈𝚺₁ ⊢!. □(σ ➝ π) ➝ □σ ➝ □π :=
   complete₀ <| oRing_consequence_of _ _ fun (V : Type) _ _ ↦ by
     simpa [models_iff] using modus_ponens_sentence T
+
+variable (T)
+
+abbrev _root_.LO.FirstOrder.Theory.standardProvability : Provability 𝐈𝚺₁ T where
+  prov := T.provable
+  D1 := provable_D1
+
+variable {T}
+
+instance : T.standardProvability.HBL2 := ⟨fun _ _ ↦ provable_D2⟩
+
+lemma standardProvability_def (σ : Sentence L) : T.standardProvability σ = T.provabilityPred σ := rfl
+
+instance [T.Δ₁] : T.standardProvability.Sound ℕ := ⟨fun {σ} ↦ by simp [Arithmetic.standardProvability_def, models₀_iff]⟩
+
+end
+
+section arithmetic
+
+variable {T : Theory ℒₒᵣ} [T.Δ₁]
+
+local prefix:90 "□" => T.provabilityPred
 
 lemma provable_sigma_one_complete [𝐏𝐀⁻ ⪯ T] {σ : Sentence ℒₒᵣ} (hσ : Hierarchy 𝚺 1 σ) :
     𝐈𝚺₁ ⊢!. σ ➝ □σ :=
@@ -46,30 +72,14 @@ lemma provable_sound {σ} : U ⊢!. □σ → T ⊢!. σ := fun h ↦ by
 lemma provable_complete [𝐈𝚺₁ ⪯ U] {σ} : T ⊢!. σ ↔ U ⊢!. □σ :=
   ⟨fun h ↦ Entailment.weakening inferInstance (provable_D1 h), provable_sound⟩
 
-end
+instance [𝐏𝐀⁻ ⪯ T] : T.standardProvability.HBL3 := ⟨fun _ ↦ provable_D3⟩
+
+instance [𝐏𝐀⁻ ⪯ T] : T.standardProvability.HBL where
+
+instance [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T.standardProvability.GoedelSound := ⟨fun h ↦ by simpa using provable_sound h⟩
+
+end arithmetic
 
 open ProvabilityLogic
-
-variable (T : ArithmeticTheory) [T.Δ₁]
-
-instance : Diagonalization 𝐈𝚺₁ where
-  fixpoint := fixpoint
-  diag θ := diagonal θ
-
-abbrev _root_.LO.FirstOrder.ArithmeticTheory.standardPr : ProvabilityPredicate 𝐈𝚺₁ T where
-  prov := T.provable
-  D1 := provable_D1
-
-instance : T.standardPr.HBL2 := ⟨fun _ _ ↦ provable_D2⟩
-
-instance [𝐏𝐀⁻ ⪯ T] : T.standardPr.HBL3 := ⟨fun _ ↦ provable_D3⟩
-
-instance [𝐏𝐀⁻ ⪯ T] : T.standardPr.HBL where
-
-instance [T.SoundOnHierarchy 𝚺 1] : T.standardPr.GoedelSound := ⟨fun h ↦ by simpa using provable_sound h⟩
-
-lemma standardPr_def (σ : Sentence ℒₒᵣ) : T.standardPr σ = T.provabilityPred σ := rfl
-
-instance [T.Δ₁] : T.standardPr.Sound ℕ := ⟨fun {σ} ↦ by simp [Arithmetic.standardPr_def, models₀_iff]⟩
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Internal/RosserProvability.lean
+++ b/Foundation/FirstOrder/Internal/RosserProvability.lean
@@ -117,16 +117,18 @@ end
 
 open ProvabilityLogic
 
-variable {T : ArithmeticTheory} [T.Δ₁] [Entailment.Consistent T]
+variable {L : Language} [L.Encodable] [L.LORDefinable]
+
+variable {T : Theory L} [T.Δ₁] [Entailment.Consistent T]
 
 variable (T)
 
-abbrev _root_.LO.FirstOrder.ArithmeticTheory.rosserPr : ProvabilityPredicate 𝐈𝚺₁ T where
+abbrev _root_.LO.FirstOrder.Theory.rosserProvability : Provability 𝐈𝚺₁ T where
   prov := T.rosserProvable
   D1 := rosserProvable_D1
 
-instance : T.rosserPr.Rosser := ⟨rosserProvable_rosser⟩
+instance : T.rosserProvability.Rosser := ⟨rosserProvable_rosser⟩
 
-lemma rosserPr_def (σ : Sentence ℒₒᵣ) : T.rosserPr σ = T.rosserPred σ := rfl
+lemma rosserProvability_def (σ : Sentence L) : T.rosserProvability σ = T.rosserPred σ := rfl
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/Modal/Logic/S/Consistent.lean
+++ b/Foundation/Modal/Logic/S/Consistent.lean
@@ -17,7 +17,7 @@ lemma iff_provable_GL_provable_box_S {A : Modal.Formula _} : Modal.GL ⊢! A ↔
   . intro h;
     apply GL.arithmetical_completeness (T := 𝐈𝚺₁);
     intro f;
-    exact Iff.mp 𝐈𝚺₁.standardPr.sound (S.arithmetical_soundness h f)
+    exact Iff.mp 𝐈𝚺₁.standardProvability.sound (S.arithmetical_soundness h f)
 
 theorem S.no_boxbot : Modal.S ⊬ □⊥ := iff_provable_GL_provable_box_S.not.mp $ by
   simp only [Hilbert.Normal.iff_logic_provable_provable];

--- a/Foundation/ProvabilityLogic/GL/Completeness.lean
+++ b/Foundation/ProvabilityLogic/GL/Completeness.lean
@@ -25,8 +25,8 @@ open Modal
 open Modal.Kripke
 open Modal.Formula.Kripke
 
-variable {L : Language} [L.DecidableEq] [Semiterm.Operator.GoedelNumber L (Sentence L)]
-         {T₀ T : Theory L} [T₀ ⪯ T] (𝔅 : ProvabilityPredicate T₀ T) [𝔅.HBL]
+variable {L : Language} [L.DecidableEq] [L.ReferenceableBy L]
+         {T₀ T : Theory L} [T₀ ⪯ T] (𝔅 : Provability T₀ T) [𝔅.HBL]
          {A B : Modal.Formula _}
 
 structure SolovaySentences (F : Kripke.Frame) (r : F) [F.IsFiniteTree r] [Fintype F] where
@@ -489,7 +489,7 @@ lemma solovay_unprovable [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] {i :
 variable (T F r)
 
 instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
-    [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : SolovaySentences T.standardPr F r where
+    [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : SolovaySentences T.standardProvability F r where
   σ := T.solovay
   SC1 i j ne :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
@@ -498,11 +498,11 @@ instance _root_.LO.ProvabilityLogic.SolovaySentences.standard
   SC2 i j h :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
     oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
-      simpa [models_iff, standardPr_def] using Solovay.consistent h
+      simpa [models_iff, standardProvability_def] using Solovay.consistent h
   SC3 i h :=
     have : 𝐄𝐐 ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝐈𝚺₁) inferInstance inferInstance
     oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
-    simpa [models_iff, standardPr_def] using Solovay.box_disjunction h
+    simpa [models_iff, standardProvability_def] using Solovay.box_disjunction h
   SC4 i ne := solovay_unprovable ne
 
 lemma _root_.LO.ProvabilityLogic.SolovaySentences.standard_σ_def [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] :
@@ -523,29 +523,29 @@ variable {T : ArithmeticTheory} [T.Δ₁] [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierar
 
 /-- Arithmetical completeness of GL-/
 theorem GL.arithmetical_completeness :
-    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr A) → Modal.GL ⊢! A := by
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardProvability A) → Modal.GL ⊢! A := by
   simp only [Hilbert.Normal.iff_logic_provable_provable];
   contrapose;
   intro hA;
   push_neg;
   obtain ⟨M₁, r₁, _, hA₁⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp hA;
   have : Fintype (M₁.extendRoot r₁ 1).World := Fintype.ofFinite _
-  let σ : SolovaySentences T.standardPr (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root :=
+  let σ : SolovaySentences T.standardProvability (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root :=
     SolovaySentences.standard (M₁.extendRoot r₁ 1).toFrame Frame.extendRoot.root T
   use σ.realization;
-  have : 𝐈𝚺₁ ⊢!. σ r₁ ➝ σ.realization.interpret T.standardPr (∼A) :=
+  have : 𝐈𝚺₁ ⊢!. σ r₁ ➝ σ.realization.interpret T.standardProvability (∼A) :=
     σ.mainlemma (A := ∼A) (i := r₁) (by trivial) |>.1 $ Model.extendRoot.inr_satisfies_iff |>.not.mpr hA₁;
-  replace : 𝐈𝚺₁ ⊢!. σ.realization.interpret T.standardPr A ➝ ∼(σ r₁) := by
+  replace : 𝐈𝚺₁ ⊢!. σ.realization.interpret T.standardProvability A ➝ ∼(σ r₁) := by
     apply CN!_of_CN!_right;
     apply C!_trans this;
     apply K!_right neg_equiv!;
-  replace : T ⊢!. σ.realization.interpret T.standardPr A ➝ ∼(σ r₁) := WeakerThan.pbl this;
+  replace : T ⊢!. σ.realization.interpret T.standardProvability A ➝ ∼(σ r₁) := WeakerThan.pbl this;
   by_contra hC;
   have : T ⊢!. ∼(σ r₁) := this ⨀ hC;
   exact σ.SC4 _ (by rintro ⟨⟩) this;
 
 theorem GL.arithmetical_completeness_iff :
-    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr A) ↔ Modal.GL ⊢! A :=
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardProvability A) ↔ Modal.GL ⊢! A :=
   ⟨GL.arithmetical_completeness, GL.arithmetical_soundness⟩
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/GL/Soundness.lean
+++ b/Foundation/ProvabilityLogic/GL/Soundness.lean
@@ -6,12 +6,12 @@ open Entailment
 open Modal
 open Modal.Hilbert
 open FirstOrder
-open ProvabilityPredicate
+open Provability
 
-variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
+variable {L : FirstOrder.Language} [L.ReferenceableBy L]
          [L.DecidableEq]
          {T U : FirstOrder.Theory L} [Diagonalization T]  [T ⪯ U]
-         {𝔅 : ProvabilityPredicate T U} [𝔅.HBL]
+         {𝔅 : Provability T U} [𝔅.HBL]
 
 lemma GL.arithmetical_soundness (h : Modal.GL ⊢! A) {f : Realization L} : U ⊢!. f.interpret 𝔅 A := by
   replace h := Normal.iff_logic_provable_provable.mp h;

--- a/Foundation/ProvabilityLogic/GL/Unprovability.lean
+++ b/Foundation/ProvabilityLogic/GL/Unprovability.lean
@@ -5,16 +5,16 @@ namespace LO.ProvabilityLogic
 
 open Modal.Logic FirstOrder
 
-namespace ProvabilityPredicate
+namespace Provability
 
 open LO.Entailment
 
-variable {L : Language} [L.DecidableEq] [Semiterm.Operator.GoedelNumber L (Sentence L)] [DecidableEq (Sentence L)]
+variable {L : Language} [L.DecidableEq] [L.ReferenceableBy L] [DecidableEq (Sentence L)]
          {T₀ T : Theory L} [T₀ ⪯ T]
-         {𝔅 : ProvabilityPredicate T₀ T}
+         {𝔅 : Provability T₀ T}
          {σ π : Sentence L}
 
-def indep (𝔅 : ProvabilityPredicate T₀ T) (σ : Sentence L) : Sentence L := ∼(𝔅 σ) ⋏ ∼(𝔅 (∼σ))
+def indep (𝔅 : Provability T₀ T) (σ : Sentence L) : Sentence L := ∼(𝔅 σ) ⋏ ∼(𝔅 (∼σ))
 
 lemma indep_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
     T ⊢!. 𝔅.indep σ ➝ 𝔅.indep π := by
@@ -42,7 +42,7 @@ lemma indep_iff_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
   . intro H; exact K!_left (indep_iff_distribute_inside h) ⨀ H;
   . intro H; exact K!_right (indep_iff_distribute_inside h) ⨀ H;
 
-end ProvabilityPredicate
+end Provability
 
 end ProvabilityLogic
 
@@ -61,7 +61,7 @@ variable {T : ArithmeticTheory} [T.Δ₁]
 section Corollary
 
 /-- Gödel's Second Incompleteness Theorem -/
-example [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : T ⊬. T.standardPr.con := by
+example [𝐈𝚺₁ ⪯ T] [T.SoundOn (Hierarchy 𝚷 2)] : T ⊬. T.standardProvability.con := by
   have h := GL.arithmetical_completeness_iff (T := T) |>.not.mpr $ GL.unprovable_notbox (φ := ⊥);
   push_neg at h;
   obtain ⟨f, h⟩ := h;
@@ -72,7 +72,7 @@ end Corollary
 section Independency
 
 lemma iff_modalConsis_bewConsis_inside :
-    T ⊢!. f.interpret T.standardPr (∼□⊥) ⭤ T.standardPr.con := by
+    T ⊢!. f.interpret T.standardProvability (∼□⊥) ⭤ T.standardProvability.con := by
   apply K!_intro;
   . refine C!_trans (K!_left Realization.iff_interpret_neg_inside) ?_;
     apply contra!;
@@ -84,7 +84,7 @@ lemma iff_modalConsis_bewConsis_inside :
 variable [𝐈𝚺₁ ⪯ T]
 
 lemma iff_modalIndep_bewIndep_inside :
-    T ⊢!. f.interpret T.standardPr (Modal.independency A) ⭤ T.standardPr.indep (f.interpret T.standardPr A) := by
+    T ⊢!. f.interpret T.standardProvability (Modal.independency A) ⭤ T.standardProvability.indep (f.interpret T.standardProvability A) := by
   apply K!_intro;
   . refine C!_trans (K!_left $ Realization.iff_interpret_and_inside) ?_;
     apply CKK!_of_C!_of_C!;
@@ -92,7 +92,7 @@ lemma iff_modalIndep_bewIndep_inside :
     . apply C!_trans (K!_left $ Realization.iff_interpret_neg_inside (A := □(∼A))) ?_;
       apply contra!;
       apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply T.standardPr.prov_distribute_imply;
+      apply T.standardProvability.prov_distribute_imply;
       apply K!_right $ Realization.iff_interpret_neg_inside;
   . refine C!_trans ?_ (K!_right $ Realization.iff_interpret_and_inside);
     apply CKK!_of_C!_of_C!;
@@ -100,21 +100,21 @@ lemma iff_modalIndep_bewIndep_inside :
     . apply C!_trans ?_ (K!_right $ Realization.iff_interpret_neg_inside (A := □(∼A)));
       apply contra!;
       apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply T.standardPr.prov_distribute_imply;
+      apply T.standardProvability.prov_distribute_imply;
       apply K!_left $ Realization.iff_interpret_neg_inside;
 
 lemma iff_modalIndep_bewIndep :
-    T ⊢!. f.interpret T.standardPr (Modal.independency A) ↔ T ⊢!. T.standardPr.indep (f.interpret T.standardPr A) := by
+    T ⊢!. f.interpret T.standardProvability (Modal.independency A) ↔ T ⊢!. T.standardProvability.indep (f.interpret T.standardProvability A) := by
   constructor;
   . intro h; exact (K!_left iff_modalIndep_bewIndep_inside) ⨀ h;
   . intro h; exact (K!_right iff_modalIndep_bewIndep_inside) ⨀ h;
 
 lemma iff_not_modalIndep_not_bewIndep_inside :
-    T ⊢!. ∼f.interpret T.standardPr (Modal.independency A) ⭤ ∼T.standardPr.indep (f.interpret T.standardPr A) :=
+    T ⊢!. ∼f.interpret T.standardProvability (Modal.independency A) ⭤ ∼T.standardProvability.indep (f.interpret T.standardProvability A) :=
   ENN!_of_E! iff_modalIndep_bewIndep_inside
 
 lemma iff_not_modalIndep_not_bewIndep :
-    T ⊢!. ∼f.interpret T.standardPr (Modal.independency A) ↔ T ⊢!. ∼T.standardPr.indep (f.interpret T.standardPr A) := by
+    T ⊢!. ∼f.interpret T.standardProvability (Modal.independency A) ↔ T ⊢!. ∼T.standardProvability.indep (f.interpret T.standardProvability A) := by
   constructor;
   . intro h; exact (K!_left iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
   . intro h; exact (K!_right iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
@@ -122,13 +122,13 @@ lemma iff_not_modalIndep_not_bewIndep :
 variable [T.SoundOn (Hierarchy 𝚷 2)]
 
 lemma unprovable_independency_of_consistency :
-    T ⊬. T.standardPr.indep (T.standardPr.con) := by
+    T ⊬. T.standardProvability.indep (T.standardProvability.con) := by
   let g : Realization ℒₒᵣ := λ _ => ⊥;
-  suffices T ⊬. g.interpret T.standardPr (Modal.independency (∼□⊥)) by
+  suffices T ⊬. g.interpret T.standardProvability (Modal.independency (∼□⊥)) by
     have H₁ := iff_modalIndep_bewIndep (f := g) (T := T) (A := ∼□⊥);
-    have H₂ := T.standardPr.indep_iff_distribute (T := T)
-      (σ := g.interpret T.standardPr (∼□⊥))
-      (π := T.standardPr.con)
+    have H₂ := T.standardProvability.indep_iff_distribute (T := T)
+      (σ := g.interpret T.standardProvability (∼□⊥))
+      (π := T.standardProvability.con)
       iff_modalConsis_bewConsis_inside;
     exact Iff.trans H₁ H₂ |>.not.mp this;
   have h := GL.arithmetical_completeness_iff (T := T) |>.not.mpr $ GL.unprovable_independency (φ := ∼□⊥);
@@ -137,20 +137,20 @@ lemma unprovable_independency_of_consistency :
   congr;
 
 lemma unrefutable_independency_of_consistency :
-    T ⊬. ∼T.standardPr.indep (T.standardPr.con) := by
+    T ⊬. ∼T.standardProvability.indep (T.standardProvability.con) := by
   let g : Realization ℒₒᵣ := λ _ => ⊥;
-  suffices T ⊬. ∼g.interpret T.standardPr (Modal.independency (∼□⊥)) by
+  suffices T ⊬. ∼g.interpret T.standardProvability (Modal.independency (∼□⊥)) by
     have H₁ := iff_not_modalIndep_not_bewIndep (f := g) (T := T) (A := ∼□⊥);
     have H₂ : T ⊢!.
-      ∼T.standardPr.indep (g.interpret T.standardPr (∼□⊥)) ⭤
-      ∼T.standardPr.indep T.standardPr.con
-      := ENN!_of_E! $ T.standardPr.indep_iff_distribute_inside (T := T)
-      (σ := g.interpret T.standardPr (∼□⊥))
-      (π := T.standardPr.con)
+      ∼T.standardProvability.indep (g.interpret T.standardProvability (∼□⊥)) ⭤
+      ∼T.standardProvability.indep T.standardProvability.con
+      := ENN!_of_E! $ T.standardProvability.indep_iff_distribute_inside (T := T)
+      (σ := g.interpret T.standardProvability (∼□⊥))
+      (π := T.standardProvability.con)
       iff_modalConsis_bewConsis_inside;
     replace H₂ :
-      T ⊢!. ∼T.standardPr.indep (g.interpret T.standardPr (∼□⊥)) ↔
-      T ⊢!. ∼T.standardPr.indep T.standardPr.con
+      T ⊢!. ∼T.standardProvability.indep (g.interpret T.standardProvability (∼□⊥)) ↔
+      T ⊢!. ∼T.standardProvability.indep T.standardProvability.con
       := by
       constructor;
       . intro H; exact K!_left H₂ ⨀ H;
@@ -163,7 +163,7 @@ lemma unrefutable_independency_of_consistency :
   congr;
 
 theorem undecidable_independency_of_consistency :
-    Independent T.toAxiom (T.standardPr.indep (T.standardPr.con)) := by
+    Independent T.toAxiom (T.standardProvability.indep (T.standardProvability.con)) := by
   constructor;
   . exact unprovable_independency_of_consistency;
   . exact unrefutable_independency_of_consistency;

--- a/Foundation/ProvabilityLogic/Grz/Completeness.lean
+++ b/Foundation/ProvabilityLogic/Grz/Completeness.lean
@@ -10,20 +10,20 @@ open Entailment FiniteContext
 
 namespace ProvabilityLogic
 
-variable {L} [Semiterm.Operator.GoedelNumber L (Sentence L)] [DecidableEq (Sentence L)]
+variable {L : Language} [L.ReferenceableBy L] [L.DecidableEq]
          {T₀ T : Theory L} [T₀ ⪯ T] {A : Modal.Formula ℕ}
 
 namespace Realization
 
-variable {𝔅 : ProvabilityPredicate T₀ T} {f : Realization L} {A B : Modal.Formula _}
+variable {𝔅 : Provability T₀ T} {f : Realization L} {A B : Modal.Formula _}
 
-def strongInterpret (f : Realization L) (𝔅 : ProvabilityPredicate T₀ T) : Formula ℕ → Sentence L
+def strongInterpret (f : Realization L) (𝔅 : Provability T₀ T) : Formula ℕ → Sentence L
   | .atom a => f a
   | ⊥ => ⊥
   | φ ➝ ψ => (f.strongInterpret 𝔅 φ) ➝ (f.strongInterpret 𝔅 ψ)
   | □φ => (f.strongInterpret 𝔅 φ) ⋏ 𝔅 (f.strongInterpret 𝔅 φ)
 
-lemma iff_interpret_boxdot_strongInterpret_inside [L.DecidableEq] [𝔅.HBL2] :
+lemma iff_interpret_boxdot_strongInterpret_inside [𝔅.HBL2] :
     T ⊢!. f.interpret 𝔅 (Aᵇ) ⭤ f.strongInterpret 𝔅 A := by
   induction A with
   | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
@@ -40,14 +40,14 @@ lemma iff_interpret_boxdot_strongInterpret_inside [L.DecidableEq] [𝔅.HBL2] :
       . exact K!_right ih;
       . exact 𝔅.prov_distribute_imply'' $ K!_right ih;
 
-lemma iff_interpret_boxdot_strongInterpret [L.DecidableEq] [𝔅.HBL2] :
+lemma iff_interpret_boxdot_strongInterpret [𝔅.HBL2] :
     T ⊢!. f.interpret 𝔅 (Aᵇ) ↔ T ⊢!. f.strongInterpret 𝔅 A := by
   constructor;
   . intro h; exact (K!_left iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
   . intro h; exact (K!_right iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
 
 lemma iff_models_interpret_boxdot_strongInterpret
-    [L.DecidableEq] {M} [Nonempty M] [Structure L M] [M ⊧ₘ* T] [𝔅.HBL2] [𝔅.Sound M] :
+    {M} [Nonempty M] [Structure L M] [M ⊧ₘ* T] [𝔅.HBL2] [𝔅.Sound M] :
     M ⊧ₘ₀ f.interpret 𝔅 (Aᵇ) ↔ M ⊧ₘ₀ f.strongInterpret 𝔅 A := by
   induction A with
   | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
@@ -83,7 +83,7 @@ lemma iff_models_interpret_boxdot_strongInterpret
 end Realization
 
 theorem Grz.arithmetical_completeness_iff {T : ArithmeticTheory} [T.Δ₁] [𝐈𝚺₁ ⪯ T] [T.SoundOn (Arithmetic.Hierarchy 𝚷 2)] :
-    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret T.standardPr A) ↔ Modal.Grz ⊢! A := by
+    (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.strongInterpret T.standardProvability A) ↔ Modal.Grz ⊢! A := by
   constructor;
   . intro h;
     suffices Modal.GL ⊢! Aᵇ by apply iff_boxdot_GL_Grz.mp this;
@@ -93,12 +93,12 @@ theorem Grz.arithmetical_completeness_iff {T : ArithmeticTheory} [T.Δ₁] [𝐈
     apply h;
   . intro h f;
     replace h := iff_boxdot_GL_Grz.mpr h;
-    have : (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardPr (Aᵇ)) := GL.arithmetical_completeness_iff.mpr h;
+    have : (∀ {f : Realization ℒₒᵣ}, T ⊢!. f.interpret T.standardProvability (Aᵇ)) := GL.arithmetical_completeness_iff.mpr h;
     exact Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ this;
 
 theorem Grz.arithmetical_completeness_model_iff
     {T : ArithmeticTheory} [T.Δ₁] [𝐈𝚺₁ ⪯ T] [ℕ ⊧ₘ* T] :
-    (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret T.standardPr A) ↔ Modal.Grz ⊢! A := by
+    (∀ {f : Realization ℒₒᵣ}, ℕ ⊧ₘ₀ f.strongInterpret T.standardProvability A) ↔ Modal.Grz ⊢! A := by
   apply Iff.trans ?_ Modal.Logic.iff_provable_Grz_provable_boxdot_S;
   apply Iff.trans ?_ (S.arithmetical_completeness_iff (T := T)).symm;
   have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -6,54 +6,56 @@ import Foundation.Meta.ClProver
 # Abstract incompleteness theorems and related results
 -/
 
-namespace LO.ProvabilityLogic
+namespace LO
+
+abbrev FirstOrder.Language.ReferenceableBy (L L₀ : Language) := Semiterm.Operator.GoedelNumber L₀ (Sentence L)
+
+namespace ProvabilityLogic
 
 open FirstOrder
 
-variable {L : Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
+variable {L₀ L : Language}
 
-structure ProvabilityPredicate (T₀ : Theory L) (T : Theory L) where
-  prov : Semisentence L 1
+structure Provability [L.ReferenceableBy L₀] (T₀ : Theory L₀) (T : Theory L) where
+  prov : Semisentence L₀ 1
   protected D1 {σ : Sentence L} : T ⊢!. σ → T₀ ⊢!. prov/[⌜σ⌝]
 
-namespace ProvabilityPredicate
+namespace Provability
 
-variable {T₀ T : Theory L}
+variable [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L}
 
-@[coe] def pr (𝔅 : ProvabilityPredicate T₀ T) (σ : Sentence L) : Sentence L := 𝔅.prov/[⌜σ⌝]
+@[coe] def pr (𝔅 : Provability T₀ T) (σ : Sentence L) : Sentence L₀ := 𝔅.prov/[⌜σ⌝]
 
-instance : CoeFun (ProvabilityPredicate T₀ T) (fun _ ↦ Sentence L → Sentence L) := ⟨pr⟩
+instance : CoeFun (Provability T₀ T) (fun _ ↦ Sentence L → Sentence L₀) := ⟨pr⟩
 
-def con (𝔅 : ProvabilityPredicate T₀ T) : Sentence L := ∼𝔅 ⊥
+def con (𝔅 : Provability T₀ T) : Sentence L₀ := ∼𝔅 ⊥
 
-end ProvabilityPredicate
+end Provability
 
-class Diagonalization (T : Theory L) where
+class Diagonalization [L.ReferenceableBy L] (T : Theory L) where
   fixpoint : Semisentence L 1 → Sentence L
   diag (θ) : T ⊢!. fixpoint θ ⭤ θ/[⌜fixpoint θ⌝]
 
-namespace ProvabilityPredicate
+namespace Provability
 
-variable {T₀ T : Theory L}
-
-class HBL2 (𝔅 : ProvabilityPredicate T₀ T) where
+class HBL2 [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L} (𝔅 : Provability T₀ T) where
   protected D2 (σ τ : Sentence L) : T₀ ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ
 
-class HBL3 (𝔅 : ProvabilityPredicate T₀ T) where
+class HBL3 [L.ReferenceableBy L] {T₀ T : Theory L} (𝔅 : Provability T₀ T) where
   protected D3 (σ : Sentence L) : T₀ ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ)
 
-class HBL (𝔅 : ProvabilityPredicate T₀ T) extends 𝔅.HBL2, 𝔅.HBL3
+class HBL [L.ReferenceableBy L] {T₀ T : Theory L} (𝔅 : Provability T₀ T) extends 𝔅.HBL2, 𝔅.HBL3
 
-class Loeb (𝔅 : ProvabilityPredicate T₀ T) where
+class Loeb [L.ReferenceableBy L] {T₀ T : Theory L} (𝔅 : Provability T₀ T) where
   protected LT {σ : Sentence L} : T ⊢!. 𝔅 σ ➝ σ → T ⊢!. σ
 
-class FormalizedLoeb (𝔅 : ProvabilityPredicate T₀ T) where
+class FormalizedLoeb [L.ReferenceableBy L] {T₀ T : Theory L} (𝔅 : Provability T₀ T) where
   protected FLT (σ : Sentence L) : T₀ ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ
 
-class Rosser (𝔅 : ProvabilityPredicate T₀ T) where
+class Rosser [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L} (𝔅 : Provability T₀ T) where
   protected Ro {σ : Sentence L} : T ⊢!. ∼σ → T₀ ⊢!. ∼𝔅 σ
 
-class Sound (𝔅 : ProvabilityPredicate T₀ T) (N : outParam Type*) [Nonempty N] [Structure L N] where
+class Sound [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L} (𝔅 : Provability T₀ T) (N : outParam Type*) [Nonempty N] [Structure L₀ N] where
   protected sound {σ : Sentence L} : N ⊧ₘ₀ 𝔅 σ ↔ T ⊢!. σ
 
 protected alias sound := Sound.sound
@@ -64,32 +66,15 @@ section
 
 open LO.Entailment
 
-variable {T₀ T : Theory L}
-         {𝔅 : ProvabilityPredicate T₀ T}
-         {σ τ : Sentence L}
-
 protected alias D2 := HBL2.D2
 protected alias D3 := HBL3.D3
 protected alias LT := Loeb.LT
 protected alias FLT := FormalizedLoeb.FLT
 protected alias Ro := Rosser.Ro
 
-lemma D1_shift [L.DecidableEq] [T₀ ⪯ T] : T ⊢!. σ → T ⊢!. 𝔅 σ := by
-  intro h;
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D1 h;
+section irreflexsive_syntactic_language
 
-lemma D2_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] : T ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D2;
-
-lemma D3_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL3] : T ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ) := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D3;
-
-lemma FLT_shift [L.DecidableEq] [T₀ ⪯ T] [𝔅.FormalizedLoeb] : T ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.FLT;
+variable [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L} {𝔅 : Provability T₀ T}
 
 lemma D2' [𝔅.HBL2] (σ τ) : T₀ ⊢!. 𝔅 (σ ➝ τ) → T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := by
   intro h;
@@ -97,42 +82,62 @@ lemma D2' [𝔅.HBL2] (σ τ) : T₀ ⊢!. 𝔅 (σ ➝ τ) → T₀ ⊢!. 𝔅 
 
 lemma prov_distribute_imply [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) : T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := 𝔅.D2' σ τ <| 𝔅.D1 h
 
-lemma prov_distribute_imply' [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] (h : T₀ ⊢!. σ ➝ τ) :
-    T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := prov_distribute_imply $ WeakerThan.pbl h
-
-lemma prov_distribute_imply'' [L.DecidableEq] [T₀ ⪯ T] [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) :
-    T ⊢!. 𝔅 σ ➝ 𝔅 τ := WeakerThan.pbl $ prov_distribute_imply h
-
 lemma prov_distribute_iff [𝔅.HBL2] (h : T ⊢!. σ ⭤ τ) : T₀ ⊢!. 𝔅 σ ⭤ 𝔅 τ := by
   apply E!_intro;
   . exact prov_distribute_imply $ K!_left h;
   . exact prov_distribute_imply $ K!_right h;
 
-lemma prov_distribute_and  [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ ⋏ 𝔅 τ := by
+lemma prov_distribute_and [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ ⋏ 𝔅 τ := by
   have h₁ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ := 𝔅.D2' _ _ <| 𝔅.D1 and₁!;
   have h₂ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 τ := 𝔅.D2' _ _ <| 𝔅.D1 and₂!;
   exact right_K!_intro h₁ h₂;
 
-def prov_distribute_and' [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 (σ ⋏ τ) → T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ := λ h => prov_distribute_and ⨀ h
+def prov_distribute_and' [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢!. 𝔅 (σ ⋏ τ) → T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ := λ h => prov_distribute_and ⨀ h
 
-def prov_collect_and [𝔅.HBL2] [DecidableEq (Sentence L)] : T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ ➝ 𝔅 (σ ⋏ τ) := by
+def prov_collect_and [𝔅.HBL2] [L₀.DecidableEq] [L.DecidableEq] : T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ ➝ 𝔅 (σ ⋏ τ) := by
   have : T₀ ⊢!. 𝔅 σ ➝ 𝔅 (τ ➝ σ ⋏ τ) := prov_distribute_imply (by cl_prover)
   cl_prover [this, 𝔅.D2 τ (σ ⋏ τ)]
 
+end irreflexsive_syntactic_language
+section reflexive_syntactic_language
+
+variable [L.DecidableEq] [L.ReferenceableBy L] {T₀ T : Theory L} [T₀ ⪯ T] {𝔅 : Provability T₀ T}
+
+lemma D1_shift : T ⊢!. σ → T ⊢!. 𝔅 σ := by
+  intro h;
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
+  apply 𝔅.D1 h;
+
+lemma D2_shift [𝔅.HBL2] : T ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ := by
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
+  apply 𝔅.D2;
+
+lemma D3_shift [𝔅.HBL3] : T ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ) := by
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
+  apply 𝔅.D3;
+
+lemma FLT_shift [𝔅.FormalizedLoeb] : T ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
+  apply 𝔅.FLT;
+
+lemma prov_distribute_imply' [𝔅.HBL2] (h : T₀ ⊢!. σ ➝ τ) :
+    T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := prov_distribute_imply $ WeakerThan.pbl h
+
+lemma prov_distribute_imply'' [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) :
+    T ⊢!. 𝔅 σ ➝ 𝔅 τ := WeakerThan.pbl $ prov_distribute_imply h
+
+end reflexive_syntactic_language
+
 end
 
-variable {T₀ T : Theory L} {𝔅 : ProvabilityPredicate T₀ T}
+open LO.Entailment Diagonalization Provability
 
-open LO.Entailment
-open Diagonalization
-open ProvabilityPredicate
-
-def goedel [Diagonalization T₀] (𝔅 : ProvabilityPredicate T₀ T) : Sentence L :=
+def goedel [L.ReferenceableBy L] {T₀ T : Theory L} [Diagonalization T₀] (𝔅 : Provability T₀ T) : Sentence L :=
   fixpoint T₀ “x. ¬!𝔅.prov x”
 
 section GoedelSentence
 
-variable [Diagonalization T₀]
+variable [L.ReferenceableBy L] {T₀ T : Theory L} [Diagonalization T₀] {𝔅 : Provability T₀ T}
 
 local notation "𝗚" => 𝔅.goedel
 
@@ -147,12 +152,14 @@ variable {𝔅}
 
 end GoedelSentence
 
-class GoedelSound (𝔅 : ProvabilityPredicate T₀ T) [Diagonalization T₀] where
+class GoedelSound [L.ReferenceableBy L] {T₀ T : Theory L} (𝔅 : Provability T₀ T) [Diagonalization T₀] where
   goedel_sound : T ⊢!. 𝔅 𝔅.goedel → T ⊢!. 𝔅.goedel
 
 section First
 
-variable (𝔅) [T₀ ⪯ T] [Diagonalization T₀] [L.DecidableEq] [Consistent T]
+variable [L.DecidableEq] [L.ReferenceableBy L] {T₀ T : Theory L} [T₀ ⪯ T] [Diagonalization T₀] [Consistent T]
+
+variable (𝔅 : Provability T₀ T)
 
 local notation "𝗚" => 𝔅.goedel
 
@@ -185,7 +192,7 @@ end First
 
 section Second
 
-variable [L.DecidableEq] [𝔅.HBL]
+variable [L.DecidableEq] [L.ReferenceableBy L] {T₀ T : Theory L} {𝔅 : Provability T₀ T} [𝔅.HBL]
 
 lemma formalized_consistent_of_existance_unprovable (σ) : T₀ ⊢!. ∼𝔅 σ ➝ 𝔅.con := contra! $ 𝔅.D2 _ _ ⨀ (𝔅.D1 efq!)
 
@@ -228,13 +235,13 @@ end Second
 
 section Loeb
 
-def kreisel [Diagonalization T₀]
-    (𝔅 : ProvabilityPredicate T₀ T) [𝔅.HBL]
-    (σ : Sentence L) : Sentence L := fixpoint T₀ “x. !𝔅.prov x → !σ”
+variable [L.ReferenceableBy L] {T₀ T : Theory L}
+
+def kreisel [Diagonalization T₀] (𝔅 : Provability T₀ T) [𝔅.HBL] (σ : Sentence L) : Sentence L := fixpoint T₀ “x. !𝔅.prov x → !σ”
 
 section KrieselSentence
 
-variable {𝔅 : ProvabilityPredicate T₀ T} [𝔅.HBL] [Diagonalization T₀]
+variable [Diagonalization T₀] {𝔅 : Provability T₀ T} [𝔅.HBL]
 
 local prefix:80 "𝗞" => 𝔅.kreisel
 
@@ -257,7 +264,7 @@ end KrieselSentence
 
 section LoebTheorem
 
-variable [L.DecidableEq] [T₀ ⪯ T] [Diagonalization T₀] [𝔅.HBL]
+variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] {𝔅 : Provability T₀ T} [𝔅.HBL]
 
 local notation "𝗞" => 𝔅.kreisel
 
@@ -278,7 +285,7 @@ instance [L.DecidableEq] : 𝔅.FormalizedLoeb := ⟨formalized_loeb_theorem (T 
 
 end LoebTheorem
 
-variable [Consistent T]
+variable  {𝔅 : Provability T₀ T} [Consistent T]
 
 lemma unprovable_con_via_loeb [L.DecidableEq] [𝔅.Loeb] : T ⊬. 𝔅.con := by
   by_contra hC;
@@ -308,7 +315,7 @@ end Loeb
 
 section Rosser
 
-variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [Consistent T]
+variable [L.DecidableEq] [L.ReferenceableBy L] {T₀ T : Theory L} [Diagonalization T₀] [T₀ ⪯ T] [Consistent T] {𝔅 : Provability T₀ T}
 
 local notation "𝗥" => 𝔅.goedel
 
@@ -326,8 +333,10 @@ theorem rosser_independent : Independent (T : Axiom L) 𝗥 := by
   . apply unprovable_goedel
   . apply unrefutable_rosser
 
-theorem rosser_first_incompleteness (𝔅 : ProvabilityPredicate T₀ T) [𝔅.Rosser] : ¬Entailment.Complete (T : Axiom L) :=
+theorem rosser_first_incompleteness (𝔅 : Provability T₀ T) [𝔅.Rosser] : ¬Entailment.Complete (T : Axiom L) :=
   Entailment.incomplete_iff_exists_undecidable.mpr ⟨𝔅.goedel, rosser_independent⟩
+
+variable (𝔅)
 
 omit [Diagonalization T₀] [Consistent T] in
 /-- If `𝔅` satisfies Rosser provability condition, then `𝔅.con` is provable from `T`. -/
@@ -337,4 +346,4 @@ theorem kriesel_remark : T ⊢!. 𝔅.con := by
 
 end Rosser
 
-end LO.ProvabilityLogic.ProvabilityPredicate
+end LO.ProvabilityLogic.Provability

--- a/Foundation/ProvabilityLogic/Interpretation.lean
+++ b/Foundation/ProvabilityLogic/Interpretation.lean
@@ -10,7 +10,7 @@ open Entailment FiniteContext
 open FirstOrder ProvabilityLogic
 open Modal Modal.Hilbert
 
-variable {L : Language} [Semiterm.Operator.GoedelNumber L (Sentence L)] {T₀ T : Theory L}
+variable {L : Language} [L.ReferenceableBy L] {T₀ T : Theory L}
 
 namespace ProvabilityLogic
 
@@ -21,7 +21,7 @@ namespace Realization
 
 /-- Mapping modal formulae to first-order sentence -/
 def interpret
-  (f : Realization L) (𝔅 : ProvabilityPredicate T₀ T) : Formula ℕ → FirstOrder.Sentence L
+  (f : Realization L) (𝔅 : Provability T₀ T) : Formula ℕ → FirstOrder.Sentence L
   | .atom a => f a
   | □φ => 𝔅 (f.interpret 𝔅 φ)
   | ⊥ => ⊥
@@ -30,7 +30,7 @@ def interpret
 
 section
 
-variable {𝔅 : ProvabilityPredicate T₀ T} {f : Realization L} {A B : Modal.Formula _}
+variable {𝔅 : Provability T₀ T} {f : Realization L} {A B : Modal.Formula _}
 
 lemma iff_interpret_atom : T ⊢!. f.interpret 𝔅 (.atom a) ↔ T ⊢!. f a := by  simp [Realization.interpret];
 lemma iff_interpret_imp : T ⊢!. f.interpret 𝔅 (A ➝ B) ↔ T ⊢!. (f.interpret 𝔅 A) ➝ (f.interpret 𝔅 B) := by simp [Realization.interpret];

--- a/Foundation/ProvabilityLogic/N/Soundness.lean
+++ b/Foundation/ProvabilityLogic/N/Soundness.lean
@@ -6,12 +6,12 @@ open Entailment
 open Modal
 open Modal.Hilbert
 open FirstOrder
-open ProvabilityPredicate
+open Provability
 
-variable {L : FirstOrder.Language} [Semiterm.Operator.GoedelNumber L (Sentence L)]
+variable {L : FirstOrder.Language} [L.ReferenceableBy L]
          [L.DecidableEq]
          {T U : FirstOrder.Theory L} [T ⪯ U]
-         {𝔅 : ProvabilityPredicate T U}
+         {𝔅 : Provability T U}
 
 lemma N.arithmetical_soundness (h : Hilbert.N ⊢! A) {f : Realization L} : U ⊢!. f.interpret 𝔅 A := by
   induction h using Hilbert.Normal.rec! with

--- a/Foundation/ProvabilityLogic/S/Completeness.lean
+++ b/Foundation/ProvabilityLogic/S/Completeness.lean
@@ -15,10 +15,10 @@ namespace LO.ProvabilityLogic
 open Entailment
 open Modal
 open FirstOrder
-open ProvabilityPredicate
+open Provability
 
 variable {T₀ T : ArithmeticTheory} [T₀ ⪯ T] [Diagonalization T₀]
-         {𝔅 : ProvabilityPredicate T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.Sound ℕ]
+         {𝔅 : Provability T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.Sound ℕ]
          {A B : Formula ℕ}
 
 open Entailment FiniteContext
@@ -33,7 +33,7 @@ lemma GL_S_TFAE :
     [
       Modal.GL ⊢! (A.rflSubformula.conj ➝ A),
       Modal.S ⊢! A,
-      ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardPr A)
+      ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardProvability A)
     ].TFAE := by
   tfae_have 1 → 2 := by
     intro h;
@@ -63,13 +63,13 @@ lemma GL_S_TFAE :
         $ (Satisfies.fconj_def.mp
         $ Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr hA₁) φ hφ;
     have : Fintype M₀.World := Fintype.ofFinite _
-    let σ : SolovaySentences T.standardPr (M₀.toFrame) r₀ :=
+    let σ : SolovaySentences T.standardProvability (M₀.toFrame) r₀ :=
       SolovaySentences.standard M₀.toFrame Frame.extendRoot.root T
     use σ.realization;
     have H :
       ∀ B ∈ A.subformulas,
-      (r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ (σ.realization.interpret T.standardPr B)) ∧
-      (¬r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ ∼(σ.realization.interpret T.standardPr B)) := by
+      (r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ (σ.realization.interpret T.standardProvability B)) ∧
+      (¬r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ ∼(σ.realization.interpret T.standardProvability B)) := by
       intro B B_sub;
       induction B with
       | hfalsum => simp [Satisfies, Realization.interpret];
@@ -106,16 +106,16 @@ lemma GL_S_TFAE :
         constructor;
         . intro h;
           apply C!_of_conseq!;
-          apply T.standardPr.D1;
+          apply T.standardProvability.D1;
           apply Entailment.WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-          have : 𝐈𝚺₁ ⊢!. ((⩖ j, σ j)) ➝ σ.realization.interpret T.standardPr B := by
+          have : 𝐈𝚺₁ ⊢!. ((⩖ j, σ j)) ➝ σ.realization.interpret T.standardProvability B := by
             apply left_Fdisj'!_intro;
             have hrfl : r₁ ⊧ □B ➝ B := by
               apply hA₁;
               simpa [Formula.rflSubformula];
             rintro (i | i) _;
             . rw [(show (Sum.inl i) = r₀ by simp [r₀]; omega)]
-              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization.interpret T.standardPr B by convert this;
+              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization.interpret T.standardProvability B by convert this;
               apply ihB (by grind) |>.1;
               exact hrfl h;
             . by_cases e : i = r₁;
@@ -134,24 +134,24 @@ lemma GL_S_TFAE :
           have := Satisfies.box_def.not.mp h;
           push_neg at this;
           obtain ⟨i, Rij, hA⟩ := this;
-          have : 𝐈𝚺₁ ⊢!. σ.σ (Sum.inr i) ➝ ∼σ.realization.interpret T.standardPr B :=
+          have : 𝐈𝚺₁ ⊢!. σ.σ (Sum.inr i) ➝ ∼σ.realization.interpret T.standardProvability B :=
             σ.mainlemma (A := B) (i := i) (by trivial) |>.2
             <| Model.extendRoot.inr_satisfies_iff (n := 1) |>.not.mpr hA;
-          have : 𝐈𝚺₁ ⊢!. ∼T.standardPr (∼σ (Sum.inr i)) ➝ ∼T.standardPr (σ.realization.interpret T.standardPr B) :=
+          have : 𝐈𝚺₁ ⊢!. ∼T.standardProvability (∼σ (Sum.inr i)) ➝ ∼T.standardProvability (σ.realization.interpret T.standardProvability B) :=
             contra!
-            $ T.standardPr.prov_distribute_imply'
+            $ T.standardProvability.prov_distribute_imply'
             $ CN!_of_CN!_right $ this;
           refine C!_trans ?_ this;
           apply σ.SC2;
           tauto;
     have : ℕ ⊧ₘ* 𝐈𝚺₁ := models_of_subtheory (U := 𝐈𝚺₁) (T := T) (M := ℕ) inferInstance;
-    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization.interpret T.standardPr A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂;
+    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization.interpret T.standardProvability A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂;
     simp only [models₀_imply_iff, models₀_not_iff] at this;
     exact this <| by
       simpa [models₀_iff, σ, SolovaySentences.standard_σ_def] using ISigma1.Metamath.SolovaySentences.solovay_root_sound
   tfae_finish;
 
-theorem S.arithmetical_completeness_iff : Modal.S ⊢! A ↔ ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardPr A) := GL_S_TFAE.out 1 2
+theorem S.arithmetical_completeness_iff : Modal.S ⊢! A ↔ ∀ f : Realization ℒₒᵣ, ℕ ⊧ₘ₀ (f.interpret T.standardProvability A) := GL_S_TFAE.out 1 2
 
 end ProvabilityLogic
 

--- a/Foundation/ProvabilityLogic/S/Soundness.lean
+++ b/Foundation/ProvabilityLogic/S/Soundness.lean
@@ -6,10 +6,10 @@ namespace LO.ProvabilityLogic
 open Entailment
 open Modal
 open FirstOrder
-open ProvabilityPredicate
+open Provability
 
 variable {T₀ T : FirstOrder.Theory ℒₒᵣ} [T₀ ⪯ T] [Diagonalization T₀]
-         {𝔅 : ProvabilityPredicate T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.Sound ℕ]
+         {𝔅 : Provability T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.Sound ℕ]
          {A B : Formula ℕ}
 
 theorem S.arithmetical_soundness (h : Modal.S ⊢! A) (f : Realization ℒₒᵣ) : ℕ ⊧ₘ₀ f.interpret 𝔅 A := by

--- a/pages/src/first_order/goedel2.md
+++ b/pages/src/first_order/goedel2.md
@@ -242,15 +242,15 @@ $$
 
 ```lean
 theorem unprovable_goedel
-    (𝔅 : ProvabilityPredicate T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] :
+    (𝔅 : Provability T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] :
     T ⊬. 𝔅.goedel
 
 theorem unrefutable_goedel
-    (𝔅 : ProvabilityPredicate T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] [𝔅.GoedelSound] :
+    (𝔅 : Provability T₀ T) [T₀ ⪯ T] [Diagonalization T₀] [Consistent T] [𝔅.GoedelSound] :
     T ⊬. ∼𝔅.goedel
 ```
-- [LO.ProvabilityLogic.ProvabilityPredicate.unprovable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.unprovable_goedel)
-- [LO.ProvabilityLogic.ProvabilityPredicate.unrefutable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.unrefutable_goedel)
+- [LO.ProvabilityLogic.Provability.unprovable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.Provability.unprovable_goedel)
+- [LO.ProvabilityLogic.Provability.unrefutable_goedel](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.Provability.unrefutable_goedel)
 
 Define formalized incompleteness sentence $\mathrm{Con}_T$:
 $$
@@ -260,10 +260,10 @@ $$
 #### Lemma: $T \vdash \mathrm{Con}_T \leftrightarrow G_T$
 ```lean
 theorem goedel_iff_consistency
-    (𝔅 : ProvabilityPredicate T₀ T) [𝔅.HBL] [T₀ ⪯ T] [Diagonalization T₀] :
+    (𝔅 : Provability T₀ T) [𝔅.HBL] [T₀ ⪯ T] [Diagonalization T₀] :
     T₀ ⊢!. 𝔅.goedel ⭤ 𝔅.con
 ```
-- [LO.ProvabilityLogic.ProvabilityPredicate.goedel_iff_consistency](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.ProvabilityPredicate.goedel_iff_consistency)
+- [LO.ProvabilityLogic.Provability.goedel_iff_consistency](https://formalizedformallogic.github.io/Foundation/doc/Foundation/ProvabilityLogic/Incompleteness.html#LO.ProvabilityLogic.Provability.goedel_iff_consistency)
 
 #### Theorem: $T$ cannot prove its own consistency, i.e., $T \nvdash \mathrm{Con}_T$ if $T$ is consistent. Moreover, $\mathrm{Con}_T$ is undecidable from $T$ if $\mathbb{N} \models T$.
 


### PR DESCRIPTION
`ProvabilityPredicate T₀ T` の `T₀`, `T` は言語が等しい必要があったが，その条件を除去した．