### PR TITLE
add(FirstOrder): `𝐑₀ ⪱ 𝐐`

### DIFF
--- a/Foundation/FirstOrder/Q/Basic.lean
+++ b/Foundation/FirstOrder/Q/Basic.lean
@@ -19,6 +19,7 @@ inductive RobinsonQ : ArithmeticTheory
   | addSucc    : RobinsonQ “a b | a + (b + 1) = (a + b) + 1”
   | mulZero    : RobinsonQ   “a | a * 0 = 0”
   | mulSucc    : RobinsonQ “a b | a * (b + 1) = a * b + a”
+  | ltDef      : RobinsonQ “a b | a < b ↔ ∃ c, a + (c + 1) = b”
   | zeroAddOne : RobinsonQ “0 + 1 = 1”
 
 notation "𝐐" => RobinsonQ
@@ -30,6 +31,14 @@ open ORingStruc
 @[simp] instance : ℕ ⊧ₘ* 𝐐 := ⟨by
   intro σ h
   rcases h <;> simp [models_def, add_assoc, mul_add]
+  case ltDef =>
+    intro f;
+    constructor;
+    . intro h;
+      use (f 1 - f 0 - 1);
+      omega;
+    . rintro ⟨c, hc⟩;
+      simp [←hc];
   case equal h =>
     have : ℕ ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h⟩
@@ -58,6 +67,9 @@ protected lemma mul_succ (a b : M) : a * (b + 1) = a * b + a := by
 
 @[simp] protected lemma zero_add_one : (0 + 1 : M) = 1 := by
   simpa [models_iff] using ModelsTheory.models M RobinsonQ.zeroAddOne (fun _ ↦ 0)
+
+protected lemma lt_def {a b : M} : a < b ↔ ∃ c : M, a + (c + 1) = b := by
+  simpa [models_iff] using ModelsTheory.models M RobinsonQ.ltDef (a :>ₙ fun _ ↦ b)
 
 @[simp] lemma numeral_zero_add (n : ℕ) : 0 + (numeral n : M) = numeral n := by
   match n with
@@ -142,21 +154,6 @@ lemma exists_numeral_of_ne_zero {n : ℕ} (h : n ≠ 0) : ∃ m, (numeral n : M)
                     _ = numeral (n + 1) + numeral 1       := by simp [numeral_add_one];
                     _ = numeral (m + 1) + numeral 1       := by rw [hm];
 
-lemma numeral_ne_of_ne_zero {n : ℕ} (h : m ≠ 0) : (numeral n : M) ≠ numeral (n + m)  := by
-  match m with
-  | 0 => contradiction
-  | 1 => apply numeral_succ_ne;
-  | m + 2 =>
-    by_contra e;
-    sorry;
-  /-
-  | 1 => apply numeral_succ_ne
-  | m + 2 =>
-    by_contra e;
-
-    sorry;
-  -/
-
 lemma numeral_succ_inj {n m : ℕ} (h : (numeral (n + 1) : M) = numeral (m + 1)) : (numeral n : M) = (numeral m : M) := by
   rw [←numeral_add_one, ←numeral_add_one] at h;
   apply succ_inj h;
@@ -175,6 +172,27 @@ lemma numeral_ne_of_ne {n m : ℕ} (h : n ≠ m) : (numeral n : M) ≠ numeral m
     contrapose! this;
     apply numeral_succ_inj this;
 
+lemma numeral_lt_of_lt {n m : ℕ} (h : n < m) : (numeral n : M) < numeral m := by
+  apply RobinsonQ.lt_def.mpr;
+  obtain ⟨k, rfl, hk⟩ := RobinsonQ.lt_def.mp h;
+  use (numeral k : M);
+  calc
+    (numeral n + (numeral k + 1) : M) = numeral n + (numeral k + numeral 1) := by simp;
+                                    _ = numeral n + (numeral (k + 1))       := by rw [numeral_add];
+                                    _ = numeral (n + (k + 1))               := by rw [numeral_add];
+
+lemma lt_of_numeral_lt {n m : ℕ} (h : (numeral n : M) < numeral m) : n < m := by sorry;
+
+lemma exists_numeral_of_lt {n : ℕ} {x : M} : x < numeral n → ∃ m : ℕ, x = numeral m := by
+  match n with
+  | 0 =>
+    intro h;
+    sorry;
+  | 1 =>
+    sorry;
+  | n + 2 =>
+    sorry;
+
 instance : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
   intro φ h
   rcases h
@@ -189,10 +207,13 @@ instance : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
     intro x;
     constructor;
     . intro hx;
-      rcases eq_nat_of_lt_nat hx with ⟨x, rfl⟩;
-      sorry;
+      obtain ⟨m, rfl⟩ := exists_numeral_of_lt hx;
+      use m;
+      constructor;
+      . exact lt_of_numeral_lt hx;
+      . rfl;
     . rintro ⟨i, hi, rfl⟩;
-      sorry;
+      apply numeral_lt_of_lt hi;
 
 instance : 𝐑₀ ⪯ 𝐐 := oRing_weakerThan_of.{0} _ _ fun _ _ _ ↦ inferInstance
 


### PR DESCRIPTION
`𝐐` に `<`の公理が無いように思えたので追加したが，結局 `Ω₄` のうまいやり方が思いつかない．