### PR TITLE
chore: removing ending semicolons

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/Definability/Hierarchy.lean
+++ b/Foundation/FirstOrder/Arithmetic/Definability/Hierarchy.lean
@@ -197,7 +197,7 @@ def rew (ω : Rew ℒₒᵣ ξ₁ n₁ ξ₂ n₂) : {Γ : HierarchySymbol} → 
 
 @[simp] lemma ProperWithParamOn.rew {φ : 𝚫-[m].Semiformula M n₁}
     (h : φ.ProperWithParamOn M) (f : Fin n₁ → Semiterm ℒₒᵣ M n₂) : (φ.rew (Rew.substs f)).ProperWithParamOn M := by
-  rcases φ; intro e;
+  rcases φ; intro e
   simp only [Semiformula.rew, sigma_mkDelta, val_rew, Semiformula.eval_rew, pi_mkDelta]
   exact h.iff _
 

--- a/Foundation/FirstOrder/Basic/Eq.lean
+++ b/Foundation/FirstOrder/Basic/Eq.lean
@@ -182,7 +182,7 @@ lemma eval_mk {e} {ε} {φ : Semiformula L μ n} :
   case hall n φ ih =>
     constructor
     · intro h a; exact (ih (e := a :> e)).mp (by simpa [Matrix.comp_vecCons] using h ⟦a⟧)
-    · intro h a;
+    · intro h a
       induction' a using Quotient.ind with a
       simpa [Matrix.comp_vecCons] using ih.mpr (h a)
   case hex n φ ih =>
@@ -212,7 +212,7 @@ variable {L M}
 lemma rel_eq (a b : QuotEq L M) : (@Semiformula.Operator.Eq.eq L _).val (M := QuotEq L M) ![a, b] ↔ a = b := by
   induction' a using Quotient.ind with a
   induction' b using Quotient.ind with b
-  rw [of_eq_of]; simp [eqv, Semiformula.Operator.val];
+  rw [of_eq_of]; simp [eqv, Semiformula.Operator.val]
   simpa [Evalm, Matrix.fun_eq_vec_two, Empty.eq_elim] using
     eval_mk (H := H) (e := ![a, b]) (ε := Empty.elim) (φ := Semiformula.Operator.Eq.eq.sentence)
 
@@ -241,7 +241,7 @@ lemma consequence_iff_eq' {T : Theory L} [𝐄𝐐 ⪯ T] {φ : SyntacticFormula
 lemma satisfiable_iff_eq {T : Theory L} [𝐄𝐐 ⪯ T] :
     Semantics.Satisfiable (Struc.{v, u} L) T ↔ (∃ (M : Type v) (_ : Nonempty M) (_ : Structure L M) (_ : Structure.Eq L M), M ⊧ₘ* T) := by
   simp [satisfiable_iff]; constructor
-  · intro ⟨M, x, s, hM⟩;
+  · intro ⟨M, x, s, hM⟩
     haveI : Nonempty M := ⟨x⟩
     have H : M ⊧ₘ* (𝐄𝐐 : Theory L) := models_of_subtheory hM
     have e : Structure.Eq.QuotEq L M ≡ₑ[L] M := Structure.Eq.QuotEq.elementaryEquiv L M

--- a/Foundation/FirstOrder/Basic/Operator.lean
+++ b/Foundation/FirstOrder/Basic/Operator.lean
@@ -302,7 +302,7 @@ def comp (o : Operator L k) (w : Fin k → Semiterm.Operator L l) : Operator L l
 lemma operator_comp (o : Operator L k) (w : Fin k → Semiterm.Operator L l) (v : Fin l → Semiterm L ξ n) :
   (o.comp w).operator v = o.operator (fun x => (w x).operator v) := by
     unfold operator Rewriting.embedding Rewriting.substitute comp
-    simp only [operator, ← TransitiveRewriting.comp_app, Rew.emb_eq_id, Rew.comp_id];
+    simp only [operator, ← TransitiveRewriting.comp_app, Rew.emb_eq_id, Rew.comp_id]
     congr 2
     ext
     · simp [Rew.comp_app]; congr

--- a/Foundation/FirstOrder/ISigma1/HFS/Seq.lean
+++ b/Foundation/FirstOrder/ISigma1/HFS/Seq.lean
@@ -144,7 +144,7 @@ private lemma znth_graph {x s i : V} : x = znth s i ↔ ∃ l ≤ 2 * s, l = lh 
   simp [znth, Classical.choose!_eq_iff]
 
 lemma znth_defined : 𝚺₀-Function₂ (znth : V → V → V) via znthDef := by
-  intro v;
+  intro v
   simpa [znthDef, -not_and, not_and_or] using znth_graph (V := V)
 
 @[simp] lemma eval_znthDef (v) :

--- a/Foundation/FirstOrder/ISigma1/Ind.lean
+++ b/Foundation/FirstOrder/ISigma1/Ind.lean
@@ -30,7 +30,7 @@ open HierarchySymbol
 theorem bounded_all_sigma1_order_induction {f : V → V → V} (hf : 𝚺₁-Function₂ f) {P : V → V → Prop} (hP : 𝚺₁-Relation P)
     (ind : ∀ x y, (∀ x' < x, ∀ y' ≤ f x y, P x' y') → P x y) : ∀ x y, P x y := by
   have maxf : ∀ x y, ∃ m, ∀ x' ≤ x, ∀ y' ≤ y, f x' y' ≤ m := by
-    intro x y;
+    intro x y
     rcases sigma₁_replacement₂ hf (under (x + 1)) (under (y + 1)) |>.exists with ⟨m, hm⟩
     exact ⟨m, fun x' hx' y' hy' ↦
       le_of_lt <| lt_of_mem <| hm (f x' y') |>.mpr

--- a/Foundation/FirstOrder/Incompleteness/Dense.lean
+++ b/Foundation/FirstOrder/Incompleteness/Dense.lean
@@ -10,18 +10,18 @@ variable {F S : Type*} [DecidableEq F] [LogicalConnective F] [Entailment F S] [C
          {𝓢 : S} [Entailment.Cl 𝓢]
 
 lemma consistent_cons_of_unprovable_neg (h : 𝓢 ⊬ ∼φ) : Consistent (cons φ 𝓢) := by
-  apply consistent_iff_exists_unprovable.mpr;
-  use ⊥;
-  apply deduction_iff.not.mpr;
-  contrapose! h;
-  simp only [not_not];
-  cl_prover [h];
+  apply consistent_iff_exists_unprovable.mpr
+  use ⊥
+  apply deduction_iff.not.mpr
+  contrapose! h
+  simp only [not_not]
+  cl_prover [h]
 
 lemma consistent_cons_of_unprovable (h : 𝓢 ⊬ φ) : Consistent (cons (∼φ) 𝓢) := by
-  apply consistent_cons_of_unprovable_neg;
-  contrapose! h;
-  simp_all only [not_not];
-  cl_prover [h];
+  apply consistent_cons_of_unprovable_neg
+  contrapose! h
+  simp_all only [not_not]
+  cl_prover [h]
 
 end Entailment
 
@@ -35,33 +35,33 @@ variable {F S : Type*} [DecidableEq F] [LogicalConnective F] [Entailment F S] [C
 lemma dense_of_finite_extend_incomplete
     (hE : ∀ φ : F, Entailment.Consistent (cons φ 𝓢) → ¬Entailment.Complete (cons φ 𝓢))
     (h : φ < ψ) : ∃ ξ : LindenbaumAlgebra 𝓢, φ < ξ ∧ ξ < ψ := by
-  obtain ⟨φ, rfl⟩ := Quotient.exists_rep φ;
-  obtain ⟨ψ, rfl⟩ := Quotient.exists_rep ψ;
-  have h₁ : 𝓢 ⊢! φ ➝ ψ := le_def _ |>.mp $ le_of_lt h;
-  have h₂ : 𝓢 ⊬  ψ ➝ φ := le_def _ |>.not.mp $ not_le_of_gt h;
+  obtain ⟨φ, rfl⟩ := Quotient.exists_rep φ
+  obtain ⟨ψ, rfl⟩ := Quotient.exists_rep ψ
+  have h₁ : 𝓢 ⊢! φ ➝ ψ := le_def _ |>.mp $ le_of_lt h
+  have h₂ : 𝓢 ⊬  ψ ➝ φ := le_def _ |>.not.mp $ not_le_of_gt h
   obtain ⟨ρ, hρ⟩ := Entailment.incomplete_iff_exists_undecidable.mp $ @hE (∼φ ⋏ ψ) $ by
-    apply consistent_iff_exists_unprovable.mpr;
-    use ⊥;
-    apply deduction_iff.not.mpr;
-    contrapose! h₂;
-    simp only [not_not];
-    cl_prover [h₂];
-  use ⟦φ ⋎ (ψ ⋏ ∼ρ)⟧;
-  refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩;
-  . apply le_def _ |>.mpr;
-    cl_prover;
-  . apply le_def _ |>.not.mpr;
-    by_contra! hC;
-    apply hρ.1;
-    apply deduction_iff.mpr;
-    cl_prover [h₁, hC];
-  . apply le_def _ |>.mpr;
-    cl_prover [h₁];
-  . apply le_def _ |>.not.mpr;
-    by_contra hC;
-    apply hρ.2;
-    apply deduction_iff.mpr;
-    cl_prover [h₁, hC];
+    apply consistent_iff_exists_unprovable.mpr
+    use ⊥
+    apply deduction_iff.not.mpr
+    contrapose! h₂
+    simp only [not_not]
+    cl_prover [h₂]
+  use ⟦φ ⋎ (ψ ⋏ ∼ρ)⟧
+  refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
+  . apply le_def _ |>.mpr
+    cl_prover
+  . apply le_def _ |>.not.mpr
+    by_contra! hC
+    apply hρ.1
+    apply deduction_iff.mpr
+    cl_prover [h₁, hC]
+  . apply le_def _ |>.mpr
+    cl_prover [h₁]
+  . apply le_def _ |>.not.mpr
+    by_contra hC
+    apply hρ.2
+    apply deduction_iff.mpr
+    cl_prover [h₁, hC]
 
 end Entailment.LindenbaumAlgebra
 

--- a/Foundation/FirstOrder/Incompleteness/First.lean
+++ b/Foundation/FirstOrder/Incompleteness/First.lean
@@ -57,16 +57,16 @@ theorem incomplete
       (inconsistent_of_provable_of_unprovable (this.mp h) h) inferInstance ⟩
 
 theorem exists_true_but_unprovable_sentence (T : ArithmeticTheory) [T.Δ₁] [𝐑₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1] : ∃ σ : Sentence ℒₒᵣ, ℕ ⊧ₘ₀ σ ∧ T ⊬. σ := by
-  obtain ⟨σ, hσ⟩ := incomplete_iff_exists_undecidable.mp $ Arithmetic.incomplete T;
-  by_cases ℕ ⊧ₘ₀ σ;
-  . use σ;
-    constructor;
-    . assumption;
-    . exact hσ.1;
-  . use ∼σ;
-    constructor;
-    . simpa;
-    . exact hσ.2;
+  obtain ⟨σ, hσ⟩ := incomplete_iff_exists_undecidable.mp $ Arithmetic.incomplete T
+  by_cases ℕ ⊧ₘ₀ σ
+  . use σ
+    constructor
+    . assumption
+    . exact hσ.1
+  . use ∼σ
+    constructor
+    . simpa
+    . exact hσ.2
 
 
 end LO.FirstOrder.Arithmetic
@@ -76,15 +76,15 @@ namespace LO.FirstOrderTrueArith
 open LO.Entailment FirstOrder Arithmetic
 
 instance {T : ArithmeticTheory} [ℕ ⊧ₘ* T] [T.Δ₁] [𝐑₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1] : T ⪱ 𝐓𝐀 := by
-  constructor;
+  constructor
   . infer_instance
-  . obtain ⟨σ, σTrue, σUnprov⟩ := exists_true_but_unprovable_sentence T;
-    apply Entailment.not_weakerThan_iff.mpr;
-    use σ;
-    constructor;
-    . apply FirstOrderTrueArith.provable_iff.mpr;
-      simpa;
-    . apply Axiom.provable_iff (σ := σ) |>.not.mp;
-      simpa;
+  . obtain ⟨σ, σTrue, σUnprov⟩ := exists_true_but_unprovable_sentence T
+    apply Entailment.not_weakerThan_iff.mpr
+    use σ
+    constructor
+    . apply FirstOrderTrueArith.provable_iff.mpr
+      simpa
+    . apply Axiom.provable_iff (σ := σ) |>.not.mp
+      simpa
 
 end LO.FirstOrderTrueArith

--- a/Foundation/FirstOrder/Incompleteness/Halting.lean
+++ b/Foundation/FirstOrder/Incompleteness/Halting.lean
@@ -12,58 +12,58 @@ open Classical
 
 lemma incomplete_of_REPred_not_ComputablePred_Nat' {P : ℕ → Prop} (hRE : REPred P) (hC : ¬ComputablePred P) :
   ∃ φ : ArithmeticSemisentence 1, ∃ a : ℕ, T ⊬. φ/[a] ∧ T ⊬. ∼φ/[a] := by
-  let φ := codeOfREPred P;
-  use φ;
-  have hP : P = { n : ℕ | T ⊢!. φ/[n] } := Set.ext fun x ↦ re_complete hRE;
+  let φ := codeOfREPred P
+  use φ
+  have hP : P = { n : ℕ | T ⊢!. φ/[n] } := Set.ext fun x ↦ re_complete hRE
   have ⟨d, hd⟩ : ∃ d : ℕ, ¬(¬P d ↔ T ⊢!. ∼φ/[d]) := by
-    by_contra h;
-    apply hC;
-    apply ComputablePred.computable_iff_re_compl_re.mpr;
-    constructor;
-    . assumption;
-    . suffices REPred fun a : ℕ ↦ T ⊬. φ/[a] by simpa [hP] using this;
-      have : 𝚺₁-Predicate fun b : ℕ ↦ T.Provable (neg ℒₒᵣ <| substs ℒₒᵣ ?[InternalArithmetic.numeral b] ⌜φ⌝) := by clear hP; definability;
-      apply REPred.of_eq (re_iff_sigma1.mpr this);
-      intro a;
-      push_neg at h;
-      apply Iff.trans ?_ $ show T ⊢!. ∼φ/[a] ↔ ¬T ⊢!. φ/[a] by simpa [hP] using h a |>.symm;
+    by_contra h
+    apply hC
+    apply ComputablePred.computable_iff_re_compl_re.mpr
+    constructor
+    . assumption
+    . suffices REPred fun a : ℕ ↦ T ⊬. φ/[a] by simpa [hP] using this
+      have : 𝚺₁-Predicate fun b : ℕ ↦ T.Provable (neg ℒₒᵣ <| substs ℒₒᵣ ?[InternalArithmetic.numeral b] ⌜φ⌝) := by clear hP; definability
+      apply REPred.of_eq (re_iff_sigma1.mpr this)
+      intro a
+      push_neg at h
+      apply Iff.trans ?_ $ show T ⊢!. ∼φ/[a] ↔ ¬T ⊢!. φ/[a] by simpa [hP] using h a |>.symm
       apply Iff.trans ?_ $ show T ⊢! ∼(φ : SyntacticSemiformula ℒₒᵣ 1)/[↑a] ↔ T ⊢!. ∼φ/[a] by
-        convert Axiom.provable_iff.symm;
-        simp [Rewriting.embedding_substs_eq_substs_coe₁];
-      constructor;
-      . rintro hP; apply Theory.Provable.sound; simpa [Semiformula.quote_def] using hP;
-      . rintro hφ; simpa [Semiformula.quote_def] using internalize_provability (V := ℕ) hφ;
-  push_neg at hd;
-  rcases hd with (⟨hd₁, hd₂⟩ | ⟨hd₁, hd₂⟩);
-  . use d;
-    constructor;
-    . simpa [hP] using hd₁;
-    . simpa;
-  . exfalso;
-    apply Entailment.Consistent.not_bot (𝓢 := T.toAxiom) inferInstance;
-    replace hd₁ : T ⊢!. φ/[d] := by simpa [hP] using hd₁;
-    cl_prover [hd₁, hd₂];
+        convert Axiom.provable_iff.symm
+        simp [Rewriting.embedding_substs_eq_substs_coe₁]
+      constructor
+      . rintro hP; apply Theory.Provable.sound; simpa [Semiformula.quote_def] using hP
+      . rintro hφ; simpa [Semiformula.quote_def] using internalize_provability (V := ℕ) hφ
+  push_neg at hd
+  rcases hd with (⟨hd₁, hd₂⟩ | ⟨hd₁, hd₂⟩)
+  . use d
+    constructor
+    . simpa [hP] using hd₁
+    . simpa
+  . exfalso
+    apply Entailment.Consistent.not_bot (𝓢 := T.toAxiom) inferInstance
+    replace hd₁ : T ⊢!. φ/[d] := by simpa [hP] using hd₁
+    cl_prover [hd₁, hd₂]
 
 /--
   If r.e. but not recursive predicate `P` on `ℕ` exists, then implies incompleteness.
 -/
 lemma incomplete_of_REPred_not_ComputablePred_Nat {P : ℕ → Prop} (hRE : REPred P) (hC : ¬ComputablePred P) : ¬Entailment.Complete (T : Axiom ℒₒᵣ) := by
-  obtain ⟨φ, a, hφ₁, hφ₂⟩ := incomplete_of_REPred_not_ComputablePred_Nat' T hRE hC;
-  apply incomplete_iff_exists_undecidable.mpr;
-  use φ/[⌜a⌝];
-  constructor <;> assumption;
+  obtain ⟨φ, a, hφ₁, hφ₂⟩ := incomplete_of_REPred_not_ComputablePred_Nat' T hRE hC
+  apply incomplete_iff_exists_undecidable.mpr
+  use φ/[⌜a⌝]
+  constructor <;> assumption
 
 /-
 lemma _root_.REPred.iff_decoded_pred {A : α → Prop} [Primcodable α] : REPred A ↔ REPred λ n : ℕ ↦ match Encodable.decode n with | some a => A a | none => False := by
-  sorry;
+  sorry
 
 lemma _root_.ComputablePred.iff_decoded_pred {A : α → Prop} [h : Primcodable α] : ComputablePred A ↔ ComputablePred λ n : ℕ ↦ match Encodable.decode n with | some a => A a | none => False := by
-  sorry;
+  sorry
 
 lemma incomplete_of_REPred_not_ComputablePred₂ {P : α → Prop} [h : Primcodable α] (hRE : REPred P) (hC : ¬ComputablePred P) : ¬Entailment.Complete (T : Axiom ℒₒᵣ) := by
-  apply incomplete_of_REPred_not_ComputablePred (P := λ n : ℕ ↦ match h.decode n with | some a => P a | none => False);
-  . exact REPred.iff_decoded_pred.mp hRE;
-  . exact ComputablePred.iff_decoded_pred.not.mp hC;
+  apply incomplete_of_REPred_not_ComputablePred (P := λ n : ℕ ↦ match h.decode n with | some a => P a | none => False)
+  . exact REPred.iff_decoded_pred.mp hRE
+  . exact ComputablePred.iff_decoded_pred.not.mp hC
 
 /--
   Halting problem is r.e. but not recursive, so Gödel's first incompleteness theorem follows.

--- a/Foundation/FirstOrder/Incompleteness/Tarski.lean
+++ b/Foundation/FirstOrder/Incompleteness/Tarski.lean
@@ -11,12 +11,12 @@ variable {T : Theory ℒₒᵣ} [𝐈𝚺₁ ⪯ T] [Entailment.Consistent T]
   There is no predicate `τ`, s.t. for any sentence `σ`, `σ` is provable in `T` iff `τ/[⌜σ⌝]` is so.
 -/
 lemma not_exists_tarski_predicate : ¬∃ τ : Semisentence ℒₒᵣ 1, ∀ σ, T ⊢!. σ ⭤ τ/[⌜σ⌝] := by
-  rintro ⟨τ, hτ⟩;
-  apply Entailment.Consistent.not_bot (𝓢 := T.toAxiom);
-  . infer_instance;
-  . have h₁ : T ⊢!. fixedpoint (∼τ) ⭤ τ/[⌜fixedpoint (∼τ)⌝] := by simpa using hτ $ fixedpoint “x. ¬!τ x”;;
-    have h₂ : T ⊢!. fixedpoint (∼τ) ⭤ ∼τ/[⌜fixedpoint (∼τ)⌝] := by simpa using diagonal (T := T) “x. ¬!τ x”;
-    cl_prover [h₁, h₂];
+  rintro ⟨τ, hτ⟩
+  apply Entailment.Consistent.not_bot (𝓢 := T.toAxiom)
+  . infer_instance
+  . have h₁ : T ⊢!. fixedpoint (∼τ) ⭤ τ/[⌜fixedpoint (∼τ)⌝] := by simpa using hτ $ fixedpoint “x. ¬!τ x”;
+    have h₂ : T ⊢!. fixedpoint (∼τ) ⭤ ∼τ/[⌜fixedpoint (∼τ)⌝] := by simpa using diagonal (T := T) “x. ¬!τ x”
+    cl_prover [h₁, h₂]
 
 end LO.ISigma1
 
@@ -26,8 +26,8 @@ namespace LO.FirstOrderTrueArith
 open FirstOrder Arithmetic
 
 lemma provable_iff₀ {σ : Sentence ℒₒᵣ} : 𝐓𝐀 ⊢!. σ ↔ ℕ ⊧ₘ₀ σ := by
-  apply Iff.trans ?_ $ provable_iff (φ := σ);
-  exact Axiom.provable_iff;
+  apply Iff.trans ?_ $ provable_iff (φ := σ)
+  exact Axiom.provable_iff
 
 end LO.FirstOrderTrueArith
 
@@ -39,12 +39,12 @@ namespace LO.FirstOrder.Arithmetic
   Tarski's Undefinability of Truth Theorem.
 -/
 theorem undefinability_of_truth : ¬∃ τ : Semisentence ℒₒᵣ 1, ∀ σ : Sentence ℒₒᵣ, ℕ ⊧ₘ₀ σ ↔ ℕ ⊧ₘ₀ τ/[⌜σ⌝] := by
-  have := ISigma1.not_exists_tarski_predicate (T := 𝐓𝐀);
-  contrapose! this;
-  obtain ⟨τ, hτ⟩ := this;
-  use τ;
-  intro σ;
-  apply FirstOrderTrueArith.provable_iff₀.mpr;
-  simpa using hτ σ;
+  have := ISigma1.not_exists_tarski_predicate (T := 𝐓𝐀)
+  contrapose! this
+  obtain ⟨τ, hτ⟩ := this
+  use τ
+  intro σ
+  apply FirstOrderTrueArith.provable_iff₀.mpr
+  simpa using hτ σ
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Internal/Syntax/Formula/Basic.lean
+++ b/Foundation/FirstOrder/Internal/Syntax/Formula/Basic.lean
@@ -845,7 +845,7 @@ lemma Graph.case_iff {p y : V} :
     (∃ p₁ y₁, c.Graph L (c.exChanges param) p₁ y₁ ∧ p = ^∃ p₁ ∧ y = c.ex param p₁ y₁) ) :=
   Iff.trans (c.construction L).case (by
     constructor
-    · rintro ⟨param, p', y', e, H⟩;
+    · rintro ⟨param, p', y', e, H⟩
       rcases show _ = param ∧ p = p' ∧ y = y' by simpa using e with ⟨rfl, rfl, rfl⟩
       refine H
     · intro H; exact ⟨_, _, _, rfl, H⟩)

--- a/Foundation/FirstOrder/Internal/Syntax/Proof/Coding.lean
+++ b/Foundation/FirstOrder/Internal/Syntax/Proof/Coding.lean
@@ -93,7 +93,7 @@ lemma setShift_quote (Γ : Finset (SyntacticFormula L)) :
 
 @[simp] lemma formulaSet_quote_finset (Γ : Finset (SyntacticFormula L)) : IsFormulaSet L (⌜Γ⌝ : V) := by
   intro x hx
-  rcases Derivation2.Sequent.mem_quote hx with ⟨p, _, rfl⟩;
+  rcases Derivation2.Sequent.mem_quote hx with ⟨p, _, rfl⟩
   simp [Semiformula.quote_def]
 
 noncomputable instance : GoedelQuote (Finset (SyntacticFormula L)) (Metamath.Sequent V L) := ⟨fun Γ ↦ ⟨⌜Γ⌝, by simp⟩⟩
@@ -111,7 +111,7 @@ noncomputable instance : GoedelQuote (Finset (SyntacticFormula L)) (Metamath.Seq
 @[simp] lemma Sequent.typed_quote_singleton (φ : SyntacticFormula L) :
     (⌜({φ} : Finset (SyntacticFormula L))⌝ : Metamath.Sequent V L) = {⌜φ⌝} := by
   rw [show ({φ} : Finset (SyntacticFormula L)) = insert φ ∅ by simp]
-  rw [Sequent.typed_quote_insert];
+  rw [Sequent.typed_quote_insert]
   simp [Sequent.insert_empty_eq_singleton]
 
 @[simp] lemma setShift_typed_quote (Γ : Finset (SyntacticFormula L)) :
@@ -135,7 +135,7 @@ lemma Sequent.coe_eq (Γ : Finset (SyntacticFormula L)) : (↑(⌜Γ⌝ : ℕ) :
 lemma isFormulaSet_sound {s : ℕ} : IsFormulaSet L s → ∃ S : Finset (SyntacticFormula L), ⌜S⌝ = s := by
   intro h
   have : ∀ x, ∃ φ : SyntacticFormula L, x ∈ s → ⌜φ⌝ = x := by
-    intro x;
+    intro x
     by_cases hx : x ∈ s
     · simpa [hx] using (h x hx).sound
     · simp [hx]

--- a/Foundation/FirstOrder/Internal/Syntax/Term/Basic.lean
+++ b/Foundation/FirstOrder/Internal/Syntax/Term/Basic.lean
@@ -590,7 +590,7 @@ lemma graph_existsUnique_vec {k w : V} (hw : IsUTermVec L k w) :
   refine ExistsUnique.intro w' ⟨hw'k.symm, hw'⟩ ?_
   intro w'' ⟨hkw'', hw''⟩
   refine nth_ext (by simp [hw'k, ←hkw'']) (by
-    intro i hi;
+    intro i hi
     exact c.graph_unique param (hw'' i (by simpa [hkw''] using hi)) (hw' i (by simpa [hkw''] using hi)))
 
 variable (L c param)

--- a/Foundation/FirstOrder/Internal/Syntax/Term/Functions.lean
+++ b/Foundation/FirstOrder/Internal/Syntax/Term/Functions.lean
@@ -245,7 +245,7 @@ lemma termShiftVec_cons {k t ts : V} (ht : IsUTerm L t) (hts : IsUTermVec L k ts
   · definability
   · intro z; simp
   · intro x; simp
-  · intro k f v hkf hv ih;
+  · intro k f v hkf hv ih
     simp only [hkf, hv, termShift_func, func_iff, true_and]
     exact ⟨by simp [hv], by intro i hi; rw [nth_termShiftVec hv hi]; exact ih i hi⟩
 
@@ -254,7 +254,7 @@ lemma termShiftVec_cons {k t ts : V} (ht : IsUTerm L t) (hts : IsUTermVec L k ts
   · definability
   · intro z hz; simp [hz]
   · intro x; simp
-  · intro k f v hkf hv ih;
+  · intro k f v hkf hv ih
     simp only [hkf, hv.isUTerm, termShift_func, func, true_and]
     refine IsSemitermVec.iff.mpr ⟨?_, ?_⟩
     · simp [termShiftVec, hv.isUTerm]
@@ -380,7 +380,7 @@ lemma termBShiftVec_cons {k t ts : V} (ht : IsUTerm L t) (hts : IsUTermVec L k t
   · definability
   · intro z hz; simp [hz]
   · intro x; simp
-  · intro k f v hkf hv ih;
+  · intro k f v hkf hv ih
     simp only [hkf, hv.isUTerm, termBShift_func, func, true_and]
     refine IsSemitermVec.iff.mpr ⟨?_, ?_⟩
     · simp [hv.isUTerm]

--- a/Foundation/FirstOrder/Omega1/Nuon.lean
+++ b/Foundation/FirstOrder/Omega1/Nuon.lean
@@ -52,7 +52,7 @@ lemma ext_graph (z S L i : V) : z = S{L}[i] ↔
       ↔ ∃ b ≤ S, Exponential (i * ‖L‖) b ∧ ∃ hL ≤ 2 * L + 1, Exponential ‖L‖ hL ∧ z = S / b % hL
     by simpa [lt, not_le.mpr lt]
     constructor
-    · rintro ⟨b, hb, Hb, rfl⟩;
+    · rintro ⟨b, hb, Hb, rfl⟩
       refine ⟨b, hb, Hb, L ⨳ 1, by simp, exponential_smash_one L, rfl⟩
     · rintro ⟨b, hb, Hb, hL, _, HhL, _, _, rfl, rfl⟩
       exact ⟨b, hb, Hb, by rw [HhL.uniq (exponential_smash_one L)]⟩
@@ -439,7 +439,7 @@ lemma four_mul_smash_self (a : V) : (4 * a) ⨳ (4 * a) ≤ (a ⨳ a) ^ 16 := ca
 
 @[simp] lemma pos_sq_iff {a : V} : 0 < √a ↔ 0 < a :=
   ⟨fun h ↦ lt_of_lt_of_le h (by simp),
-    by intro h; by_contra A; simp at A;
+    by intro h; by_contra A; simp at A
        simp [show a = 0 from by simpa [A] using sqrt_lt_sq a] at h⟩
 
 @[simp] lemma pow_four_le_pow_four {a b : V} : a ^ 4 ≤ b ^ 4 ↔ a ≤ b := by simp [pow_four_eq_sq_sq]

--- a/Foundation/FirstOrder/PeanoMinus/Basic.lean
+++ b/Foundation/FirstOrder/PeanoMinus/Basic.lean
@@ -248,7 +248,7 @@ noncomputable scoped instance : LinearOrder M where
     rcases PeanoMinus.lt_tri x y with (h | rfl | h) <;> simp [*, le_def]
   lt_iff_le_not_ge := fun x y ↦
     ⟨ fun h => ⟨Or.inr h, by
-      simp only [le_def]; rintro (rfl | h');
+      simp only [le_def]; rintro (rfl | h')
       · exact lt_irrefl y h
       · exact lt_irrefl _ (PeanoMinus.lt_trans _ _ _ h h') ⟩,
      by simp only [le_def, not_or, and_imp]
@@ -336,7 +336,7 @@ instance : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
   case Ω₃ n m h =>
     simp [models_iff, numeral_eq_natCast, h]
   case Ω₄ n =>
-    suffices ∀ x : M, x < ↑n ↔ ∃ i < n, x = ↑i by simpa [models_iff, numeral_eq_natCast];
+    suffices ∀ x : M, x < ↑n ↔ ∃ i < n, x = ↑i by simpa [models_iff, numeral_eq_natCast]
     intro x
     constructor
     · intro hx; rcases eq_nat_of_lt_nat hx with ⟨x, rfl⟩; exact ⟨x, by simpa using hx, by simp⟩

--- a/Foundation/FirstOrder/PeanoMinus/Q.lean
+++ b/Foundation/FirstOrder/PeanoMinus/Q.lean
@@ -2,13 +2,13 @@ import Foundation.FirstOrder.Q.Basic
 import Foundation.FirstOrder.PeanoMinus.Basic
 
 lemma Nat.iff_lt_exists_add_succ : n < m ↔ ∃ k, m = n + (k + 1) := by
-  constructor;
-  . intro h;
-    use m - n - 1;
-    omega;
-  . rintro ⟨k, rfl⟩;
-    apply Nat.lt_add_of_pos_right;
-    omega;
+  constructor
+  . intro h
+    use m - n - 1
+    omega
+  . rintro ⟨k, rfl⟩
+    apply Nat.lt_add_of_pos_right
+    omega
 
 
 namespace LO.RobinsonQ
@@ -71,11 +71,11 @@ instance : ORingStruc OmegaAddOne where
 
 variable {a b : OmegaAddOne}
 
-@[simp] lemma add_zero : a + 0 = a := by match a with | ⊤ | .some n => trivial;
+@[simp] lemma add_zero : a + 0 = a := by match a with | ⊤ | .some n => trivial
 
-@[simp] lemma add_succ : a + (b + 1) = a + b + 1 := by match a, b with | ⊤, ⊤ | ⊤, .some n | .some m, ⊤ | .some n, .some m => tauto;
+@[simp] lemma add_succ : a + (b + 1) = a + b + 1 := by match a, b with | ⊤, ⊤ | ⊤, .some n | .some m, ⊤ | .some n, .some m => tauto
 
-@[simp] lemma mul_zero : a * 0 = 0 := by match a with | ⊤ | .some 0 | .some (n + 1) => rfl;
+@[simp] lemma mul_zero : a * 0 = 0 := by match a with | ⊤ | .some 0 | .some (n + 1) => rfl
 
 @[simp]
 lemma mul_succ : a * (b + 1) = a * b + a := by
@@ -91,60 +91,60 @@ lemma mul_succ : a * (b + 1) = a * b + a := by
 
 lemma succ_inj : a + 1 = b + 1 → a = b := by
   match a, b with
-  | ⊤, ⊤ | ⊤, .some m | .some n, ⊤ => simp;
+  | ⊤, ⊤ | ⊤, .some m | .some n, ⊤ => simp
   | .some n, .some m =>
-    intro h;
-    apply Option.mem_some_iff.mpr;
-    simpa using Option.mem_some_iff.mp h;
+    intro h
+    apply Option.mem_some_iff.mpr
+    simpa using Option.mem_some_iff.mp h
 
 @[simp]
 lemma succ_ne_zero : a + 1 ≠ 0 := by
   match a with
-  | ⊤       => simp;
-  | .some n => apply Option.mem_some_iff.not.mpr; simp;
+  | ⊤       => simp
+  | .some n => apply Option.mem_some_iff.not.mpr; simp
 
 @[simp]
 lemma zero_or_succ : a = 0 ∨ ∃ b, a = b + 1 := by
   match a with
-  | .some 0 => left; rfl;
-  | .some (n + 1) => right; use n; rfl;
-  | ⊤ => right; use ⊤; rfl;
+  | .some 0 => left; rfl
+  | .some (n + 1) => right; use n; rfl
+  | ⊤ => right; use ⊤; rfl
 
 @[simp]
 lemma lt_def : a < b ↔ ∃ c, a + c + 1 = b := by
   match a, b with
-  | ⊤, ⊤ => simp;
-  | ⊤, .some n => simp [(show ¬(⊤ : OmegaAddOne) < .some n by tauto)];
+  | ⊤, ⊤ => simp
+  | ⊤, .some n => simp [(show ¬(⊤ : OmegaAddOne) < .some n by tauto)]
   | .some m, ⊤ =>
-    simp only [(show .some m < (⊤ : OmegaAddOne) by tauto), true_iff];
-    use ⊤;
-    simp;
+    simp only [(show .some m < (⊤ : OmegaAddOne) by tauto), true_iff]
+    use ⊤
+    simp
   | .some m, .some n =>
-    apply Iff.trans (show some m < some n ↔ m < n by rfl);
-    apply Iff.trans Nat.iff_lt_exists_add_succ;
-    constructor;
-    . intro h;
-      obtain ⟨k, rfl⟩ : ∃ k : ℕ, m + (k + 1) = n := by tauto;
-      use k;
-      tauto;
-    . rintro ⟨c, hc⟩;
+    apply Iff.trans (show some m < some n ↔ m < n by rfl)
+    apply Iff.trans Nat.iff_lt_exists_add_succ
+    constructor
+    . intro h
+      obtain ⟨k, rfl⟩ : ∃ k : ℕ, m + (k + 1) = n := by tauto
+      use k
+      tauto
+    . rintro ⟨c, hc⟩
       match c with
-      | .none => simp at hc;
-      | .some c => use c; exact Option.mem_some_iff.mp hc |>.symm;
+      | .none => simp at hc
+      | .some c => use c; exact Option.mem_some_iff.mp hc |>.symm
 
 end OmegaAddOne
 
 set_option linter.flexible false in
 instance : OmegaAddOne ⊧ₘ* 𝐐 := ⟨by
-  intro σ h;
-  rcases h;
+  intro σ h
+  rcases h
   case equal h =>
     have : OmegaAddOne ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h
   case succInj =>
-    suffices ∀ (f : ℕ → OmegaAddOne), f 0 + 1 = f 1 + 1 → f 0 = f 1 by simpa [models_iff];
-    intro _; apply OmegaAddOne.succ_inj;
-  all_goals simp [models_iff];
+    suffices ∀ (f : ℕ → OmegaAddOne), f 0 + 1 = f 1 + 1 → f 0 = f 1 by simpa [models_iff]
+    intro _; apply OmegaAddOne.succ_inj
+  all_goals simp [models_iff]
 ⟩
 
 end Countermodel
@@ -170,44 +170,44 @@ instance : M ⊧ₘ* 𝐐 := modelsTheory_iff.mpr <| by
     have : M ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h
   case addSucc h =>
-    suffices ∀ (f : ℕ → M), f 0 + (f 1 + 1) = f 0 + f 1 + 1 by simpa [models_iff];
-    intro f;
+    suffices ∀ (f : ℕ → M), f 0 + (f 1 + 1) = f 0 + f 1 + 1 by simpa [models_iff]
+    intro f
     rw [add_assoc]
   case mulSucc h =>
-    suffices ∀ (f : ℕ → M), f 0 * (f 1 + 1) = f 0 * f 1 + f 0 by simpa [models_iff];
-    intro f;
+    suffices ∀ (f : ℕ → M), f 0 * (f 1 + 1) = f 0 * f 1 + f 0 by simpa [models_iff]
+    intro f
     calc
       f 0 * (f 1 + 1) = (f 0 * f 1) + (f 0 * 1) := by rw [mul_add_distr]
       _               = (f 0 * f 1) + f 0       := by rw [mul_one]
-    ;
+    
   case zeroOrSucc h =>
-    suffices ∀ (f : ℕ → M), f 0 = 0 ∨ ∃ x, f 0 = x + 1 by simpa [models_iff];
-    intro f;
-    by_cases h : 0 < f 0;
-    . right; apply eq_succ_of_pos h;
-    . left; simpa using h;
+    suffices ∀ (f : ℕ → M), f 0 = 0 ∨ ∃ x, f 0 = x + 1 by simpa [models_iff]
+    intro f
+    by_cases h : 0 < f 0
+    . right; apply eq_succ_of_pos h
+    . left; simpa using h
   case ltDef h =>
-    suffices ∀ (f : ℕ → M), f 0 < f 1 ↔ ∃ x, f 0 + (x + 1) = f 1 by simpa [models_iff];
-    intro f;
-    apply Iff.trans lt_iff_exists_add;
-    constructor;
-    . rintro ⟨a, ha₁, ha₂⟩;
-      obtain ⟨b, rfl⟩ : ∃ b, a = b + 1 := eq_succ_of_pos ha₁;
-      use b;
-      tauto;
-    . rintro ⟨a, ha⟩;
-      use (a + 1);
-      constructor;
-      . simp;
-      . apply ha.symm;
-  all_goals simp [models_iff];
+    suffices ∀ (f : ℕ → M), f 0 < f 1 ↔ ∃ x, f 0 + (x + 1) = f 1 by simpa [models_iff]
+    intro f
+    apply Iff.trans lt_iff_exists_add
+    constructor
+    . rintro ⟨a, ha₁, ha₂⟩
+      obtain ⟨b, rfl⟩ : ∃ b, a = b + 1 := eq_succ_of_pos ha₁
+      use b
+      tauto
+    . rintro ⟨a, ha⟩
+      use (a + 1)
+      constructor
+      . simp
+      . apply ha.symm
+  all_goals simp [models_iff]
 
 instance : 𝐐 ⪯ 𝐏𝐀⁻ := oRing_weakerThan_of.{0} _ _ fun _ _ _ ↦ inferInstance
 
 instance w : 𝐐 ⪱ 𝐏𝐀⁻ := Entailment.StrictlyWeakerThan.of_unprovable_provable RobinsonQ.unprovable_neSucc $ by
-  apply oRing_provable_of.{0};
-  intro _ _ _;
-  simp [models_iff];
+  apply oRing_provable_of.{0}
+  intro _ _ _
+  simp [models_iff]
 
 end PeanoMinus
 

--- a/Foundation/FirstOrder/Q/Basic.lean
+++ b/Foundation/FirstOrder/Q/Basic.lean
@@ -33,14 +33,14 @@ open ORingStruc
   intro σ h
   rcases h <;> simp [models_def, add_assoc, mul_add]
   case ltDef =>
-    intro f;
-    constructor;
-    . intro h;
-      use (f 1 - f 0 - 1);
-      omega;
-    . rintro ⟨c, hc⟩;
-      simp [←hc];
-  case zeroOrSucc => omega;
+    intro f
+    constructor
+    . intro h
+      use (f 1 - f 0 - 1)
+      omega
+    . rintro ⟨c, hc⟩
+      simp [←hc]
+  case zeroOrSucc => omega
   case equal h =>
     have : ℕ ⊧ₘ* (𝐄𝐐 : ArithmeticTheory) := inferInstance
     exact modelsTheory_iff.mp this h⟩
@@ -68,58 +68,58 @@ protected lemma mul_succ (a b : M) : a * (b + 1) = a * b + a := by
   simpa [models_iff] using ModelsTheory.models M RobinsonQ.mulSucc (a :>ₙ fun _ ↦ b)
 
 lemma zero_or_succ {a : M} : a = 0 ∨ ∃ b : M, a = b + 1 := by
-  simpa [models_iff] using ModelsTheory.models M RobinsonQ.zeroOrSucc (λ _ ↦ a);
+  simpa [models_iff] using ModelsTheory.models M RobinsonQ.zeroOrSucc (λ _ ↦ a)
 
 lemma exists_succ_of_ne_zero {a : M} (ha : a ≠ 0) : ∃ b : M, a = b + 1 := by
-  have := zero_or_succ (a := a);
-  tauto;
+  have := zero_or_succ (a := a)
+  tauto
 
 lemma exists_succ_of_ne_zero' {a : M} (ha : a ≠ 0) : ∃ b : M, b + 1 = a := by
-  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero ha;
-  use b;
+  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero ha
+  use b
 
 protected lemma lt_def {a b : M} : a < b ↔ ∃ c : M, a + (c + 1) = b := by
   simpa [models_iff] using ModelsTheory.models M RobinsonQ.ltDef (a :>ₙ fun _ ↦ b)
 
 @[simp]
 lemma one_ne_zero : (1 : M) ≠ 0 := by
-  by_contra h;
-  apply RobinsonQ.succ_ne_zero (M := M) (a := 0);
-  rw [h];
-  apply RobinsonQ.add_zero;
+  by_contra h
+  apply RobinsonQ.succ_ne_zero (M := M) (a := 0)
+  rw [h]
+  apply RobinsonQ.add_zero
 
 @[simp]
-lemma one_add_zero : (1 : M) + 0 = 1 := by simp;
+lemma one_add_zero : (1 : M) + 0 = 1 := by simp
 
 @[simp]
 lemma zero_add_one : (0 : M) + 1 = 1 := by
-  obtain ⟨a, ha⟩ := exists_succ_of_ne_zero' (M := M) one_ne_zero;
-  convert ha;
-  by_contra;
-  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero' (M := M) (a := a) (by tauto);
-  apply RobinsonQ.succ_ne_zero (M := M) (a := (0 + b));
-  apply succ_inj;
+  obtain ⟨a, ha⟩ := exists_succ_of_ne_zero' (M := M) one_ne_zero
+  convert ha
+  by_contra
+  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero' (M := M) (a := a) (by tauto)
+  apply RobinsonQ.succ_ne_zero (M := M) (a := (0 + b))
+  apply succ_inj
   calc
-    0 + b + 1 + 1 = 0 + (b + 1) + 1 := by rw [RobinsonQ.add_succ (a := 0) (b := b)];
-    _             = 0 + (b + 1 + 1) := by rw [RobinsonQ.add_succ (a := 0) (b := (b + 1))];
-    _             = 0 + 1           := by rw [ha];
+    0 + b + 1 + 1 = 0 + (b + 1) + 1 := by rw [RobinsonQ.add_succ (a := 0) (b := b)]
+    _             = 0 + (b + 1 + 1) := by rw [RobinsonQ.add_succ (a := 0) (b := (b + 1))]
+    _             = 0 + 1           := by rw [ha]
 
 lemma succ_inj_zero {a : M} : a + 1 = 1 → a = 0 := by
-  nth_rw 2 [←zero_add_one];
-  apply succ_inj;
+  nth_rw 2 [←zero_add_one]
+  apply succ_inj
 
 lemma eq_zero_of_eq_add_zero {a b : M} (h : a + b = 0) : a = 0 ∧ b = 0 := by
-  set_option push_neg.use_distrib true in contrapose! h;
-  rcases h with ha | hb;
-  . obtain ⟨c, rfl⟩ := exists_succ_of_ne_zero (M := M) ha;
-    by_cases hb0 : b = 0;
+  set_option push_neg.use_distrib true in contrapose! h
+  rcases h with ha | hb
+  . obtain ⟨c, rfl⟩ := exists_succ_of_ne_zero (M := M) ha
+    by_cases hb0 : b = 0
     . subst hb0; rwa [RobinsonQ.add_zero]
-    . obtain ⟨d, rfl⟩ := exists_succ_of_ne_zero (M := M) hb0;
-      rw [RobinsonQ.add_succ (a := c + 1) (b := d)];
-      apply RobinsonQ.succ_ne_zero;
-  . obtain ⟨c, rfl⟩ := exists_succ_of_ne_zero' (M := M) hb;
-    rw [RobinsonQ.add_succ];
-    simp;
+    . obtain ⟨d, rfl⟩ := exists_succ_of_ne_zero (M := M) hb0
+      rw [RobinsonQ.add_succ (a := c + 1) (b := d)]
+      apply RobinsonQ.succ_ne_zero
+  . obtain ⟨c, rfl⟩ := exists_succ_of_ne_zero' (M := M) hb
+    rw [RobinsonQ.add_succ]
+    simp
 
 
 @[simp]
@@ -137,30 +137,30 @@ lemma zero_mul_one : (0 : M) * 1 = 0 := calc
 
 @[simp]
 lemma not_le_zero {a : M} : ¬a < 0 := by
-  apply RobinsonQ.lt_def.not.mpr;
-  push_neg;
-  intro b;
+  apply RobinsonQ.lt_def.not.mpr
+  push_neg
+  intro b
   calc
     a + (b + 1) = (a + b) + 1 := RobinsonQ.add_succ _ _
-    _           ≠ 0           := by simp;
+    _           ≠ 0           := by simp
 
 lemma lt_of_not_zero {a b : M} (ha : b ≠ 0) : a < a + b := by
-  apply RobinsonQ.lt_def.mpr;
-  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero (M := M) ha;
-  use b;
+  apply RobinsonQ.lt_def.mpr
+  obtain ⟨b, rfl⟩ := exists_succ_of_ne_zero (M := M) ha
+  use b
 
 @[simp]
 lemma iff_le_one_eq_zero {a : M} : a < 1 ↔ a = 0 := by
-  constructor;
-  . rw [RobinsonQ.lt_def];
-    rintro ⟨b, hb⟩;
-    apply eq_zero_of_eq_add_zero (b := b) ?_ |>.1;
-    apply succ_inj_zero;
-    rwa [RobinsonQ.add_succ] at hb;
-  . rintro rfl;
-    apply RobinsonQ.lt_def.mpr;
-    use 0;
-    simp;
+  constructor
+  . rw [RobinsonQ.lt_def]
+    rintro ⟨b, hb⟩
+    apply eq_zero_of_eq_add_zero (b := b) ?_ |>.1
+    apply succ_inj_zero
+    rwa [RobinsonQ.add_succ] at hb
+  . rintro rfl
+    apply RobinsonQ.lt_def.mpr
+    use 0
+    simp
 
 
 @[simp] lemma numeral_zero_add (n : ℕ) : 0 + (numeral n : M) = numeral n := by
@@ -171,7 +171,7 @@ lemma iff_le_one_eq_zero {a : M} : a < 1 ↔ a = 0 := by
 
 lemma numeral_add_one (n : ℕ) : (numeral n : M) + 1 = numeral (n + 1) := by
   match n with
-  |     0 => simp;
+  |     0 => simp
   | n + 1 => rfl
 
 lemma numeral_add (n m : ℕ) : (numeral n : M) + numeral m = numeral (n + m) := by
@@ -210,81 +210,81 @@ lemma numeral_mul {n m : ℕ} : (numeral n : M) * numeral m = numeral (n * m) :=
 lemma exists_numeral_of_ne_zero {n : ℕ} (h : n ≠ 0) : ∃ m, (numeral n : M) = (numeral (m + 1)) := by
   match n with
   |     0 => contradiction
-  |     1 => use 0;
+  |     1 => use 0
   | n + 2 =>
-    obtain ⟨m, hm⟩ := exists_numeral_of_ne_zero (n := n + 1) (by omega);
-    use m + 1;
+    obtain ⟨m, hm⟩ := exists_numeral_of_ne_zero (n := n + 1) (by omega)
+    use m + 1
     calc
-      numeral (n + 2) = numeral (n + 1 + 1)               := by simp;
-                    _ = numeral (n + 1) + numeral 1       := by simp [numeral_add_one];
-                    _ = numeral (m + 1) + numeral 1       := by rw [hm];
+      numeral (n + 2) = numeral (n + 1 + 1)               := by simp
+                    _ = numeral (n + 1) + numeral 1       := by simp [numeral_add_one]
+                    _ = numeral (m + 1) + numeral 1       := by rw [hm]
 
 lemma numeral_zero_succ_ne {n : ℕ} : (numeral 0 : M) ≠ (numeral (n + 1))  := by
-  apply Ne.symm;
-  simp [←numeral_add];
+  apply Ne.symm
+  simp [←numeral_add]
 
 
 lemma numeral_succ_inj {n m : ℕ} (h : (numeral (n + 1) : M) = numeral (m + 1)) : (numeral n : M) = (numeral m : M) := by
-  rw [←numeral_add_one, ←numeral_add_one] at h;
-  apply succ_inj h;
+  rw [←numeral_add_one, ←numeral_add_one] at h
+  apply succ_inj h
 
 lemma numeral_ne_of_ne {n m : ℕ} (h : n ≠ m) : (numeral n : M) ≠ numeral m := by
   match n, m with
   | 0, m =>
-    obtain ⟨k, hk⟩ := exists_numeral_of_ne_zero (M := M) h.symm;
-    rw [hk];
-    exact numeral_zero_succ_ne;
+    obtain ⟨k, hk⟩ := exists_numeral_of_ne_zero (M := M) h.symm
+    rw [hk]
+    exact numeral_zero_succ_ne
   | n + 1, 0 =>
-    apply Ne.symm;
-    exact numeral_zero_succ_ne;
+    apply Ne.symm
+    exact numeral_zero_succ_ne
   | n + 1, m + 1 =>
-    have := numeral_ne_of_ne (n := n) (m := m) (by omega);
-    contrapose! this;
-    apply numeral_succ_inj this;
+    have := numeral_ne_of_ne (n := n) (m := m) (by omega)
+    contrapose! this
+    apply numeral_succ_inj this
 
 lemma numeral_lt_of_lt {n m : ℕ} (h : n < m) : (numeral n : M) < numeral m := by
-  apply RobinsonQ.lt_def.mpr;
-  obtain ⟨k, rfl, hk⟩ := RobinsonQ.lt_def.mp h;
-  use (numeral k : M);
+  apply RobinsonQ.lt_def.mpr
+  obtain ⟨k, rfl, hk⟩ := RobinsonQ.lt_def.mp h
+  use (numeral k : M)
   calc
-    (numeral n + (numeral k + 1) : M) = numeral n + (numeral k + numeral 1) := by simp;
-                                    _ = numeral n + (numeral (k + 1))       := by rw [numeral_add];
-                                    _ = numeral (n + (k + 1))               := by rw [numeral_add];
+    (numeral n + (numeral k + 1) : M) = numeral n + (numeral k + numeral 1) := by simp
+                                    _ = numeral n + (numeral (k + 1))       := by rw [numeral_add]
+                                    _ = numeral (n + (k + 1))               := by rw [numeral_add]
 
 lemma numeral_lt_add {n m : ℕ} (hm : m ≠ 0) : (numeral n : M) < numeral n + numeral m := by
-  rw [numeral_add];
-  apply numeral_lt_of_lt;
-  omega;
+  rw [numeral_add]
+  apply numeral_lt_of_lt
+  omega
 
 @[simp]
-lemma numeral_lt_succ {n : ℕ} : (numeral n : M) < numeral n + numeral 1 := numeral_lt_add $ by omega;
+lemma numeral_lt_succ {n : ℕ} : (numeral n : M) < numeral n + numeral 1 := numeral_lt_add $ by omega
 
 lemma iff_lt_numeral_exists_numeral {n : ℕ} {x : M} : x < numeral n ↔ ∃ m < n, x = numeral m := by
   match n with
-  | 0 => simp;
-  | 1 => simp;
+  | 0 => simp
+  | 1 => simp
   | n + 2 =>
-    constructor;
-    . intro h;
-      obtain ⟨a, ha⟩ := RobinsonQ.lt_def.mp h;
-      by_cases ha0 : a = 0;
-      . subst ha0;
-        use n + 1;
-        constructor;
-        . omega;
-        . apply succ_inj;
-          simpa using ha;
+    constructor
+    . intro h
+      obtain ⟨a, ha⟩ := RobinsonQ.lt_def.mp h
+      by_cases ha0 : a = 0
+      . subst ha0
+        use n + 1
+        constructor
+        . omega
+        . apply succ_inj
+          simpa using ha
       . obtain ⟨m, hm, rfl⟩ := iff_lt_numeral_exists_numeral (x := x) (n := n + 1) |>.mp $ by
-          have ha : x + a = numeral (n + 1) := succ_inj $ by rwa [RobinsonQ.add_succ] at ha;
-          rw [←ha];
-          apply lt_of_not_zero ha0;
-        use m;
-        constructor;
-        . omega;
-        . rfl;
-    . rintro ⟨m, hm, rfl⟩;
-      apply numeral_lt_of_lt;
-      exact hm;
+          have ha : x + a = numeral (n + 1) := succ_inj $ by rwa [RobinsonQ.add_succ] at ha
+          rw [←ha]
+          apply lt_of_not_zero ha0
+        use m
+        constructor
+        . omega
+        . rfl
+    . rintro ⟨m, hm, rfl⟩
+      apply numeral_lt_of_lt
+      exact hm
 
 instance : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
   intro φ h
@@ -294,10 +294,10 @@ instance : M ⊧ₘ* 𝐑₀ := modelsTheory_iff.mpr <| by
     exact modelsTheory_iff.mp this h
   case Ω₁ n m => simp [models_iff, numeral_add]
   case Ω₂ n m => simp [models_iff, numeral_mul]
-  case Ω₃ n m h => simp [models_iff, numeral_ne_of_ne h];
+  case Ω₃ n m h => simp [models_iff, numeral_ne_of_ne h]
   case Ω₄ n =>
-    suffices ∀ (x : M), x < numeral n ↔ ∃ i < n, x = numeral i by simpa [models_iff];
-    apply iff_lt_numeral_exists_numeral;
+    suffices ∀ (x : M), x < numeral n ↔ ∃ i < n, x = numeral i by simpa [models_iff]
+    apply iff_lt_numeral_exists_numeral
 
 instance : 𝐑₀ ⪯ 𝐐 := oRing_weakerThan_of.{0} _ _ fun _ _ _ ↦ inferInstance
 

--- a/Foundation/FirstOrder/R0/Representation.lean
+++ b/Foundation/FirstOrder/R0/Representation.lean
@@ -134,7 +134,7 @@ private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
     · rintro rfl rfl; rfl
   case comp m n c d ihc ihd =>
     simp [Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq, Matrix.comp_vecCons']
-    intro w₁ hc₁ hd₁ w₂ hc₂ hd₂;
+    intro w₁ hc₁ hd₁ w₂ hc₂ hd₂
     have : w₁ = w₂ := funext fun i => ihd i (hd₁ i) (hd₂ i)
     rcases this with rfl
     exact ihc hc₁ hc₂

--- a/Foundation/Logic/Disjunctive.lean
+++ b/Foundation/Logic/Disjunctive.lean
@@ -11,20 +11,20 @@ class Disjunctive (𝓢 : S) : Prop where
 alias disjunctive := Disjunctive.disjunctive
 
 lemma iff_disjunctive {𝓢 : S}  : (Disjunctive 𝓢) ↔ ∀ {φ ψ}, 𝓢 ⊢! φ ⋎ ψ → 𝓢 ⊢! φ ∨ 𝓢 ⊢! ψ := by
-  constructor;
-  . apply Disjunctive.disjunctive;
-  . exact λ d ↦ ⟨d⟩;
+  constructor
+  . apply Disjunctive.disjunctive
+  . exact λ d ↦ ⟨d⟩
 
 lemma iff_complete_disjunctive [DecidableEq F] {𝓢 : S} [Entailment.Cl 𝓢] : (Entailment.Complete 𝓢) ↔ (Disjunctive 𝓢) := by
-  constructor;
-  . intro hComp;
-    apply iff_disjunctive.mpr;
-    intro φ ψ hpq;
-    rcases (hComp φ) with (hp | hnp);
-    . left; assumption;
-    . right; exact of_C!_of_C!_of_A! (C_of_N hnp) C!_id hpq;
-  . intro hDisj φ;
-    replace hDisj : ∀ {φ ψ}, 𝓢 ⊢! φ ⋎ ψ → 𝓢 ⊢! φ ∨ 𝓢 ⊢! ψ := iff_disjunctive.mp hDisj;
-    exact @hDisj φ (∼φ) lem!;
+  constructor
+  . intro hComp
+    apply iff_disjunctive.mpr
+    intro φ ψ hpq
+    rcases (hComp φ) with (hp | hnp)
+    . left; assumption
+    . right; exact of_C!_of_C!_of_A! (C_of_N hnp) C!_id hpq
+  . intro hDisj φ
+    replace hDisj : ∀ {φ ψ}, 𝓢 ⊢! φ ⋎ ψ → 𝓢 ⊢! φ ∨ 𝓢 ⊢! ψ := iff_disjunctive.mp hDisj
+    exact @hDisj φ (∼φ) lem!
 
 end LO.Entailment

--- a/Foundation/Logic/Entailment.lean
+++ b/Foundation/Logic/Entailment.lean
@@ -106,7 +106,7 @@ instance : Trans (α := S) (β := T) (γ := U) (· ⪯ ·) (· ⪯ ·) (· ⪯ �
 lemma weakerThan_iff : 𝓢 ⪯ 𝓣 ↔ (∀ {f}, 𝓢 ⊢! f → 𝓣 ⊢! f) :=
   ⟨fun h _ hf ↦ h.subset hf, fun h ↦ ⟨fun _ hf ↦ h hf⟩⟩
 
-lemma not_weakerThan_iff : ¬𝓢 ⪯ 𝓣 ↔ (∃ f, 𝓢 ⊢! f ∧ 𝓣 ⊬ f) := by simp [weakerThan_iff, Unprovable];
+lemma not_weakerThan_iff : ¬𝓢 ⪯ 𝓣 ↔ (∃ f, 𝓢 ⊢! f ∧ 𝓣 ⊬ f) := by simp [weakerThan_iff, Unprovable]
 
 lemma strictlyWeakerThan_iff : 𝓢 ⪱ 𝓣 ↔ (∀ {f}, 𝓢 ⊢! f → 𝓣 ⊢! f) ∧ (∃ f, 𝓢 ⊬ f ∧ 𝓣 ⊢! f) := by
   constructor
@@ -568,8 +568,8 @@ section
 variable {𝓢 : S} {𝓜 : M} [Complete 𝓢 𝓜]
 
 lemma exists_countermodel_of_not_provable {f : F} (h : 𝓢 ⊬ f) : ¬𝓜 ⊧ f := by
-  contrapose! h;
-  simpa using Complete.complete (𝓢 := 𝓢) h;
+  contrapose! h
+  simpa using Complete.complete (𝓢 := 𝓢) h
 
 lemma meaningful_of_consistent : Entailment.Consistent 𝓢 → Semantics.Meaningful 𝓜 := by
   contrapose

--- a/Foundation/Logic/HilbertStyle/Basic.lean
+++ b/Foundation/Logic/HilbertStyle/Basic.lean
@@ -30,7 +30,7 @@ alias mdp := ModusPonens.mdp
 infixl:90 "⨀" => mdp
 
 lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! φ ➝ ψ → 𝓢 ⊢! φ → 𝓢 ⊢! ψ := by
-  rintro ⟨hpq⟩ ⟨hp⟩;
+  rintro ⟨hpq⟩ ⟨hp⟩
   exact ⟨hpq ⨀ hp⟩
 infixl:90 "⨀" => mdp!
 infixl:90 "⨀!" => mdp!
@@ -195,8 +195,8 @@ lemma K!_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! φ 
 
 lemma E!_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! φ ⭤ ψ ↔ 𝓢 ⊢! φ ➝ ψ ∧ 𝓢 ⊢! ψ ➝ φ := ⟨fun h ↦ ⟨K!_left h, K!_right h⟩, fun h ↦ K!_intro h.1 h.2⟩
 
-lemma C_of_E_mp! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! φ ➝ ψ := by exact E!_intro_iff.mp h |>.1;
-lemma C_of_E_mpr! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ψ ➝ φ := by exact E!_intro_iff.mp h |>.2;
+lemma C_of_E_mp! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! φ ➝ ψ := by exact E!_intro_iff.mp h |>.1
+lemma C_of_E_mpr! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ψ ➝ φ := by exact E!_intro_iff.mp h |>.2
 
 lemma iff_of_E!  [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! φ ↔ 𝓢 ⊢! ψ := ⟨fun hp ↦ K!_left h ⨀ hp, fun hq ↦ K!_right h ⨀ hq⟩
 
@@ -207,7 +207,7 @@ def E_Id [HasAxiomAndInst 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] 
 @[simp] def E!_id [HasAxiomAndInst 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! φ ⭤ φ := ⟨E_Id φ⟩
 
 instance [NegAbbrev F] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] [HasAxiomAndInst 𝓢] : Entailment.NegationEquiv 𝓢 where
-  negEquiv := by intro φ; simp [Axioms.NegEquiv, NegAbbrev.neg]; apply E_Id;
+  negEquiv := by intro φ; simp [Axioms.NegEquiv, NegAbbrev.neg]; apply E_Id
 
 
 def NO [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ ∼⊥ := N_of_CO (C_id ⊥)
@@ -242,19 +242,19 @@ lemma C!_trans [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hpq : 𝓢 ⊢! 
 lemma C!_replace [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h₁ : 𝓢 ⊢! ψ₁ ➝ φ₁) (h₂ : 𝓢 ⊢! φ₂ ➝ ψ₂) : 𝓢 ⊢! φ₁ ➝ φ₂ → 𝓢 ⊢! ψ₁ ➝ ψ₂ := λ h => C!_trans h₁ $ C!_trans h h₂
 
 lemma unprovable_C!_trans [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (hpq : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊬ φ ➝ χ → 𝓢 ⊬ ψ ➝ χ := by
-  contrapose; simp [neg_neg];
-  exact C!_trans hpq;
+  contrapose; simp [neg_neg]
+  exact C!_trans hpq
 
 def E_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (h₁ : 𝓢 ⊢ φ ⭤ ψ) (h₂ : 𝓢 ⊢ ψ ⭤ χ) : 𝓢 ⊢ φ ⭤ χ := by
-  apply E_intro;
-  . exact C_trans (K_left h₁) (K_left h₂);
-  . exact C_trans (K_right h₂) (K_right h₁);
+  apply E_intro
+  . exact C_trans (K_left h₁) (K_left h₂)
+  . exact C_trans (K_right h₂) (K_right h₁)
 lemma E!_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢]  (h₁ : 𝓢 ⊢! φ ⭤ ψ) (h₂ : 𝓢 ⊢! ψ ⭤ χ) : 𝓢 ⊢! φ ⭤ χ := ⟨E_trans h₁.some h₂.some⟩
 
 lemma uniff_of_E! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (H : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊬ φ ↔ 𝓢 ⊬ ψ := by
-  constructor;
-  . intro hp hq; have := K!_right H ⨀ hq; contradiction;
-  . intro hq hp; have := K!_left H ⨀ hp; contradiction;
+  constructor
+  . intro hp hq; have := K!_right H ⨀ hq; contradiction
+  . intro hq hp; have := K!_left H ⨀ hp; contradiction
 
 def CCCC [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (φ ψ χ : F) : 𝓢 ⊢ φ ➝ ψ ➝ χ ➝ φ := C_trans imply₁ imply₁
 @[simp] lemma CCCC! [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (φ ψ χ : F) : 𝓢 ⊢! φ ➝ ψ ➝ χ ➝ φ := ⟨CCCC φ ψ χ⟩
@@ -282,7 +282,7 @@ def ECKCC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] 
   let b₁ : 𝓢 ⊢ (φ ⋏ ψ ➝ χ) ➝ φ ➝ ψ ➝ χ :=
     CCCC (φ ⋏ ψ ➝ χ) φ ψ ⨀₃ C_of_conseq (ψ := φ ⋏ ψ ➝ χ) and₃
   let b₂ : 𝓢 ⊢ (φ ➝ ψ ➝ χ) ➝ φ ⋏ ψ ➝ χ :=
-    imply₁ ⨀₂ (C_of_conseq (ψ := φ ➝ ψ ➝ χ) and₁) ⨀₂ (C_of_conseq (ψ := φ ➝ ψ ➝ χ) and₂);
+    imply₁ ⨀₂ (C_of_conseq (ψ := φ ➝ ψ ➝ χ) and₁) ⨀₂ (C_of_conseq (ψ := φ ➝ ψ ➝ χ) and₂)
   exact E_intro b₁ b₂
 lemma ECKCC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] : 𝓢 ⊢! (φ ⋏ ψ ➝ χ) ⭤ (φ ➝ ψ ➝ χ) := ⟨ECKCC φ ψ χ⟩
 
@@ -290,7 +290,7 @@ def CC_of_CK [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ �
 def CK_of_CC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢] (d : 𝓢 ⊢ φ ➝ ψ ➝ χ) : 𝓢 ⊢ φ ⋏ ψ ➝ χ := (K_right $ ECKCC φ ψ χ) ⨀ d
 
 lemma CK!_iff_CC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImply₁ 𝓢] [HasAxiomImply₂ 𝓢]: (𝓢 ⊢! φ ⋏ ψ ➝ χ) ↔ (𝓢 ⊢! φ ➝ ψ ➝ χ) := by
-  apply Iff.intro;
+  apply Iff.intro
   . intro ⟨h⟩; exact ⟨CC_of_CK h⟩
   . intro ⟨h⟩; exact ⟨CK_of_CC h⟩
 
@@ -347,19 +347,19 @@ lemma left_Conj₂!_intro [DecidableEq F] (h : φ ∈ Γ) : 𝓢 ⊢! ⋀Γ ➝ 
 def Conj₂_intro (Γ : List F) (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢ φ) : 𝓢 ⊢ ⋀Γ :=
   match Γ with
   |          [] => verum
-  |         [ψ] => by apply b; simp;
+  |         [ψ] => by apply b; simp
   | ψ :: χ :: Γ => by
-    simp;
+    simp
     exact K_intro (b ψ (by simp)) (Conj₂_intro _ (by aesop))
 lemma Conj₂!_intro (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢! φ) : 𝓢 ⊢! ⋀Γ := ⟨Conj₂_intro Γ (λ φ hp => (b φ hp).some)⟩
 
 def right_Conj₂_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ φ ➝ ψ) : 𝓢 ⊢ φ ➝ ⋀Γ :=
   match Γ with
   |          [] => C_of_conseq verum
-  |         [ψ] => by apply b; simp;
+  |         [ψ] => by apply b; simp
   | ψ :: χ :: Γ => by
-    simp;
-    apply CK_of_C_of_C (b ψ (by simp)) (right_Conj₂_intro φ _ (fun ψ hq ↦ b ψ (by simp [hq])));
+    simp
+    apply CK_of_C_of_C (b ψ (by simp)) (right_Conj₂_intro φ _ (fun ψ hq ↦ b ψ (by simp [hq])))
 lemma right_Conj₂!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! φ ➝ ⋀Γ := ⟨right_Conj₂_intro φ Γ (λ ψ hq => (b ψ hq).some)⟩
 
 def CConj₂Conj₂ [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ ➝ ⋀Δ :=

--- a/Foundation/Logic/HilbertStyle/Cl.lean
+++ b/Foundation/Logic/HilbertStyle/Cl.lean
@@ -12,91 +12,91 @@ variable {F : Type*} [LogicalConnective F] [DecidableEq F]
 
 @[simp]
 lemma CCCCOONCN! : 𝓢 ⊢! ((φ ➝ ψ ➝ ⊥) ➝ ⊥) ➝ ∼(φ ➝ ∼ψ) := by
-  apply C!_trans (K!_right neg_equiv!) ?_;
-  apply contra!;
-  apply CCC!_of_C!_right;
-  apply K!_left neg_equiv!;
+  apply C!_trans (K!_right neg_equiv!) ?_
+  apply contra!
+  apply CCC!_of_C!_right
+  apply K!_left neg_equiv!
 
 lemma CN!_of_AN! (h : 𝓢 ⊢! ∼φ ⋎ ∼ψ) : 𝓢 ⊢! φ ➝ ∼ψ := by
-  apply A!_cases CNC! imply₁! h;
+  apply A!_cases CNC! imply₁! h
 
 @[simp]
 lemma CCCCOOK! : 𝓢 ⊢! ((φ ➝ (ψ ➝ ⊥)) ➝ ⊥) ➝ (φ ⋏ ψ) := by
-  apply C!_trans CCCCOONCN! ?_;
+  apply C!_trans CCCCOONCN! ?_
   apply CN!_of_CN!_left
-  apply deduct'!;
+  apply deduct'!
   have : [∼(φ ⋏ ψ)] ⊢[𝓢]! ∼φ ⋎ ∼ψ := ANN!_of_NK! $ by_axm!
-  exact A!_cases CNC! imply₁! this;
+  exact A!_cases CNC! imply₁! this
 
 lemma K!_of_CCCO! (h : 𝓢 ⊢! ((φ ➝ (ψ ➝ ⊥)) ➝ ⊥)) : 𝓢 ⊢! (φ ⋏ ψ) := CCCCOOK! ⨀ h
 
 lemma CCCOO!_of_K! (b : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! (φ ➝ ψ ➝ ⊥) ➝ ⊥ := by
-  apply deduct'!;
-  have h₁ : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! φ := of'! $ K!_left b;
-  have h₂ : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! ψ := of'! $ K!_right b;
-  have H : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! φ ➝ ψ ➝ ⊥ := by_axm!;
-  exact (H ⨀ h₁) ⨀ h₂;
+  apply deduct'!
+  have h₁ : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! φ := of'! $ K!_left b
+  have h₂ : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! ψ := of'! $ K!_right b
+  have H : [φ ➝ ψ ➝ ⊥] ⊢[𝓢]! φ ➝ ψ ➝ ⊥ := by_axm!
+  exact (H ⨀ h₁) ⨀ h₂
 
 @[simp]
 lemma CKCCCOO! : 𝓢 ⊢! (φ ⋏ ψ) ➝ ((φ ➝ ψ ➝ ⊥) ➝ ⊥) := by
-  apply deduct'!;
-  apply CCCOO!_of_K!;
-  apply by_axm!;
-  simp;
+  apply deduct'!
+  apply CCCOO!_of_K!
+  apply by_axm!
+  simp
 
 lemma CCC!_of_C!_of_C! (h₁ : 𝓢 ⊢! ψ ➝ φ) (h₂ : 𝓢 ⊢! χ ➝ ξ) : 𝓢 ⊢! (φ ➝ χ) ➝ (ψ ➝ ξ) := by
-  replace h₁ : [ψ, φ ➝ χ] ⊢[𝓢]! ψ ➝ φ := of'! $ h₁;
-  replace h₂ : [ψ, φ ➝ χ] ⊢[𝓢]! χ ➝ ξ := of'! $ h₂;
-  have h₃ : [ψ, φ ➝ χ] ⊢[𝓢]! φ ➝ χ := by_axm!;
-  apply deduct'!;
-  apply deduct!;
+  replace h₁ : [ψ, φ ➝ χ] ⊢[𝓢]! ψ ➝ φ := of'! $ h₁
+  replace h₂ : [ψ, φ ➝ χ] ⊢[𝓢]! χ ➝ ξ := of'! $ h₂
+  have h₃ : [ψ, φ ➝ χ] ⊢[𝓢]! φ ➝ χ := by_axm!
+  apply deduct'!
+  apply deduct!
   exact h₂ ⨀ (h₃ ⨀ (h₁ ⨀ (by_axm!)))
 
 @[simp]
 lemma CCCOA! : 𝓢 ⊢! ((φ ➝ ⊥) ➝ ψ) ➝ (φ ⋎ ψ) := by
-  apply deduct'!;
-  apply A!_cases or₁! ?_ lem!;
-  . apply deduct!;
-    apply A!_intro_right;
-    have H₁ : [∼φ, (φ ➝ ⊥) ➝ ψ] ⊢[𝓢]! φ ➝ ⊥ := N!_iff_CO!.mp by_axm!;
-    have H₂ : [∼φ, (φ ➝ ⊥) ➝ ψ] ⊢[𝓢]! (φ ➝ ⊥) ➝ ψ := by_axm!;
-    exact H₂ ⨀ H₁;
+  apply deduct'!
+  apply A!_cases or₁! ?_ lem!
+  . apply deduct!
+    apply A!_intro_right
+    have H₁ : [∼φ, (φ ➝ ⊥) ➝ ψ] ⊢[𝓢]! φ ➝ ⊥ := N!_iff_CO!.mp by_axm!
+    have H₂ : [∼φ, (φ ➝ ⊥) ➝ ψ] ⊢[𝓢]! (φ ➝ ⊥) ➝ ψ := by_axm!
+    exact H₂ ⨀ H₁
 
 @[simp]
 lemma CACCO! : 𝓢 ⊢! (φ ⋎ ψ) ➝ ((φ ➝ ⊥) ➝ ψ) := by
-  apply deduct'!;
-  apply deduct!;
-  have : [φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ ⋎ ψ := by_axm!;
-  apply A!_cases ?_ C!_id this;
-  . apply deduct!;
-    refine efq! ⨀ ?_;
-    have H₁ : [φ, φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ := by_axm!;
-    have H₂ : [φ, φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ ➝ ⊥ := by_axm!;
-    exact H₂ ⨀ H₁;
+  apply deduct'!
+  apply deduct!
+  have : [φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ ⋎ ψ := by_axm!
+  apply A!_cases ?_ C!_id this
+  . apply deduct!
+    refine efq! ⨀ ?_
+    have H₁ : [φ, φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ := by_axm!
+    have H₂ : [φ, φ ➝ ⊥, φ ⋎ ψ] ⊢[𝓢]! φ ➝ ⊥ := by_axm!
+    exact H₂ ⨀ H₁
 
 lemma ENCKN! : 𝓢 ⊢! ∼(φ ➝ ψ) ⭤ (φ ⋏ ∼ψ) := by
-  apply K!_intro;
-  . apply deduct'!;
-    apply K!_intro;
-    . apply deductInv'!;
-      apply CN!_of_CN!_left;
+  apply K!_intro
+  . apply deduct'!
+    apply K!_intro
+    . apply deductInv'!
+      apply CN!_of_CN!_left
       exact CNC!
-    . apply deductInv'!;
-      apply CN!_of_CN!_left;
-      apply C!_swap;
-      apply deduct'!;
-      exact dne!;
-  . apply not_imply_prem''! and₁! and₂!;
+    . apply deductInv'!
+      apply CN!_of_CN!_left
+      apply C!_swap
+      apply deduct'!
+      exact dne!
+  . apply not_imply_prem''! and₁! and₂!
 
 lemma NC!_iff_KN! : 𝓢 ⊢! ∼(φ ➝ ψ) ↔ 𝓢 ⊢! (φ ⋏ ∼ψ) := by
-  constructor;
-  . intro h; exact (K!_left ENCKN!) ⨀ h;
-  . intro h; exact (K!_right ENCKN!) ⨀ h;
+  constructor
+  . intro h; exact (K!_left ENCKN!) ⨀ h
+  . intro h; exact (K!_right ENCKN!) ⨀ h
 
 lemma NC!_of_N!_of_! (hp : 𝓢 ⊢! φ) (hnq : 𝓢 ⊢! ∼ψ) : 𝓢 ⊢! ∼(φ ➝ ψ) := by
-  apply NC!_iff_KN!.mpr;
-  apply K!_intro;
-  . exact hp;
-  . exact hnq;
+  apply NC!_iff_KN!.mpr
+  apply K!_intro
+  . exact hp
+  . exact hnq
 
 end LO.Entailment

--- a/Foundation/Logic/HilbertStyle/Context.lean
+++ b/Foundation/Logic/HilbertStyle/Context.lean
@@ -327,28 +327,28 @@ def mdp [DecidableEq F] {Γ : Set F} (bpq : Γ *⊢[𝓢] φ ➝ ψ) (bp : Γ *�
 lemma by_axm! [DecidableEq F] (h : φ ∈ Γ) : Γ *⊢[𝓢]! φ := Entailment.by_axm _ (by simpa)
 
 def emptyPrf {φ : F} : ∅ *⊢[𝓢] φ → 𝓢 ⊢ φ := by
-  rintro ⟨Γ, hΓ, h⟩;
-  have := List.eq_nil_iff_forall_not_mem.mpr hΓ;
-  subst this;
-  exact FiniteContext.emptyPrf h;
+  rintro ⟨Γ, hΓ, h⟩
+  have := List.eq_nil_iff_forall_not_mem.mpr hΓ
+  subst this
+  exact FiniteContext.emptyPrf h
 
 lemma emptyPrf! {φ : F} : ∅ *⊢[𝓢]! φ → 𝓢 ⊢! φ := fun h ↦ ⟨emptyPrf h.some⟩
 
 lemma provable_iff_provable {φ : F} : 𝓢 ⊢! φ ↔ ∅ *⊢[𝓢]! φ := ⟨of!, emptyPrf!⟩
 
 lemma iff_provable_context_provable_finiteContext_toList [DecidableEq F] {Δ : Finset F} : ↑Δ *⊢[𝓢]! φ ↔ Δ.toList ⊢[𝓢]! φ := by
-  constructor;
-  . intro h;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply FiniteContext.weakening! ?_ hΓ₂;
-    intro ψ hψ;
-    simpa using hΓ₁ ψ hψ;
-  . intro h;
-    apply Context.provable_iff.mpr;
-    use Δ.toList;
-    constructor;
-    . simp;
-    . assumption;
+  constructor
+  . intro h
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply FiniteContext.weakening! ?_ hΓ₂
+    intro ψ hψ
+    simpa using hΓ₁ ψ hψ
+  . intro h
+    apply Context.provable_iff.mpr
+    use Δ.toList
+    constructor
+    . simp
+    . assumption
 
 instance minimal [DecidableEq F] (Γ : Context F 𝓢) : Entailment.Minimal Γ where
   mdp := mdp

--- a/Foundation/Logic/HilbertStyle/Lukasiewicz.lean
+++ b/Foundation/Logic/HilbertStyle/Lukasiewicz.lean
@@ -39,50 +39,50 @@ variable {𝓢 : S} {φ φ₁ φ₂ ψ ψ₁ ψ₂ χ s t : F}
 
 variable [Entailment.Lukasiewicz 𝓢]
 
-def verum : 𝓢 ⊢ ⊤ := by simp [LukasiewiczAbbrev.top]; exact C_id ⊥;
+def verum : 𝓢 ⊢ ⊤ := by simp [LukasiewiczAbbrev.top]; exact C_id ⊥
 instance : HasAxiomVerum 𝓢 := ⟨Lukasiewicz.verum⟩
 
 def dne : 𝓢 ⊢ ∼∼φ ➝ φ := by
-  have d₁ : 𝓢 ⊢ ∼∼φ ➝ (∼∼(∼∼φ) ➝ ∼∼φ) ➝ ∼φ ➝ ∼(∼∼φ) := C_of_conseq $ elimContra;
-  have d₂ : 𝓢 ⊢ ∼∼φ ➝ ∼∼(∼∼φ) ➝ ∼∼φ := imply₁;
-  have d₃ : 𝓢 ⊢ ∼∼φ ➝ (∼φ ➝ ∼(∼∼φ)) ➝ ∼∼φ ➝ φ := C_of_conseq $ elimContra;
-  have d₄ : 𝓢 ⊢ ∼∼φ ➝ ∼φ ➝ ∼(∼∼φ) := d₁ ⨀₁ d₂;
-  have d₅ : 𝓢 ⊢ ∼∼φ ➝ ∼∼φ ➝ φ := d₃ ⨀₁ d₄;
-  have d₆ : 𝓢 ⊢ ∼∼φ ➝ ∼∼φ := C_id _;
-  exact d₅ ⨀₁ d₆;
+  have d₁ : 𝓢 ⊢ ∼∼φ ➝ (∼∼(∼∼φ) ➝ ∼∼φ) ➝ ∼φ ➝ ∼(∼∼φ) := C_of_conseq $ elimContra
+  have d₂ : 𝓢 ⊢ ∼∼φ ➝ ∼∼(∼∼φ) ➝ ∼∼φ := imply₁
+  have d₃ : 𝓢 ⊢ ∼∼φ ➝ (∼φ ➝ ∼(∼∼φ)) ➝ ∼∼φ ➝ φ := C_of_conseq $ elimContra
+  have d₄ : 𝓢 ⊢ ∼∼φ ➝ ∼φ ➝ ∼(∼∼φ) := d₁ ⨀₁ d₂
+  have d₅ : 𝓢 ⊢ ∼∼φ ➝ ∼∼φ ➝ φ := d₃ ⨀₁ d₄
+  have d₆ : 𝓢 ⊢ ∼∼φ ➝ ∼∼φ := C_id _
+  exact d₅ ⨀₁ d₆
 instance : HasAxiomDNE 𝓢 := ⟨λ φ => Lukasiewicz.dne (φ := φ)⟩
 
 def dni : 𝓢 ⊢ φ ➝ ∼∼φ := by
-  have d₁ : 𝓢 ⊢ (∼(∼∼φ) ➝ ∼φ) ➝ φ ➝ ∼∼φ := elimContra;
-  have d₂ : 𝓢 ⊢ ∼(∼∼φ) ➝ ∼φ := dne (φ := ∼φ);
-  exact d₁ ⨀ d₂;
+  have d₁ : 𝓢 ⊢ (∼(∼∼φ) ➝ ∼φ) ➝ φ ➝ ∼∼φ := elimContra
+  have d₂ : 𝓢 ⊢ ∼(∼∼φ) ➝ ∼φ := dne (φ := ∼φ)
+  exact d₁ ⨀ d₂
 
 def explode (h₁ : 𝓢 ⊢ φ) (h₂ : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ ψ := by
-  have d₁ := imply₁ (𝓢 := 𝓢) (φ := ∼φ) (ψ := ∼ψ);
-  have := d₁ ⨀ h₂;
-  exact elimContra ⨀ this ⨀ h₁;
+  have d₁ := imply₁ (𝓢 := 𝓢) (φ := ∼φ) (ψ := ∼ψ)
+  have := d₁ ⨀ h₂
+  exact elimContra ⨀ this ⨀ h₁
 
 def explodeHyp (h₁ : 𝓢 ⊢ φ ➝ ψ) (h₂ : 𝓢 ⊢ φ ➝ ∼ψ) : 𝓢 ⊢ φ ➝ χ := by
   have : 𝓢 ⊢ φ ➝ ∼ψ ➝ ∼χ ➝ ∼ψ := C_of_conseq imply₁ (ψ := φ)
-  have : 𝓢 ⊢ φ ➝ ∼χ ➝ ∼ψ := this ⨀₁ h₂;
-  have : 𝓢 ⊢ φ ➝ ψ ➝ χ := (C_of_conseq elimContra (ψ := φ)) ⨀₁ this;
-  exact this ⨀₁ h₁;
+  have : 𝓢 ⊢ φ ➝ ∼χ ➝ ∼ψ := this ⨀₁ h₂
+  have : 𝓢 ⊢ φ ➝ ψ ➝ χ := (C_of_conseq elimContra (ψ := φ)) ⨀₁ this
+  exact this ⨀₁ h₁
 
 def explodeHyp₂ (h₁ : 𝓢 ⊢ φ ➝ ψ ➝ χ) (h₂ : 𝓢 ⊢ φ ➝ ψ ➝ ∼χ) : 𝓢 ⊢ φ ➝ ψ ➝ s := by
   have : 𝓢 ⊢ φ ➝ ψ ➝ ∼χ ➝ ∼s ➝ ∼χ := C_of_conseq (C_of_conseq imply₁ (ψ := ψ)) (ψ := φ)
-  have : 𝓢 ⊢ φ ➝ ψ ➝ ∼(s) ➝ ∼χ := this ⨀₂ h₂;
-  have : 𝓢 ⊢ φ ➝ ψ ➝ χ ➝ s := (C_of_conseq (C_of_conseq elimContra (ψ := ψ)) (ψ := φ)) ⨀₂ this;
-  exact this ⨀₂ h₁;
+  have : 𝓢 ⊢ φ ➝ ψ ➝ ∼(s) ➝ ∼χ := this ⨀₂ h₂
+  have : 𝓢 ⊢ φ ➝ ψ ➝ χ ➝ s := (C_of_conseq (C_of_conseq elimContra (ψ := ψ)) (ψ := φ)) ⨀₂ this
+  exact this ⨀₂ h₁
 
 def efq : 𝓢 ⊢ ⊥ ➝ φ := by
-  have := explodeHyp (𝓢 := 𝓢) (φ := ⊥) (ψ := ⊤) (χ := φ);
-  exact this (by simp; exact imply₁) (by simp; exact imply₁);
+  have := explodeHyp (𝓢 := 𝓢) (φ := ⊥) (ψ := ⊤) (χ := φ)
+  exact this (by simp; exact imply₁) (by simp; exact imply₁)
 instance : HasAxiomEFQ 𝓢 := ⟨λ φ => Lukasiewicz.efq (φ := φ)⟩
 
 def CCCCC (h : 𝓢 ⊢ φ ➝ ψ ➝ χ) : 𝓢 ⊢ ψ ➝ φ ➝ χ := by
-  refine mdp₂ (χ := ψ) ?_ ?_;
-  . exact C_of_conseq h;
-  . exact imply₁;
+  refine mdp₂ (χ := ψ) ?_ ?_
+  . exact C_of_conseq h
+  . exact imply₁
 
 def mdpIn₁ : 𝓢 ⊢ (φ ➝ ψ) ➝ φ ➝ ψ := C_id _
 
@@ -93,8 +93,8 @@ def mdp₂In₁ : 𝓢 ⊢ (φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ (φ ➝ χ) :=
 def mdp₂In₂ : 𝓢 ⊢ (φ ➝ ψ) ➝ (φ ➝ ψ ➝ χ) ➝ (φ ➝ χ) := CCCCC mdp₂In₁
 
 def C_trans'₁ (bpq : 𝓢 ⊢ φ ➝ ψ) : 𝓢 ⊢ (ψ ➝ χ) ➝ (φ ➝ χ) := by
-  apply CCCCC;
-  exact C_trans bpq mdpIn₂;
+  apply CCCCC
+  exact C_trans bpq mdpIn₂
 
 def C_trans'₂ (bqr: 𝓢 ⊢ ψ ➝ χ) : 𝓢 ⊢ (φ ➝ ψ) ➝ (φ ➝ χ) := imply₂ ⨀ (C_of_conseq bqr)
 
@@ -105,26 +105,26 @@ def C_trans₁ : 𝓢 ⊢ (φ ➝ ψ) ➝ (ψ ➝ χ) ➝ (φ ➝ χ) := CCCCC C
 def dhypBoth (h : 𝓢 ⊢ ψ ➝ χ) : 𝓢 ⊢ (φ ➝ ψ) ➝ (φ ➝ χ) := imply₂ ⨀ (C_of_conseq $ h)
 
 def explode₂₁ : 𝓢 ⊢ ∼φ ➝ φ ➝ ψ := by
-  simp;
-  exact dhypBoth efq;
+  simp
+  exact dhypBoth efq
 
 def explode₁₂ : 𝓢 ⊢ φ ➝ ∼φ ➝ ψ := CCCCC explode₂₁
 
-def contraIntro : 𝓢 ⊢ (φ ➝ ψ) ➝ (∼ψ ➝ ∼φ):= by simpa using C_trans₁;
+def contraIntro : 𝓢 ⊢ (φ ➝ ψ) ➝ (∼ψ ➝ ∼φ):= by simpa using C_trans₁
 
 def contraIntro' : 𝓢 ⊢ (φ ➝ ψ) → 𝓢 ⊢ (∼ψ ➝ ∼φ) := λ h => contraIntro ⨀ h
 
 def andElim₁ : 𝓢 ⊢ φ ⋏ ψ ➝ φ := by
-  simp only [LukasiewiczAbbrev.and];
-  have : 𝓢 ⊢ ∼φ ➝ φ ➝ ∼ψ := explodeHyp₂ explode₂₁ imply₁;
+  simp only [LukasiewiczAbbrev.and]
+  have : 𝓢 ⊢ ∼φ ➝ φ ➝ ∼ψ := explodeHyp₂ explode₂₁ imply₁
   have : 𝓢 ⊢ ∼(φ ➝ ∼ψ) ➝ ∼∼φ := contraIntro' explode₂₁
-  exact C_trans this dne;
+  exact C_trans this dne
 
 def andElim₂ : 𝓢 ⊢ φ ⋏ ψ ➝ ψ := by
-  simp only [LukasiewiczAbbrev.and];
-  have : 𝓢 ⊢ ∼ψ ➝ φ ➝ ∼ψ := imply₁ (φ := ∼ψ) (ψ := φ);
-  have : 𝓢 ⊢ ∼(φ ➝ ∼ψ) ➝ ∼∼ψ := contraIntro' this;
-  exact C_trans this dne;
+  simp only [LukasiewiczAbbrev.and]
+  have : 𝓢 ⊢ ∼ψ ➝ φ ➝ ∼ψ := imply₁ (φ := ∼ψ) (ψ := φ)
+  have : 𝓢 ⊢ ∼(φ ➝ ∼ψ) ➝ ∼∼ψ := contraIntro' this
+  exact C_trans this dne
 instance : HasAxiomAndElim 𝓢 := ⟨λ φ ψ => Lukasiewicz.andElim₁ (φ := φ) (ψ := ψ), λ φ ψ => Lukasiewicz.andElim₂ (φ := φ) (ψ := ψ)⟩
 
 def andImplyLeft : 𝓢 ⊢ (φ₁ ➝ ψ) ➝ φ₁ ⋏ φ₂ ➝ ψ := (CCCCC $ C_of_conseq (C_id _)) ⨀₂ (C_of_conseq andElim₁)
@@ -134,51 +134,51 @@ def andImplyRight : 𝓢 ⊢ (φ₂ ➝ ψ) ➝ φ₁ ⋏ φ₂ ➝ ψ := (CCCCC
 def andImplyRight' (h : 𝓢 ⊢ (φ₂ ➝ ψ)) : 𝓢 ⊢ φ₁ ⋏ φ₂ ➝ ψ := andImplyRight ⨀ h
 
 def andInst'' (hp : 𝓢 ⊢ φ) (hq : 𝓢 ⊢ ψ) : 𝓢 ⊢ φ ⋏ ψ := by
-  simp only [LukasiewiczAbbrev.and];
+  simp only [LukasiewiczAbbrev.and]
   have : 𝓢 ⊢ (φ ➝ ∼ψ) ➝ φ ➝ ∼ψ := C_id _
-  have : 𝓢 ⊢ (φ ➝ ∼ψ) ➝ ∼ψ := this ⨀₁ C_of_conseq hp;
-  have : 𝓢 ⊢ ψ ➝ ∼(φ ➝ ∼ψ) := C_trans dni $ contraIntro' this;
-  exact this ⨀ hq;
+  have : 𝓢 ⊢ (φ ➝ ∼ψ) ➝ ∼ψ := this ⨀₁ C_of_conseq hp
+  have : 𝓢 ⊢ ψ ➝ ∼(φ ➝ ∼ψ) := C_trans dni $ contraIntro' this
+  exact this ⨀ hq
 
 def andInst : 𝓢 ⊢ φ ➝ ψ ➝ φ ⋏ ψ := by
-  have d₁ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ φ ➝ ∼ψ := C_of_conseq <| C_of_conseq <| C_id (φ ➝ ∼ψ);
-  have d₂ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ φ := CCCC (φ := φ) (ψ := ψ) (χ := (φ ➝ ∼ψ));
-  have d₃ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ψ := C_of_conseq <| imply₁;
-  have d₄ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ∼ψ := d₁ ⨀₃ d₂;
-  have d₄ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ψ ➝ ⊥ := by simpa using d₄;
-  simpa using d₄ ⨀₃ d₃;
+  have d₁ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ φ ➝ ∼ψ := C_of_conseq <| C_of_conseq <| C_id (φ ➝ ∼ψ)
+  have d₂ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ φ := CCCC (φ := φ) (ψ := ψ) (χ := (φ ➝ ∼ψ))
+  have d₃ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ψ := C_of_conseq <| imply₁
+  have d₄ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ∼ψ := d₁ ⨀₃ d₂
+  have d₄ : 𝓢 ⊢ φ ➝ ψ ➝ (φ ➝ ∼ψ) ➝ ψ ➝ ⊥ := by simpa using d₄
+  simpa using d₄ ⨀₃ d₃
 
 instance : HasAxiomAndInst 𝓢 := ⟨λ φ ψ => Lukasiewicz.andInst (φ := φ) (ψ := ψ)⟩
 
 
 def orInst₁ : 𝓢 ⊢ φ ➝ φ ⋎ ψ := by
-  simp only [LukasiewiczAbbrev.or];
-  exact explode₁₂;
+  simp only [LukasiewiczAbbrev.or]
+  exact explode₁₂
 
 def orInst₂ : 𝓢 ⊢ ψ ➝ φ ⋎ ψ := by
-  simp [LukasiewiczAbbrev.or];
-  exact imply₁;
+  simp [LukasiewiczAbbrev.or]
+  exact imply₁
 
 instance : HasAxiomOrInst 𝓢 := ⟨λ φ ψ => Lukasiewicz.orInst₁ (φ := φ) (ψ := ψ), λ φ ψ => Lukasiewicz.orInst₂ (φ := φ) (ψ := ψ)⟩
 
 -- or_imply
 def orElim : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ) := by
-  simp only [LukasiewiczAbbrev.or];
+  simp only [LukasiewiczAbbrev.or]
   have d₁ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ (φ ➝ χ) ➝ ∼χ ➝ ∼φ
-    := (C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| contraIntro (φ := φ) (ψ := χ));
+    := (C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| contraIntro (φ := φ) (ψ := χ))
   have d₂ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼χ ➝ ∼φ
-    := d₁ ⨀₃ (CCCC (φ ➝ χ) (ψ ➝ χ) (∼φ ➝ ψ));
+    := d₁ ⨀₃ (CCCC (φ ➝ χ) (ψ ➝ χ) (∼φ ➝ ψ))
   have d₃ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼χ ➝ ψ
-    := (C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| imply₁ (φ := ∼φ ➝ ψ) (ψ := ∼χ)) ⨀₄ d₂;
+    := (C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| imply₁ (φ := ∼φ ➝ ψ) (ψ := ∼χ)) ⨀₄ d₂
   have d₄ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼χ ➝ χ
-    := (C_of_conseq (ψ := φ ➝ χ) <| CCCC (φ := ψ ➝ χ) (ψ := ∼φ ➝ ψ) (χ := ∼χ)) ⨀₄ d₃;
+    := (C_of_conseq (ψ := φ ➝ χ) <| CCCC (φ := ψ ➝ χ) (ψ := ∼φ ➝ ψ) (χ := ∼χ)) ⨀₄ d₃
   have d₅ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼χ ➝ χ ➝ ⊥
-    := by simpa using C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| C_id (φ := ∼χ);
+    := by simpa using C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| C_id (φ := ∼χ)
   have d₆ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼∼χ
-    := by simpa using d₅ ⨀₄ d₄;
+    := by simpa using d₅ ⨀₄ d₄
   have d₇ : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (∼φ ➝ ψ) ➝ ∼∼χ ➝ χ
-    := C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| dne (φ := χ);
-  exact d₇ ⨀₃ d₆;
+    := C_of_conseq (ψ := φ ➝ χ) <| C_of_conseq (ψ := ψ ➝ χ) <| C_of_conseq (ψ := ∼φ ➝ ψ) <| dne (φ := χ)
+  exact d₇ ⨀₃ d₆
 
 instance : HasAxiomOrElim 𝓢 := ⟨λ φ ψ χ => Lukasiewicz.orElim (φ := φ) (ψ := ψ) (χ := χ)⟩
 

--- a/Foundation/Logic/HilbertStyle/Supplemental.lean
+++ b/Foundation/Logic/HilbertStyle/Supplemental.lean
@@ -16,19 +16,19 @@ open FiniteContext
 open List
 
 @[simp] lemma CONV! : 𝓢 ⊢! ⊤ ➝ ∼⊥ := by
-  apply FiniteContext.deduct'!;
-  exact NO!;
+  apply FiniteContext.deduct'!
+  exact NO!
 
 def innerMDP [DecidableEq F] : 𝓢 ⊢ φ ⋏ (φ ➝ ψ) ➝ ψ := by
-  apply deduct';
-  have hp  : [φ, φ ➝ ψ] ⊢[𝓢] φ := FiniteContext.byAxm;
-  have hpq : [φ, φ ➝ ψ] ⊢[𝓢] φ ➝ ψ := FiniteContext.byAxm;
-  exact hpq ⨀ hp;
+  apply deduct'
+  have hp  : [φ, φ ➝ ψ] ⊢[𝓢] φ := FiniteContext.byAxm
+  have hpq : [φ, φ ➝ ψ] ⊢[𝓢] φ ➝ ψ := FiniteContext.byAxm
+  exact hpq ⨀ hp
 lemma inner_mdp! [DecidableEq F] : 𝓢 ⊢! φ ⋏ (φ ➝ ψ) ➝ ψ := ⟨innerMDP⟩
 
 def bot_of_mem_either [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
-  have hp : Γ ⊢[𝓢] φ := FiniteContext.byAxm h₁;
-  have hnp : Γ ⊢[𝓢] φ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm h₂;
+  have hp : Γ ⊢[𝓢] φ := FiniteContext.byAxm h₁
+  have hnp : Γ ⊢[𝓢] φ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm h₂
   exact hnp ⨀ hp
 
 @[simp] lemma bot_of_mem_either! [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
@@ -37,22 +37,22 @@ def efq_of_mem_either [DecidableEq F] [HasAxiomEFQ 𝓢] (h₁ : φ ∈ Γ) (h�
 @[simp] lemma efq_of_mem_either! [DecidableEq F] [HasAxiomEFQ 𝓢] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ψ := ⟨efq_of_mem_either h₁ h₂⟩
 
 def CNC [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ ∼φ ➝ φ ➝ ψ := by
-  apply deduct';
-  apply deduct;
-  apply efq_of_mem_either (φ := φ) (by simp) (by simp);
+  apply deduct'
+  apply deduct
+  apply efq_of_mem_either (φ := φ) (by simp) (by simp)
 @[simp] lemma CNC! [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ∼φ ➝ φ ➝ ψ := ⟨CNC⟩
 
 def CCN [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ φ ➝ ∼φ ➝ ψ := by
-  apply deduct';
-  apply deduct;
-  apply efq_of_mem_either (φ := φ) (by simp) (by simp);
+  apply deduct'
+  apply deduct
+  apply efq_of_mem_either (φ := φ) (by simp) (by simp)
 @[simp] lemma CCN! [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! φ ➝ ∼φ ➝ ψ := ⟨CCN⟩
 
 lemma C_of_N [DecidableEq F] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! ∼φ) : 𝓢 ⊢! φ ➝ ψ := by
-  apply provable_iff_provable.mpr;
-  apply deduct_iff.mpr;
-  have dnp : [φ] ⊢[𝓢]! φ ➝ ⊥ := of'! $ N!_iff_CO!.mp h;
-  exact of_O! (dnp ⨀ FiniteContext.id!);
+  apply provable_iff_provable.mpr
+  apply deduct_iff.mpr
+  have dnp : [φ] ⊢[𝓢]! φ ➝ ⊥ := of'! $ N!_iff_CO!.mp h
+  exact of_O! (dnp ⨀ FiniteContext.id!)
 
 lemma CN!_of_! [DecidableEq F] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! φ) : 𝓢 ⊢! ∼φ ➝ ψ := CCN! ⨀ h
 
@@ -66,41 +66,41 @@ def A_of_ANNNN [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ ∼∼φ ⋎ ∼∼ψ) : 𝓢 �
 lemma A!_of_ANNNN! [HasAxiomDNE 𝓢] (d : 𝓢 ⊢! ∼∼φ ⋎ ∼∼ψ) : 𝓢 ⊢! φ ⋎ ψ := ⟨A_of_ANNNN d.some⟩
 
 def right_A_intro_left (h : 𝓢 ⊢ φ ➝ χ) : 𝓢 ⊢ φ ➝ (χ ⋎ ψ) := by
-  apply deduct';
-  apply A_intro_left;
-  apply deductInv;
-  exact of h;
+  apply deduct'
+  apply A_intro_left
+  apply deductInv
+  exact of h
 lemma right_A!_intro_left (h : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! φ ➝ (χ ⋎ ψ) := ⟨right_A_intro_left h.some⟩
 
 def right_A_intro_right (h : 𝓢 ⊢ ψ ➝ χ) : 𝓢 ⊢ ψ ➝ (φ ⋎ χ) := by
-  apply deduct';
-  apply A_intro_right;
-  apply deductInv;
-  exact of h;
+  apply deduct'
+  apply A_intro_right
+  apply deductInv
+  exact of h
 lemma right_A!_intro_right (h : 𝓢 ⊢! ψ ➝ χ) : 𝓢 ⊢! ψ ➝ (φ ⋎ χ) := ⟨right_A_intro_right h.some⟩
 
 def right_K_intro [DecidableEq F] (hq : 𝓢 ⊢ φ ➝ ψ) (hr : 𝓢 ⊢ φ ➝ χ) : 𝓢 ⊢ φ ➝ ψ ⋏ χ := by
-  apply deduct';
-  replace hq : [] ⊢[𝓢] φ ➝ ψ := of hq;
-  replace hr : [] ⊢[𝓢] φ ➝ χ := of hr;
+  apply deduct'
+  replace hq : [] ⊢[𝓢] φ ➝ ψ := of hq
+  replace hr : [] ⊢[𝓢] φ ➝ χ := of hr
   exact K_intro (mdp' hq FiniteContext.id) (mdp' hr FiniteContext.id)
 lemma right_K!_intro [DecidableEq F] (hq : 𝓢 ⊢! φ ➝ ψ) (hr : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! φ ➝ ψ ⋏ χ := ⟨right_K_intro hq.some hr.some⟩
 
 lemma left_K!_symm (d : 𝓢 ⊢! φ ⋏ ψ ➝ χ) : 𝓢 ⊢! ψ ⋏ φ ➝ χ := C!_trans CKK! d
 
 lemma left_K!_intro_right [DecidableEq F] (h : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! (ψ ⋏ φ) ➝ χ := by
-  apply CK!_iff_CC!.mpr;
-  apply deduct'!;
-  exact FiniteContext.of'! (Γ := [ψ]) h;
+  apply CK!_iff_CC!.mpr
+  apply deduct'!
+  exact FiniteContext.of'! (Γ := [ψ]) h
 
 lemma left_K!_intro_left [DecidableEq F] (h : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! (φ ⋏ ψ) ➝ χ := C!_trans CKK! (left_K!_intro_right h)
 
 lemma cut! [DecidableEq F] (d₁ : 𝓢 ⊢! φ₁ ⋏ c ➝ ψ₁) (d₂ : 𝓢 ⊢! φ₂ ➝ c ⋎ ψ₂) : 𝓢 ⊢! φ₁ ⋏ φ₂ ➝ ψ₁ ⋎ ψ₂ := by
-  apply deduct'!;
-  exact of_C!_of_C!_of_A! (right_A!_intro_left $ of'! (CK!_iff_CC!.mp d₁) ⨀ (K!_left id!)) or₂! (of'! d₂ ⨀ K!_right id!);
+  apply deduct'!
+  exact of_C!_of_C!_of_A! (right_A!_intro_left $ of'! (CK!_iff_CC!.mp d₁) ⨀ (K!_left id!)) or₂! (of'! d₂ ⨀ K!_right id!)
 
 def inner_A_symm : 𝓢 ⊢ φ ⋎ ψ ➝ ψ ⋎ φ := by
-  apply deduct';
+  apply deduct'
   exact of_C_of_C_of_A or₂ or₁ $ FiniteContext.id
 lemma or_comm! : 𝓢 ⊢! φ ⋎ ψ ➝ ψ ⋎ φ := ⟨inner_A_symm⟩
 
@@ -108,40 +108,40 @@ def A_symm (h : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ψ ⋎ φ := inner_A_symm ⨀ h
 lemma or_comm'! (h : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ψ ⋎ φ := ⟨A_symm h.some⟩
 
 lemma A!_assoc : 𝓢 ⊢! φ ⋎ (ψ ⋎ χ) ↔ 𝓢 ⊢! (φ ⋎ ψ) ⋎ χ := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     exact of_C!_of_C!_of_A!
       (right_A!_intro_left $ right_A!_intro_left C!_id)
       (by
-        apply provable_iff_provable.mpr;
-        apply deduct_iff.mpr;
-        exact of_C!_of_C!_of_A! (right_A!_intro_left $ right_A!_intro_right C!_id) (right_A!_intro_right C!_id) id!;
+        apply provable_iff_provable.mpr
+        apply deduct_iff.mpr
+        exact of_C!_of_C!_of_A! (right_A!_intro_left $ right_A!_intro_right C!_id) (right_A!_intro_right C!_id) id!
       )
-      h;
-  . intro h;
+      h
+  . intro h
     exact of_C!_of_C!_of_A!
       (by
-        apply provable_iff_provable.mpr;
-        apply deduct_iff.mpr;
-        exact of_C!_of_C!_of_A! (right_A!_intro_left C!_id) (right_A!_intro_right $ right_A!_intro_left C!_id) id!;
+        apply provable_iff_provable.mpr
+        apply deduct_iff.mpr
+        exact of_C!_of_C!_of_A! (right_A!_intro_left C!_id) (right_A!_intro_right $ right_A!_intro_left C!_id) id!
       )
       (right_A!_intro_right $ right_A!_intro_right C!_id)
-      h;
+      h
 
 lemma K!_assoc : 𝓢 ⊢! (φ ⋏ ψ) ⋏ χ ⭤ φ ⋏ (ψ ⋏ χ) := by
-  apply E!_intro;
-  . apply FiniteContext.deduct'!;
-    have hp : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! φ := K!_left $ K!_left id!;
-    have hq : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! ψ := K!_right $ K!_left id!;
-    have hr : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! χ := K!_right id!;
-    exact K!_intro hp (K!_intro hq hr);
-  . apply FiniteContext.deduct'!;
-    have hp : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! φ := K!_left id!;
-    have hq : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! ψ := K!_left $ K!_right id!;
-    have hr : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! χ := K!_right $ K!_right id!;
-    apply K!_intro;
-    . exact K!_intro hp hq;
-    . exact hr;
+  apply E!_intro
+  . apply FiniteContext.deduct'!
+    have hp : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! φ := K!_left $ K!_left id!
+    have hq : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! ψ := K!_right $ K!_left id!
+    have hr : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢]! χ := K!_right id!
+    exact K!_intro hp (K!_intro hq hr)
+  . apply FiniteContext.deduct'!
+    have hp : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! φ := K!_left id!
+    have hq : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! ψ := K!_left $ K!_right id!
+    have hr : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢]! χ := K!_right $ K!_right id!
+    apply K!_intro
+    . exact K!_intro hp hq
+    . exact hr
 
 lemma K!_assoc_mp (h : 𝓢 ⊢! (φ ⋏ ψ) ⋏ χ) : 𝓢 ⊢! φ ⋏ (ψ ⋏ χ) := C_of_E_mp! K!_assoc ⨀ h
 lemma K!_assoc_mpr (h : 𝓢 ⊢! φ ⋏ (ψ ⋏ χ)) : 𝓢 ⊢! (φ ⋏ ψ) ⋏ χ := C_of_E_mpr! K!_assoc ⨀ h
@@ -150,7 +150,7 @@ def K_replace_left (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ φ ➝ χ) : 𝓢 ⊢
 lemma K!_replace_left (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! χ ⋏ ψ := ⟨K_replace_left hc.some h.some⟩
 
 def CKK_of_C (h : 𝓢 ⊢ φ ➝ χ) : 𝓢 ⊢ φ ⋏ ψ ➝ χ ⋏ ψ := by
-  apply deduct';
+  apply deduct'
   exact K_replace_left FiniteContext.id (of h)
 lemma CKK!_of_C! (h : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! φ ⋏ ψ ➝ χ ⋏ ψ := ⟨CKK_of_C h.some⟩
 
@@ -158,7 +158,7 @@ def K_replace_right (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ ψ ➝ χ) : 𝓢 �
 lemma K!_replace_right (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! ψ ➝ χ) : 𝓢 ⊢! φ ⋏ χ := ⟨K_replace_right hc.some h.some⟩
 
 def CKK_of_C' (h : 𝓢 ⊢ ψ ➝ χ) : 𝓢 ⊢ φ ⋏ ψ ➝ φ ⋏ χ := by
-  apply deduct';
+  apply deduct'
   exact K_replace_right (FiniteContext.id) (of h)
 lemma CKK!_of_C!' (h : 𝓢 ⊢! ψ ➝ χ) : 𝓢 ⊢! φ ⋏ ψ ➝ φ ⋏ χ := ⟨CKK_of_C' h.some⟩
 
@@ -166,7 +166,7 @@ def K_replace (hc : 𝓢 ⊢ φ ⋏ ψ) (h₁ : 𝓢 ⊢ φ ➝ χ) (h₂ : 𝓢
 lemma K!_replace (hc : 𝓢 ⊢! φ ⋏ ψ) (h₁ : 𝓢 ⊢! φ ➝ χ) (h₂ : 𝓢 ⊢! ψ ➝ ξ) : 𝓢 ⊢! χ ⋏ ξ := ⟨K_replace hc.some h₁.some h₂.some⟩
 
 def CKK_of_C_of_C (h₁ : 𝓢 ⊢ φ ➝ χ) (h₂ : 𝓢 ⊢ ψ ➝ ξ) : 𝓢 ⊢ φ ⋏ ψ ➝ χ ⋏ ξ := by
-  apply deduct';
+  apply deduct'
   exact K_replace FiniteContext.id (of h₁) (of h₂)
 lemma CKK!_of_C!_of_C! (h₁ : 𝓢 ⊢! φ ➝ χ) (h₂ : 𝓢 ⊢! ψ ➝ ξ) : 𝓢 ⊢! φ ⋏ ψ ➝ χ ⋏ ξ := ⟨CKK_of_C_of_C h₁.some h₂.some⟩
 
@@ -174,7 +174,7 @@ def A_replace_left (hc : 𝓢 ⊢ φ ⋎ ψ) (hp : 𝓢 ⊢ φ ➝ χ) : 𝓢 �
 lemma A!_replace_left (hc : 𝓢 ⊢! φ ⋎ ψ) (hp : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! χ ⋎ ψ := ⟨A_replace_left hc.some hp.some⟩
 
 def CAA_of_C_left (hp : 𝓢 ⊢ φ ➝ χ) : 𝓢 ⊢ φ ⋎ ψ ➝ χ ⋎ ψ := by
-  apply deduct';
+  apply deduct'
   exact A_replace_left FiniteContext.id (of hp)
 lemma or_replace_left! (hp : 𝓢 ⊢! φ ➝ χ) : 𝓢 ⊢! φ ⋎ ψ ➝ χ ⋎ ψ := ⟨CAA_of_C_left hp.some⟩
 
@@ -182,7 +182,7 @@ def A_replace_right (hc : 𝓢 ⊢ φ ⋎ ψ) (hq : 𝓢 ⊢ ψ ➝ χ) : 𝓢 �
 lemma A!_replace_right (hc : 𝓢 ⊢! φ ⋎ ψ) (hq : 𝓢 ⊢! ψ ➝ χ) : 𝓢 ⊢! φ ⋎ χ := ⟨A_replace_right hc.some hq.some⟩
 
 def CAA_of_C_right (hq : 𝓢 ⊢ ψ ➝ χ) : 𝓢 ⊢ φ ⋎ ψ ➝ φ ⋎ χ := by
-  apply deduct';
+  apply deduct'
   exact A_replace_right FiniteContext.id (of hq)
 lemma CAA!_of_C!_right (hq : 𝓢 ⊢! ψ ➝ χ) : 𝓢 ⊢! φ ⋎ ψ ➝ φ ⋎ χ := ⟨CAA_of_C_right hq.some⟩
 
@@ -191,51 +191,51 @@ def A_replace (h : 𝓢 ⊢ φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢ φ₁ ➝ φ₂) (hq
 lemma A!_replace (h : 𝓢 ⊢! φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢! φ₁ ➝ φ₂) (hq : 𝓢 ⊢! ψ₁ ➝ ψ₂) : 𝓢 ⊢! φ₂ ⋎ ψ₂ := ⟨A_replace h.some hp.some hq.some⟩
 
 def CAA_of_C_of_C (hp : 𝓢 ⊢ φ₁ ➝ φ₂) (hq : 𝓢 ⊢ ψ₁ ➝ ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ ➝ φ₂ ⋎ ψ₂ := by
-  apply deduct';
-  exact A_replace FiniteContext.id (of hp) (of hq) ;
+  apply deduct'
+  exact A_replace FiniteContext.id (of hp) (of hq) 
 lemma CAA!_of_C!_of_C! (hp : 𝓢 ⊢! φ₁ ➝ φ₂) (hq : 𝓢 ⊢! ψ₁ ➝ ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ ➝ φ₂ ⋎ ψ₂ := ⟨CAA_of_C_of_C hp.some hq.some⟩
 
 def EAA_of_E_of_E (hp : 𝓢 ⊢ φ₁ ⭤ φ₂) (hq : 𝓢 ⊢ ψ₁ ⭤ ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ ⭤ φ₂ ⋎ ψ₂ := by
-  apply E_intro;
-  . exact CAA_of_C_of_C (K_left hp) (K_left hq);
-  . exact CAA_of_C_of_C (K_right hp) (K_right hq);
+  apply E_intro
+  . exact CAA_of_C_of_C (K_left hp) (K_left hq)
+  . exact CAA_of_C_of_C (K_right hp) (K_right hq)
 lemma EAA!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ ⭤ φ₂) (hq : 𝓢 ⊢! ψ₁ ⭤ ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ ⭤ φ₂ ⋎ ψ₂ := ⟨EAA_of_E_of_E hp.some hq.some⟩
 
 lemma EAAAA! : 𝓢 ⊢! φ ⋎ (ψ ⋎ χ) ⭤ (φ ⋎ ψ) ⋎ χ := by
-  apply E!_intro;
-  . exact deduct'! $ A!_assoc.mp id!;
-  . exact deduct'! $ A!_assoc.mpr id!;
+  apply E!_intro
+  . exact deduct'! $ A!_assoc.mp id!
+  . exact deduct'! $ A!_assoc.mpr id!
 
 lemma EAA!_of_E!_right (d : 𝓢 ⊢! ψ ⭤ χ) : 𝓢 ⊢! φ ⋎ ψ ⭤ φ ⋎ χ := by
-  apply E!_intro;
-  . apply CAA!_of_C!_right; exact K!_left d;
-  . apply CAA!_of_C!_right; exact K!_right d;
+  apply E!_intro
+  . apply CAA!_of_C!_right; exact K!_left d
+  . apply CAA!_of_C!_right; exact K!_right d
 
 lemma EAA!_of_E!_left (d : 𝓢 ⊢! φ ⭤ χ) : 𝓢 ⊢! φ ⋎ ψ ⭤ χ ⋎ ψ := by
-  apply E!_intro;
-  . apply or_replace_left!; exact K!_left d;
-  . apply or_replace_left!; exact K!_right d;
+  apply E!_intro
+  . apply or_replace_left!; exact K!_left d
+  . apply or_replace_left!; exact K!_right d
 
 def EKK_of_E_of_E (hp : 𝓢 ⊢ φ₁ ⭤ φ₂) (hq : 𝓢 ⊢ ψ₁ ⭤ ψ₂) : 𝓢 ⊢ φ₁ ⋏ ψ₁ ⭤ φ₂ ⋏ ψ₂ := by
-  apply E_intro;
-  . exact CKK_of_C_of_C (K_left hp) (K_left hq);
-  . exact CKK_of_C_of_C (K_right hp) (K_right hq);
+  apply E_intro
+  . exact CKK_of_C_of_C (K_left hp) (K_left hq)
+  . exact CKK_of_C_of_C (K_right hp) (K_right hq)
 lemma EKK!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ ⭤ φ₂) (hq : 𝓢 ⊢! ψ₁ ⭤ ψ₂) : 𝓢 ⊢! φ₁ ⋏ ψ₁ ⭤ φ₂ ⋏ ψ₂ := ⟨EKK_of_E_of_E hp.some hq.some⟩
 
 def ECC_of_E_of_E (hp : 𝓢 ⊢ φ₁ ⭤ φ₂) (hq : 𝓢 ⊢ ψ₁ ⭤ ψ₂) : 𝓢 ⊢ (φ₁ ➝ ψ₁) ⭤ (φ₂ ➝ ψ₂) := by
-  apply E_intro;
-  . apply deduct'; exact C_trans (of $ K_right hp) $ C_trans (FiniteContext.id) (of $ K_left hq);
-  . apply deduct'; exact C_trans (of $ K_left hp) $ C_trans (FiniteContext.id) (of $ K_right hq);
+  apply E_intro
+  . apply deduct'; exact C_trans (of $ K_right hp) $ C_trans (FiniteContext.id) (of $ K_left hq)
+  . apply deduct'; exact C_trans (of $ K_left hp) $ C_trans (FiniteContext.id) (of $ K_right hq)
 lemma ECC!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ ⭤ φ₂) (hq : 𝓢 ⊢! ψ₁ ⭤ ψ₂) : 𝓢 ⊢! (φ₁ ➝ ψ₁) ⭤ (φ₂ ➝ ψ₂) := ⟨ECC_of_E_of_E hp.some hq.some⟩
 
 lemma C!_repalce [DecidableEq F] (hp : 𝓢 ⊢! φ₁ ⭤ φ₂) (hq : 𝓢 ⊢! ψ₁ ⭤ ψ₂) : 𝓢 ⊢! φ₁ ➝ ψ₁ ↔ 𝓢 ⊢! φ₂ ➝ ψ₂ :=
   iff_of_E! (ECC!_of_E!_of_E! hp hq)
 
 def dni [DecidableEq F] : 𝓢 ⊢ φ ➝ ∼∼φ := by
-  apply deduct';
-  apply N_of_CO;
-  apply deduct;
-  exact bot_of_mem_either (φ := φ) (by simp) (by simp);
+  apply deduct'
+  apply N_of_CO
+  apply deduct
+  exact bot_of_mem_either (φ := φ) (by simp) (by simp)
 @[simp] lemma dni! [DecidableEq F] : 𝓢 ⊢! φ ➝ ∼∼φ := ⟨dni⟩
 
 def dni' [DecidableEq F] (b : 𝓢 ⊢ φ) : 𝓢 ⊢ ∼∼φ := dni ⨀ b
@@ -260,15 +260,15 @@ def dn [DecidableEq F] [HasAxiomDNE 𝓢] : 𝓢 ⊢ φ ⭤ ∼∼φ := E_intro 
 
 
 def CCCNN [DecidableEq F] : 𝓢 ⊢ (φ ➝ ψ) ➝ (∼ψ ➝ ∼φ) := by
-  apply deduct';
-  apply deduct;
-  apply N_of_CO;
-  apply deduct;
-  have dp  : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] φ := FiniteContext.byAxm;
-  have dpq : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] φ ➝ ψ := FiniteContext.byAxm;
-  have dq  : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] ψ := dpq ⨀ dp;
-  have dnq : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] ψ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm;
-  exact dnq ⨀ dq;
+  apply deduct'
+  apply deduct
+  apply N_of_CO
+  apply deduct
+  have dp  : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] φ := FiniteContext.byAxm
+  have dpq : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] φ ➝ ψ := FiniteContext.byAxm
+  have dq  : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] ψ := dpq ⨀ dp
+  have dnq : [φ, ∼ψ, φ ➝ ψ] ⊢[𝓢] ψ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm
+  exact dnq ⨀ dq
 @[simp] def CCCNN! [DecidableEq F] : 𝓢 ⊢! (φ ➝ ψ) ➝ (∼ψ ➝ ∼φ) := ⟨CCCNN⟩
 
 @[deprecated "use `CCCNN`"] alias contra₀ := CCCNN
@@ -312,9 +312,9 @@ lemma ENN!_of_E! [DecidableEq F] (b : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ∼φ ⭤
 
 
 def EN_of_EN_right [DecidableEq F] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢ φ ⭤ ∼ψ) : 𝓢 ⊢ ∼φ ⭤ ψ := by
-  apply E_intro;
-  . apply CN_of_CN_left $  K_right h;
-  . apply CN_of_CN_right $  K_left h;
+  apply E_intro
+  . apply CN_of_CN_left $  K_right h
+  . apply CN_of_CN_right $  K_left h
 lemma EN!_of_EN!_right [DecidableEq F] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢! φ ⭤ ∼ψ) : 𝓢 ⊢! ∼φ ⭤ ψ := ⟨EN_of_EN_right h.some⟩
 
 def EN_of_EN_left [DecidableEq F] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢ ∼φ ⭤ ψ) : 𝓢 ⊢ φ ⭤ ∼ψ := E_symm $ EN_of_EN_right $ E_symm h
@@ -325,7 +325,7 @@ section NegationEquiv
 variable [Entailment.NegationEquiv 𝓢]
 
 def ENNCCOO [DecidableEq F] : 𝓢 ⊢ ∼∼φ ⭤ ((φ ➝ ⊥) ➝ ⊥) := by
-  apply E_intro;
+  apply E_intro
   . exact C_trans (by apply contra; exact K_right negEquiv) (K_left negEquiv)
   . exact C_trans (K_right negEquiv) (by apply contra; exact K_left negEquiv)
 @[simp] lemma ENNCCOO! [DecidableEq F] : 𝓢 ⊢! ∼∼φ ⭤ ((φ ➝ ⊥) ➝ ⊥) := ⟨ENNCCOO⟩
@@ -336,9 +336,9 @@ lemma ECCOO! [DecidableEq F] [HasAxiomDNE 𝓢] : 𝓢 ⊢! φ ⭤ ((φ ➝ ⊥)
 end NegationEquiv
 
 def CCCOCOC [DecidableEq F] [HasAxiomElimContra 𝓢] : 𝓢 ⊢ ((ψ ➝ ⊥) ➝ (φ ➝ ⊥)) ➝ (φ ➝ ψ) := by
-  refine C_trans ?_ elimContra;
-  apply deduct';
-  exact C_trans (C_trans (K_left negEquiv) FiniteContext.byAxm) (K_right negEquiv);
+  refine C_trans ?_ elimContra
+  apply deduct'
+  exact C_trans (C_trans (K_left negEquiv) FiniteContext.byAxm) (K_right negEquiv)
 @[simp] lemma CCCOCOC! [DecidableEq F] [HasAxiomElimContra 𝓢] : 𝓢 ⊢! ((ψ ➝ ⊥) ➝ (φ ➝ ⊥)) ➝ (φ ➝ ψ) := ⟨CCCOCOC⟩
 
 
@@ -351,36 +351,36 @@ lemma tne'! [DecidableEq F] (b : 𝓢 ⊢! ∼(∼∼φ)) : 𝓢 ⊢! ∼φ := �
 def tneIff [DecidableEq F] : 𝓢 ⊢ ∼∼∼φ ⭤ ∼φ := K_intro tne dni
 
 def CCC_of_C_left (h : 𝓢 ⊢ ψ ➝ φ) : 𝓢 ⊢ (φ ➝ χ) ➝ (ψ ➝ χ) := by
-  apply deduct';
-  exact C_trans (of h) id;
+  apply deduct'
+  exact C_trans (of h) id
 lemma CCC!_of_C!_left (h : 𝓢 ⊢! ψ ➝ φ) : 𝓢 ⊢! (φ ➝ χ) ➝ (ψ ➝ χ) := ⟨CCC_of_C_left h.some⟩
 
 @[deprecated "use `CCC_of_C_left`"] alias rev_dhyp_imp' := CCC_of_C_left
 @[deprecated "use `CCC!_of_C!_left`"] alias rev_dhyp_imp'! := CCC!_of_C!_left
 
 lemma C!_iff_C!_of_iff_left (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! φ ➝ χ ↔ 𝓢 ⊢! ψ ➝ χ := by
-  constructor;
-  . exact C!_trans $ K!_right h;
-  . exact C!_trans $ K!_left h;
+  constructor
+  . exact C!_trans $ K!_right h
+  . exact C!_trans $ K!_left h
 
 lemma C!_iff_C!_of_iff_right (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! χ ➝ φ ↔ 𝓢 ⊢! χ ➝ ψ := by
-  constructor;
-  . intro hrp; exact C!_trans hrp $ K!_left h;
-  . intro hrq; exact C!_trans hrq $ K!_right h;
+  constructor
+  . intro hrp; exact C!_trans hrp $ K!_left h
+  . intro hrq; exact C!_trans hrq $ K!_right h
 
 def C_swap [DecidableEq F] (h : 𝓢 ⊢ φ ➝ ψ ➝ χ) : 𝓢 ⊢ ψ ➝ φ ➝ χ := by
-  apply deduct';
-  apply deduct;
-  exact (of (Γ := [φ, ψ]) h) ⨀ FiniteContext.byAxm ⨀ FiniteContext.byAxm;
+  apply deduct'
+  apply deduct
+  exact (of (Γ := [φ, ψ]) h) ⨀ FiniteContext.byAxm ⨀ FiniteContext.byAxm
 lemma C!_swap [DecidableEq F] (h : 𝓢 ⊢! (φ ➝ ψ ➝ χ)) : 𝓢 ⊢! (ψ ➝ φ ➝ χ) := ⟨C_swap h.some⟩
 
 def CCCCC [DecidableEq F] : 𝓢 ⊢ (φ ➝ ψ ➝ χ) ➝ (ψ ➝ φ ➝ χ) := deduct' $ C_swap FiniteContext.id
 @[simp] lemma CCCCC! [DecidableEq F] : 𝓢 ⊢! (φ ➝ ψ ➝ χ) ➝ (ψ ➝ φ ➝ χ) := ⟨CCCCC⟩
 
 def C_of_CC [DecidableEq F] (h : 𝓢 ⊢ φ ➝ φ ➝ ψ) : 𝓢 ⊢ φ ➝ ψ := by
-  apply deduct';
-  have := of (Γ := [φ]) h;
-  exact this ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm);
+  apply deduct'
+  have := of (Γ := [φ]) h
+  exact this ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm)
 lemma C!_of_CC! [DecidableEq F] (h : 𝓢 ⊢! φ ➝ φ ➝ ψ) : 𝓢 ⊢! φ ➝ ψ := ⟨C_of_CC h.some⟩
 
 def CCC [DecidableEq F] : 𝓢 ⊢ φ ➝ (φ ➝ ψ) ➝ ψ := C_swap $ C_id _
@@ -391,9 +391,9 @@ lemma CCC!_of_C!_right (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! (χ ➝ φ) ➝ (χ
 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def CNNCCNNNN [DecidableEq F] : 𝓢 ⊢ ∼∼(φ ➝ ψ) ➝ (∼∼φ ➝ ∼∼ψ) := by
-  apply C_swap;
-  apply deduct';
-  exact C_trans (CNNNN_of_C $ deductInv $ of $ C_swap $ CCCNNNN) tne;
+  apply C_swap
+  apply deduct'
+  exact C_trans (CNNNN_of_C $ deductInv $ of $ C_swap $ CCCNNNN) tne
 @[simp] lemma CNNCCNNNN! [DecidableEq F] : 𝓢 ⊢! ∼∼(φ ➝ ψ) ➝ (∼∼φ ➝ ∼∼ψ) := ⟨CNNCCNNNN⟩
 
 noncomputable def CNNNN_of_NNC [DecidableEq F] (b : 𝓢 ⊢ ∼∼(φ ➝ ψ)) : 𝓢 ⊢ ∼∼φ ➝ ∼∼ψ := CNNCCNNNN ⨀ b
@@ -405,16 +405,16 @@ lemma O!_intro_of_KN! (h : 𝓢 ⊢! φ ⋏ ∼φ) : 𝓢 ⊢! ⊥ := ⟨O_intro
 alias lac'! := O!_intro_of_KN!
 
 def CKNO : 𝓢 ⊢ φ ⋏ ∼φ ➝ ⊥ := by
-  apply deduct';
+  apply deduct'
   exact O_intro_of_KN (φ := φ) $ FiniteContext.id
 @[simp] lemma CKNO! : 𝓢 ⊢! φ ⋏ ∼φ ➝ ⊥ := ⟨CKNO⟩
 /-- Law of contradiction -/
 alias lac! := CKNO!
 
 def CANC [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ (∼φ ⋎ ψ) ➝ (φ ➝ ψ) := left_A_intro (by
-    apply emptyPrf;
-    apply deduct;
-    apply deduct;
+    apply emptyPrf
+    apply deduct
+    apply deduct
     exact efq_of_mem_either (φ := φ) (by simp) (by simp)
   ) imply₁
 @[simp] lemma CANC! [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! (∼φ ⋎ ψ) ➝ (φ ➝ ψ) := ⟨CANC⟩
@@ -429,12 +429,12 @@ def NK_of_ANN [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋎ ∼ψ) : 𝓢 ⊢ ∼(φ �
 lemma NK!_of_ANN! [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋎ ∼ψ) : 𝓢 ⊢! ∼(φ ⋏ ψ) := ⟨NK_of_ANN d.some⟩
 
 def CKNNNA [DecidableEq F] : 𝓢 ⊢ (∼φ ⋏ ∼ψ) ➝ ∼(φ ⋎ ψ) := by
-  apply CK_of_CC;
-  apply deduct';
-  apply deduct;
-  apply N_of_CO;
-  apply deduct;
-  exact of_C_of_C_of_A (CO_of_N FiniteContext.byAxm) (CO_of_N FiniteContext.byAxm) (FiniteContext.byAxm (φ := φ ⋎ ψ));
+  apply CK_of_CC
+  apply deduct'
+  apply deduct
+  apply N_of_CO
+  apply deduct
+  exact of_C_of_C_of_A (CO_of_N FiniteContext.byAxm) (CO_of_N FiniteContext.byAxm) (FiniteContext.byAxm (φ := φ ⋎ ψ))
 @[simp] lemma CKNNNA! [DecidableEq F] : 𝓢 ⊢! ∼φ ⋏ ∼ψ ➝ ∼(φ ⋎ ψ) := ⟨CKNNNA⟩
 
 def NA_of_KNN [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋏ ∼ψ) : 𝓢 ⊢ ∼(φ ⋎ ψ) := CKNNNA ⨀ d
@@ -442,7 +442,7 @@ lemma NA!_of_KNN! [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋏ ∼ψ) : 𝓢 ⊢! �
 
 
 def CNAKNN [DecidableEq F] : 𝓢 ⊢ ∼(φ ⋎ ψ) ➝ (∼φ ⋏ ∼ψ) := by
-  apply deduct';
+  apply deduct'
   exact K_intro (deductInv $ contra $ or₁) (deductInv $ contra $ or₂)
 @[simp] lemma CNAKNN! [DecidableEq F] : 𝓢 ⊢! ∼(φ ⋎ ψ) ➝ (∼φ ⋏ ∼ψ) := ⟨CNAKNN⟩
 
@@ -452,9 +452,9 @@ lemma KNN!_of_NA! [DecidableEq F] (b : 𝓢 ⊢! ∼(φ ⋎ ψ)) : 𝓢 ⊢! ∼
 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def CNKANN [DecidableEq F] [HasAxiomDNE 𝓢] : 𝓢 ⊢ ∼(φ ⋏ ψ) ➝ (∼φ ⋎ ∼ψ) := by
-  apply CN_of_CN_left;
-  apply deduct';
-  exact K_replace (KNN_of_NA $ FiniteContext.id) dne dne;
+  apply CN_of_CN_left
+  apply deduct'
+  exact K_replace (KNN_of_NA $ FiniteContext.id) dne dne
 @[simp] lemma CNKANN! [DecidableEq F] [HasAxiomDNE 𝓢] : 𝓢 ⊢! ∼(φ ⋏ ψ) ➝ (∼φ ⋎ ∼ψ) := ⟨CNKANN⟩
 
 noncomputable def ANN_of_NK [DecidableEq F] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢ ∼(φ ⋏ ψ)) : 𝓢 ⊢ ∼φ ⋎ ∼ψ := CNKANN ⨀ b
@@ -462,35 +462,35 @@ lemma ANN!_of_NK! [DecidableEq F] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢! ∼(φ ⋏ �
 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def AN_of_C [DecidableEq F] [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ φ ➝ ψ) : 𝓢 ⊢ ∼φ ⋎ ψ := by
-  apply of_NN;
-  apply N_of_CO;
-  apply deduct';
-  have d₁ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼∼φ ⋏ ∼ψ := KNN_of_NA $ FiniteContext.id;
-  have d₂ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼φ ➝ ⊥ := CO_of_N $ K_left d₁;
-  have d₃ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼φ := (of (Γ := [∼(∼φ ⋎ ψ)]) $ contra d) ⨀ (K_right d₁);
-  exact d₂ ⨀ d₃;
+  apply of_NN
+  apply N_of_CO
+  apply deduct'
+  have d₁ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼∼φ ⋏ ∼ψ := KNN_of_NA $ FiniteContext.id
+  have d₂ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼φ ➝ ⊥ := CO_of_N $ K_left d₁
+  have d₃ : [∼(∼φ ⋎ ψ)] ⊢[𝓢] ∼φ := (of (Γ := [∼(∼φ ⋎ ψ)]) $ contra d) ⨀ (K_right d₁)
+  exact d₂ ⨀ d₃
 lemma AN!_of_C! [DecidableEq F] [HasAxiomDNE 𝓢] (d : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! ∼φ ⋎ ψ := ⟨AN_of_C d.some⟩
 
 noncomputable def CCAN [DecidableEq F] [HasAxiomDNE 𝓢]  : 𝓢 ⊢ (φ ➝ ψ) ➝ (∼φ ⋎ ψ) := by
-  apply deduct';
-  apply AN_of_C;
-  exact FiniteContext.byAxm;
+  apply deduct'
+  apply AN_of_C
+  exact FiniteContext.byAxm
 lemma CCAN! [DecidableEq F] [HasAxiomDNE 𝓢] : 𝓢 ⊢! (φ ➝ ψ) ➝ ∼φ ⋎ ψ := ⟨CCAN⟩
 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def CCNNNNNNC [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢ (∼∼φ ➝ ∼∼ψ) ➝ ∼∼(φ ➝ ψ) := by
-  apply deduct';
-  apply N_of_CO;
+  apply deduct'
+  apply N_of_CO
   exact C_trans
     (by
-      apply deductInv;
-      apply CC_of_CK;
-      apply deduct;
-      have d₁ : [(∼∼φ ➝ ∼∼ψ) ⋏ ∼(φ ➝ ψ)] ⊢[𝓢] ∼∼φ ➝ ∼∼ψ := K_left (ψ := ∼(φ ➝ ψ)) $ FiniteContext.id;
+      apply deductInv
+      apply CC_of_CK
+      apply deduct
+      have d₁ : [(∼∼φ ➝ ∼∼ψ) ⋏ ∼(φ ➝ ψ)] ⊢[𝓢] ∼∼φ ➝ ∼∼ψ := K_left (ψ := ∼(φ ➝ ψ)) $ FiniteContext.id
       have d₂ : [(∼∼φ ➝ ∼∼ψ) ⋏ ∼(φ ➝ ψ)] ⊢[𝓢] ∼∼φ ⋏ ∼ψ := KNN_of_NA $ (contra CANC) ⨀ (K_right (φ := (∼∼φ ➝ ∼∼ψ)) $ FiniteContext.id)
       exact K_intro (K_right d₂) (d₁ ⨀ (K_left d₂))
     )
-    (CKNO (φ := ∼ψ));
+    (CKNO (φ := ∼ψ))
 
 @[simp] lemma CCNNNNNNC! [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! (∼∼φ ➝ ∼∼ψ) ➝ ∼∼(φ ➝ ψ) := ⟨CCNNNNNNC⟩
 
@@ -502,13 +502,13 @@ section
 
 instance [DecidableEq F] [HasAxiomEFQ 𝓢] [HasAxiomLEM 𝓢] : HasAxiomDNE 𝓢 where
   dne φ := by
-    apply deduct';
+    apply deduct'
     exact of_C_of_C_of_A (C_id _) (by
-      apply deduct;
-      have nnp : [∼φ, ∼∼φ] ⊢[𝓢] ∼φ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm;
-      have np : [∼φ, ∼∼φ] ⊢[𝓢] ∼φ := FiniteContext.byAxm;
-      exact of_O $ nnp ⨀ np;
-    ) $ of lem;;
+      apply deduct
+      have nnp : [∼φ, ∼∼φ] ⊢[𝓢] ∼φ ➝ ⊥ := CO_of_N $ FiniteContext.byAxm
+      have np : [∼φ, ∼∼φ] ⊢[𝓢] ∼φ := FiniteContext.byAxm
+      exact of_O $ nnp ⨀ np
+    ) $ of lem;
 
 end
 
@@ -522,15 +522,15 @@ noncomputable instance [DecidableEq F] [HasAxiomDNE 𝓢] : HasAxiomLEM 𝓢 whe
 
 instance [DecidableEq F] [HasAxiomDNE 𝓢] : HasAxiomEFQ 𝓢 where
   efq φ := by
-    apply C_of_CNN;
-    exact C_trans (K_left negEquiv) $ C_trans (C_swap imply₁) (K_right negEquiv);
+    apply C_of_CNN
+    exact C_trans (K_left negEquiv) $ C_trans (C_swap imply₁) (K_right negEquiv)
 
 
 instance [DecidableEq F] [HasAxiomDNE 𝓢] : HasAxiomElimContra 𝓢 where
   elimContra φ ψ := by
-    apply deduct';
-    have : [∼ψ ➝ ∼φ] ⊢[𝓢] ∼ψ ➝ ∼φ := FiniteContext.byAxm;
-    exact C_of_CNN this;
+    apply deduct'
+    have : [∼ψ ➝ ∼φ] ⊢[𝓢] ∼ψ ➝ ∼φ := FiniteContext.byAxm
+    exact C_of_CNN this
 
 end
 
@@ -581,193 +581,193 @@ lemma left_Uconj!_intro [DecidableEq F] [Fintype ι] (φ : ι → F) (i) : 𝓢 
 
 lemma Conj₂!_iff_forall_provable [DecidableEq F] {Γ : List F} : (𝓢 ⊢! ⋀Γ) ↔ (∀ φ ∈ Γ, 𝓢 ⊢! φ) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
+  | hnil => simp
+  | hsingle => simp
   | hcons φ Γ hΓ ih =>
-    simp_all;
-    constructor;
-    . intro h;
-      constructor;
-      . exact K!_left h;
-      . exact ih.mp (K!_right h);
-    . rintro ⟨h₁, h₂⟩;
-      exact K!_intro h₁ (ih.mpr h₂);
+    simp_all
+    constructor
+    . intro h
+      constructor
+      . exact K!_left h
+      . exact ih.mp (K!_right h)
+    . rintro ⟨h₁, h₂⟩
+      exact K!_intro h₁ (ih.mpr h₂)
 
 lemma CConj₂Conj₂!_of_subset [DecidableEq F] (h : ∀ φ, φ ∈ Γ → φ ∈ Δ) : 𝓢 ⊢! ⋀Δ ➝ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp_all; exact left_Conj₂!_intro h;
-  | hcons φ Γ hne ih => simp_all; exact right_K!_intro (left_Conj₂!_intro h.1) ih;
+  | hnil => simp
+  | hsingle => simp_all; exact left_Conj₂!_intro h
+  | hcons φ Γ hne ih => simp_all; exact right_K!_intro (left_Conj₂!_intro h.1) ih
 
 lemma CConj₂Conj₂!_of_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢]! φ) : 𝓢 ⊢! ⋀Δ ➝ ⋀Γ :=
   by induction Γ using List.induction_with_singleton with
-  | hnil => exact C!_of_conseq! verum!;
-  | hsingle => simp_all; exact provable_iff.mp h;
-  | hcons φ Γ hne ih => simp_all; exact right_K!_intro (provable_iff.mp h.1) ih;
+  | hnil => exact C!_of_conseq! verum!
+  | hsingle => simp_all; exact provable_iff.mp h
+  | hcons φ Γ hne ih => simp_all; exact right_K!_intro (provable_iff.mp h.1) ih
 
 lemma CConj₂!_of_forall_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢]! φ) : Δ ⊢[𝓢]! ⋀Γ := provable_iff.mpr $ CConj₂Conj₂!_of_provable h
 
 lemma CConj₂!_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) : 𝓢 ⊢! φ ➝ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hcons χ Γ h ih =>
-    simp_all;
-    have ⟨he₁, he₂⟩ := he; subst he₁;
-    exact right_K!_intro C!_id ih;
-  | _ => simp_all;
+    simp_all
+    have ⟨he₁, he₂⟩ := he; subst he₁
+    exact right_K!_intro C!_id ih
+  | _ => simp_all
 
 lemma C!_of_CConj₂!_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) (hd : 𝓢 ⊢! ⋀Γ ➝ ψ) : 𝓢 ⊢! φ ➝ ψ := C!_trans (CConj₂!_of_unique he) hd
 
 lemma CConj₂!_iff_CKConj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(φ :: Γ) ➝ ψ ↔ 𝓢 ⊢! φ ⋏ ⋀Γ ➝ ψ := by
   induction Γ with
   | nil =>
-    simp [CK!_iff_CC!];
-    constructor;
-    . intro h; apply C!_swap; exact C!_of_conseq! h;
-    . intro h; exact C!_swap h ⨀ verum!;
-  | cons ψ ih => simp;
+    simp [CK!_iff_CC!]
+    constructor
+    . intro h; apply C!_swap; exact C!_of_conseq! h
+    . intro h; exact C!_swap h ⨀ verum!
+  | cons ψ ih => simp
 
 
 @[simp] lemma CConj₂AppendKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(Γ ++ Δ) ➝ ⋀Γ ⋏ ⋀Δ := by
-  apply FiniteContext.deduct'!;
-  have : [⋀(Γ ++ Δ)] ⊢[𝓢]! ⋀(Γ ++ Δ) := id!;
-  have d := Conj₂!_iff_forall_provable.mp this;
-  apply K!_intro;
-  . apply Conj₂!_iff_forall_provable.mpr;
-    intro φ hp;
-    exact d φ (by simp; left; exact hp);
-  . apply Conj₂!_iff_forall_provable.mpr;
-    intro φ hp;
-    exact d φ (by simp; right; exact hp);
+  apply FiniteContext.deduct'!
+  have : [⋀(Γ ++ Δ)] ⊢[𝓢]! ⋀(Γ ++ Δ) := id!
+  have d := Conj₂!_iff_forall_provable.mp this
+  apply K!_intro
+  . apply Conj₂!_iff_forall_provable.mpr
+    intro φ hp
+    exact d φ (by simp; left; exact hp)
+  . apply Conj₂!_iff_forall_provable.mpr
+    intro φ hp
+    exact d φ (by simp; right; exact hp)
 
 @[simp]
 lemma CKConj₂RemoveConj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(Γ.remove φ) ⋏ φ ➝ ⋀Γ := by
-  apply deduct'!;
-  apply Conj₂!_iff_forall_provable.mpr;
-  intro ψ hq;
-  by_cases e : ψ = φ;
-  . subst e; exact K!_right id!;
-  . exact Conj₂!_iff_forall_provable.mp (K!_left id!) ψ (by apply List.mem_remove_iff.mpr; simp_all);
+  apply deduct'!
+  apply Conj₂!_iff_forall_provable.mpr
+  intro ψ hq
+  by_cases e : ψ = φ
+  . subst e; exact K!_right id!
+  . exact Conj₂!_iff_forall_provable.mp (K!_left id!) ψ (by apply List.mem_remove_iff.mpr; simp_all)
 
 lemma CKConj₂Remove!_of_CConj₂! [DecidableEq F] (b : 𝓢 ⊢! ⋀Γ ➝ ψ) : 𝓢 ⊢! ⋀(Γ.remove φ) ⋏ φ ➝ ψ := C!_trans CKConj₂RemoveConj₂! b
 
 
 lemma Conj₂Append!_iff_KConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(Γ ++ Δ) ↔ 𝓢 ⊢! ⋀Γ ⋏ ⋀Δ := by
-  constructor;
-  . intro h;
-    replace h := Conj₂!_iff_forall_provable.mp h;
-    apply K!_intro;
-    . apply Conj₂!_iff_forall_provable.mpr;
-      intro φ hp; exact h φ (by simp only [List.mem_append]; left; simpa);
-    . apply Conj₂!_iff_forall_provable.mpr;
-      intro φ hp; exact h φ (by simp only [List.mem_append]; right; simpa);
-  . intro h;
-    apply Conj₂!_iff_forall_provable.mpr;
-    simp only [List.mem_append];
-    rintro φ (hp₁ | hp₂);
-    . exact (Conj₂!_iff_forall_provable.mp $ K!_left h) φ hp₁;
-    . exact (Conj₂!_iff_forall_provable.mp $ K!_right h) φ hp₂;
+  constructor
+  . intro h
+    replace h := Conj₂!_iff_forall_provable.mp h
+    apply K!_intro
+    . apply Conj₂!_iff_forall_provable.mpr
+      intro φ hp; exact h φ (by simp only [List.mem_append]; left; simpa)
+    . apply Conj₂!_iff_forall_provable.mpr
+      intro φ hp; exact h φ (by simp only [List.mem_append]; right; simpa)
+  . intro h
+    apply Conj₂!_iff_forall_provable.mpr
+    simp only [List.mem_append]
+    rintro φ (hp₁ | hp₂)
+    . exact (Conj₂!_iff_forall_provable.mp $ K!_left h) φ hp₁
+    . exact (Conj₂!_iff_forall_provable.mp $ K!_right h) φ hp₂
 
 
 @[simp] lemma EConj₂AppendKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(Γ ++ Δ) ⭤ ⋀Γ ⋏ ⋀Δ := by
-  apply E!_intro;
-  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mp; exact id!;
-  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mpr; exact id!;
+  apply E!_intro
+  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mp; exact id!
+  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mpr; exact id!
 
 
 lemma CConj₂Append!_iff_CKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢! ⋀(Γ ++ Δ) ➝ φ ↔ 𝓢 ⊢! (⋀Γ ⋏ ⋀Δ) ➝ φ := by
-  constructor;
-  . intro h; exact C!_trans (K!_right EConj₂AppendKConj₂Conj₂!) h;
-  . intro h; exact C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) h;
+  constructor
+  . intro h; exact C!_trans (K!_right EConj₂AppendKConj₂Conj₂!) h
+  . intro h; exact C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) h
 
 @[simp] lemma CFConjConj₂ [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢! ⋀Γ.toList ➝ Γ.conj := by
-  apply CConj₂Conj₂!_of_provable;
-  apply FiniteContext.by_axm!;
+  apply CConj₂Conj₂!_of_provable
+  apply FiniteContext.by_axm!
 
 @[simp] lemma CConj₂Conj_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢! ⋀Γ ➝ Γ.toFinset.conj := by
-  apply C!_trans ?_ CFConjConj₂;
-  apply CConj₂Conj₂!_of_subset;
-  simp;
+  apply C!_trans ?_ CFConjConj₂
+  apply CConj₂Conj₂!_of_subset
+  simp
 
 @[simp] lemma CConj₂FConj [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢! Γ.conj ➝ ⋀Γ.toList := by
-  apply right_Conj₂!_intro;
-  intro φ hφ;
-  apply left_Fconj!_intro;
-  simpa using hφ;
+  apply right_Conj₂!_intro
+  intro φ hφ
+  apply left_Fconj!_intro
+  simpa using hφ
 
 @[simp] lemma CConj₂FConj_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢! Γ.toFinset.conj ➝ ⋀Γ := by
-  apply C!_trans $ CConj₂FConj;
-  apply CConj₂Conj₂!_of_subset;
-  simp;
+  apply C!_trans $ CConj₂FConj
+  apply CConj₂Conj₂!_of_subset
+  simp
 
 lemma FConj_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢! Γ.conj ➝ φ ↔ Γ *⊢[𝓢]! φ := by
-  constructor;
-  . intro h;
-    apply Context.provable_iff.mpr;
-    use Γ.toList;
-    constructor;
-    . simp;
-    . apply FiniteContext.provable_iff.mpr;
-      exact C!_trans (by simp) h;
-  . intro h;
-    obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff.mp h;
+  constructor
+  . intro h
+    apply Context.provable_iff.mpr
+    use Γ.toList
+    constructor
+    . simp
+    . apply FiniteContext.provable_iff.mpr
+      exact C!_trans (by simp) h
+  . intro h
+    obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff.mp h
     replace hΔ₂ : 𝓢 ⊢! ⋀Γ.toList ➝ φ := C!_trans (CConj₂Conj₂!_of_subset (by simpa)) $ FiniteContext.provable_iff.mp hΔ₂
-    exact C!_trans (by simp) hΔ₂;
+    exact C!_trans (by simp) hΔ₂
 
 lemma FConj!_iff_forall_provable [DecidableEq F] {Γ : Finset F} : (𝓢 ⊢! Γ.conj) ↔ (∀ φ ∈ Γ, 𝓢 ⊢! φ) := by
-  apply Iff.trans Conj₂!_iff_forall_provable;
-  constructor <;> simp_all;
+  apply Iff.trans Conj₂!_iff_forall_provable
+  constructor <;> simp_all
 
 lemma FConj_of_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) (hΓ : 𝓢 ⊢! Γ.conj) : 𝓢 ⊢! Δ.conj := by
-  rw [FConj!_iff_forall_provable] at hΓ ⊢;
-  intro φ hφ;
-  apply hΓ;
-  apply h hφ;
+  rw [FConj!_iff_forall_provable] at hΓ ⊢
+  intro φ hφ
+  apply hΓ
+  apply h hφ
 
 lemma CFConj_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) : 𝓢 ⊢! Γ.conj ➝ Δ.conj := by
-  apply FConj_DT.mpr;
-  apply FConj_of_FConj!_of_subset h;
-  apply FConj_DT.mp;
-  simp;
+  apply FConj_DT.mpr
+  apply FConj_of_FConj!_of_subset h
+  apply FConj_DT.mp
+  simp
 
 @[simp] lemma CFconjUnionKFconj! [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢! (Γ ∪ Δ).conj ➝ Γ.conj ⋏ Δ.conj := by
-  apply FConj_DT.mpr;
+  apply FConj_DT.mpr
   apply K!_intro <;>
-  . apply FConj_DT.mp;
-    apply CFConj_FConj!_of_subset;
-    simp;
+  . apply FConj_DT.mp
+    apply CFConj_FConj!_of_subset
+    simp
 
 @[simp] lemma CinsertFConjKFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢! (insert φ Γ).conj ➝ φ ⋏ Γ.conj := by
-  suffices 𝓢 ⊢! ({φ} ∪ Γ).conj ➝ (Finset.conj {φ}) ⋏ Γ.conj by simpa using this;
-  apply CFconjUnionKFconj!;
+  suffices 𝓢 ⊢! ({φ} ∪ Γ).conj ➝ (Finset.conj {φ}) ⋏ Γ.conj by simpa using this
+  apply CFconjUnionKFconj!
 
 @[simp] lemma CKFconjFconjUnion! [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢! Γ.conj ⋏ Δ.conj ➝ (Γ ∪ Δ).conj := by
-  apply right_Fconj!_intro;
-  simp only [Finset.mem_union];
-  rintro φ (hφ | hφ);
+  apply right_Fconj!_intro
+  simp only [Finset.mem_union]
+  rintro φ (hφ | hφ)
   . apply left_K!_intro_left
-    apply left_Fconj!_intro hφ;
-  . apply left_K!_intro_right;
-    apply left_Fconj!_intro hφ;
+    apply left_Fconj!_intro hφ
+  . apply left_K!_intro_right
+    apply left_Fconj!_intro hφ
 
 @[simp]
 lemma CKFConjinsertFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢! φ ⋏ Γ.conj ➝ (insert φ Γ).conj := by
-  suffices 𝓢 ⊢! (Finset.conj {φ}) ⋏ Γ.conj ➝ ({φ} ∪ Γ).conj by simpa using this;
-  apply CKFconjFconjUnion!;
+  suffices 𝓢 ⊢! (Finset.conj {φ}) ⋏ Γ.conj ➝ ({φ} ∪ Γ).conj by simpa using this
+  apply CKFconjFconjUnion!
 
 lemma FConj_DT' [DecidableEq F] {Γ Δ : Finset F} : Γ *⊢[𝓢]! Δ.conj ➝ φ ↔ ↑(Γ ∪ Δ) *⊢[𝓢]! φ := by
-  constructor;
-  . intro h; exact FConj_DT.mp $ C!_trans CFconjUnionKFconj! $ CK!_iff_CC!.mpr $ FConj_DT.mpr h;
-  . intro h; exact FConj_DT.mp $ CK!_iff_CC!.mp $ C!_trans CKFconjFconjUnion! $ FConj_DT.mpr h;
+  constructor
+  . intro h; exact FConj_DT.mp $ C!_trans CFconjUnionKFconj! $ CK!_iff_CC!.mpr $ FConj_DT.mpr h
+  . intro h; exact FConj_DT.mp $ CK!_iff_CC!.mp $ C!_trans CKFconjFconjUnion! $ FConj_DT.mpr h
 
 lemma CFconjFconj!_of_provable [DecidableEq F] {Γ Δ : Finset _} (h : ∀ φ, φ ∈ Γ → Δ *⊢[𝓢]! φ) : 𝓢 ⊢! Δ.conj ➝ Γ.conj := by
   have : 𝓢 ⊢! ⋀(Δ.toList) ➝ ⋀(Γ.toList) := CConj₂Conj₂!_of_provable $ by
-    intro φ hφ;
+    intro φ hφ
     apply Context.iff_provable_context_provable_finiteContext_toList.mp
-    apply h φ;
-    simpa using hφ;
-  refine C!_replace ?_ ?_ this;
-  . simp;
-  . simp;
+    apply h φ
+    simpa using hφ
+  refine C!_replace ?_ ?_ this
+  . simp
+  . simp
 
 end Conjunction
 
@@ -842,198 +842,198 @@ lemma left_Udisj!_intro [DecidableEq F] [HasAxiomEFQ 𝓢] [Fintype ι] (ψ : ι
   left_Fdisj'!_intro _ _ (by simpa)
 
 lemma EDisj₂AppendADisj₂Disj₂! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ⭤ ⋁Γ ⋎ ⋁Δ := by
-  induction Γ using List.induction_with_singleton generalizing Δ <;> induction Δ using List.induction_with_singleton;
+  induction Γ using List.induction_with_singleton generalizing Δ <;> induction Δ using List.induction_with_singleton
   case hnil.hnil =>
-    simp_all;
-    apply E!_intro;
-    . simp;
-    . exact left_A!_intro efq! efq!;
+    simp_all
+    apply E!_intro
+    . simp
+    . exact left_A!_intro efq! efq!
   case hnil.hsingle =>
-    simp_all;
-    apply E!_intro;
-    . simp;
-    . exact left_A!_intro efq! C!_id;
+    simp_all
+    apply E!_intro
+    . simp
+    . exact left_A!_intro efq! C!_id
   case hsingle.hnil =>
-    simp_all;
-    apply E!_intro;
-    . simp;
-    . exact left_A!_intro C!_id efq!;
+    simp_all
+    apply E!_intro
+    . simp
+    . exact left_A!_intro C!_id efq!
   case hcons.hnil =>
-    simp_all;
-    apply E!_intro;
-    . simp;
-    . exact left_A!_intro C!_id efq!;
+    simp_all
+    apply E!_intro
+    . simp
+    . exact left_A!_intro C!_id efq!
   case hnil.hcons =>
-    simp_all;
-    apply E!_intro;
-    . simp;
-    . exact left_A!_intro efq! C!_id;
-  case hsingle.hsingle => simp_all;
-  case hsingle.hcons => simp_all;
+    simp_all
+    apply E!_intro
+    . simp
+    . exact left_A!_intro efq! C!_id
+  case hsingle.hsingle => simp_all
+  case hsingle.hcons => simp_all
   case hcons.hsingle φ ps hps ihp ψ =>
-    simp_all;
+    simp_all
     apply E!_trans (by
-      apply EAA!_of_E!_right;
-      simpa using @ihp [ψ];
-    ) EAAAA!;
+      apply EAA!_of_E!_right
+      simpa using @ihp [ψ]
+    ) EAAAA!
   case hcons.hcons φ ps hps ihp ψ qs hqs ihq =>
-    simp_all;
+    simp_all
     exact E!_trans (by
-      apply EAA!_of_E!_right;
+      apply EAA!_of_E!_right
       exact E!_trans (@ihp (ψ :: qs)) (by
-        apply EAA!_of_E!_right;
-        simp_all;
+        apply EAA!_of_E!_right
+        simp_all
       )
-    ) EAAAA!;
+    ) EAAAA!
 
 
 lemma Disj₂Append!_iff_ADisj₂Disj₂! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ↔ 𝓢 ⊢! ⋁Γ ⋎ ⋁Δ := by
-  constructor;
-  . intro h; exact (K!_left EDisj₂AppendADisj₂Disj₂!) ⨀ h;
-  . intro h; exact (K!_right EDisj₂AppendADisj₂Disj₂!) ⨀ h;
+  constructor
+  . intro h; exact (K!_left EDisj₂AppendADisj₂Disj₂!) ⨀ h
+  . intro h; exact (K!_right EDisj₂AppendADisj₂Disj₂!) ⨀ h
 
 
 lemma CDisj₂!_iff_CADisj₂! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! φ ➝ ⋁(ψ :: Γ) ↔ 𝓢 ⊢! φ ➝ ψ ⋎ ⋁Γ := by
   induction Γ with
   | nil =>
-    simp;
-    constructor;
-    . intro h; exact C!_trans h or₁!;
-    . intro h; exact C!_trans h $ left_A!_intro C!_id efq!;
-  | cons ψ ih => simp;
+    simp
+    constructor
+    . intro h; exact C!_trans h or₁!
+    . intro h; exact C!_trans h $ left_A!_intro C!_id efq!
+  | cons ψ ih => simp
 
 @[simp]
 lemma CDisj₂ADisj₂Remove! [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ➝ φ ⋎ ⋁(Γ.remove φ) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
+  | hnil => simp
   | hsingle ψ =>
-    simp;
-    by_cases h: ψ = φ;
-    . subst_vars; simp;
-    . simp [(List.remove_singleton_of_ne h)];
+    simp
+    by_cases h: ψ = φ
+    . subst_vars; simp
+    . simp [(List.remove_singleton_of_ne h)]
   | hcons ψ Γ h ih =>
-    simp_all;
-    by_cases hpq : ψ = φ;
-    . simp_all only [ne_eq, List.remove_cons_self]; exact left_A!_intro or₁! ih;
-    . simp_all [(List.remove_cons_of_ne Γ hpq)];
-      by_cases hqΓ : Γ.remove φ = [];
-      . simp_all;
-        exact left_A!_intro or₂! (C!_trans ih $ CAA!_of_C!_right efq!);
-      . simp_all;
-        exact left_A!_intro (C!_trans or₁! or₂!) (C!_trans ih (CAA!_of_C!_right or₂!));
+    simp_all
+    by_cases hpq : ψ = φ
+    . simp_all only [ne_eq, List.remove_cons_self]; exact left_A!_intro or₁! ih
+    . simp_all [(List.remove_cons_of_ne Γ hpq)]
+      by_cases hqΓ : Γ.remove φ = []
+      . simp_all
+        exact left_A!_intro or₂! (C!_trans ih $ CAA!_of_C!_right efq!)
+      . simp_all
+        exact left_A!_intro (C!_trans or₁! or₂!) (C!_trans ih (CAA!_of_C!_right or₂!))
 
 lemma left_Disj₂!_intro' [DecidableEq F] [HasAxiomEFQ 𝓢] (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢! ⋁Γ ➝ φ := by
   induction Γ using List.induction_with_singleton with
   | hcons ψ Δ hΔ ih =>
-    simp_all;
-    have ⟨hd₁, hd₂⟩ := hd; subst hd₁;
-    apply provable_iff_provable.mpr;
-    apply deduct_iff.mpr;
+    simp_all
+    have ⟨hd₁, hd₂⟩ := hd; subst hd₁
+    apply provable_iff_provable.mpr
+    apply deduct_iff.mpr
     exact of_C!_of_C!_of_A! (by simp) (weakening! (by simp) $ provable_iff_provable.mp $ ih) id!
-  | _ => simp_all;
+  | _ => simp_all
 
 lemma of_Disj₂!_of_mem_eq [DecidableEq F] [HasAxiomEFQ 𝓢] (hd : ∀ ψ ∈ Γ, ψ = φ) (h : 𝓢 ⊢! ⋁Γ) : 𝓢 ⊢! φ := (left_Disj₂!_intro' hd) ⨀ h
 
 
 @[simp] lemma CFDisjDisj₂ [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! ⋁Γ.toList ➝ Γ.disj := by
-  apply left_Disj₂!_intro;
-  intro ψ hψ;
-  apply right_Fdisj!_intro;
-  simpa using hψ;
+  apply left_Disj₂!_intro
+  intro ψ hψ
+  apply right_Fdisj!_intro
+  simpa using hψ
 
 @[simp] lemma CDisj₂Disj [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! Γ.disj ➝ ⋁Γ.toList := by
-  apply left_Fdisj!_intro;
-  intro ψ hψ;
-  apply right_Disj₂!_intro;
-  simpa;
+  apply left_Fdisj!_intro
+  intro ψ hψ
+  apply right_Disj₂!_intro
+  simpa
 
 lemma CDisj₂Disj₂_of_subset [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) : 𝓢 ⊢! ⋁Γ ➝ ⋁Δ := by
   match Δ with
   | [] =>
-    have : Γ = [] := List.iff_nil_forall.mpr h;
-    subst this;
-    simp;
+    have : Γ = [] := List.iff_nil_forall.mpr h
+    subst this
+    simp
   | [φ] =>
-    apply left_Disj₂!_intro;
-    intro ψ hψ;
-    have := h ψ hψ;
-    simp_all;
+    apply left_Disj₂!_intro
+    intro ψ hψ
+    have := h ψ hψ
+    simp_all
   | φ :: Δ =>
-    apply left_Disj₂!_intro;
-    intro ψ hψ;
-    apply right_Disj₂!_intro;
-    apply h;
-    exact hψ;
+    apply left_Disj₂!_intro
+    intro ψ hψ
+    apply right_Disj₂!_intro
+    apply h
+    exact hψ
 
 lemma CFDisjFDisj_of_subset [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ Δ : Finset F} (h : Γ ⊆ Δ) : 𝓢 ⊢! Γ.disj ➝ Δ.disj := by
-  refine C!_trans (C!_trans ?_ (CDisj₂Disj₂_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp;
+  refine C!_trans (C!_trans ?_ (CDisj₂Disj₂_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp
 
 lemma EDisj₂FDisj [DecidableEq F] {Γ : List F} [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ⭤ Γ.toFinset.disj := by
   match Γ with
-  | [] => simp;
+  | [] => simp
   | φ :: Γ =>
-    apply E!_intro;
-    . apply left_Disj₂!_intro;
-      simp only [List.mem_cons, List.toFinset_cons, forall_eq_or_imp];
-      constructor;
-      . apply right_Fdisj!_intro;
-        simp_all;
-      . intro ψ hψ;
-        apply right_Fdisj!_intro;
-        simp_all;
-    . apply left_Fdisj!_intro;
-      simp only [List.toFinset_cons, Finset.mem_insert, List.mem_toFinset, forall_eq_or_imp];
-      constructor;
-      . apply right_Disj₂!_intro;
-        tauto;
-      . intro ψ hψ;
-        apply right_Disj₂!_intro;
-        tauto;
+    apply E!_intro
+    . apply left_Disj₂!_intro
+      simp only [List.mem_cons, List.toFinset_cons, forall_eq_or_imp]
+      constructor
+      . apply right_Fdisj!_intro
+        simp_all
+      . intro ψ hψ
+        apply right_Fdisj!_intro
+        simp_all
+    . apply left_Fdisj!_intro
+      simp only [List.toFinset_cons, Finset.mem_insert, List.mem_toFinset, forall_eq_or_imp]
+      constructor
+      . apply right_Disj₂!_intro
+        tauto
+      . intro ψ hψ
+        apply right_Disj₂!_intro
+        tauto
 
 lemma EDisj₂FDisj!_doubleton [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁[φ, ψ] ⭤ Finset.disj {φ, ψ} := by
-  convert EDisj₂FDisj (𝓢 := 𝓢) (Γ := [φ, ψ]);
-  simp;
+  convert EDisj₂FDisj (𝓢 := 𝓢) (Γ := [φ, ψ])
+  simp
 
 lemma EConj₂_FConj!_doubleton [DecidableEq F] [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁[φ, ψ] ↔ 𝓢 ⊢! Finset.disj {φ, ψ} := by
-  constructor;
-  . intro h; exact (C_of_E_mp! $ EDisj₂FDisj!_doubleton) ⨀ h;
-  . intro h; exact (C_of_E_mpr! $ EDisj₂FDisj!_doubleton) ⨀ h;
+  constructor
+  . intro h; exact (C_of_E_mp! $ EDisj₂FDisj!_doubleton) ⨀ h
+  . intro h; exact (C_of_E_mpr! $ EDisj₂FDisj!_doubleton) ⨀ h
 
 @[simp]
 lemma CAFDisjinsertFDisj! [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! φ ⋎ Γ.disj ➝ (insert φ Γ).disj := by
-  apply left_A!_intro;
-  . apply right_Fdisj!_intro; simp;
-  . apply CFDisjFDisj_of_subset; simp;
+  apply left_A!_intro
+  . apply right_Fdisj!_intro; simp
+  . apply CFDisjFDisj_of_subset; simp
 
 @[simp]
 lemma CinsertFDisjAFDisj! [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! (insert φ Γ).disj ➝ φ ⋎ Γ.disj := by
-  apply left_Fdisj!_intro;
-  simp only [Finset.mem_insert, forall_eq_or_imp, or₁!, true_and];
-  intro ψ hψ;
-  apply right_A!_intro_right;
-  apply right_Fdisj!_intro;
-  assumption;
+  apply left_Fdisj!_intro
+  simp only [Finset.mem_insert, forall_eq_or_imp, or₁!, true_and]
+  intro ψ hψ
+  apply right_A!_intro_right
+  apply right_Fdisj!_intro
+  assumption
 
 @[simp] lemma CAFdisjFdisjUnion [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ Δ : Finset F} : 𝓢 ⊢! Γ.disj ⋎ Δ.disj ➝ (Γ ∪ Δ).disj := by
   apply left_A!_intro <;>
-  . apply CFDisjFDisj_of_subset;
-    simp;
+  . apply CFDisjFDisj_of_subset
+    simp
 
 @[simp]
 lemma CFdisjUnionAFdisj [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ Δ : Finset F} : 𝓢 ⊢! (Γ ∪ Δ).disj ➝ Γ.disj ⋎ Δ.disj := by
-  apply left_Fdisj!_intro;
-  simp only [Finset.mem_union];
-  rintro ψ (hψ | hψ);
-  . apply C!_trans (ψ := Γ.disj) ?_ or₁!;
-    apply right_Fdisj!_intro;
-    assumption;
-  . apply C!_trans (ψ := Δ.disj) ?_ or₂!;
-    apply right_Fdisj!_intro;
-    assumption;
+  apply left_Fdisj!_intro
+  simp only [Finset.mem_union]
+  rintro ψ (hψ | hψ)
+  . apply C!_trans (ψ := Γ.disj) ?_ or₁!
+    apply right_Fdisj!_intro
+    assumption
+  . apply C!_trans (ψ := Δ.disj) ?_ or₂!
+    apply right_Fdisj!_intro
+    assumption
 
 lemma left_Fdisj!_intro' [DecidableEq F] {Γ : Finset _} [HasAxiomEFQ 𝓢] (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢! Γ.disj ➝ φ := by
-  apply C!_trans ?_ $ left_Disj₂!_intro' (Γ := Γ.toList) (by simpa);
-  simp;
+  apply C!_trans ?_ $ left_Disj₂!_intro' (Γ := Γ.toList) (by simpa)
+  simp
 
 end disjunction
 
@@ -1043,55 +1043,55 @@ section
 variable {Γ Δ : Finset F}
 
 lemma CFConj_CDisj!_of_A [DecidableEq F] [HasAxiomEFQ 𝓢] (hφψ : φ ⋎ ψ ∈ Γ) (hφ : φ ∈ Δ) (hψ : ψ ∈ Δ) : 𝓢 ⊢! Γ.conj ➝ Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {φ, ψ});
-  . apply C!_trans (ψ := Finset.conj {φ ⋎ ψ}) ?_;
-    . apply FConj_DT.mpr;
-      suffices ↑{φ ⋎ ψ} *⊢[𝓢]! [φ, ψ].disj₂ by simpa using EConj₂_FConj!_doubleton.mp this;
-      apply Context.by_axm!;
-      simp;
-    . apply CFConj_FConj!_of_subset;
-      simpa;
-  . apply left_Fdisj!_intro;
-    simp only [Finset.mem_insert, Finset.mem_singleton, forall_eq_or_imp, forall_eq];
+  apply C!_trans (ψ := Finset.disj {φ, ψ})
+  . apply C!_trans (ψ := Finset.conj {φ ⋎ ψ}) ?_
+    . apply FConj_DT.mpr
+      suffices ↑{φ ⋎ ψ} *⊢[𝓢]! [φ, ψ].disj₂ by simpa using EConj₂_FConj!_doubleton.mp this
+      apply Context.by_axm!
+      simp
+    . apply CFConj_FConj!_of_subset
+      simpa
+  . apply left_Fdisj!_intro
+    simp only [Finset.mem_insert, Finset.mem_singleton, forall_eq_or_imp, forall_eq]
     constructor <;>
-    . apply right_Fdisj!_intro;
-      assumption;
+    . apply right_Fdisj!_intro
+      assumption
 
 lemma CFConj_CDisj!_of_K_intro [DecidableEq F] (hp : φ ∈ Γ) (hpq : ψ ∈ Γ) (hψ : φ ⋏ ψ ∈ Δ) : 𝓢 ⊢! Γ.conj ➝ Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {φ ⋏ ψ});
-  . apply C!_trans (ψ := Finset.conj {φ, ψ}) ?_;
-    . apply FConj_DT.mpr;
-      simp only [Finset.coe_insert, Finset.coe_singleton, Finset.disj_singleton];
-      apply K!_intro <;> exact Context.by_axm! $ by simp;
-    . apply CFConj_FConj!_of_subset;
-      apply Finset.doubleton_subset.mpr;
-      tauto;
-  . simp only [Finset.disj_singleton];
-    apply right_Fdisj!_intro _ hψ;
+  apply C!_trans (ψ := Finset.disj {φ ⋏ ψ})
+  . apply C!_trans (ψ := Finset.conj {φ, ψ}) ?_
+    . apply FConj_DT.mpr
+      simp only [Finset.coe_insert, Finset.coe_singleton, Finset.disj_singleton]
+      apply K!_intro <;> exact Context.by_axm! $ by simp
+    . apply CFConj_FConj!_of_subset
+      apply Finset.doubleton_subset.mpr
+      tauto
+  . simp only [Finset.disj_singleton]
+    apply right_Fdisj!_intro _ hψ
 
 lemma CFConj_CDisj!_of_innerMDP [DecidableEq F] (hp : φ ∈ Γ) (hpq : φ ➝ ψ ∈ Γ) (hψ : ψ ∈ Δ) : 𝓢 ⊢! Γ.conj ➝ Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {ψ});
-  . apply C!_trans (ψ := Finset.conj {φ, φ ➝ ψ}) ?_;
-    . apply FConj_DT.mpr;
-      have h₁ : ({φ, φ ➝ ψ}) *⊢[𝓢]! φ ➝ ψ := Context.by_axm! $ by simp;
-      have h₂ : ({φ, φ ➝ ψ}) *⊢[𝓢]! φ := Context.by_axm! $ by simp;
-      simpa using h₁ ⨀ h₂;
-    . apply CFConj_FConj!_of_subset;
-      apply Finset.doubleton_subset.mpr;
-      tauto;
-  . simp only [Finset.disj_singleton];
-    apply right_Fdisj!_intro _ hψ;
+  apply C!_trans (ψ := Finset.disj {ψ})
+  . apply C!_trans (ψ := Finset.conj {φ, φ ➝ ψ}) ?_
+    . apply FConj_DT.mpr
+      have h₁ : ({φ, φ ➝ ψ}) *⊢[𝓢]! φ ➝ ψ := Context.by_axm! $ by simp
+      have h₂ : ({φ, φ ➝ ψ}) *⊢[𝓢]! φ := Context.by_axm! $ by simp
+      simpa using h₁ ⨀ h₂
+    . apply CFConj_FConj!_of_subset
+      apply Finset.doubleton_subset.mpr
+      tauto
+  . simp only [Finset.disj_singleton]
+    apply right_Fdisj!_intro _ hψ
 
 lemma iff_FiniteContext_Context [DecidableEq F] {Γ : List F} : Γ ⊢[𝓢]! φ ↔ ↑Γ.toFinset *⊢[𝓢]! φ := by
-  constructor;
-  . intro h;
-    replace h := FiniteContext.provable_iff.mp h;
-    apply FConj_DT.mp;
-    exact C!_trans (by simp) h;
-  . intro h;
-    replace h := FConj_DT.mpr h;
-    apply FiniteContext.provable_iff.mpr;
-    exact C!_trans (by simp) h;
+  constructor
+  . intro h
+    replace h := FiniteContext.provable_iff.mp h
+    apply FConj_DT.mp
+    exact C!_trans (by simp) h
+  . intro h
+    replace h := FConj_DT.mpr h
+    apply FiniteContext.provable_iff.mpr
+    exact C!_trans (by simp) h
 
 end
 
@@ -1102,98 +1102,98 @@ section
 @[simp]
 lemma CNDisj₁Conj₂! [DecidableEq F] : 𝓢 ⊢! ∼⋁Γ ➝ ⋀(Γ.map (∼·)) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
+  | hnil => simp
+  | hsingle => simp
   | hcons φ Γ hΓ ih =>
-    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
-    refine C!_trans CNAKNN! ?_;
-    apply CKK!_of_C!' ih;
+    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty]
+    refine C!_trans CNAKNN! ?_
+    apply CKK!_of_C!' ih
 
 /--- Finset version of `CNAKNN!` -/
 @[simp]
 lemma CNFdisjFconj! [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! ∼Γ.disj ➝ (Γ.image (∼·)).conj := by
-  apply C!_replace ?_ ?_ $ CNDisj₁Conj₂! (Γ := Γ.toList);
-  . apply contra!;
-    exact CFDisjDisj₂;
-  . apply CConj₂Conj₂!_of_provable;
-    intro φ hφ;
+  apply C!_replace ?_ ?_ $ CNDisj₁Conj₂! (Γ := Γ.toList)
+  . apply contra!
+    exact CFDisjDisj₂
+  . apply CConj₂Conj₂!_of_provable
+    intro φ hφ
     apply FiniteContext.by_axm!
-    simpa using hφ;
+    simpa using hφ
 
 /--- Finset version of `CKNNNA!` -/
 @[simp]
 lemma CConj₂NNDisj₂! [DecidableEq F] : 𝓢 ⊢! ⋀Γ.map (∼·) ➝ ∼⋁Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
+  | hnil => simp
+  | hsingle => simp
   | hcons φ Γ hΓ ih =>
-    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
-    apply C!_trans ?_ CKNNNA!;
-    apply CKK!_of_C!' ih;
+    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty]
+    apply C!_trans ?_ CKNNNA!
+    apply CKK!_of_C!' ih
 
 /--- Finset version of `CKNNNA!` -/
 @[simp]
 lemma CFconjNNFconj! [DecidableEq F] [HasAxiomEFQ 𝓢] {Γ : Finset F} : 𝓢 ⊢! (Γ.image (∼·)).conj ➝ ∼Γ.disj := by
-  apply C!_replace ?_ ?_ $ CConj₂NNDisj₂! (Γ := Γ.toList);
-  . apply CConj₂Conj₂!_of_provable;
-    intro φ hφ;
+  apply C!_replace ?_ ?_ $ CConj₂NNDisj₂! (Γ := Γ.toList)
+  . apply CConj₂Conj₂!_of_provable
+    intro φ hφ
     apply FiniteContext.by_axm!
-    simpa using hφ;
-  . apply contra!;
-    simp;
+    simpa using hφ
+  . apply contra!
+    simp
 
 @[simp]
 lemma CNDisj₂NConj₂! [DecidableEq F] [HasAxiomDNE 𝓢] {Γ : List F} : 𝓢 ⊢! ∼⋁(Γ.map (∼·)) ➝ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
+  | hnil => simp
+  | hsingle => simp
   | hcons φ Γ hΓ ih =>
-    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
+    simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty]
     suffices 𝓢 ⊢! ∼(∼φ ⋎ ∼∼⋁List.map (fun x ↦ ∼x) Γ) ➝ φ ⋏ ⋀Γ by
-      apply C!_trans ?_ this;
-      apply contra!;
-      apply CAA!_of_C!_right;
-      exact dne!;
-    apply C!_trans CNAKNN! ?_;
-    apply CKK!_of_C!_of_C!;
-    . exact dne!;
-    . exact C!_trans dne! ih;
+      apply C!_trans ?_ this
+      apply contra!
+      apply CAA!_of_C!_right
+      exact dne!
+    apply C!_trans CNAKNN! ?_
+    apply CKK!_of_C!_of_C!
+    . exact dne!
+    . exact C!_trans dne! ih
 
 lemma CNFdisj₂NFconj₂! [DecidableEq F] [HasAxiomDNE 𝓢] {Γ : Finset F} : 𝓢 ⊢! ∼(Γ.image (∼·)).disj ➝ Γ.conj := by
-  apply C!_replace ?_ ?_ $ CNDisj₂NConj₂! (Γ := Γ.toList);
-  . apply contra!;
-    apply left_Disj₂!_intro;
-    intro ψ hψ;
-    apply right_Fdisj!_intro;
-    simpa using hψ;
-  . simp;
+  apply C!_replace ?_ ?_ $ CNDisj₂NConj₂! (Γ := Γ.toList)
+  . apply contra!
+    apply left_Disj₂!_intro
+    intro ψ hψ
+    apply right_Fdisj!_intro
+    simpa using hψ
+  . simp
 
 end
 
 namespace Context
 
 lemma provable_iff_finset [DecidableEq F] {Γ : Set F} {φ : F} : Γ *⊢[𝓢]! φ ↔ ∃ Δ : Finset F, (Δ.toSet ⊆ Γ) ∧ Δ *⊢[𝓢]! φ := by
-  apply Iff.trans Context.provable_iff;
-  constructor;
-  . rintro ⟨Δ, hΔ₁, hΔ₂⟩;
-    use Δ.toFinset;
-    constructor;
-    . simpa;
+  apply Iff.trans Context.provable_iff
+  constructor
+  . rintro ⟨Δ, hΔ₁, hΔ₂⟩
+    use Δ.toFinset
+    constructor
+    . simpa
     . apply provable_iff.mpr
-      use Δ;
-      constructor <;> simp_all;
-  . rintro ⟨Δ, hΔ₁, hΔ₂⟩;
-    use Δ.toList;
-    constructor;
-    . simpa;
-    . apply FiniteContext.provable_iff.mpr;
-      refine C!_trans ?_ (FConj_DT.mpr hΔ₂);
-      simp;
+      use Δ
+      constructor <;> simp_all
+  . rintro ⟨Δ, hΔ₁, hΔ₂⟩
+    use Δ.toList
+    constructor
+    . simpa
+    . apply FiniteContext.provable_iff.mpr
+      refine C!_trans ?_ (FConj_DT.mpr hΔ₂)
+      simp
 
 lemma bot_of_mem_neg [DecidableEq F] {Γ : Set F}  (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ *⊢[𝓢]! ⊥ := by
-  replace h₁ : Γ *⊢[𝓢]! φ := by_axm! h₁;
-  replace h₂ : Γ *⊢[𝓢]! φ ➝ ⊥ := N!_iff_CO!.mp $ by_axm! h₂;
-  exact h₂ ⨀ h₁;
+  replace h₁ : Γ *⊢[𝓢]! φ := by_axm! h₁
+  replace h₂ : Γ *⊢[𝓢]! φ ➝ ⊥ := N!_iff_CO!.mp $ by_axm! h₂
+  exact h₂ ⨀ h₁
 
 end Context
 

--- a/Foundation/Logic/Incomparable.lean
+++ b/Foundation/Logic/Incomparable.lean
@@ -17,7 +17,7 @@ lemma Incomparable.of_unprovable
   (h₂ : ∃ ψ, 𝓣 ⊢! ψ ∧ 𝓢 ⊬ ψ)
   : Incomparable (𝓢 : S) (𝓣 : T) := by
   constructor <;>
-  . apply Entailment.not_weakerThan_iff.mpr;
-    assumption;
+  . apply Entailment.not_weakerThan_iff.mpr
+    assumption
 
 end LO.Entailment

--- a/Foundation/Logic/Kripke/Basic.lean
+++ b/Foundation/Logic/Kripke/Basic.lean
@@ -70,7 +70,7 @@ abbrev FrameClass.toFiniteFrameClass (𝔽 : FrameClass) : FiniteFrameClass := {
 postfix:max "ꟳ" => FrameClass.toFiniteFrameClass
 
 
-lemma FrameClass.iff_mem_restrictFinite {𝔽 : FrameClass} {F : Frame} (h : F ∈ 𝔽) [Finite F.World] : ⟨F⟩ ∈ 𝔽ꟳ := by simpa;
+lemma FrameClass.iff_mem_restrictFinite {𝔽 : FrameClass} {F : Frame} (h : F ∈ 𝔽) [Finite F.World] : ⟨F⟩ ∈ 𝔽ꟳ := by simpa
 
 section
 
@@ -174,17 +174,17 @@ abbrev ClassicalFrame : Kripke.Frame where
 
 namespace ClassicalFrame
 
-@[simp] lemma transitive : Transitive ClassicalFrame := by simp [Transitive];
+@[simp] lemma transitive : Transitive ClassicalFrame := by simp [Transitive]
 
-@[simp] lemma reflexive : Reflexive ClassicalFrame := by simp [Reflexive];
+@[simp] lemma reflexive : Reflexive ClassicalFrame := by simp [Reflexive]
 
-@[simp] lemma euclidean : Euclidean ClassicalFrame := by simp [Euclidean];
+@[simp] lemma euclidean : Euclidean ClassicalFrame := by simp [Euclidean]
 
-@[simp] lemma symmetric : Symmetric ClassicalFrame := by simp [Symmetric];
+@[simp] lemma symmetric : Symmetric ClassicalFrame := by simp [Symmetric]
 
-@[simp] lemma extensive : Coreflexive ClassicalFrame := by simp [Coreflexive];
+@[simp] lemma extensive : Coreflexive ClassicalFrame := by simp [Coreflexive]
 
-@[simp] lemma universal : Universal ClassicalFrame := by simp [Universal];
+@[simp] lemma universal : Universal ClassicalFrame := by simp [Universal]
 
 end ClassicalFrame
 
@@ -199,18 +199,18 @@ end Classical
 
 /-- Frame with single world and identiy relation -/
 abbrev terminalFrame : FiniteFrame where
-  World := Unit;
+  World := Unit
   Rel := λ _ _ => True
 
 @[simp]
 lemma terminalFrame.iff_rel' {x y : terminalFrame.World} : x ≺ y ↔ x = y := by
-  simp [Frame.Rel'];
+  simp [Frame.Rel']
 
 @[simp]
 lemma terminalFrame.iff_relItr' {x y : terminalFrame.World} : x ≺^[n] y ↔ x = y := by
   induction n with
-  | zero => simp;
-  | succ n ih => simp_all;
+  | zero => simp
+  | succ n ih => simp_all
 
 
 
@@ -219,7 +219,7 @@ abbrev PointFrame : FiniteFrame where
   Rel := (λ _ _ => False)
 
 @[simp]
-lemma PointFrame.iff_rel' {x y : PointFrame.World} : ¬(x ≺ y) := by simp [Frame.Rel'];
+lemma PointFrame.iff_rel' {x y : PointFrame.World} : ¬(x ≺ y) := by simp [Frame.Rel']
 
 
 end LO.Kripke

--- a/Foundation/Logic/LindenbaumAlgebra.lean
+++ b/Foundation/Logic/LindenbaumAlgebra.lean
@@ -138,7 +138,7 @@ lemma provable_iff_eq_top {φ : F} : 𝓢 ⊢! φ ↔ (⟦φ⟧ : LindenbaumAlge
 lemma inconsistent_iff_trivial : Inconsistent 𝓢 ↔ (∀ φ : LindenbaumAlgebra 𝓢, φ = ⊤) := by
   simp only [Inconsistent, provable_iff_eq_top]
   constructor
-  · intro h φ;
+  · intro h φ
     induction φ using Quotient.ind
     simp [h]
   · intro h f; simp [h]

--- a/Foundation/Logic/LogicSymbol.lean
+++ b/Foundation/Logic/LogicSymbol.lean
@@ -376,7 +376,7 @@ prefix:80 "⋀" => List.conj₂
 
 @[simp] lemma conj₂_cons_nonempty {a : α} {as : List α} (h : as ≠ [] := by assumption) : ⋀(a :: as) = a ⋏ ⋀as := by
   cases as with
-  | nil => contradiction;
+  | nil => contradiction
   | cons ψ rs => simp [List.conj₂]
 
 def conj' (f : ι → α) (l : List ι) : α := (l.map f).conj₂
@@ -417,7 +417,7 @@ prefix:80 "⋁" => disj₂
 
 @[simp] lemma disj₂_cons_nonempty {a : α} {as : List α} (h : as ≠ [] := by assumption) : ⋁(a :: as) = a ⋎ ⋁as := by
   cases as with
-  | nil => contradiction;
+  | nil => contradiction
   | cons ψ rs => simp [disj₂]
 
 def disj' (f : ι → α) (l : List ι) : α := (l.map f).disj₂
@@ -450,7 +450,7 @@ lemma map_conj₂ [LogicalConnective β] [FunLike G α β] [LogicalConnective.Ho
 
 lemma map_conj_append_prop [FunLike G α Prop] [LogicalConnective.HomClass G α Prop]
     (f : G) (l₁ l₂ : List α) : f (l₁ ++ l₂).conj ↔ f (l₁.conj ⋏ l₂.conj) := by
-  induction l₁ <;> induction l₂ <;> aesop;
+  induction l₁ <;> induction l₂ <;> aesop
 
 lemma map_conj' [LogicalConnective β] [FunLike G α β] [LogicalConnective.HomClass G α β]
     (F : G) (l : List ι) (f : ι → α) : F (l.conj' f) = l.conj' (F ∘ f) := by
@@ -477,7 +477,7 @@ lemma map_disj₂ [LogicalConnective β] [FunLike G α β] [LogicalConnective.Ho
   induction l using List.induction_with_singleton' <;> simp [*]
 
 lemma map_disj_append_prop [FunLike F α Prop] [LogicalConnective.HomClass F α Prop] (f : F) (l₁ l₂ : List α) : f (l₁ ++ l₂).disj ↔ f (l₁.disj ⋎ l₂.disj) := by
-  induction l₁ <;> induction l₂ <;> aesop;
+  induction l₁ <;> induction l₂ <;> aesop
 
 lemma map_disj' [LogicalConnective β] [FunLike G α β] [LogicalConnective.HomClass G α β]
     (F : G) (l : List ι) (f : ι → α) : F (l.disj' f) = l.disj' (F ∘ f) := by

--- a/Foundation/Modal/Boxdot/Basic.lean
+++ b/Foundation/Modal/Boxdot/Basic.lean
@@ -19,17 +19,17 @@ postfix:90 "ᵇ" => Formula.boxdotTranslate
 
 theorem Hilbert.of_provable_boxdotTranslated_axiomInstances {H₁ H₂ : Hilbert.Normal α} [Entailment.K H₂]
   (h : ∀ φ ∈ H₁.axiomInstances, H₂ ⊢! φᵇ) : H₁ ⊢! φ → H₂ ⊢! φᵇ := by
-  intro d;
+  intro d
   induction d using Hilbert.Normal.rec! with
   | @axm φ s hs =>
-    apply h;
-    use φ;
-    tauto;
-  | mdp ihpq ihp => exact ihpq ⨀ ihp;
-  | nec ihp => exact boxdot_nec! $ ihp;
-  | imply₂ => exact imply₂!;
-  | imply₁ => exact imply₁!;
-  | ec => exact elim_contra!;
+    apply h
+    use φ
+    tauto
+  | mdp ihpq ihp => exact ihpq ⨀ ihp
+  | nec ihp => exact boxdot_nec! $ ihp
+  | imply₂ => exact imply₂!
+  | imply₁ => exact imply₁!
+  | ec => exact elim_contra!
 
 namespace Formula.Kripke.Satisfies
 
@@ -40,108 +40,108 @@ variable {M : Kripke.Model} {x : M} {φ ψ : Formula _}
 lemma iff_boxdotboxdot : x ⊧ φᵇᵇ ↔ x ⊧ φᵇ := by
   induction φ generalizing x with
   | hbox φ ih =>
-    suffices x ⊧ (φᵇ) → (x ⊧ (□φᵇᵇ) ↔ x ⊧ (□φᵇ)) by simpa [Formula.boxdotTranslate, Box.boxdot, ih];
-    intro h₁;
-    constructor;
-    . intro h₂ y Rxy; exact ih.mp $ @h₂ y Rxy;
-    . intro h₂ y Rxy; exact ih.mpr $ @h₂ y Rxy;
-  | _ => simp_all [Formula.boxdotTranslate];
+    suffices x ⊧ (φᵇ) → (x ⊧ (□φᵇᵇ) ↔ x ⊧ (□φᵇ)) by simpa [Formula.boxdotTranslate, Box.boxdot, ih]
+    intro h₁
+    constructor
+    . intro h₂ y Rxy; exact ih.mp $ @h₂ y Rxy
+    . intro h₂ y Rxy; exact ih.mpr $ @h₂ y Rxy
+  | _ => simp_all [Formula.boxdotTranslate]
 
-lemma boxdot_and : x ⊧ (φ ⋏ ψ)ᵇ ↔ x ⊧ φᵇ ⋏ ψᵇ := by simp [boxdotTranslate];
+lemma boxdot_and : x ⊧ (φ ⋏ ψ)ᵇ ↔ x ⊧ φᵇ ⋏ ψᵇ := by simp [boxdotTranslate]
 
 lemma boxdotTranslate_lconj {l : List _} : x ⊧ l.conjᵇ ↔ x ⊧ (l.map (·ᵇ)).conj := by
   induction l with
-  | nil => simp [Formula.boxdotTranslate];
+  | nil => simp [Formula.boxdotTranslate]
   | cons φ l ih =>
-    apply Iff.trans boxdot_and;
-    apply Iff.trans Satisfies.and_def;
-    suffices x ⊧ φᵇ → (x ⊧ (l.conjᵇ) ↔ ∀ ψ ∈ l, x ⊧ (ψᵇ)) by simpa;
-    intro hφ;
-    constructor;
-    . intro hl ψ hψ;
-      have := ih.mp hl;
-      apply Satisfies.conj₁_def.mp this;
-      simp;
-      tauto;
-    . intro h;
-      apply ih.mpr;
-      apply Satisfies.conj₁_def.mpr;
-      simpa;
+    apply Iff.trans boxdot_and
+    apply Iff.trans Satisfies.and_def
+    suffices x ⊧ φᵇ → (x ⊧ (l.conjᵇ) ↔ ∀ ψ ∈ l, x ⊧ (ψᵇ)) by simpa
+    intro hφ
+    constructor
+    . intro hl ψ hψ
+      have := ih.mp hl
+      apply Satisfies.conj₁_def.mp this
+      simp
+      tauto
+    . intro h
+      apply ih.mpr
+      apply Satisfies.conj₁_def.mpr
+      simpa
 
 lemma boxdotTranslate_lconj₂ {l : List _} : x ⊧ (⋀l)ᵇ ↔ x ⊧ ⋀(l.map (·ᵇ)) := by
   induction l using List.induction_with_singleton with
-  | hnil => simp [Formula.boxdotTranslate];
-  | hsingle φ => simp;
+  | hnil => simp [Formula.boxdotTranslate]
+  | hsingle φ => simp
   | hcons φ l hl ih =>
-    suffices x ⊧ ((φ ⋏ ⋀l)ᵇ) ↔ x ⊧ (φᵇ) ∧ ∀ a ∈ l, x ⊧ (aᵇ) by simpa [hl, boxdot_and];
-    apply Iff.trans boxdot_and;
-    apply Iff.trans Satisfies.and_def;
-    suffices x ⊧ φᵇ → (x ⊧ (⋀l)ᵇ ↔ ∀ ψ ∈ l, x ⊧ (ψᵇ)) by simpa;
-    intro hφ;
-    constructor;
-    . intro hl ψ hψ;
-      have := ih.mp hl;
-      apply Satisfies.conj_def.mp this;
-      simp;
-      tauto;
-    . intro h;
-      apply ih.mpr;
-      apply Satisfies.conj_def.mpr;
-      simpa;
+    suffices x ⊧ ((φ ⋏ ⋀l)ᵇ) ↔ x ⊧ (φᵇ) ∧ ∀ a ∈ l, x ⊧ (aᵇ) by simpa [hl, boxdot_and]
+    apply Iff.trans boxdot_and
+    apply Iff.trans Satisfies.and_def
+    suffices x ⊧ φᵇ → (x ⊧ (⋀l)ᵇ ↔ ∀ ψ ∈ l, x ⊧ (ψᵇ)) by simpa
+    intro hφ
+    constructor
+    . intro hl ψ hψ
+      have := ih.mp hl
+      apply Satisfies.conj_def.mp this
+      simp
+      tauto
+    . intro h
+      apply ih.mpr
+      apply Satisfies.conj_def.mpr
+      simpa
 
 lemma boxdotTranslate_fconj₂ {Γ : Finset _} : x ⊧ Γ.conjᵇ ↔ x ⊧ (Γ.image (·ᵇ)).conj := by
   obtain ⟨l, rfl⟩ : ∃ l : List _, l.toFinset = Γ := ⟨Γ.toList, by simp⟩
   induction l with
-  | nil => simp [Formula.boxdotTranslate];
+  | nil => simp [Formula.boxdotTranslate]
   | cons φ l ih =>
-    apply Iff.trans boxdotTranslate_lconj₂;
-    suffices (∀ ψ, (φᵇ = ψ ∨ ∃ ξ ∈ l, ξᵇ = ψ) → x ⊧ ψ) ↔ x ⊧ (φᵇ) ∧ ∀ ξ ∈ l, x ⊧ (ξᵇ) by simpa;
-    constructor;
-    . intro h;
-      constructor;
-      . apply h;
-        tauto;
-      . intro ψ hψ;
-        apply h;
-        right;
-        use ψ;
-    . rintro ⟨h₁, h₂⟩ _ (rfl | ⟨ψ, hψ, rfl⟩);
-      . assumption;
-      . apply h₂;
-        assumption;
+    apply Iff.trans boxdotTranslate_lconj₂
+    suffices (∀ ψ, (φᵇ = ψ ∨ ∃ ξ ∈ l, ξᵇ = ψ) → x ⊧ ψ) ↔ x ⊧ (φᵇ) ∧ ∀ ξ ∈ l, x ⊧ (ξᵇ) by simpa
+    constructor
+    . intro h
+      constructor
+      . apply h
+        tauto
+      . intro ψ hψ
+        apply h
+        right
+        use ψ
+    . rintro ⟨h₁, h₂⟩ _ (rfl | ⟨ψ, hψ, rfl⟩)
+      . assumption
+      . apply h₂
+        assumption
 
 lemma iff_boxdotTranslateMultibox_boxdotTranslateBoxlt : x ⊧ (□^[n]φ)ᵇ ↔ x ⊧ □^≤[n] φᵇ := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
     suffices (∀ k < n + 1, x ⊧ (□^[k]φᵇ)) ∧ x ⊧ (□(□^[n]φ)ᵇ) ↔ (∀ k < n + 2, x ⊧ (□^[k]φᵇ)) by
-      simpa [Box.boxdot, boxdotTranslate, ih];
-    constructor;
-    . rintro ⟨h₁, h₂⟩ k hk;
-      apply Satisfies.multibox_def.mpr;
-      intro y Rxy;
-      by_cases ek : k = n + 1;
-      . subst ek;
-        obtain ⟨u, Ryu, Ruy⟩ := Rxy;
-        apply Satisfies.multibox_def.mp (Satisfies.fconj_def.mp (ih.mp $ h₂ u Ryu) _ ?_) Ruy;
-        . simp;
-          tauto;
-      . exact Satisfies.multibox_def.mp (h₁ k (by omega)) Rxy;
-    . intro h;
-      constructor;
-      . intro k hk;
-        apply Satisfies.multibox_def.mpr;
-        intro y Rxy;
-        apply Satisfies.multibox_def.mp (@h k (by omega)) Rxy;
-      . intro y Rxy;
-        apply ih.mpr;
-        apply Satisfies.fconj_def.mpr;
-        simp only [Finset.mem_image, Finset.mem_range, Satisfies.iff_models, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂];
-        intro k hk;
-        apply Satisfies.multibox_def.mpr;
-        intro u Ryu;
-        apply Satisfies.multibox_def.mp $ @h (k + 1) (by omega);
-        use y;
+      simpa [Box.boxdot, boxdotTranslate, ih]
+    constructor
+    . rintro ⟨h₁, h₂⟩ k hk
+      apply Satisfies.multibox_def.mpr
+      intro y Rxy
+      by_cases ek : k = n + 1
+      . subst ek
+        obtain ⟨u, Ryu, Ruy⟩ := Rxy
+        apply Satisfies.multibox_def.mp (Satisfies.fconj_def.mp (ih.mp $ h₂ u Ryu) _ ?_) Ruy
+        . simp
+          tauto
+      . exact Satisfies.multibox_def.mp (h₁ k (by omega)) Rxy
+    . intro h
+      constructor
+      . intro k hk
+        apply Satisfies.multibox_def.mpr
+        intro y Rxy
+        apply Satisfies.multibox_def.mp (@h k (by omega)) Rxy
+      . intro y Rxy
+        apply ih.mpr
+        apply Satisfies.fconj_def.mpr
+        simp only [Finset.mem_image, Finset.mem_range, Satisfies.iff_models, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+        intro k hk
+        apply Satisfies.multibox_def.mpr
+        intro u Ryu
+        apply Satisfies.multibox_def.mp $ @h (k + 1) (by omega)
+        use y
 
 end Formula.Kripke.Satisfies
 
@@ -156,67 +156,67 @@ variable {F : Frame} {φ : Formula _}
 lemma iff_boxdot_reflexive_closure : (Satisfies ⟨F, V⟩ x (φᵇ)) ↔ (Satisfies ⟨F^=, V⟩ x φ) := by
   induction φ generalizing x with
   | himp φ ψ ihp ihq =>
-    constructor;
-    . intro h hp;
-      apply ihq.mp;
-      exact h $ ihp.mpr hp;
-    . intro h hp;
-      apply ihq.mpr;
-      exact h $ ihp.mp hp;
+    constructor
+    . intro h hp
+      apply ihq.mp
+      exact h $ ihp.mpr hp
+    . intro h hp
+      apply ihq.mpr
+      exact h $ ihp.mp hp
   | hbox φ ih =>
-    simp [Formula.boxdotTranslate, Box.boxdot, Satisfies];
-    constructor;
-    . rintro ⟨h₁, h₂⟩;
-      intro y Rxy;
-      rcases (Relation.reflGen_iff _ _ _ |>.mp Rxy) with (rfl | Rxy);
-      . apply ih.mp h₁;
-      . exact ih.mp $ h₂ y Rxy;
-    . rintro h;
-      constructor;
-      . exact ih.mpr $ @h x ReflGen.refl;
-      . intro y Rxy;
-        apply ih.mpr;
-        exact @h y (ReflGen.single Rxy);
-  | _ => rfl;
+    simp [Formula.boxdotTranslate, Box.boxdot, Satisfies]
+    constructor
+    . rintro ⟨h₁, h₂⟩
+      intro y Rxy
+      rcases (Relation.reflGen_iff _ _ _ |>.mp Rxy) with (rfl | Rxy)
+      . apply ih.mp h₁
+      . exact ih.mp $ h₂ y Rxy
+    . rintro h
+      constructor
+      . exact ih.mpr $ @h x ReflGen.refl
+      . intro y Rxy
+        apply ih.mpr
+        exact @h y (ReflGen.single Rxy)
+  | _ => rfl
 
 lemma iff_frame_boxdot_reflexive_closure : (F ⊧ (φᵇ)) ↔ ((F^=) ⊧ φ) := by
-  constructor;
-  . intro h V x; apply iff_boxdot_reflexive_closure.mp; exact h V x;
-  . intro h V x; apply iff_boxdot_reflexive_closure.mpr; exact h V x;
+  constructor
+  . intro h V x; apply iff_boxdot_reflexive_closure.mp; exact h V x
+  . intro h V x; apply iff_boxdot_reflexive_closure.mpr; exact h V x
 
 lemma iff_reflexivize_irreflexivize [F.IsReflexive] {x : F.World} {V} : (Satisfies ⟨F, V⟩ x φ) ↔ (Satisfies ⟨F^≠^=, V⟩ x φ) := by
   induction φ generalizing x with
-  | hatom φ => rfl;
-  | hfalsum => rfl;
+  | hatom φ => rfl
+  | hfalsum => rfl
   | himp φ ψ ihp ihq =>
-    constructor;
-    . intro h hp;
-      apply ihq.mp;
-      exact h $ ihp.mpr hp;
-    . intro h hp;
-      apply ihq.mpr;
-      exact h $ ihp.mp hp;
+    constructor
+    . intro h hp
+      apply ihq.mp
+      exact h $ ihp.mpr hp
+    . intro h hp
+      apply ihq.mpr
+      exact h $ ihp.mp hp
   | hbox φ ihp =>
-    constructor;
-    . intro h y Rxy;
-      apply ihp (x := y) |>.mp;
+    constructor
+    . intro h y Rxy
+      apply ihp (x := y) |>.mp
       exact h y $ by
         induction Rxy with
-        | refl => apply IsRefl.refl;
-        | single h => exact h.1;
-    . intro h y Rxy;
-      by_cases e : x = y;
-      . subst e;
-        apply ihp.mpr;
-        exact h x ReflGen.refl;
-      . apply ihp (x := y) |>.mpr;
+        | refl => apply IsRefl.refl
+        | single h => exact h.1
+    . intro h y Rxy
+      by_cases e : x = y
+      . subst e
+        apply ihp.mpr
+        exact h x ReflGen.refl
+      . apply ihp (x := y) |>.mpr
         exact h y $ by
-          exact ReflGen.single ⟨Rxy, (by simpa)⟩;
+          exact ReflGen.single ⟨Rxy, (by simpa)⟩
 
 lemma iff_reflexivize_irreflexivize' [F.IsReflexive] : (F ⊧ φ) ↔ ((F^≠^=) ⊧ φ) := by
-  constructor;
-  . intro h V x; apply iff_reflexivize_irreflexivize.mp; exact h V x;
-  . intro h V x; apply iff_reflexivize_irreflexivize.mpr; exact h V x;
+  constructor
+  . intro h V x; apply iff_reflexivize_irreflexivize.mp; exact h V x
+  . intro h V x; apply iff_reflexivize_irreflexivize.mpr; exact h V x
 
 end Kripke
 

--- a/Foundation/Modal/Boxdot/GLPoint3_GrzPoint3.lean
+++ b/Foundation/Modal/Boxdot/GLPoint3_GrzPoint3.lean
@@ -21,73 +21,73 @@ open Modal.Kripke
 open Entailment
 
 lemma provable_boxdotTranslated_GLPoint3_of_GrzPoint3 : Hilbert.GrzPoint3 ⊢! φ → Hilbert.GLPoint3 ⊢! φᵇ := Hilbert.of_provable_boxdotTranslated_axiomInstances $ by
-  intro φ hp;
-  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨s, _, rfl⟩);
-  . exact boxdot_axiomK!;
+  intro φ hp
+  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨s, _, rfl⟩)
+  . exact boxdot_axiomK!
   . exact boxdot_Grz_of_L!
-  . apply Complete.complete (𝓢 := Hilbert.GLPoint3) (𝓜 := FrameClass.finite_GLPoint3);
-    rintro F hF V x;
-    replace hF := Set.mem_setOf_eq.mp hF;
-    apply Satisfies.or_def.mpr;
-    by_contra hC;
-    push_neg at hC;
-    obtain ⟨hC₁, hC₂⟩ := hC;
-    replace hC₁ := not_and_or.mp $ Satisfies.and_def.not.mp hC₁;
-    replace hC₂ := not_and_or.mp $ Satisfies.and_def.not.mp hC₂;
+  . apply Complete.complete (𝓢 := Hilbert.GLPoint3) (𝓜 := FrameClass.finite_GLPoint3)
+    rintro F hF V x
+    replace hF := Set.mem_setOf_eq.mp hF
+    apply Satisfies.or_def.mpr
+    by_contra hC
+    push_neg at hC
+    obtain ⟨hC₁, hC₂⟩ := hC
+    replace hC₁ := not_and_or.mp $ Satisfies.and_def.not.mp hC₁
+    replace hC₂ := not_and_or.mp $ Satisfies.and_def.not.mp hC₂
     rcases hC₁ with (hC₁ | hC₁) <;>
     rcases hC₂ with (hC₂ | hC₂)
-    . replace hC₁ := Satisfies.imp_def₂.not.mp hC₁;
-      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂;
-      push_neg at hC₁ hC₂;
-      tauto;
-    . replace hC₁ := Satisfies.imp_def₂.not.mp hC₁;
-      replace hC₂ := Satisfies.box_def.not.mp hC₂;
-      push_neg at hC₁ hC₂;
-      obtain ⟨hC₁₁, hC₁₂⟩ := hC₁;
+    . replace hC₁ := Satisfies.imp_def₂.not.mp hC₁
+      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂
+      push_neg at hC₁ hC₂
+      tauto
+    . replace hC₁ := Satisfies.imp_def₂.not.mp hC₁
+      replace hC₂ := Satisfies.box_def.not.mp hC₂
+      push_neg at hC₁ hC₂
+      obtain ⟨hC₁₁, hC₁₂⟩ := hC₁
       obtain ⟨hC₁₁₁, hC₁₂₁⟩ := Satisfies.and_def.mp hC₁₁
-      obtain ⟨y, Rxy, hC₂⟩ := hC₂;
-      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂;
-      push_neg at hC₂;
-      exact hC₂.2 $ hC₁₂₁ y Rxy;
-    . replace hC₁ := Satisfies.box_def.not.mp hC₁;
-      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂;
-      push_neg at hC₁ hC₂;
-      obtain ⟨y, Rxy, hC₁⟩ := hC₁;
-      replace hC₁ := Satisfies.imp_def₂.not.mp hC₁;
-      push_neg at hC₁;
-      obtain ⟨hC₂₁, hC₂₂⟩ := hC₂;
+      obtain ⟨y, Rxy, hC₂⟩ := hC₂
+      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂
+      push_neg at hC₂
+      exact hC₂.2 $ hC₁₂₁ y Rxy
+    . replace hC₁ := Satisfies.box_def.not.mp hC₁
+      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂
+      push_neg at hC₁ hC₂
+      obtain ⟨y, Rxy, hC₁⟩ := hC₁
+      replace hC₁ := Satisfies.imp_def₂.not.mp hC₁
+      push_neg at hC₁
+      obtain ⟨hC₂₁, hC₂₂⟩ := hC₂
       obtain ⟨hC₂₁₁, hC₂₂₁⟩ := Satisfies.and_def.mp hC₂₁
-      exact hC₁.2 $ hC₂₂₁ y Rxy;
-    . replace hC₁ := Satisfies.box_def.not.mp hC₁;
-      replace hC₂ := Satisfies.box_def.not.mp hC₂;
-      push_neg at hC₁ hC₂;
-      obtain ⟨y, Rxy, hC₁⟩ := hC₁;
-      obtain ⟨z, Rxz, hC₂⟩ := hC₂;
-      replace hC₁ := Satisfies.imp_def₂.not.mp hC₁;
-      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂;
-      push_neg at hC₁ hC₂;
-      obtain ⟨hC₁₁, hC₁₂⟩ := hC₁;
+      exact hC₁.2 $ hC₂₂₁ y Rxy
+    . replace hC₁ := Satisfies.box_def.not.mp hC₁
+      replace hC₂ := Satisfies.box_def.not.mp hC₂
+      push_neg at hC₁ hC₂
+      obtain ⟨y, Rxy, hC₁⟩ := hC₁
+      obtain ⟨z, Rxz, hC₂⟩ := hC₂
+      replace hC₁ := Satisfies.imp_def₂.not.mp hC₁
+      replace hC₂ := Satisfies.imp_def₂.not.mp hC₂
+      push_neg at hC₁ hC₂
+      obtain ⟨hC₁₁, hC₁₂⟩ := hC₁
       obtain ⟨hC₁₁₁, hC₁₁₂⟩ := Satisfies.and_def.mp hC₁₁
-      obtain ⟨hC₂₁, hC₂₂⟩ := hC₂;
+      obtain ⟨hC₂₁, hC₂₂⟩ := hC₂
       obtain ⟨hC₂₁₁, hC₂₁₂⟩ := Satisfies.and_def.mp hC₂₁
-      rcases F.p_connected' Rxy Rxz (by by_contra eyz; subst eyz; tauto) with (Ryz | Rzy);
-      . exact hC₂₂ $ hC₁₁₂ z Ryz;
-      . exact hC₁₂ $ hC₂₁₂ y Rzy;
+      rcases F.p_connected' Rxy Rxz (by by_contra eyz; subst eyz; tauto) with (Ryz | Rzy)
+      . exact hC₂₂ $ hC₁₁₂ z Ryz
+      . exact hC₁₂ $ hC₂₁₂ y Rzy
 
 lemma provable_GrzPoint3_of_boxdotTranslated_GLPoint3 : Hilbert.GLPoint3 ⊢! φᵇ → Hilbert.GrzPoint3 ⊢! φ := by
-  intro h;
-  replace h := Sound.sound (𝓜 := FrameClass.finite_GLPoint3) h;
-  apply Complete.complete (𝓜 := FrameClass.finite_GrzPoint3);
-  contrapose! h;
-  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ h;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply iff_not_validOnFrameClass_exists_frame.mpr;
-  use F^≠;
-  constructor;
-  . apply Set.mem_setOf_eq.mpr; infer_instance;
-  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr;
-    apply iff_reflexivize_irreflexivize'.not.mp;
-    exact h;
+  intro h
+  replace h := Sound.sound (𝓜 := FrameClass.finite_GLPoint3) h
+  apply Complete.complete (𝓜 := FrameClass.finite_GrzPoint3)
+  contrapose! h
+  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ h
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply iff_not_validOnFrameClass_exists_frame.mpr
+  use F^≠
+  constructor
+  . apply Set.mem_setOf_eq.mpr; infer_instance
+  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr
+    apply iff_reflexivize_irreflexivize'.not.mp
+    exact h
 
 theorem iff_boxdotTranslatedGLPoint3_GrzPoint3 : Hilbert.GLPoint3 ⊢! φᵇ ↔ Hilbert.GrzPoint3 ⊢! φ := ⟨
   provable_GrzPoint3_of_boxdotTranslated_GLPoint3,
@@ -95,6 +95,6 @@ theorem iff_boxdotTranslatedGLPoint3_GrzPoint3 : Hilbert.GLPoint3 ⊢! φᵇ ↔
 ⟩
 
 theorem iff_boxdot_GLPoint3_GrzPoint3 : Modal.GLPoint3 ⊢! φᵇ ↔ Modal.GrzPoint3 ⊢! φ := by
-  simpa using iff_boxdotTranslatedGLPoint3_GrzPoint3;
+  simpa using iff_boxdotTranslatedGLPoint3_GrzPoint3
 
 end LO.Modal

--- a/Foundation/Modal/Boxdot/GL_Grz.lean
+++ b/Foundation/Modal/Boxdot/GL_Grz.lean
@@ -23,24 +23,24 @@ open Entailment
 
 
 lemma provable_boxdot_GL_of_provable_Grz : Hilbert.Grz ⊢! φ → Hilbert.GL ⊢! φᵇ := Hilbert.of_provable_boxdotTranslated_axiomInstances $ by
-  intro φ hp;
-  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩);
-  . exact boxdot_axiomK!;
+  intro φ hp
+  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩)
+  . exact boxdot_axiomK!
   . exact boxdot_Grz_of_L!
 
 lemma provable_Grz_of_provable_boxdot_GL : Hilbert.GL ⊢! φᵇ → Hilbert.Grz ⊢! φ := by
-  contrapose;
-  intro h;
-  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ (not_imp_not.mpr $ Complete.complete (𝓜 := FrameClass.finite_Grz)) h;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply not_imp_not.mpr $ Sound.sound (𝓜 := FrameClass.finite_GL);
-  apply iff_not_validOnFrameClass_exists_frame.mpr;
-  use F^≠;
-  constructor;
-  . apply Set.mem_setOf_eq.mpr; infer_instance;
-  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr;
-    apply iff_reflexivize_irreflexivize'.not.mp;
-    assumption;
+  contrapose
+  intro h
+  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ (not_imp_not.mpr $ Complete.complete (𝓜 := FrameClass.finite_Grz)) h
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply not_imp_not.mpr $ Sound.sound (𝓜 := FrameClass.finite_GL)
+  apply iff_not_validOnFrameClass_exists_frame.mpr
+  use F^≠
+  constructor
+  . apply Set.mem_setOf_eq.mpr; infer_instance
+  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr
+    apply iff_reflexivize_irreflexivize'.not.mp
+    assumption
 
 theorem iff_provable_boxdot_GL_provable_Grz : Hilbert.GL ⊢! φᵇ ↔ Hilbert.Grz ⊢! φ := ⟨
   provable_Grz_of_provable_boxdot_GL,
@@ -48,6 +48,6 @@ theorem iff_provable_boxdot_GL_provable_Grz : Hilbert.GL ⊢! φᵇ ↔ Hilbert.
 ⟩
 
 theorem iff_boxdot_GL_Grz : Modal.GL ⊢! φᵇ ↔ Modal.Grz ⊢! φ := by
-  simpa using iff_provable_boxdot_GL_provable_Grz;
+  simpa using iff_provable_boxdot_GL_provable_Grz
 
 end LO.Modal

--- a/Foundation/Modal/Boxdot/GL_S.lean
+++ b/Foundation/Modal/Boxdot/GL_S.lean
@@ -11,30 +11,30 @@ variable {φ : Formula _}
 lemma iff_provable_rflSubformula_GL_provable_S : Modal.GL ⊢! (φ.rflSubformula.conj ➝ φ) ↔ Modal.S ⊢! φ := ProvabilityLogic.GL_S_TFAE (T := 𝐈𝚺₁) |>.out 0 1
 
 lemma iff_provable_boxdot_GL_provable_boxdot_S : Modal.GL ⊢! φᵇ ↔ Modal.S ⊢! φᵇ := by
-  constructor;
-  . apply Entailment.WeakerThan.wk;
-    infer_instance;
-  . intro h;
-    simp only [Hilbert.Normal.iff_logic_provable_provable];
-    apply Logic.GL.Kripke.iff_provable_satisfies_FiniteTransitiveTree.mpr;
-    replace h := iff_provable_rflSubformula_GL_provable_S.mpr h;
-    replace h := Hilbert.Normal.iff_logic_provable_provable.mp h;
-    replace h := Logic.GL.Kripke.iff_provable_satisfies_FiniteTransitiveTree.mp h;
-    intro M r _;
-    obtain ⟨i, hi⟩ := Kripke.Model.extendRoot.inr_satisfies_axiomT_set (M := M) (Γ := φᵇ.subformulas.prebox);
-    let M₁ := M.extendRoot ⟨φᵇ.subformulas.prebox.card + 1, by omega⟩;
-    let i₁ : M₁.World := Sum.inl i;
+  constructor
+  . apply Entailment.WeakerThan.wk
+    infer_instance
+  . intro h
+    simp only [Hilbert.Normal.iff_logic_provable_provable]
+    apply Logic.GL.Kripke.iff_provable_satisfies_FiniteTransitiveTree.mpr
+    replace h := iff_provable_rflSubformula_GL_provable_S.mpr h
+    replace h := Hilbert.Normal.iff_logic_provable_provable.mp h
+    replace h := Logic.GL.Kripke.iff_provable_satisfies_FiniteTransitiveTree.mp h
+    intro M r _
+    obtain ⟨i, hi⟩ := Kripke.Model.extendRoot.inr_satisfies_axiomT_set (M := M) (Γ := φᵇ.subformulas.prebox)
+    let M₁ := M.extendRoot ⟨φᵇ.subformulas.prebox.card + 1, by omega⟩
+    let i₁ : M₁.World := Sum.inl i
     refine Model.extendRoot.inl_satisfies_boxdot_iff.mpr
       $ Model.pointGenerate.modal_equivalent_at_root (r := i₁) |>.mp
-      $ @h (M₁↾i₁) Model.pointGenerate.root ?_ ?_;
-    . exact {};
+      $ @h (M₁↾i₁) Model.pointGenerate.root ?_ ?_
+    . exact {}
     . apply @Model.pointGenerate.modal_equivalent_at_root (r := i₁) |>.mpr
-      apply Satisfies.fconj_def.mpr;
-      intro ψ hψ;
-      apply Satisfies.fconj_def.mp hi;
-      simp only [Finset.mem_image, Finset.mem_preimage, Function.iterate_one] at hψ ⊢;
-      obtain ⟨ξ, hξ, rfl⟩ := hψ;
-      use ξ;
+      apply Satisfies.fconj_def.mpr
+      intro ψ hψ
+      apply Satisfies.fconj_def.mp hi
+      simp only [Finset.mem_image, Finset.mem_preimage, Function.iterate_one] at hψ ⊢
+      obtain ⟨ξ, hξ, rfl⟩ := hψ
+      use ξ
 
 end Modal.Logic
 

--- a/Foundation/Modal/Boxdot/Grz_S.lean
+++ b/Foundation/Modal/Boxdot/Grz_S.lean
@@ -4,8 +4,8 @@ import Foundation.Modal.Boxdot.GL_S
 namespace LO.Modal.Logic
 
 lemma iff_provable_Grz_provable_boxdot_S : Modal.S ⊢! φᵇ ↔ Modal.Grz ⊢! φ := by
-  apply Iff.trans iff_provable_boxdot_GL_provable_boxdot_S.symm;
-  simp only [Hilbert.Normal.iff_logic_provable_provable];
-  exact iff_provable_boxdot_GL_provable_Grz;
+  apply Iff.trans iff_provable_boxdot_GL_provable_boxdot_S.symm
+  simp only [Hilbert.Normal.iff_logic_provable_provable]
+  exact iff_provable_boxdot_GL_provable_Grz
 
 end LO.Modal.Logic

--- a/Foundation/Modal/Boxdot/Jerabek.lean
+++ b/Foundation/Modal/Boxdot/Jerabek.lean
@@ -23,87 +23,87 @@ def Frame.twice (F : Frame) : Frame where
 local postfix:100 "×2" => Frame.twice
 
 instance [F.IsReflexive] : F×2.IsReflexive where
-  refl := by rintro ⟨x, i⟩; simp [Frame.twice];
+  refl := by rintro ⟨x, i⟩; simp [Frame.twice]
 
 instance [F.IsTransitive] : F×2.IsTransitive where
   trans := by
-    rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Ryj;
-    simp only [Frame.twice] at Rxy Ryj;
-    exact F.trans Rxy Ryj;
+    rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Ryj
+    simp only [Frame.twice] at Rxy Ryj
+    exact F.trans Rxy Ryj
 
 instance [F.IsSymmetric] : F×2.IsSymmetric where
   symm := by
-    rintro ⟨x, i⟩ ⟨y, j⟩ Rxy;
-    simp only [Frame.twice] at Rxy;
-    exact F.symm Rxy;
+    rintro ⟨x, i⟩ ⟨y, j⟩ Rxy
+    simp only [Frame.twice] at Rxy
+    exact F.symm Rxy
 
 instance [F.IsPiecewiseStronglyConvergent] : F×2.IsPiecewiseStronglyConvergent := by
-  constructor;
-  rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Rxz;
-  simp only [Frame.twice] at Rxy Rxz;
-  obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz;
-  use (u, i);
-  constructor <;> simpa [Frame.twice];
+  constructor
+  rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Rxz
+  simp only [Frame.twice] at Rxy Rxz
+  obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz
+  use (u, i)
+  constructor <;> simpa [Frame.twice]
 
 instance [F.IsPiecewiseStronglyConnected] : F×2.IsPiecewiseStronglyConnected := by
-  constructor;
-  rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Rxz;
-  simp only [Frame.twice] at Rxy Rxz;
-  rcases F.ps_connected Rxy Rxz with (Ryz | Rzy);
-  . left; simpa;
-  . right; simpa;
+  constructor
+  rintro ⟨x, i⟩ ⟨y, j⟩ ⟨z, k⟩ Rxy Rxz
+  simp only [Frame.twice] at Rxy Rxz
+  rcases F.ps_connected Rxy Rxz with (Ryz | Rzy)
+  . left; simpa
+  . right; simpa
 
 
 def Frame.twice.PMorphism (F : Frame) : F×2 →ₚ F where
   toFun := Prod.fst
   forth := by
-    rintro ⟨x, _⟩ ⟨y, _⟩ h;
-    simpa using h;
+    rintro ⟨x, _⟩ ⟨y, _⟩ h
+    simpa using h
   back := by
-    intro ⟨x, i⟩ y Rxy;
-    use ⟨y, true⟩;
-    constructor;
-    . simp;
-    . tauto;
+    intro ⟨x, i⟩ y Rxy
+    use ⟨y, true⟩
+    constructor
+    . simp
+    . tauto
 
 class FrameClass.JerabekAssumption (C : FrameClass) where
   twice : ∀ F ∈ C, F×2 ∈ C
 
 instance : FrameClass.KT.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  infer_instance;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  infer_instance
 
 instance : FrameClass.KTB.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 instance : FrameClass.S4.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 instance : FrameClass.S4Point2.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 instance : FrameClass.S4Point3.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 instance : FrameClass.S5.JerabekAssumption := by
-  constructor;
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  constructor
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 end Kripke
 
@@ -118,7 +118,7 @@ def flag (φ : Formula α) : Bool → Formula α
 
 @[simp]
 lemma atom_flag_boxdotTranslated : (flag (.atom a) b)ᵇ = (flag (.atom a) b) := by
-  match b with | true | false => rfl;
+  match b with | true | false => rfl
 
 end Formula
 
@@ -135,11 +135,11 @@ def BoxdotProperty (L₀ : Logic α) := ∀ {L : Logic _}, L.IsNormal → Lᵇ�
 def StrongBoxdotProperty (L₀ : Logic α) := ∀ {L : Logic _}, L.IsNormal → Lᵇ⁻¹ ⊆ L₀ → L ⊆ L₀
 
 lemma BDP_of_SBDP : StrongBoxdotProperty L₀ → BoxdotProperty L₀ := by
-  intro hSBDP;
-  intro L _ hL;
-  apply hSBDP;
-  . assumption;
-  . rw [hL];
+  intro hSBDP
+  intro L _ hL
+  apply hSBDP
+  . assumption
+  . rw [hL]
 
 end Logic
 
@@ -156,52 +156,52 @@ open Kripke
 
 def Formula.Kripke.Satisfies.neither_flag {M : Model} {x : M} {φ : Formula ℕ} : ¬(x ⊧ φ.flag b ∧ x ⊧ φ.flag !b) := by
   match b with
-  | true  => simp [Formula.flag];
-  | false => simp [Formula.flag];
+  | true  => simp [Formula.flag]
+  | false => simp [Formula.flag]
 
 section
 
 variable {L : Logic ℕ} [L.IsNormal] {n : ℕ} {Γ Δ : Finset (Formula ℕ)} {φ : Formula ℕ} {p} {b}
 
 private lemma jerabek_SBDP.lemma₁ : Hilbert.K ⊢! (flag (.atom p) b) ⋏ □φᵇ ➝ ⊡((flag (.atom p) !b) ➝ φᵇ) := by
-  apply Complete.complete (𝓜 := Kripke.FrameClass.K);
-  intro F hF V x hx;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply Satisfies.and_def.mpr;
-  constructor;
-  . intro hx₁;
-    by_contra hC;
-    apply Satisfies.neither_flag;
-    constructor;
-    . exact Satisfies.and_def.mp hx |>.1;
-    . assumption;
-  . replace hx := Satisfies.and_def.mp hx |>.2;
-    intro y Rxy h;
-    apply hx;
-    assumption;
+  apply Complete.complete (𝓜 := Kripke.FrameClass.K)
+  intro F hF V x hx
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply Satisfies.and_def.mpr
+  constructor
+  . intro hx₁
+    by_contra hC
+    apply Satisfies.neither_flag
+    constructor
+    . exact Satisfies.and_def.mp hx |>.1
+    . assumption
+  . replace hx := Satisfies.and_def.mp hx |>.2
+    intro y Rxy h
+    apply hx
+    assumption
 
 private lemma jerabek_SBDP.lemma₂ : L ⊢! (flag (.atom p) b) ⋏ □φᵇ ➝ ⊡((flag (.atom p) !b) ➝ φᵇ) := by
-  apply normal_provable_of_K_provable;
-  simpa using lemma₁;
+  apply normal_provable_of_K_provable
+  simpa using lemma₁
 
 private lemma jerabek_SBDP.lemma₃ : L ⊢! (□^[n]Γ.conj)ᵇ ➝ □^≤[n](Γ.image (·ᵇ)).conj := by
-  apply normal_provable_of_K_provable;
-  apply Complete.complete (𝓜 := Kripke.FrameClass.K);
-  intro F hF V x h;
-  apply Satisfies.fconj_def.mpr;
-  simp only [Finset.mem_image, Finset.mem_range, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂];
-  intro k hk;
-  apply Satisfies.multibox_def.mpr;
-  intro y Rxy;
-  apply Satisfies.fconj_def.mpr;
-  simp only [Finset.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂];
-  intro ξ hξ;
-  replace h : Satisfies _ x (□^[k]Γ.conjᵇ) := Satisfies.fconj_def.mp (Satisfies.iff_boxdotTranslateMultibox_boxdotTranslateBoxlt.mp h) _ ?_;
-  . apply Satisfies.fconj_def.mp (Satisfies.boxdotTranslate_fconj₂.mp $ Satisfies.multibox_def.mp h Rxy) _;
-    simp only [Finset.mem_image];
-    use ξ;
-  . simp only [Finset.mem_image, Finset.mem_range];
-    use k;
+  apply normal_provable_of_K_provable
+  apply Complete.complete (𝓜 := Kripke.FrameClass.K)
+  intro F hF V x h
+  apply Satisfies.fconj_def.mpr
+  simp only [Finset.mem_image, Finset.mem_range, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+  intro k hk
+  apply Satisfies.multibox_def.mpr
+  intro y Rxy
+  apply Satisfies.fconj_def.mpr
+  simp only [Finset.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+  intro ξ hξ
+  replace h : Satisfies _ x (□^[k]Γ.conjᵇ) := Satisfies.fconj_def.mp (Satisfies.iff_boxdotTranslateMultibox_boxdotTranslateBoxlt.mp h) _ ?_
+  . apply Satisfies.fconj_def.mp (Satisfies.boxdotTranslate_fconj₂.mp $ Satisfies.multibox_def.mp h Rxy) _
+    simp only [Finset.mem_image]
+    use ξ
+  . simp only [Finset.mem_image, Finset.mem_range]
+    use k
 
 end
 
@@ -213,82 +213,82 @@ theorem jerabek_SBDP
   (C : Kripke.FrameClass) [C.JerabekAssumption]
   [sound : Sound L₀ C] [complete : Complete L₀ C]
   : L₀.StrongBoxdotProperty := by
-  intro L _;
-  contrapose!;
-  intro hL;
-  obtain ⟨φ, hφL, hφL₀⟩ := Set.not_subset.mp hL;
-  apply Set.not_subset.mpr;
+  intro L _
+  contrapose!
+  intro hL
+  obtain ⟨φ, hφL, hφL₀⟩ := Set.not_subset.mp hL
+  apply Set.not_subset.mpr
 
-  let q := Formula.freshAtom φ;
-  let X₀ := φ.subformulas.prebox.image (λ ψ => □((.atom q) ➝ ψ) ➝ ψ);
-  let X₁ := φ.subformulas.prebox.image (λ ψ => □(∼(.atom q) ➝ ψ) ➝ ψ);
-  let X := X₀ ∪ X₁;
-  let XB := X.image (·ᵇ);
+  let q := Formula.freshAtom φ
+  let X₀ := φ.subformulas.prebox.image (λ ψ => □((.atom q) ➝ ψ) ➝ ψ)
+  let X₁ := φ.subformulas.prebox.image (λ ψ => □(∼(.atom q) ➝ ψ) ➝ ψ)
+  let X := X₀ ∪ X₁
+  let XB := X.image (·ᵇ)
 
   have Claim1 : ∀ ψ ∈ φ.subformulas.prebox, (L, XB.toSet) ⊢! □ψᵇ ➝ ψᵇ := by
-    intro ψ hψ;
+    intro ψ hψ
     have H₁ : ∀ b, (L, XB.toSet) ⊢! (flag (.atom q) b) ⋏ □ψᵇ ➝ ⊡((flag (.atom q) !b) ➝ ψᵇ) := by
-      intro b;
-      apply GlobalConsequence.thm!;
-      apply jerabek_SBDP.lemma₂;
+      intro b
+      apply GlobalConsequence.thm!
+      apply jerabek_SBDP.lemma₂
     have H₂ : ∀ b, (L, XB.toSet) ⊢! ⊡((flag (.atom q) b) ➝ ψᵇ) ➝ ψᵇ := by
-      intro b;
+      intro b
       suffices (L, XB.toSet) ⊢! (□((flag (.atom q) b) ➝ ψ) ➝ ψ)ᵇ by
-        simpa only [Formula.boxdotTranslate, Formula.atom_flag_boxdotTranslated] using this;
-      apply GlobalConsequence.ctx!;
-      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, XB];
-      use (□((flag (atom q) b) ➝ ψ) ➝ ψ);
-      constructor;
-      . match b with | true | false => simpa [X, X₀, X₁, flag] using hψ;
-      . rfl;
+        simpa only [Formula.boxdotTranslate, Formula.atom_flag_boxdotTranslated] using this
+      apply GlobalConsequence.ctx!
+      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, XB]
+      use (□((flag (atom q) b) ➝ ψ) ➝ ψ)
+      constructor
+      . match b with | true | false => simpa [X, X₀, X₁, flag] using hψ
+      . rfl
     have H₃ : ∀ b, (L, XB.toSet) ⊢! (flag (.atom q) b) ➝ (□ψᵇ ➝ ψᵇ) := by
-      intro b;
-      cl_prover [(H₁ b), (H₂ !b)];
-    have H₄ : (L, XB.toSet) ⊢!  atom q ➝ □ψᵇ ➝ ψᵇ := H₃ true;
-    have H₅ : (L, XB.toSet) ⊢! ∼atom q ➝ □ψᵇ ➝ ψᵇ := H₃ false;
-    cl_prover [H₄, H₅];
+      intro b
+      cl_prover [(H₁ b), (H₂ !b)]
+    have H₄ : (L, XB.toSet) ⊢!  atom q ➝ □ψᵇ ➝ ψᵇ := H₃ true
+    have H₅ : (L, XB.toSet) ⊢! ∼atom q ➝ □ψᵇ ➝ ψᵇ := H₃ false
+    cl_prover [H₄, H₅]
   have Claim2 : ∀ ψ ∈ φ.subformulas, (L, XB.toSet) ⊢! ψ ⭤ ψᵇ := by
-    intro ψ hψ;
+    intro ψ hψ
     induction ψ with
-    | hfalsum => simp [Formula.boxdotTranslate];
-    | hatom a => simp [Formula.boxdotTranslate];
+    | hfalsum => simp [Formula.boxdotTranslate]
+    | hatom a => simp [Formula.boxdotTranslate]
     | himp ψ₁ ψ₂ ihψ₁ ihψ₂ =>
-      replace ihψ₁ := ihψ₁ (by grind);
-      replace ihψ₂ := ihψ₂ (by grind);
-      dsimp [Formula.boxdotTranslate];
-      cl_prover [ihψ₁, ihψ₂];
+      replace ihψ₁ := ihψ₁ (by grind)
+      replace ihψ₂ := ihψ₂ (by grind)
+      dsimp [Formula.boxdotTranslate]
+      cl_prover [ihψ₁, ihψ₂]
     | hbox ψ ihψ =>
-      replace ihψ : (L, XB.toSet) ⊢! ψ ⭤ ψᵇ := ihψ (by grind);
-      have H₁ : (L, XB.toSet) ⊢! □ψ ⭤ □ψᵇ := box_congruence! ihψ;
+      replace ihψ : (L, XB.toSet) ⊢! ψ ⭤ ψᵇ := ihψ (by grind)
+      have H₁ : (L, XB.toSet) ⊢! □ψ ⭤ □ψᵇ := box_congruence! ihψ
       have H₂ : (L, XB.toSet) ⊢! □ψᵇ ⭤ ⊡ψᵇ := by
-        apply Entailment.E!_intro;
-        . have : (L, XB.toSet) ⊢! □ψᵇ ➝ ψᵇ := Claim1 ψ (by simpa);
-          cl_prover [this];
-        . cl_prover;
-      cl_prover [H₁, H₂];
+        apply Entailment.E!_intro
+        . have : (L, XB.toSet) ⊢! □ψᵇ ➝ ψᵇ := Claim1 ψ (by simpa)
+          cl_prover [this]
+        . cl_prover
+      cl_prover [H₁, H₂]
   have : (L, XB.toSet) ⊢! φᵇ := by
-    have h₁ : (L, XB.toSet) ⊢! φ ➝ φᵇ := C_of_E_mp! $ Claim2 φ (by grind);
+    have h₁ : (L, XB.toSet) ⊢! φ ➝ φᵇ := C_of_E_mp! $ Claim2 φ (by grind)
     have h₂ : (L, XB.toSet) ⊢! φ := by
-      apply GlobalConsequence.thm!;
-      simpa using hφL;
-    exact h₁ ⨀ h₂;
-  obtain ⟨Γ, n, hΓ, hφ⟩ := GlobalConsequence.iff_finite_boxlt_provable.mp this;
-  replace hφ : L ⊢! (□^≤[n]XB.conj) ➝ φᵇ := C!_trans (boxlt_fconj_regularity_of_subset hΓ) hφ;
-  let χ := (□^[n](X.conj) ➝ φ);
-  have hχ : L ⊢! χᵇ := by apply C!_trans jerabek_SBDP.lemma₃ hφ;
-  use χ;
-  constructor;
-  . constructor;
-    . suffices L ⊢! χ by simpa;
-      apply dhyp!;
-      simpa using hφL;
-    . assumption;
-  . suffices L₀ ⊬ (□^[n]X.conj) ➝ φ by simpa;
-    apply sound.not_provable_of_countermodel;
-    apply not_validOnFrameClass_of_exists_model_world;
+      apply GlobalConsequence.thm!
+      simpa using hφL
+    exact h₁ ⨀ h₂
+  obtain ⟨Γ, n, hΓ, hφ⟩ := GlobalConsequence.iff_finite_boxlt_provable.mp this
+  replace hφ : L ⊢! (□^≤[n]XB.conj) ➝ φᵇ := C!_trans (boxlt_fconj_regularity_of_subset hΓ) hφ
+  let χ := (□^[n](X.conj) ➝ φ)
+  have hχ : L ⊢! χᵇ := by apply C!_trans jerabek_SBDP.lemma₃ hφ
+  use χ
+  constructor
+  . constructor
+    . suffices L ⊢! χ by simpa
+      apply dhyp!
+      simpa using hφL
+    . assumption
+  . suffices L₀ ⊬ (□^[n]X.conj) ➝ φ by simpa
+    apply sound.not_provable_of_countermodel
+    apply not_validOnFrameClass_of_exists_model_world
 
-    have : ¬C ⊧ φ := complete.exists_countermodel_of_not_provable (by simpa using hφL₀);
-    obtain ⟨M, x, hMC, hF⟩ := Kripke.exists_model_world_of_not_validOnFrameClass this;
+    have : ¬C ⊧ φ := complete.exists_countermodel_of_not_provable (by simpa using hφL₀)
+    obtain ⟨M, x, hMC, hF⟩ := Kripke.exists_model_world_of_not_validOnFrameClass this
     let M₂ : Kripke.Model := {
       toFrame := M.toFrame.twice
       Val := λ ⟨w, i⟩ a =>
@@ -296,66 +296,66 @@ theorem jerabek_SBDP
         else M.Val w a
     }
     have : M.IsReflexive := by
-      apply reflexive_of_validate_AxiomT;
-      apply sound.sound;
-      . apply hKT.pbl;
-        simp;
-      . assumption;
+      apply reflexive_of_validate_AxiomT
+      apply sound.sound
+      . apply hKT.pbl
+        simp
+      . assumption
 
     -- Memo: BdRV Prop 2.14
     have H2 : ∀ ψ ∈ φ.subformulas, ∀ w : M.World, ∀ b : Bool, Satisfies M₂ (w, b) ψ ↔ Satisfies M w ψ := by
-      intro ψ hψ w b;
+      intro ψ hψ w b
       induction ψ generalizing w b with
-      | hfalsum => simp [Satisfies];
+      | hfalsum => simp [Satisfies]
       | hatom a =>
-        have : a ≠ q := Formula.ne_freshAtom_of_mem_subformulas hψ |>.symm;
-        simp [Satisfies, M₂, this];
+        have : a ≠ q := Formula.ne_freshAtom_of_mem_subformulas hψ |>.symm
+        simp [Satisfies, M₂, this]
       | himp ψ₁ ψ₂ ihψ₁ ihψ₂ =>
-        replace ihψ₁ := ihψ₁ (by grind);
-        replace ihψ₂ := ihψ₂ (by grind);
+        replace ihψ₁ := ihψ₁ (by grind)
+        replace ihψ₂ := ihψ₂ (by grind)
         simp [Satisfies, ihψ₁, ihψ₂]
       | hbox ψ ihψ =>
-        replace ihψ := ihψ (by grind);
-        constructor;
-        . intro h v Rwv;
-          apply ihψ v _ |>.mp;
-          apply h (v, b);
+        replace ihψ := ihψ (by grind)
+        constructor
+        . intro h v Rwv
+          apply ihψ v _ |>.mp
+          apply h (v, b)
           simpa [Frame.Rel', M₂, Frame.twice]
-        . intro h v Rwv;
-          apply ihψ v.1 v.2 |>.mpr;
-          apply h;
-          simpa [Frame.Rel', M₂, Frame.twice] using Rwv;
+        . intro h v Rwv
+          apply ihψ v.1 v.2 |>.mpr
+          apply h
+          simpa [Frame.Rel', M₂, Frame.twice] using Rwv
 
-    use M₂, (x, true);
-    constructor;
-    . exact Kripke.FrameClass.JerabekAssumption.twice (C := C) _ hMC;
-    . apply Satisfies.not_imp_def.mpr;
-      constructor;
+    use M₂, (x, true)
+    constructor
+    . exact Kripke.FrameClass.JerabekAssumption.twice (C := C) _ hMC
+    . apply Satisfies.not_imp_def.mpr
+      constructor
       . have : M₂ ⊧ X.conj := by
-          intro x;
-          apply Satisfies.fconj_def.mpr;
-          rintro ψ hψ;
-          rcases (by simpa [X, X₀, X₁] using hψ) with (⟨ψ, _, rfl⟩ | ⟨ψ, _, rfl⟩);
-          . intro hψ₁;
-            by_cases hψ : Satisfies M x.1 ψ;
-            . exact H2 _ (by grind) _ _ |>.mpr hψ;
-            . exfalso;
-              apply hψ;
-              apply H2 _ (by grind) _ true |>.mp;
-              apply hψ₁ (x.1, true);
-              . simp [Frame.Rel', M₂, Frame.twice];
-              . simp [Satisfies, M₂];
-          . intro hψ₁;
-            by_cases hψ : Satisfies M x.1 ψ;
-            . exact H2 _ (by grind) _ _ |>.mpr hψ;
-            . exfalso;
-              apply hψ;
-              apply H2 _ (by grind) _ false |>.mp;
-              apply hψ₁ (x.1, false);
-              . simp [Frame.Rel', M₂, Frame.twice];
-              . simp [Satisfies, M₂];
-        apply ValidOnModel.multinec n this;
-      . exact H2 φ (by grind) x _ |>.not.mpr hF;
+          intro x
+          apply Satisfies.fconj_def.mpr
+          rintro ψ hψ
+          rcases (by simpa [X, X₀, X₁] using hψ) with (⟨ψ, _, rfl⟩ | ⟨ψ, _, rfl⟩)
+          . intro hψ₁
+            by_cases hψ : Satisfies M x.1 ψ
+            . exact H2 _ (by grind) _ _ |>.mpr hψ
+            . exfalso
+              apply hψ
+              apply H2 _ (by grind) _ true |>.mp
+              apply hψ₁ (x.1, true)
+              . simp [Frame.Rel', M₂, Frame.twice]
+              . simp [Satisfies, M₂]
+          . intro hψ₁
+            by_cases hψ : Satisfies M x.1 ψ
+            . exact H2 _ (by grind) _ _ |>.mpr hψ
+            . exfalso
+              apply hψ
+              apply H2 _ (by grind) _ false |>.mp
+              apply hψ₁ (x.1, false)
+              . simp [Frame.Rel', M₂, Frame.twice]
+              . simp [Satisfies, M₂]
+        apply ValidOnModel.multinec n this
+      . exact H2 φ (by grind) x _ |>.not.mpr hF
 
 /--
   Every Logic `L₀` which is `Modal.KT ⪯ L₀` and sound and complete to frame class `C` satisfies Jeřábek's assumption, has boxdot property.

--- a/Foundation/Modal/Boxdot/K4_S4.lean
+++ b/Foundation/Modal/Boxdot/K4_S4.lean
@@ -10,20 +10,20 @@ open Formula
 
 lemma provable_boxdotTranslated_K4_of_provable_S4 : Hilbert.S4 ⊢! φ → Hilbert.K4 ⊢! φᵇ :=
   Hilbert.of_provable_boxdotTranslated_axiomInstances $ by
-    intro φ hp;
-    rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩);
-    . exact boxdot_axiomK!;
-    . exact boxdot_axiomT!;
+    intro φ hp
+    rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩)
+    . exact boxdot_axiomK!
+    . exact boxdot_axiomT!
     . exact boxdot_axiomFour!
 
 lemma provable_S4_iff_boxdotTranslated : Hilbert.S4 ⊢! φ ⭤ φᵇ := by
   induction φ with
-  | hbox φ ihp => exact E!_trans (box_iff! ihp) iff_box_boxdot!;
-  | himp φ ψ ihp ihq => exact ECC!_of_E!_of_E! ihp ihq;
-  | _ => exact E!_id;
+  | hbox φ ihp => exact E!_trans (box_iff! ihp) iff_box_boxdot!
+  | himp φ ψ ihp ihq => exact ECC!_of_E!_of_E! ihp ihq
+  | _ => exact E!_id
 
 lemma provable_S4_of_provable_boxdotTranslated_K4 (h : Hilbert.K4 ⊢! φᵇ) : Hilbert.S4 ⊢! φ := by
-  exact (K!_right provable_S4_iff_boxdotTranslated) ⨀ (WeakerThan.pbl h);
+  exact (K!_right provable_S4_iff_boxdotTranslated) ⨀ (WeakerThan.pbl h)
 
 theorem iff_boxdotTranslatedK4_S4 : Hilbert.K4 ⊢! φᵇ ↔ Hilbert.S4 ⊢! φ := ⟨
   provable_S4_of_provable_boxdotTranslated_K4,

--- a/Foundation/Modal/Boxdot/Ver_Triv.lean
+++ b/Foundation/Modal/Boxdot/Ver_Triv.lean
@@ -15,34 +15,34 @@ open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 variable {φ : Formula ℕ}
 
 lemma provable_boxdotTranslated_Ver_of_Triv : Hilbert.Triv ⊢! φ → Hilbert.Ver ⊢! φᵇ := Hilbert.of_provable_boxdotTranslated_axiomInstances $ by
-  rintro φ hp;
-  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩);
-  . exact boxdot_axiomK!;
-  . simp only [boxdotTranslate, and₁!];
-  . apply deduct'!;
-    apply K!_intro <;> simp;
+  rintro φ hp
+  rcases (by simpa using hp) with (⟨_, _, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩)
+  . exact boxdot_axiomK!
+  . simp only [boxdotTranslate, and₁!]
+  . apply deduct'!
+    apply K!_intro <;> simp
 
 lemma provable_Triv_of_boxdotTranslated_Ver : Hilbert.Ver ⊢! φᵇ → Hilbert.Triv ⊢! φ := by
-  intro h;
-  replace h := Sound.sound (𝓢 := Hilbert.Ver) (𝓜 := FrameClass.Ver) h;
-  apply Complete.complete (𝓢 := Hilbert.Triv) (𝓜 := FrameClass.Triv);
-  contrapose! h;
-  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ h;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply iff_not_validOnFrameClass_exists_frame.mpr;
-  use F^≠;
-  constructor;
+  intro h
+  replace h := Sound.sound (𝓢 := Hilbert.Ver) (𝓜 := FrameClass.Ver) h
+  apply Complete.complete (𝓢 := Hilbert.Triv) (𝓜 := FrameClass.Triv)
+  contrapose! h
+  obtain ⟨F, hF, h⟩ := iff_not_validOnFrameClass_exists_frame.mp $ h
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply iff_not_validOnFrameClass_exists_frame.mpr
+  use F^≠
+  constructor
   . exact {
       isolated := by
-        intro x y;
-        by_contra! hC;
-        obtain ⟨Rxy, nxy⟩ := hC;
-        apply nxy;
-        simpa using Rxy;
+        intro x y
+        by_contra! hC
+        obtain ⟨Rxy, nxy⟩ := hC
+        apply nxy
+        simpa using Rxy
     }
-  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr;
-    apply iff_reflexivize_irreflexivize'.not.mp;
-    exact h;
+  . apply Kripke.iff_frame_boxdot_reflexive_closure.not.mpr
+    apply iff_reflexivize_irreflexivize'.not.mp
+    exact h
 
 theorem iff_boxdotTranslated_Ver_Triv : Hilbert.Ver ⊢! φᵇ ↔ Hilbert.Triv ⊢! φ := ⟨
   provable_Triv_of_boxdotTranslated_Ver,

--- a/Foundation/Modal/Complement.lean
+++ b/Foundation/Modal/Complement.lean
@@ -18,33 +18,33 @@ variable {φ ψ : Formula α}
 @[simp] lemma neg_def : -(∼φ) = φ := by
   induction φ <;> simp_all [complement]
 
-@[simp] lemma bot_def : -(⊥ : Formula α) = ∼(⊥) := by simp only [complement]; rfl;
+@[simp] lemma bot_def : -(⊥ : Formula α) = ∼(⊥) := by simp only [complement]; rfl
 
-@[simp] lemma box_def : -(□φ) = ∼(□φ) := by simp only [complement]; rfl;
+@[simp] lemma box_def : -(□φ) = ∼(□φ) := by simp only [complement]; rfl
 
 lemma imp_def₁ (hq : ψ ≠ ⊥) : -(φ ➝ ψ) = ∼(φ ➝ ψ) := by
-  simp only [complement];
-  split;
-  . rename_i h; simp [imp_eq, falsum_eq, hq] at h;
-  . rfl;
+  simp only [complement]
+  split
+  . rename_i h; simp [imp_eq, falsum_eq, hq] at h
+  . rfl
 
 lemma imp_def₂ (hq : ψ = ⊥) : -(φ ➝ ψ) = φ := by
-  subst_vars;
-  apply neg_def;
+  subst_vars
+  apply neg_def
 
 lemma resort_box (h : -φ = □ψ) : φ = ∼□ψ := by
-  simp [complement] at h;
-  split at h;
-  . subst_vars; rfl;
-  . contradiction;
+  simp [complement] at h
+  split at h
+  . subst_vars; rfl
+  . contradiction
 
 lemma or [DecidableEq α] (φ : Formula α) : -φ = ∼φ ∨ ∃ ψ, ∼ψ = φ := by
   induction φ using Formula.cases_neg with
-  | himp _ _ hn => simp [imp_def₁ hn];
-  | hfalsum => simp;
-  | hneg => simp;
-  | hatom a => simp [complement];
-  | hbox φ => simp [complement]; rfl;
+  | himp _ _ hn => simp [imp_def₁ hn]
+  | hfalsum => simp
+  | hneg => simp
+  | hatom a => simp [complement]
+  | hbox φ => simp [complement]; rfl
 
 end complement
 
@@ -60,19 +60,19 @@ postfix:80 "⁻" => complementary
 
 variable {P P₁ P₂ : FormulaFinset α} {φ ψ χ : Formula α}
 
-lemma complementary_mem (h : φ ∈ P) : φ ∈ P⁻ := by simp_all [complementary];
+lemma complementary_mem (h : φ ∈ P) : φ ∈ P⁻ := by simp_all [complementary]
 
-lemma complementary_comp (h : φ ∈ P) : -φ ∈ P⁻ := by simp [complementary]; tauto;
+lemma complementary_comp (h : φ ∈ P) : -φ ∈ P⁻ := by simp [complementary]; tauto
 
-lemma mem_of (h : φ ∈ P⁻) : φ ∈ P ∨ ∃ ψ ∈ P, -ψ = φ := by simpa [complementary] using h;
+lemma mem_of (h : φ ∈ P⁻) : φ ∈ P ∨ ∃ ψ ∈ P, -ψ = φ := by simpa [complementary] using h
 
 lemma complementary_mem_box (hi : ∀ {ψ χ}, ψ ➝ χ ∈ P → ψ ∈ P) : □φ ∈ P⁻ → □φ ∈ P := by
-  intro h;
-  rcases (mem_of h) with (h | ⟨ψ, hq, eq⟩);
-  . assumption;
-  . replace eq := Formula.complement.resort_box eq;
-    subst eq;
-    exact hi hq;
+  intro h
+  rcases (mem_of h) with (h | ⟨ψ, hq, eq⟩)
+  . assumption
+  . replace eq := Formula.complement.resort_box eq
+    subst eq
+    exact hi hq
 
 
 class ComplementaryClosed (P : FormulaFinset α) (S : FormulaFinset α) : Prop where
@@ -92,41 +92,41 @@ variable {𝓢 : S} [Entailment.Cl 𝓢] {φ : Formula _}
 
 lemma complement_derive_bot [DecidableEq α] (hp : 𝓢 ⊢! φ) (hcp : 𝓢 ⊢! -φ) : 𝓢 ⊢! ⊥ := by
   induction φ using Formula.cases_neg with
-  | hfalsum => assumption;
-  | hatom a => unfold Formula.complement at hcp; exact hcp ⨀ hp;
-  | hneg => unfold Formula.complement at hcp; exact hp ⨀ hcp;
-  | hbox φ => unfold Formula.complement at hcp; exact hcp ⨀ hp;
+  | hfalsum => assumption
+  | hatom a => unfold Formula.complement at hcp; exact hcp ⨀ hp
+  | hneg => unfold Formula.complement at hcp; exact hp ⨀ hcp
+  | hbox φ => unfold Formula.complement at hcp; exact hcp ⨀ hp
   | himp φ ψ h =>
-    simp only [Formula.complement.imp_def₁ h] at hcp;
-    exact hcp ⨀ hp;
+    simp only [Formula.complement.imp_def₁ h] at hcp
+    exact hcp ⨀ hp
 
 lemma neg_complement_derive_bot [DecidableEq α] (hp : 𝓢 ⊢! ∼φ) (hcp : 𝓢 ⊢! ∼(-φ)) : 𝓢 ⊢! ⊥ := by
   induction φ using Formula.cases_neg with
   | hfalsum =>
-    unfold Formula.complement at hcp;
-    exact hcp ⨀ hp;
+    unfold Formula.complement at hcp
+    exact hcp ⨀ hp
   | hatom a =>
-    unfold Formula.complement at hcp;
-    exact hcp ⨀ hp;
+    unfold Formula.complement at hcp
+    exact hcp ⨀ hp
   | hneg =>
-    unfold Formula.complement at hcp;
-    exact hp ⨀ hcp;
+    unfold Formula.complement at hcp
+    exact hp ⨀ hcp
   | himp φ ψ h =>
-    simp only [Formula.complement.imp_def₁ h] at hcp;
-    exact hcp ⨀ hp;
+    simp only [Formula.complement.imp_def₁ h] at hcp
+    exact hcp ⨀ hp
   | hbox φ =>
-    unfold Formula.complement at hcp;
-    exact hcp ⨀ hp;
+    unfold Formula.complement at hcp
+    exact hcp ⨀ hp
 
 open Entailment
 
 lemma of_imply_complement_bot [DecidableEq α] (h : 𝓢 ⊢! (-φ) ➝ ⊥) : 𝓢 ⊢! φ := by
-  rcases Formula.complement.or (φ := φ) with (hφ | ⟨ψ, rfl⟩);
-  . rw [hφ] at h;
-    apply of_NN!;
-    apply N!_iff_CO!.mp h;
-  . simp only [Formula.complement] at h;
-    apply N!_iff_CO!.mpr h;
+  rcases Formula.complement.or (φ := φ) with (hφ | ⟨ψ, rfl⟩)
+  . rw [hφ] at h
+    apply of_NN!
+    apply N!_iff_CO!.mp h
+  . simp only [Formula.complement] at h
+    apply N!_iff_CO!.mpr h
 
 end
 

--- a/Foundation/Modal/ComplementClosedConsistentFinset.lean
+++ b/Foundation/Modal/ComplementClosedConsistentFinset.lean
@@ -32,64 +32,64 @@ variable [Entailment.Cl 𝓢]
 
 @[simp]
 lemma empty_conisistent [Entailment.Consistent 𝓢] : FormulaFinset.Consistent 𝓢 ∅ := by
-  apply iff_theory_consistent_formulae_consistent.mp;
-  simp only [Finset.coe_empty];
-  apply FormulaSet.emptyset_consistent;
+  apply iff_theory_consistent_formulae_consistent.mp
+  simp only [Finset.coe_empty]
+  apply FormulaSet.emptyset_consistent
 
 lemma provable_iff_insert_neg_not_consistent : FormulaFinset.Inconsistent 𝓢 (insert (∼φ) Φ) ↔ ↑Φ *⊢[𝓢]! φ := by
-  apply Iff.trans iff_inconsistent_inconsistent.symm;
-  simpa using FormulaSet.provable_iff_insert_neg_not_consistent;
+  apply Iff.trans iff_inconsistent_inconsistent.symm
+  simpa using FormulaSet.provable_iff_insert_neg_not_consistent
 
 lemma neg_provable_iff_insert_not_consistent : FormulaFinset.Inconsistent 𝓢 (insert (φ) Φ) ↔ ↑Φ *⊢[𝓢]! ∼φ := by
-  apply Iff.trans iff_inconsistent_inconsistent.symm;
-  simpa using FormulaSet.neg_provable_iff_insert_not_consistent;
+  apply Iff.trans iff_inconsistent_inconsistent.symm
+  simpa using FormulaSet.neg_provable_iff_insert_not_consistent
 
 lemma unprovable_iff_singleton_neg_consistent : FormulaFinset.Consistent 𝓢 ({∼φ}) ↔ 𝓢 ⊬ φ := by
-  apply Iff.trans iff_theory_consistent_formulae_consistent.symm;
-  simpa using FormulaSet.unprovable_iff_singleton_neg_consistent;
+  apply Iff.trans iff_theory_consistent_formulae_consistent.symm
+  simpa using FormulaSet.unprovable_iff_singleton_neg_consistent
 
 lemma unprovable_iff_singleton_compl_consistent : FormulaFinset.Consistent 𝓢 ({-φ}) ↔ 𝓢 ⊬ φ := by
-  rcases (Formula.complement.or φ) with (hp | ⟨ψ, rfl⟩);
-  . rw [hp];
-    apply unprovable_iff_singleton_neg_consistent;
-  . simp only [Formula.complement];
-    apply Iff.trans iff_theory_consistent_formulae_consistent.symm;
-    simpa using FormulaSet.unprovable_iff_singleton_consistent;
+  rcases (Formula.complement.or φ) with (hp | ⟨ψ, rfl⟩)
+  . rw [hp]
+    apply unprovable_iff_singleton_neg_consistent
+  . simp only [Formula.complement]
+    apply Iff.trans iff_theory_consistent_formulae_consistent.symm
+    simpa using FormulaSet.unprovable_iff_singleton_consistent
 
 lemma provable_iff_singleton_compl_inconsistent : (FormulaFinset.Inconsistent 𝓢 ({-φ})) ↔ 𝓢 ⊢! φ := by
-  constructor;
-  . contrapose;
-    unfold Inconsistent;
-    push_neg;
-    apply unprovable_iff_singleton_compl_consistent.mpr;
-  . contrapose;
-    unfold Inconsistent;
-    push_neg;
-    apply unprovable_iff_singleton_compl_consistent.mp;
+  constructor
+  . contrapose
+    unfold Inconsistent
+    push_neg
+    apply unprovable_iff_singleton_compl_consistent.mpr
+  . contrapose
+    unfold Inconsistent
+    push_neg
+    apply unprovable_iff_singleton_compl_consistent.mp
 
 lemma intro_union_consistent (h : ∀ {Γ₁ Γ₂ : FormulaFinset _}, (Γ₁ ⊆ P₁) → (Γ₂ ⊆ P₂) → (Γ₁ ∪ Γ₂) *⊬[𝓢] ⊥)
   : FormulaFinset.Consistent 𝓢 (P₁ ∪ P₂) := by
-  apply iff_theory_consistent_formulae_consistent.mp;
-  simpa using FormulaSet.intro_union_consistent h;
+  apply iff_theory_consistent_formulae_consistent.mp
+  simpa using FormulaSet.intro_union_consistent h
 
 /-
 lemma intro_triunion_consistent
   (h : ∀ {Γ₁ Γ₂ Γ₃ : List (Formula α)}, (∀ φ ∈ Γ₁, φ ∈ P₁) ∧ (∀ φ ∈ Γ₂, φ ∈ P₂) ∧ (∀ φ ∈ Γ₃, φ ∈ P₃) → 𝓢 ⊬ ⋀Γ₁ ⋏ ⋀Γ₂ ⋏ ⋀Γ₃ ➝ ⊥)
   : FormulaFinset.Consistent 𝓢 (P₁ ∪ P₂ ∪ P₃) := by
-  rw [←iff_theory_consistent_formulae_consistent];
-  convert FormulaSet.intro_triunion_consistent h;
-  ext;
-  constructor;
-  . simp only [Finset.coe_union, Set.mem_union, Finset.mem_coe];
-    rintro ((hp₁ | hp₂) | hp₃);
-    . left; left; assumption;
-    . left; right; assumption;
-    . right; assumption;
-  . simp only [Set.mem_union, Finset.coe_union, Finset.mem_coe];
-    rintro ((hp₁ | hp₂) | hp₃);
-    . left; left; assumption;
-    . left; right; assumption;
-    . right; assumption;
+  rw [←iff_theory_consistent_formulae_consistent]
+  convert FormulaSet.intro_triunion_consistent h
+  ext
+  constructor
+  . simp only [Finset.coe_union, Set.mem_union, Finset.mem_coe]
+    rintro ((hp₁ | hp₂) | hp₃)
+    . left; left; assumption
+    . left; right; assumption
+    . right; assumption
+  . simp only [Set.mem_union, Finset.coe_union, Finset.mem_coe]
+    rintro ((hp₁ | hp₂) | hp₃)
+    . left; left; assumption
+    . left; right; assumption
+    . right; assumption
 -/
 
 end
@@ -110,65 +110,65 @@ local notation:max t"[" l "]" => enum 𝓢 t l
 lemma next_consistent [Entailment.Cl 𝓢]
   (Φ_consis : FormulaFinset.Consistent 𝓢 Φ) (φ : Formula α)
   : FormulaFinset.Consistent 𝓢 (next 𝓢 φ Φ) := by
-  simp only [next];
-  split;
-  . simpa;
-  . rename_i h;
-    by_contra hC;
-    have h₁ : ↑Φ *⊢[𝓢]! ∼φ := FormulaFinset.neg_provable_iff_insert_not_consistent (𝓢 := 𝓢) (Φ := Φ) (φ := φ) |>.mp h;
+  simp only [next]
+  split
+  . simpa
+  . rename_i h
+    by_contra hC
+    have h₁ : ↑Φ *⊢[𝓢]! ∼φ := FormulaFinset.neg_provable_iff_insert_not_consistent (𝓢 := 𝓢) (Φ := Φ) (φ := φ) |>.mp h
     have h₂ : ↑Φ *⊢[𝓢]! ∼-φ := @FormulaFinset.neg_provable_iff_insert_not_consistent α _ (𝓢 := 𝓢) _ _ (Φ := Φ) (-φ) |>.mp $ by
-      unfold FormulaFinset.Inconsistent;
-      simpa using hC;
-    have : ↑Φ *⊢[𝓢]! ⊥ := neg_complement_derive_bot h₁ h₂;
-    contradiction;
+      unfold FormulaFinset.Inconsistent
+      simpa using hC
+    have : ↑Φ *⊢[𝓢]! ⊥ := neg_complement_derive_bot h₁ h₂
+    contradiction
 
 lemma enum_consistent [Entailment.Cl 𝓢]
   (Φ_consis : Φ.Consistent 𝓢) {l : List (Formula α)} : FormulaFinset.Consistent 𝓢 (Φ[l]) := by
   induction l with
-  | nil => exact Φ_consis;
+  | nil => exact Φ_consis
   | cons ψ qs ih =>
-    simp only [enum];
-    apply next_consistent;
-    exact ih;
+    simp only [enum]
+    apply next_consistent
+    exact ih
 
 @[simp] lemma enum_nil {Φ : FormulaFinset α} : (Φ[[]]) = Φ := by simp [enum]
 
 lemma enum_subset_step {l : List (Formula α)} : (Φ[l]) ⊆ (Φ[(ψ :: l)]) := by
-  simp [enum, next];
-  split <;> simp;
+  simp [enum, next]
+  split <;> simp
 
 lemma enum_subset {l : List (Formula α)} : Φ ⊆ Φ[l] := by
   induction l with
-  | nil => simp;
-  | cons ψ qs ih => exact Set.Subset.trans ih $ by apply enum_subset_step;
+  | nil => simp
+  | cons ψ qs ih => exact Set.Subset.trans ih $ by apply enum_subset_step
 
 lemma either {l : List (Formula α)} (hp : φ ∈ l) : φ ∈ Φ[l] ∨ -φ ∈ Φ[l] := by
   induction l with
-  | nil => simp_all;
+  | nil => simp_all
   | cons ψ qs ih =>
-    simp at hp;
-    simp [enum, next];
-    rcases hp with (rfl | hp);
-    . split <;> simp [Finset.mem_insert];
+    simp at hp
+    simp [enum, next]
+    rcases hp with (rfl | hp)
+    . split <;> simp [Finset.mem_insert]
     . split <;> {
-        simp [Finset.mem_insert];
-        rcases (ih hp) with (_ | _) <;> tauto;
+        simp [Finset.mem_insert]
+        rcases (ih hp) with (_ | _) <;> tauto
       }
 
 lemma subset {l : List (Formula α)} {φ : Formula α} (h : φ ∈ Φ[l])
   : φ ∈ Φ ∨ φ ∈ l ∨ (∃ ψ ∈ l, -ψ = φ)  := by
   induction l generalizing φ with
   | nil =>
-    simp_all;
+    simp_all
   | cons ψ qs ih =>
-    simp_all [enum, next];
-    split at h;
+    simp_all [enum, next]
+    split at h
     . rcases Finset.mem_insert.mp h with (rfl | h)
-      . tauto;
-      . rcases ih h <;> tauto;
+      . tauto
+      . rcases ih h <;> tauto
     . rcases Finset.mem_insert.mp h with (rfl | h)
-      . tauto;
-      . rcases ih h <;> tauto;
+      . tauto
+      . rcases ih h <;> tauto
 
 end exists_consistent_complementary_closed
 
@@ -178,29 +178,29 @@ lemma exists_consistent_complementary_closed
   {S : FormulaFinset α}
   (h_sub : P ⊆ S⁻) (P_consis : FormulaFinset.Consistent 𝓢 P)
   : ∃ P', P ⊆ P' ∧ FormulaFinset.Consistent 𝓢 P' ∧ P'.ComplementaryClosed S := by
-  use exists_consistent_complementary_closed.enum 𝓢 P S.toList;
-  refine ⟨?_, ?_, ?_, ?_⟩;
-  . apply enum_subset;
-  . exact enum_consistent P_consis;
-  . simp only [FormulaFinset.complementary];
-    intro φ hp;
-    simp only [Finset.mem_union, Finset.mem_image];
-    rcases subset hp with (h | h | ⟨ψ, hq₁, hq₂⟩);
-    . replace h := h_sub h;
-      simp [complementary] at h;
-      rcases h with (_ | ⟨a, b, rfl⟩);
-      . tauto;
-      . right;
-        use a;
-    . left;
-      exact Finset.mem_toList.mp h;
-    . right;
-      use ψ;
-      constructor;
-      . exact Finset.mem_toList.mp hq₁;
-      . assumption;
-  . intro φ hp;
-    exact either (by simpa);
+  use exists_consistent_complementary_closed.enum 𝓢 P S.toList
+  refine ⟨?_, ?_, ?_, ?_⟩
+  . apply enum_subset
+  . exact enum_consistent P_consis
+  . simp only [FormulaFinset.complementary]
+    intro φ hp
+    simp only [Finset.mem_union, Finset.mem_image]
+    rcases subset hp with (h | h | ⟨ψ, hq₁, hq₂⟩)
+    . replace h := h_sub h
+      simp [complementary] at h
+      rcases h with (_ | ⟨a, b, rfl⟩)
+      . tauto
+      . right
+        use a
+    . left
+      exact Finset.mem_toList.mp h
+    . right
+      use ψ
+      constructor
+      . exact Finset.mem_toList.mp hq₁
+      . assumption
+  . intro φ hp
+    exact either (by simpa)
 
 end FormulaFinset
 
@@ -229,19 +229,19 @@ variable {X X₁ X₂ : ComplementClosedConsistentFinset 𝓢 Ψ}
 @[simp] lemma unprovable_falsum : X.1 *⊬[𝓢] ⊥ := X.consistent
 
 lemma mem_compl_of_not_mem (hs : ψ ∈ Ψ) : ψ ∉ X → -ψ ∈ X := by
-  intro h;
-  rcases X.closed.either ψ (by assumption) with (h | h);
-  . contradiction;
-  . assumption;
+  intro h
+  rcases X.closed.either ψ (by assumption) with (h | h)
+  . contradiction
+  . assumption
 
 lemma mem_of_not_mem_compl (hs : ψ ∈ Ψ) : -ψ ∉ X → ψ ∈ X := by
-  apply Not.imp_symm;
-  exact mem_compl_of_not_mem hs;
+  apply Not.imp_symm
+  exact mem_compl_of_not_mem hs
 
 lemma equality_def : X₁ = X₂ ↔ X₁.1 = X₂.1 := by
-  constructor;
-  . intro h; cases h; rfl;
-  . intro h; cases X₁; cases X₂; simp_all;
+  constructor
+  . intro h; cases h; rfl
+  . intro h; cases X₁; cases X₂; simp_all
 
 variable [Entailment.Cl 𝓢]
 
@@ -249,103 +249,103 @@ lemma lindenbaum
   {Φ Ψ : FormulaFinset α}
   (X_sub : Φ ⊆ Ψ⁻) (X_consis : Φ.Consistent 𝓢)
   : ∃ X' : ComplementClosedConsistentFinset 𝓢 Ψ, Φ ⊆ X'.1 := by
-  obtain ⟨Y, ⟨_, _, _⟩⟩ := FormulaFinset.exists_consistent_complementary_closed X_sub X_consis;
-  use ⟨Y, (by assumption), (by assumption)⟩;
+  obtain ⟨Y, ⟨_, _, _⟩⟩ := FormulaFinset.exists_consistent_complementary_closed X_sub X_consis
+  use ⟨Y, (by assumption), (by assumption)⟩
 
 noncomputable instance [Entailment.Consistent 𝓢] : Inhabited (ComplementClosedConsistentFinset 𝓢 Ψ) := ⟨lindenbaum (Φ := ∅) (Ψ := Ψ) (by simp) (FormulaFinset.empty_conisistent) |>.choose⟩
 
 lemma membership_iff (hq_sub : ψ ∈ Ψ) : (ψ ∈ X) ↔ (X *⊢[𝓢]! ψ) := by
-  constructor;
-  . intro h; exact Context.by_axm! h;
-  . intro hp;
+  constructor
+  . intro h; exact Context.by_axm! h
+  . intro hp
     suffices -ψ ∉ X by
-      apply or_iff_not_imp_right.mp $ ?_;
-      assumption;
-      exact X.closed.either ψ hq_sub;
-    by_contra hC;
-    have hnp : X *⊢[𝓢]! -ψ := Context.by_axm! hC;
-    have := complement_derive_bot hp hnp;
-    simpa;
+      apply or_iff_not_imp_right.mp $ ?_
+      assumption
+      exact X.closed.either ψ hq_sub
+    by_contra hC
+    have hnp : X *⊢[𝓢]! -ψ := Context.by_axm! hC
+    have := complement_derive_bot hp hnp
+    simpa
 
 lemma mem_verum (h : ⊤ ∈ Ψ) : ⊤ ∈ X := by
-  apply membership_iff h |>.mpr;
-  exact verum!;
+  apply membership_iff h |>.mpr
+  exact verum!
 
 @[simp] lemma mem_falsum : ⊥ ∉ X := FormulaSet.not_mem_falsum_of_consistent X.consistent
 
 
 lemma iff_not_mem_compl (hq_sub : ψ ∈ Ψ := by grind) : (ψ ∈ X) ↔ (-ψ ∉ X) := by
-  constructor;
-  . intro hq; replace hq := membership_iff hq_sub |>.mp hq;
-    by_contra hnq;
+  constructor
+  . intro hq; replace hq := membership_iff hq_sub |>.mp hq
+    by_contra hnq
     induction ψ using Formula.cases_neg with
-    | hfalsum => exact unprovable_falsum hq;
+    | hfalsum => exact unprovable_falsum hq
     | hatom a =>
-      simp only [Formula.complement] at hnq;
-      have : ↑X *⊢[𝓢]! ∼(atom a) := Context.by_axm! hnq;
-      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this;
-      simpa;
+      simp only [Formula.complement] at hnq
+      have : ↑X *⊢[𝓢]! ∼(atom a) := Context.by_axm! hnq
+      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this
+      simpa
     | hbox ψ =>
-      simp only [Formula.complement] at hnq;
-      have : ↑X *⊢[𝓢]! ∼(□ψ) := Context.by_axm! hnq;
-      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this;
-      simpa;
+      simp only [Formula.complement] at hnq
+      have : ↑X *⊢[𝓢]! ∼(□ψ) := Context.by_axm! hnq
+      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this
+      simpa
     | hneg ψ =>
-      simp only [Formula.complement] at hnq;
-      have : ↑X *⊢[𝓢]! ψ := Context.by_axm! hnq;
-      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this;
-      simpa;
+      simp only [Formula.complement] at hnq
+      have : ↑X *⊢[𝓢]! ψ := Context.by_axm! hnq
+      have : ↑X *⊢[𝓢]! ⊥ := complement_derive_bot hq this
+      simpa
     | himp ψ χ h =>
-      simp only [Formula.complement.imp_def₁ h] at hnq;
-      have : ↑X *⊢[𝓢]! ∼(ψ ➝ χ) := Context.by_axm! hnq;
-      have : ↑X *⊢[𝓢]! ⊥ := this ⨀ hq;
-      simpa;
-  . intro h; exact mem_of_not_mem_compl (by assumption) h;
+      simp only [Formula.complement.imp_def₁ h] at hnq
+      have : ↑X *⊢[𝓢]! ∼(ψ ➝ χ) := Context.by_axm! hnq
+      have : ↑X *⊢[𝓢]! ⊥ := this ⨀ hq
+      simpa
+  . intro h; exact mem_of_not_mem_compl (by assumption) h
 
-lemma iff_mem_compl (hq_sub : ψ ∈ Ψ := by grind) : (ψ ∉ X) ↔ (-ψ ∈ X) := by simpa using iff_not_mem_compl hq_sub |>.not;
+lemma iff_mem_compl (hq_sub : ψ ∈ Ψ := by grind) : (ψ ∉ X) ↔ (-ψ ∈ X) := by simpa using iff_not_mem_compl hq_sub |>.not
 
 lemma iff_mem_imp
   (hsub_qr : (ψ ➝ χ) ∈ Ψ := by grind)
   (hsub_q : ψ ∈ Ψ := by grind)
   (hsub_r : χ ∈ Ψ := by grind)
   : ((ψ ➝ χ) ∈ X) ↔ (ψ ∈ X) → (-χ ∉ X) := by
-  constructor;
-  . intro hqr hq;
-    apply iff_not_mem_compl hsub_r |>.mp;
-    replace hqr := membership_iff hsub_qr |>.mp hqr;
-    replace hq := membership_iff hsub_q |>.mp hq;
-    exact membership_iff hsub_r |>.mpr $ hqr ⨀ hq;
+  constructor
+  . intro hqr hq
+    apply iff_not_mem_compl hsub_r |>.mp
+    replace hqr := membership_iff hsub_qr |>.mp hqr
+    replace hq := membership_iff hsub_q |>.mp hq
+    exact membership_iff hsub_r |>.mpr $ hqr ⨀ hq
   . intro hqr; replace hqr := not_or_of_imp hqr
-    rcases hqr with (hq | hr);
-    . apply membership_iff hsub_qr |>.mpr;
-      replace hq := mem_compl_of_not_mem hsub_q hq;
+    rcases hqr with (hq | hr)
+    . apply membership_iff hsub_qr |>.mpr
+      replace hq := mem_compl_of_not_mem hsub_q hq
       induction ψ using Formula.cases_neg with
-      | hfalsum => exact efq!;
-      | hatom a => exact C_of_N $ Context.by_axm! (by simpa using hq);
-      | hbox ψ => exact C_of_N $ Context.by_axm! (by simpa using hq);
+      | hfalsum => exact efq!
+      | hatom a => exact C_of_N $ Context.by_axm! (by simpa using hq)
+      | hbox ψ => exact C_of_N $ Context.by_axm! (by simpa using hq)
       | hneg ψ =>
-        simp only [Formula.complement.neg_def] at hq;
-        exact CN!_of_! $ Context.by_axm! hq;
+        simp only [Formula.complement.neg_def] at hq
+        exact CN!_of_! $ Context.by_axm! hq
       | himp ψ χ h =>
-        simp only [Formula.complement.imp_def₁ h] at hq;
-        exact C_of_N $ Context.by_axm! (by simpa using hq);
-    . apply membership_iff (by assumption) |>.mpr;
-      exact C!_of_conseq! $ membership_iff (by assumption) |>.mp $ iff_not_mem_compl (by assumption) |>.mpr hr;
+        simp only [Formula.complement.imp_def₁ h] at hq
+        exact C_of_N $ Context.by_axm! (by simpa using hq)
+    . apply membership_iff (by assumption) |>.mpr
+      exact C!_of_conseq! $ membership_iff (by assumption) |>.mp $ iff_not_mem_compl (by assumption) |>.mpr hr
 
 lemma iff_not_mem_imp
   (hsub_qr : (ψ ➝ χ) ∈ Ψ := by grind)
   (hsub_q : ψ ∈ Ψ := by grind)
   (hsub_r : χ ∈ Ψ := by grind)
   : ((ψ ➝ χ) ∉ X) ↔ (ψ ∈ X) ∧ (-χ ∈ X) := by
-  simpa using iff_mem_imp hsub_qr hsub_q hsub_r |>.not;
+  simpa using iff_mem_imp hsub_qr hsub_q hsub_r |>.not
 
 instance : Finite (ComplementClosedConsistentFinset 𝓢 Ψ) := by
   let f : ComplementClosedConsistentFinset 𝓢 Ψ → (Finset.powerset (Ψ⁻)) := λ X => ⟨X, by simpa using X.closed.subset⟩
   have hf : Function.Injective f := by
-    intro X₁ X₂ h;
-    apply equality_def.mpr;
-    simpa [f] using h;
-  exact Finite.of_injective f hf;
+    intro X₁ X₂ h
+    apply equality_def.mpr
+    simpa [f] using h
+  exact Finite.of_injective f hf
 
 end ComplementClosedConsistentFinset
 

--- a/Foundation/Modal/Entailment/Basic.lean
+++ b/Foundation/Modal/Entailment/Basic.lean
@@ -24,10 +24,10 @@ alias nec := Necessitation.nec
 lemma nec! : 𝓢 ⊢! φ → 𝓢 ⊢! □φ := by rintro ⟨hp⟩; exact ⟨nec hp⟩
 
 def multinec : 𝓢 ⊢ φ → 𝓢 ⊢ □^[n]φ := by
-  intro h;
+  intro h
   induction n with
-  | zero => simpa;
-  | succ n ih => simpa using nec ih;
+  | zero => simpa
+  | succ n ih => simpa using nec ih
 lemma multinec! : 𝓢 ⊢! φ → 𝓢 ⊢! □^[n]φ := by rintro ⟨hp⟩; exact ⟨multinec hp⟩
 
 end Necessitation
@@ -45,10 +45,10 @@ alias unnec := Unnecessitation.unnec
 lemma unnec! : 𝓢 ⊢! □φ → 𝓢 ⊢! φ := by rintro ⟨hp⟩; exact ⟨unnec hp⟩
 
 def multiunnec : 𝓢 ⊢ □^[n]φ → 𝓢 ⊢ φ := by
-  intro h;
+  intro h
   induction n generalizing φ with
-  | zero => simpa;
-  | succ n ih => exact unnec $ @ih (□φ) h;
+  | zero => simpa
+  | succ n ih => exact unnec $ @ih (□φ) h
 lemma multiunnec! : 𝓢 ⊢! □^[n]φ → 𝓢 ⊢! φ := by rintro ⟨hp⟩; exact ⟨multiunnec hp⟩
 
 end Unnecessitation
@@ -677,20 +677,20 @@ variable {φ ψ χ : F} {Γ Δ : List F}
 variable {𝓢 : S}
 
 instance [Entailment.Minimal 𝓢] [ModalDeMorgan F] [HasAxiomDNE 𝓢] : HasDiaDuality 𝓢 := ⟨by
-  intro φ;
-  simp only [Axioms.DiaDuality, ModalDeMorgan.box, DeMorgan.neg];
-  apply E_Id;
+  intro φ
+  simp only [Axioms.DiaDuality, ModalDeMorgan.box, DeMorgan.neg]
+  apply E_Id
 ⟩
 
 instance [Entailment.Minimal 𝓢] [DiaAbbrev F] : HasDiaDuality 𝓢 := ⟨by
-  intro φ;
-  simp only [Axioms.DiaDuality, DiaAbbrev.dia_abbrev];
-  apply E_Id;
+  intro φ
+  simp only [Axioms.DiaDuality, DiaAbbrev.dia_abbrev]
+  apply E_Id
 ⟩
 
 instance [ModusPonens 𝓢] [HasAxiomT 𝓢] : Unnecessitation 𝓢 := ⟨by
-  intro φ hp;
-  exact axiomT ⨀ hp;
+  intro φ hp
+  exact axiomT ⨀ hp
 ⟩
 
 end
@@ -840,13 +840,13 @@ variable {𝓢 : S} [Entailment.Minimal 𝓢]
 
 instance [Disjunctive 𝓢] [Unnecessitation 𝓢] : ModalDisjunctive 𝓢 where
   modal_disjunctive h := by
-    rcases disjunctive h with (h | h);
-    . left; exact unnec! h;
-    . right; exact unnec! h;
+    rcases disjunctive h with (h | h)
+    . left; exact unnec! h
+    . right; exact unnec! h
 
 private lemma unnec_of_mdp_aux [ModalDisjunctive 𝓢] (h : 𝓢 ⊢! □φ) : 𝓢 ⊢! φ := by
-    have : 𝓢 ⊢! □φ ⋎ □φ := A!_intro_left h;
-    rcases modal_disjunctive this with (h | h) <;> tauto;
+    have : 𝓢 ⊢! □φ ⋎ □φ := A!_intro_left h
+    rcases modal_disjunctive this with (h | h) <;> tauto
 
 noncomputable instance unnecessitation_of_modalDisjunctive [ModalDisjunctive 𝓢] : Unnecessitation 𝓢 where
   unnec h := (unnec_of_mdp_aux ⟨h⟩).some

--- a/Foundation/Modal/Entailment/EM.lean
+++ b/Foundation/Modal/Entailment/EM.lean
@@ -10,20 +10,20 @@ variable {𝓢 : S}
 section
 
 instance [Entailment.EM 𝓢] : Entailment.RM 𝓢 := ⟨by
-  intro φ ψ h;
+  intro φ ψ h
   haveI h₁ : 𝓢 ⊢ φ ⭤ (φ ⋏ ψ) := K_intro (CK_of_C_of_C (C_id φ) h) and₁
-  haveI h₂ : 𝓢 ⊢ □φ ⭤ □(φ ⋏ ψ) := re h₁;
-  haveI h₃ : 𝓢 ⊢ □φ ➝ □(φ ⋏ ψ) := K_left h₂;
-  haveI h₄ : 𝓢 ⊢ □(φ ⋏ ψ) ➝ (□φ ⋏ □ψ) := axiomM;
-  haveI h₅ : 𝓢 ⊢ □φ ➝ □φ ⋏ □ψ := C_trans h₃ h₄;
-  apply C_trans h₅ and₂;
+  haveI h₂ : 𝓢 ⊢ □φ ⭤ □(φ ⋏ ψ) := re h₁
+  haveI h₃ : 𝓢 ⊢ □φ ➝ □(φ ⋏ ψ) := K_left h₂
+  haveI h₄ : 𝓢 ⊢ □(φ ⋏ ψ) ➝ (□φ ⋏ □ψ) := axiomM
+  haveI h₅ : 𝓢 ⊢ □φ ➝ □φ ⋏ □ψ := C_trans h₃ h₄
+  apply C_trans h₅ and₂
 ⟩
 
 instance [Entailment.E 𝓢] [Entailment.RM 𝓢] : Entailment.EM 𝓢 where
   M φ ψ := by
-    apply CK_of_C_of_C;
-    . apply rm; exact and₁;
-    . apply rm; exact and₂;
+    apply CK_of_C_of_C
+    . apply rm; exact and₁
+    . apply rm; exact and₂
 
 end
 

--- a/Foundation/Modal/Entailment/EMC.lean
+++ b/Foundation/Modal/Entailment/EMC.lean
@@ -9,10 +9,10 @@ variable {𝓢 : S}
 
 instance [Entailment.EMC 𝓢] : Entailment.HasAxiomK 𝓢 where
   K φ ψ := by
-    haveI h₁ : 𝓢 ⊢ (□(φ ➝ ψ) ⋏ □φ) ➝ □((φ ➝ ψ) ⋏ φ) := axiomC;
+    haveI h₁ : 𝓢 ⊢ (□(φ ➝ ψ) ⋏ □φ) ➝ □((φ ➝ ψ) ⋏ φ) := axiomC
     haveI h₂ : 𝓢 ⊢ ((φ ➝ ψ) ⋏ φ) ➝ ψ := C_trans (CKK _ _) innerMDP
-    haveI h₃ : 𝓢 ⊢ □((φ ➝ ψ) ⋏ φ) ➝ □ψ := rm h₂;
-    haveI h₄ : 𝓢 ⊢ □(φ ➝ ψ) ⋏ □φ ➝ □ψ := C_trans h₁ h₃;
+    haveI h₃ : 𝓢 ⊢ □((φ ➝ ψ) ⋏ φ) ➝ □ψ := rm h₂
+    haveI h₄ : 𝓢 ⊢ □(φ ➝ ψ) ⋏ □φ ➝ □ψ := C_trans h₁ h₃
     exact CC_of_CK h₄
 
 end LO.Modal.Entailment

--- a/Foundation/Modal/Entailment/EMCN.lean
+++ b/Foundation/Modal/Entailment/EMCN.lean
@@ -12,8 +12,8 @@ variable {𝓢 : S}
 instance [Entailment.EMCN 𝓢] : Entailment.K 𝓢 where
 instance [Entailment.K 𝓢] : Entailment.EMCN 𝓢 where
   re h := by
-    apply K_intro;
-    . exact axiomK' $ nec $ K_left h;
-    . exact axiomK' $ nec $ K_right h;
+    apply K_intro
+    . exact axiomK' $ nec $ K_left h
+    . exact axiomK' $ nec $ K_right h
 
 end LO.Modal.Entailment

--- a/Foundation/Modal/Entailment/END.lean
+++ b/Foundation/Modal/Entailment/END.lean
@@ -11,9 +11,9 @@ open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 protected class END (𝓢 : S) extends Entailment.EN 𝓢, HasAxiomD 𝓢
 
 instance [Entailment.END 𝓢] : HasAxiomP 𝓢 := ⟨by
-  have : 𝓢 ⊢ ∼∼□(∼⊥) := dni' $ nec NO;
-  have : 𝓢 ⊢ ∼◇⊥ := (contra $ K_left diaDuality) ⨀ this;
-  exact (contra axiomD) ⨀ this;
+  have : 𝓢 ⊢ ∼∼□(∼⊥) := dni' $ nec NO
+  have : 𝓢 ⊢ ∼◇⊥ := (contra $ K_left diaDuality) ⨀ this
+  exact (contra axiomD) ⨀ this
 ⟩
 
 end LO.Modal.Entailment

--- a/Foundation/Modal/Entailment/GL.lean
+++ b/Foundation/Modal/Entailment/GL.lean
@@ -8,18 +8,18 @@ variable {S F : Type*} [BasicModalLogicalConnective F] [DecidableEq F] [Entailme
 variable {𝓢 : S} [Entailment.GL 𝓢]
 
 def goedel2 : 𝓢 ⊢ (∼(□⊥) ⭤ ∼(□(∼(□⊥))) : F) := by
-  apply ENN_of_E;
-  apply E_intro;
-  . apply implyBoxDistribute';
-    exact efq;
+  apply ENN_of_E
+  apply E_intro
+  . apply implyBoxDistribute'
+    exact efq
   . exact C_trans (by
-      apply implyBoxDistribute';
-      exact K_left negEquiv;
-    ) axiomL;
+      apply implyBoxDistribute'
+      exact K_left negEquiv
+    ) axiomL
 lemma goedel2! : 𝓢 ⊢! (∼(□⊥) ⭤ ∼(□(∼(□⊥))) : F) := ⟨goedel2⟩
 
-def goedel2'.mp : 𝓢 ⊢ (∼(□⊥) : F) → 𝓢 ⊢ ∼(□(∼(□⊥)) : F) := by intro h; exact (K_left goedel2) ⨀ h;
-def goedel2'.mpr : 𝓢 ⊢ ∼(□(∼(□⊥)) : F) → 𝓢 ⊢ (∼(□⊥) : F) := by intro h; exact (K_right goedel2) ⨀ h;
+def goedel2'.mp : 𝓢 ⊢ (∼(□⊥) : F) → 𝓢 ⊢ ∼(□(∼(□⊥)) : F) := by intro h; exact (K_left goedel2) ⨀ h
+def goedel2'.mpr : 𝓢 ⊢ ∼(□(∼(□⊥)) : F) → 𝓢 ⊢ (∼(□⊥) : F) := by intro h; exact (K_right goedel2) ⨀ h
 lemma goedel2'! : 𝓢 ⊢! (∼(□⊥) : F) ↔ 𝓢 ⊢! ∼(□(∼(□⊥)) : F) := ⟨λ ⟨h⟩ ↦ ⟨goedel2'.mp h⟩, λ ⟨h⟩ ↦ ⟨goedel2'.mpr h⟩⟩
 
 
@@ -30,13 +30,13 @@ variable {φ ψ : F}
 instance : HasAxiomZ 𝓢 := ⟨fun _ ↦ C_trans axiomL imply₁⟩
 
 protected def axiomFour : 𝓢 ⊢ Axioms.Four φ := by
-  dsimp [Axioms.Four];
+  dsimp [Axioms.Four]
   have : 𝓢 ⊢ φ ➝ (⊡□φ ➝ ⊡φ) := by
-    apply deduct';
-    apply deduct;
-    exact K_intro (FiniteContext.byAxm) (K_left (ψ := □□φ) $ FiniteContext.byAxm);
-  have : 𝓢 ⊢ φ ➝ (□⊡φ ➝ ⊡φ) := C_trans this (CCC_of_C_left BoxBoxdot_BoxDotbox);
-  exact C_trans (C_trans (implyBoxDistribute' this) axiomL) (implyBoxDistribute' $ and₂);
+    apply deduct'
+    apply deduct
+    exact K_intro (FiniteContext.byAxm) (K_left (ψ := □□φ) $ FiniteContext.byAxm)
+  have : 𝓢 ⊢ φ ➝ (□⊡φ ➝ ⊡φ) := C_trans this (CCC_of_C_left BoxBoxdot_BoxDotbox)
+  exact C_trans (C_trans (implyBoxDistribute' this) axiomL) (implyBoxDistribute' $ and₂)
 instance : HasAxiomFour 𝓢 := ⟨fun _ ↦ GL.axiomFour⟩
 instance : Entailment.K4 𝓢 where
 
@@ -50,50 +50,50 @@ end GL
 
 private noncomputable def lem_boxdot_Grz_of_L : 𝓢 ⊢ (⊡(⊡(φ ➝ ⊡φ) ➝ φ)) ➝ (□(φ ➝ ⊡φ) ➝ φ) := by
   have : 𝓢 ⊢ (□(φ ➝ ⊡φ) ⋏ ∼φ) ➝ ⊡(φ ➝ ⊡φ) := by
-    apply deduct';
-    apply K_intro;
-    . exact (of CNC) ⨀ and₂;
-    . exact (of (C_id _)) ⨀ and₁;
-  have : 𝓢 ⊢ ∼⊡(φ ➝ ⊡φ) ➝ (∼□(φ ➝ ⊡φ) ⋎ φ) := C_trans (contra this) $ C_trans CNKANN (CAA_of_C_right dne);
-  have : 𝓢 ⊢ (∼⊡(φ ➝ ⊡φ) ⋎ φ) ➝ (∼□(φ ➝ ⊡φ) ⋎ φ) := left_A_intro this or₂;
-  have : 𝓢 ⊢ ∼⊡(φ ➝ ⊡φ) ⋎ φ ➝ □(φ ➝ ⊡φ) ➝ φ := C_trans this CANC;
-  have : 𝓢 ⊢ (⊡(φ ➝ ⊡φ) ➝ φ) ➝ (□(φ ➝ ⊡φ) ➝ φ) := C_trans CCAN this;
-  exact C_trans boxdotAxiomT this;
+    apply deduct'
+    apply K_intro
+    . exact (of CNC) ⨀ and₂
+    . exact (of (C_id _)) ⨀ and₁
+  have : 𝓢 ⊢ ∼⊡(φ ➝ ⊡φ) ➝ (∼□(φ ➝ ⊡φ) ⋎ φ) := C_trans (contra this) $ C_trans CNKANN (CAA_of_C_right dne)
+  have : 𝓢 ⊢ (∼⊡(φ ➝ ⊡φ) ⋎ φ) ➝ (∼□(φ ➝ ⊡φ) ⋎ φ) := left_A_intro this or₂
+  have : 𝓢 ⊢ ∼⊡(φ ➝ ⊡φ) ⋎ φ ➝ □(φ ➝ ⊡φ) ➝ φ := C_trans this CANC
+  have : 𝓢 ⊢ (⊡(φ ➝ ⊡φ) ➝ φ) ➝ (□(φ ➝ ⊡φ) ➝ φ) := C_trans CCAN this
+  exact C_trans boxdotAxiomT this
 
 noncomputable def boxdot_Grz_of_L : 𝓢 ⊢ ⊡(⊡(φ ➝ ⊡φ) ➝ φ) ➝ φ := by
-  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □⊡(φ ➝ ⊡φ) ➝ □φ := axiomK;
-  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) ➝ □φ := C_trans this $ CCC_of_C_left $ imply_Box_BoxBoxdot;
+  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □⊡(φ ➝ ⊡φ) ➝ □φ := axiomK
+  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) ➝ □φ := C_trans this $ CCC_of_C_left $ imply_Box_BoxBoxdot
   have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) ➝ (φ ➝ ⊡φ) := by
-    apply deduct'; apply deduct; apply deduct;
-    exact K_intro FiniteContext.byAxm $ (of this) ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm);
-  have : 𝓢 ⊢ □□(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(□(φ ➝ ⊡φ) ➝ (φ ➝ ⊡φ)) := implyBoxDistribute' this;
-  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(□(φ ➝ ⊡φ) ➝ (φ ➝ ⊡φ)) := C_trans axiomFour this;
-  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) := C_trans this axiomL;
-  have : 𝓢 ⊢ ⊡(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) := C_trans boxdotBox this;
-  exact mdp₁ lem_boxdot_Grz_of_L this;
+    apply deduct'; apply deduct; apply deduct
+    exact K_intro FiniteContext.byAxm $ (of this) ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm)
+  have : 𝓢 ⊢ □□(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(□(φ ➝ ⊡φ) ➝ (φ ➝ ⊡φ)) := implyBoxDistribute' this
+  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(□(φ ➝ ⊡φ) ➝ (φ ➝ ⊡φ)) := C_trans axiomFour this
+  have : 𝓢 ⊢ □(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) := C_trans this axiomL
+  have : 𝓢 ⊢ ⊡(⊡(φ ➝ ⊡φ) ➝ φ) ➝ □(φ ➝ ⊡φ) := C_trans boxdotBox this
+  exact mdp₁ lem_boxdot_Grz_of_L this
 @[simp] lemma boxdot_Grz_of_L! : 𝓢 ⊢! ⊡(⊡(φ ➝ ⊡φ) ➝ φ) ➝ φ := ⟨boxdot_Grz_of_L⟩
 
 
 def imply_boxdot_boxdot_of_imply_boxdot_plain (h : 𝓢 ⊢ ⊡φ ➝ ψ) : 𝓢 ⊢ ⊡φ ➝ ⊡ψ := by
-  have : 𝓢 ⊢ □⊡φ ➝ □ψ := implyBoxDistribute' h;
-  have : 𝓢 ⊢ □φ ➝ □ψ := C_trans imply_Box_BoxBoxdot this;
-  have : 𝓢 ⊢ ⊡φ ➝ □ψ := C_trans boxdotBox this;
-  exact right_K_intro h this;
+  have : 𝓢 ⊢ □⊡φ ➝ □ψ := implyBoxDistribute' h
+  have : 𝓢 ⊢ □φ ➝ □ψ := C_trans imply_Box_BoxBoxdot this
+  have : 𝓢 ⊢ ⊡φ ➝ □ψ := C_trans boxdotBox this
+  exact right_K_intro h this
 lemma imply_boxdot_boxdot_of_imply_boxdot_plain! (h : 𝓢 ⊢! ⊡φ ➝ ψ) : 𝓢 ⊢! ⊡φ ➝ ⊡ψ := ⟨imply_boxdot_boxdot_of_imply_boxdot_plain h.some⟩
 
 
 def imply_boxdot_axiomT_of_imply_boxdot_boxdot (h : 𝓢 ⊢ ⊡φ ➝ ⊡ψ) : 𝓢 ⊢ ⊡φ ➝ (□ψ ➝ ψ) := by
-  apply deduct';
-  apply deduct;
-  have : [□ψ, ⊡φ] ⊢[𝓢] ⊡ψ := (FiniteContext.of h) ⨀ (FiniteContext.byAxm);
-  exact K_left this;
+  apply deduct'
+  apply deduct
+  have : [□ψ, ⊡φ] ⊢[𝓢] ⊡ψ := (FiniteContext.of h) ⨀ (FiniteContext.byAxm)
+  exact K_left this
 lemma imply_boxdot_axiomT_of_imply_boxdot_boxdot! (h : 𝓢 ⊢! ⊡φ ➝ ⊡ψ) : 𝓢 ⊢! ⊡φ ➝ (□ψ ➝ ψ) := ⟨imply_boxdot_axiomT_of_imply_boxdot_boxdot h.some⟩
 
 
 def imply_box_box_of_imply_boxdot_axiomT (h : 𝓢 ⊢ ⊡φ ➝ (□ψ ➝ ψ)) : 𝓢 ⊢ □φ ➝ □ψ := by
-  have : 𝓢 ⊢ □⊡φ ➝ □(□ψ ➝ ψ) := implyBoxDistribute' h;
-  have : 𝓢 ⊢ □⊡φ ➝ □ψ := C_trans this axiomL;
-  exact C_trans imply_Box_BoxBoxdot this;
+  have : 𝓢 ⊢ □⊡φ ➝ □(□ψ ➝ ψ) := implyBoxDistribute' h
+  have : 𝓢 ⊢ □⊡φ ➝ □ψ := C_trans this axiomL
+  exact C_trans imply_Box_BoxBoxdot this
 lemma imply_box_box_of_imply_boxdot_axiomT! (h : 𝓢 ⊢! ⊡φ ➝ (□ψ ➝ ψ)) : 𝓢 ⊢! □φ ➝ □ψ := ⟨imply_box_box_of_imply_boxdot_axiomT h.some⟩
 
 

--- a/Foundation/Modal/Entailment/K.lean
+++ b/Foundation/Modal/Entailment/K.lean
@@ -13,39 +13,39 @@ section
 lemma conj_cons! [DecidableEq F] : 𝓢 ⊢! (φ ⋏ ⋀Γ) ⭤ ⋀(φ :: Γ) := by
   induction Γ using List.induction_with_singleton with
   | hnil =>
-    simp only [List.conj₂_nil, List.conj₂_singleton];
-    apply E!_intro;
-    . simp;
-    . exact right_K!_intro (by simp) (by simp);
-  | _ => simp;
+    simp only [List.conj₂_nil, List.conj₂_singleton]
+    apply E!_intro
+    . simp
+    . exact right_K!_intro (by simp) (by simp)
+  | _ => simp
 
 lemma iff_top_left'! (h : 𝓢 ⊢! φ) : 𝓢 ⊢! φ ⭤ ⊤ := by
-  apply E!_intro;
-  . simp;
-  . exact C!_of_conseq! h;
+  apply E!_intro
+  . simp
+  . exact C!_of_conseq! h
 
 lemma iff_symm'! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ψ ⭤ φ := by
-  apply E!_intro;
-  . exact K!_right h;
-  . exact K!_left h;
+  apply E!_intro
+  . exact K!_right h
+  . exact K!_left h
 
 lemma iff_top_right! (h : 𝓢 ⊢! φ) : 𝓢 ⊢! ⊤ ⭤ φ := iff_symm'! $ iff_top_left'! h
 
 @[simp]
 lemma iff_not_bot_top! [DecidableEq F] : 𝓢 ⊢! ∼⊤ ⭤ ⊥ := by
-  apply E!_intro;
-  . apply CN!_of_CN!_left;
-    apply C!_of_conseq!;
-    simp;
-  . exact efq!;
+  apply E!_intro
+  . apply CN!_of_CN!_left
+    apply C!_of_conseq!
+    simp
+  . exact efq!
 
 end
 
 
 def multibox_axiomK : 𝓢 ⊢ □^[n](φ ➝ ψ) ➝ □^[n]φ ➝ □^[n]ψ := by
   induction n with
-  | zero => apply C_id;
-  | succ n ih => simpa using C_trans (axiomK' $ nec ih) (by apply axiomK);
+  | zero => apply C_id
+  | succ n ih => simpa using C_trans (axiomK' $ nec ih) (by apply axiomK)
 @[simp] lemma multibox_axiomK! : 𝓢 ⊢! □^[n](φ ➝ ψ) ➝ □^[n]φ ➝ □^[n]ψ := ⟨multibox_axiomK⟩
 
 def multibox_axiomK' (h : 𝓢 ⊢ □^[n](φ ➝ ψ)) : 𝓢 ⊢ □^[n]φ ➝ □^[n]ψ := multibox_axiomK ⨀ h
@@ -56,15 +56,15 @@ alias multiboxed_imply_distribute! := multibox_axiomK'!
 
 
 def boxIff' (h : 𝓢 ⊢ φ ⭤ ψ) : 𝓢 ⊢ (□φ ⭤ □ψ) := by
-  apply E_intro;
-  . exact axiomK' $ nec $ K_left h;
-  . exact axiomK' $ nec $ K_right h;
+  apply E_intro
+  . exact axiomK' $ nec $ K_left h
+  . exact axiomK' $ nec $ K_right h
 @[simp] lemma box_iff! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! □φ ⭤ □ψ := ⟨boxIff' h.some⟩
 
 def multiboxIff' (h : 𝓢 ⊢ φ ⭤ ψ) : 𝓢 ⊢ □^[n]φ ⭤ □^[n]ψ := by
   induction n with
-  | zero => simpa;
-  | succ n ih => simpa using boxIff' ih;
+  | zero => simpa
+  | succ n ih => simpa using boxIff' ih
 @[simp] lemma multibox_iff! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! □^[n]φ ⭤ □^[n]ψ := ⟨multiboxIff' h.some⟩
 
 
@@ -102,9 +102,9 @@ def implyBoxDistribute' (h : 𝓢 ⊢ φ ➝ ψ) : 𝓢 ⊢ □φ ➝ □ψ := i
 lemma imply_box_distribute'! (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! □φ ➝ □ψ := ⟨implyBoxDistribute' h.some⟩
 
 def collect_multibox_and : 𝓢 ⊢ □^[n]φ ⋏ □^[n]ψ ➝ □^[n](φ ⋏ ψ) := by
-  have d₁ : 𝓢 ⊢ □^[n]φ ➝ □^[n](ψ ➝ φ ⋏ ψ) := implyMultiboxDistribute' and₃;
-  have d₂ : 𝓢 ⊢ □^[n](ψ ➝ φ ⋏ ψ) ➝ (□^[n]ψ ➝ □^[n](φ ⋏ ψ)) := multibox_axiomK;
-  exact (K_right (ECKCC _ _ _)) ⨀ (C_trans d₁ d₂);
+  have d₁ : 𝓢 ⊢ □^[n]φ ➝ □^[n](ψ ➝ φ ⋏ ψ) := implyMultiboxDistribute' and₃
+  have d₂ : 𝓢 ⊢ □^[n](ψ ➝ φ ⋏ ψ) ➝ (□^[n]ψ ➝ □^[n](φ ⋏ ψ)) := multibox_axiomK
+  exact (K_right (ECKCC _ _ _)) ⨀ (C_trans d₁ d₂)
 @[simp] lemma collect_multibox_and! : 𝓢 ⊢! □^[n]φ ⋏ □^[n]ψ ➝ □^[n](φ ⋏ ψ) := ⟨collect_multibox_and⟩
 
 def collect_box_and : 𝓢 ⊢ □φ ⋏ □ψ ➝ □(φ ⋏ ψ) := collect_multibox_and (n := 1)
@@ -137,75 +137,75 @@ variable [DecidableEq F]
 def multiDiaDuality : 𝓢 ⊢ ◇^[n]φ ⭤ ∼(□^[n](∼φ)) := by
   induction n with
   | zero =>
-    simp only [Function.iterate_zero, id_eq];
-    apply dn;
+    simp only [Function.iterate_zero, id_eq]
+    apply dn
   | succ n ih =>
-    simp only [Dia.multidia_succ, Box.multibox_succ];
-    apply E_trans $ diaDuality (φ := ◇^[n]φ);
-    apply ENN_of_E;
-    apply boxIff';
-    apply E_intro;
-    . exact CN_of_CN_left $ K_right ih;
-    . exact CN_of_CN_right $ K_left ih;
+    simp only [Dia.multidia_succ, Box.multibox_succ]
+    apply E_trans $ diaDuality (φ := ◇^[n]φ)
+    apply ENN_of_E
+    apply boxIff'
+    apply E_intro
+    . exact CN_of_CN_left $ K_right ih
+    . exact CN_of_CN_right $ K_left ih
 lemma multidia_duality! : 𝓢 ⊢! ◇^[n]φ ⭤ ∼(□^[n](∼φ)) := ⟨multiDiaDuality⟩
 
 @[simp] lemma multidia_duality!_mp : 𝓢 ⊢! ◇^[n]φ ➝ ∼(□^[n](∼φ)) := C_of_E_mp! multidia_duality!
 @[simp] lemma multidia_duality!_mpr : 𝓢 ⊢! ∼(□^[n](∼φ)) ➝ ◇^[n]φ := C_of_E_mpr! multidia_duality!
 
 lemma multidia_duality'! : 𝓢 ⊢! ◇^[n]φ ↔ 𝓢 ⊢! ∼(□^[n](∼φ)) := by
-  constructor;
-  . intro h; exact (K!_left multidia_duality!) ⨀ h;
-  . intro h; exact (K!_right multidia_duality!) ⨀ h;
+  constructor
+  . intro h; exact (K!_left multidia_duality!) ⨀ h
+  . intro h; exact (K!_right multidia_duality!) ⨀ h
 
 def diaK' (h : 𝓢 ⊢ φ ➝ ψ) : 𝓢 ⊢ ◇φ ➝ ◇ψ := by
-  apply C_trans ?_ diaDuality_mpr;
-  apply C_trans diaDuality_mp ?_;
-  apply contra;
-  apply axiomK';
-  apply nec;
-  apply contra;
-  assumption;
+  apply C_trans ?_ diaDuality_mpr
+  apply C_trans diaDuality_mp ?_
+  apply contra
+  apply axiomK'
+  apply nec
+  apply contra
+  assumption
 lemma diaK'! (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! ◇φ ➝ ◇ψ := ⟨diaK' h.some⟩
 
 lemma diaK''! (h₁ : 𝓢 ⊢! φ ➝ ψ) (h₂ : 𝓢 ⊢! ◇φ) : 𝓢 ⊢! ◇ψ := (diaK'! h₁) ⨀ h₂
 
 lemma CMultidiaMultidia_of_C (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! ◇^[n]φ ➝ ◇^[n]ψ := by
   induction n with
-  | zero => simpa;
+  | zero => simpa
   | succ n ih =>
-    simp only [Dia.multidia_succ];
-    apply diaK'! ih;
+    simp only [Dia.multidia_succ]
+    apply diaK'! ih
 
 
 
 def diaIff' (h : 𝓢 ⊢ φ ⭤ ψ) : 𝓢 ⊢ (◇φ ⭤ ◇ψ) := by
-  apply E_trans diaDuality;
-  apply K_symm;
-  apply E_trans diaDuality;
-  apply ENN_of_E;
-  apply boxIff';
-  apply ENN_of_E;
-  apply K_symm;
-  assumption;
+  apply E_trans diaDuality
+  apply K_symm
+  apply E_trans diaDuality
+  apply ENN_of_E
+  apply boxIff'
+  apply ENN_of_E
+  apply K_symm
+  assumption
 @[simp] lemma dia_iff! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ◇φ ⭤ ◇ψ := ⟨diaIff' h.some⟩
 
 def multidiaIff' (h : 𝓢 ⊢ φ ⭤ ψ) : 𝓢 ⊢ ◇^[n]φ ⭤ ◇^[n]ψ := by
   induction n with
-  | zero => simpa;
-  | succ n ih => simpa using diaIff' ih;
+  | zero => simpa
+  | succ n ih => simpa using diaIff' ih
 @[simp] lemma multidia_iff! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ◇^[n]φ ⭤ ◇^[n]ψ := ⟨multidiaIff' h.some⟩
 
 
 def multiboxDuality : 𝓢 ⊢ □^[n]φ ⭤ ∼(◇^[n](∼φ)) := by
   induction n with
   | zero =>
-    simp only [Function.iterate_zero, id_eq];
-    apply dn;
+    simp only [Function.iterate_zero, id_eq]
+    apply dn
   | succ n ih =>
-    simp only [Box.multibox_succ, Dia.multidia_succ];
-    apply E_trans (boxIff' ih);
-    apply EN_of_EN_left;
-    exact E_symm $ diaDuality;
+    simp only [Box.multibox_succ, Dia.multidia_succ]
+    apply E_trans (boxIff' ih)
+    apply EN_of_EN_left
+    exact E_symm $ diaDuality
 @[simp] lemma multibox_duality! : 𝓢 ⊢! □^[n]φ ⭤ ∼(◇^[n](∼φ)) := ⟨multiboxDuality⟩
 
 @[simp] lemma multibox_duality_mp! : 𝓢 ⊢! □^[n]φ ➝ ∼(◇^[n](∼φ)) := K!_left multibox_duality!
@@ -231,17 +231,17 @@ lemma boxDuality_mpr'! (h : 𝓢 ⊢! ∼(◇(∼φ))) : 𝓢 ⊢! □φ := ⟨b
 
 @[simp]
 lemma CNDiaBoxN! : 𝓢 ⊢! □(∼φ) ➝ ∼◇φ := by
-  apply C!_trans boxDuality_mp!;
-  apply contra!;
-  apply diaK'!;
-  simp;
+  apply C!_trans boxDuality_mp!
+  apply contra!
+  apply diaK'!
+  simp
 
 lemma NDia_of_BoxN! (h : 𝓢 ⊢! □(∼φ)) : 𝓢 ⊢! ∼◇φ := CNDiaBoxN! ⨀ h
 
 lemma multibox_duality'! : 𝓢 ⊢! □^[n]φ ↔ 𝓢 ⊢! ∼(◇^[n](∼φ)) := by
-  constructor;
-  . intro h; exact (K!_left multibox_duality!) ⨀ h;
-  . intro h; exact (K!_right multibox_duality!) ⨀ h;
+  constructor
+  . intro h; exact (K!_left multibox_duality!) ⨀ h
+  . intro h; exact (K!_right multibox_duality!) ⨀ h
 
 lemma box_duality'! : 𝓢 ⊢! □φ ↔ 𝓢 ⊢! ∼(◇(∼φ)) := multibox_duality'! (n := 1)
 
@@ -253,13 +253,13 @@ def box_dni' (h : 𝓢 ⊢ □φ) : 𝓢 ⊢ □(∼∼φ) := box_dni ⨀ h
 lemma box_dni'! (h : 𝓢 ⊢! □φ) : 𝓢 ⊢! □(∼∼φ) := ⟨box_dni' h.some⟩
 
 @[simp] lemma negbox_dni! : 𝓢 ⊢! ∼□φ ➝ ∼□(∼∼φ) := by
-  apply contra!;
-  exact box_dne!;
+  apply contra!
+  exact box_dne!
 lemma negbox_dni'! (h : 𝓢 ⊢! ∼□φ) : 𝓢 ⊢! ∼□(∼∼φ) := negbox_dni! ⨀ h
 
 @[simp] lemma negbox_dne! : 𝓢 ⊢! ∼□(∼∼φ) ➝ ∼□φ := by
-  apply contra!;
-  exact box_dni!;
+  apply contra!
+  exact box_dni!
 lemma negbox_dne'! (h : 𝓢 ⊢! ∼□(∼∼φ)) : 𝓢 ⊢! ∼□φ := negbox_dne! ⨀ h
 
 
@@ -279,20 +279,20 @@ instance : Entailment.HasAxiomM 𝓢 := ⟨λ _ _ => distribute_box_and⟩
 
 
 def boxdotAxiomK : 𝓢 ⊢ ⊡(φ ➝ ψ) ➝ (⊡φ ➝ ⊡ψ) := by
-  apply deduct';
-  apply deduct;
-  have d : [φ ⋏ □φ, (φ ➝ ψ) ⋏ □(φ ➝ ψ)] ⊢[𝓢] (φ ➝ ψ) ⋏ □(φ ➝ ψ) := FiniteContext.byAxm;
+  apply deduct'
+  apply deduct
+  have d : [φ ⋏ □φ, (φ ➝ ψ) ⋏ □(φ ➝ ψ)] ⊢[𝓢] (φ ➝ ψ) ⋏ □(φ ➝ ψ) := FiniteContext.byAxm
   exact K_intro ((K_left d) ⨀ (K_left (ψ := □φ) (FiniteContext.byAxm))) <|
-    (axiomK' $ K_right d) ⨀ (K_right (φ := φ) (FiniteContext.byAxm));
+    (axiomK' $ K_right d) ⨀ (K_right (φ := φ) (FiniteContext.byAxm))
 @[simp] lemma boxdot_axiomK! : 𝓢 ⊢! ⊡(φ ➝ ψ) ➝ (⊡φ ➝ ⊡ψ) := ⟨boxdotAxiomK⟩
 
-def boxdotAxiomT : 𝓢 ⊢ ⊡φ ➝ φ := by exact and₁;
+def boxdotAxiomT : 𝓢 ⊢ ⊡φ ➝ φ := by exact and₁
 omit [DecidableEq F] in @[simp] lemma boxdot_axiomT! : 𝓢 ⊢! ⊡φ ➝ φ := ⟨boxdotAxiomT⟩
 
 def boxdotNec (d : 𝓢 ⊢ φ) : 𝓢 ⊢ ⊡φ := K_intro d (nec d)
 omit [DecidableEq F] in lemma boxdot_nec! (d : 𝓢 ⊢! φ) : 𝓢 ⊢! ⊡φ := ⟨boxdotNec d.some⟩
 
-def boxdotBox : 𝓢 ⊢ ⊡φ ➝ □φ := by exact and₂;
+def boxdotBox : 𝓢 ⊢ ⊡φ ➝ □φ := by exact and₂
 omit [DecidableEq F] in lemma boxdot_box! : 𝓢 ⊢! ⊡φ ➝ □φ := ⟨boxdotBox⟩
 
 def BoxBoxdot_BoxDotbox : 𝓢 ⊢ □⊡φ ➝ ⊡□φ := C_trans distribute_box_and (C_id _)
@@ -306,54 +306,54 @@ variable {Γ : List F}
 @[simp]
 lemma distribute_multibox_conj! : 𝓢 ⊢! □^[n]⋀Γ ➝ ⋀(Γ.multibox n) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
+  | hnil => simp
+  | hsingle => simp
   | hcons φ Γ h ih =>
-    simp only [List.conj₂_cons_nonempty h];
-    have h₁ : 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ➝ □^[n]φ := imply_multibox_distribute'! $ and₁!;
-    have h₂ : 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ➝ ⋀(Γ.multibox n) := C!_trans (imply_multibox_distribute'! $ and₂!) ih;
-    have := right_K!_intro h₁ h₂;
+    simp only [List.conj₂_cons_nonempty h]
+    have h₁ : 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ➝ □^[n]φ := imply_multibox_distribute'! $ and₁!
+    have h₂ : 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ➝ ⋀(Γ.multibox n) := C!_trans (imply_multibox_distribute'! $ and₂!) ih
+    have := right_K!_intro h₁ h₂
     exact C!_trans this $ by
-      apply right_Conj₂!_intro;
-      intro ψ hψ;
-      simp only [List.mem_cons] at hψ;
+      apply right_Conj₂!_intro
+      intro ψ hψ
+      simp only [List.mem_cons] at hψ
       rcases hψ with (rfl | hψ)
-      . apply and₁!;
-      . obtain ⟨ξ, hξ, rfl⟩ := List.exists_multibox_of_mem_multibox hψ;
-        exact left_K!_intro_right $ left_Conj₂!_intro hψ;
+      . apply and₁!
+      . obtain ⟨ξ, hξ, rfl⟩ := List.exists_multibox_of_mem_multibox hψ
+        exact left_K!_intro_right $ left_Conj₂!_intro hψ
 
 @[simp] lemma distribute_box_conj! : 𝓢 ⊢! □(⋀Γ) ➝ ⋀(Γ.box) := distribute_multibox_conj! (n := 1)
 
 lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n]⋀Γ ↔ ∀ φ ∈ Γ, 𝓢 ⊢! □^[n]φ := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ h ih =>
-    suffices 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ↔ 𝓢 ⊢! □^[n]φ ∧ ∀ ψ ∈ Γ, 𝓢 ⊢! □^[n]ψ by simp_all;
-    constructor;
-    . intro h;
-      have := distribute_multibox_and'! h;
-      constructor;
-      . exact K!_left this;
-      . exact ih.mp (K!_right this);
-    . rintro ⟨h₁, h₂⟩;
-      exact collect_multibox_and'! $ K!_intro h₁ (ih.mpr h₂);
-  | _ => simp_all;
+    suffices 𝓢 ⊢! □^[n](φ ⋏ ⋀Γ) ↔ 𝓢 ⊢! □^[n]φ ∧ ∀ ψ ∈ Γ, 𝓢 ⊢! □^[n]ψ by simp_all
+    constructor
+    . intro h
+      have := distribute_multibox_and'! h
+      constructor
+      . exact K!_left this
+      . exact ih.mp (K!_right this)
+    . rintro ⟨h₁, h₂⟩
+      exact collect_multibox_and'! $ K!_intro h₁ (ih.mpr h₂)
+  | _ => simp_all
 lemma boxConj'_iff! : 𝓢 ⊢! □⋀Γ ↔ ∀ φ ∈ Γ, 𝓢 ⊢! □φ := multiboxConj'_iff! (n := 1)
 
 lemma multiboxconj_of_conjmultibox! (d : 𝓢 ⊢! ⋀(Γ.multibox n)) : 𝓢 ⊢! □^[n]⋀Γ := by
-  apply multiboxConj'_iff!.mpr;
-  intro φ hp;
-  exact Conj₂!_iff_forall_provable.mp d (□^[n]φ) $ List.multibox_mem_of hp;
+  apply multiboxConj'_iff!.mpr
+  intro φ hp
+  exact Conj₂!_iff_forall_provable.mp d (□^[n]φ) $ List.multibox_mem_of hp
 
 @[simp]
 lemma multibox_cons_conjAux₁! :  𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ ⋀(Γ.multibox n) := by
-  apply CConj₂Conj₂!_of_subset;
-  simp_all;
+  apply CConj₂Conj₂!_of_subset
+  simp_all
 
 @[simp]
 lemma multibox_cons_conjAux₂! :  𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ □^[n]φ := by
-  suffices 𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ ⋀([φ]).multibox n by simpa;
-  apply CConj₂Conj₂!_of_subset;
-  simp_all;
+  suffices 𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ ⋀([φ]).multibox n by simpa
+  apply CConj₂Conj₂!_of_subset
+  simp_all
 
 @[simp]
 lemma multibox_cons_conj! :  𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ ⋀(Γ.multibox n) ⋏ □^[n]φ :=
@@ -362,13 +362,13 @@ lemma multibox_cons_conj! :  𝓢 ⊢! ⋀((φ :: Γ).multibox n) ➝ ⋀(Γ.mul
 @[simp]
 lemma collect_multibox_conj! : 𝓢 ⊢! ⋀(Γ.multibox n) ➝ □^[n]⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simpa using C!_of_conseq! multiboxverum!;
-  | hsingle => simp;
+  | hnil => simpa using C!_of_conseq! multiboxverum!
+  | hsingle => simp
   | hcons φ Γ h ih =>
-    simp_all only [ne_eq, not_false_eq_true, List.conj₂_cons_nonempty];
-    refine C!_trans (right_K!_intro (left_Conj₂!_intro ?_) (C!_trans ?_ ih)) collect_multibox_and!;
-    . simp;
-    . simp [List.multibox, List.multibox_nonempty h];
+    simp_all only [ne_eq, not_false_eq_true, List.conj₂_cons_nonempty]
+    refine C!_trans (right_K!_intro (left_Conj₂!_intro ?_) (C!_trans ?_ ih)) collect_multibox_and!
+    . simp
+    . simp [List.multibox, List.multibox_nonempty h]
 
 @[simp]
 lemma collect_box_conj! : 𝓢 ⊢! ⋀(Γ.box) ➝ □(⋀Γ) := collect_multibox_conj! (n := 1)
@@ -385,14 +385,14 @@ variable {Γ : Finset F}
 
 @[simp]
 lemma collect_multibox_fconj! : 𝓢 ⊢! (Γ.multibox n).conj ➝ □^[n](Γ.conj) := by
-  refine C!_replace ?_ ?_ (collect_multibox_conj! (n := n) (Γ := Γ.toList));
+  refine C!_replace ?_ ?_ (collect_multibox_conj! (n := n) (Γ := Γ.toList))
   . apply right_Conj₂!_intro
-    intro φ hφ;
-    apply left_Fconj!_intro;
-    apply Finset.mem_multibox_of_toList_multibox hφ;
+    intro φ hφ
+    apply left_Fconj!_intro
+    apply Finset.mem_multibox_of_toList_multibox hφ
   . apply multibox_axiomK'!
-    apply multinec!;
-    simp;
+    apply multinec!
+    simp
 
 @[simp] lemma collect_box_fconj! : 𝓢 ⊢! (Γ.box).conj ➝ □(Γ.conj) := collect_multibox_fconj! (n := 1)
 
@@ -400,52 +400,52 @@ end Finset
 
 
 def diaOrInst₁ : 𝓢 ⊢ ◇φ ➝ ◇(φ ⋎ ψ) := by
-  apply C_trans (K_left diaDuality);
-  apply C_trans ?h (K_right diaDuality);
-  apply contra;
-  apply axiomK';
-  apply nec;
-  apply contra;
-  exact or₁;
+  apply C_trans (K_left diaDuality)
+  apply C_trans ?h (K_right diaDuality)
+  apply contra
+  apply axiomK'
+  apply nec
+  apply contra
+  exact or₁
 @[simp] lemma dia_or_inst₁! : 𝓢 ⊢! ◇φ ➝ ◇(φ ⋎ ψ) := ⟨diaOrInst₁⟩
 
 -- TODO: `multidiaOrInst₁`
 @[simp] lemma multidia_or_inst₁! : 𝓢 ⊢! ◇^[n]φ ➝ ◇^[n](φ ⋎ ψ) := by
   induction n with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    suffices 𝓢 ⊢! ◇◇^[n]φ ➝ ◇◇^[n](φ ⋎ ψ) by simpa;
-    apply C!_trans (K!_left dia_duality!);
-    apply C!_trans ?_ (K!_right dia_duality!);
-    apply contra!;
-    apply axiomK'!;
-    apply nec!;
-    apply contra!;
-    exact ih;
+    suffices 𝓢 ⊢! ◇◇^[n]φ ➝ ◇◇^[n](φ ⋎ ψ) by simpa
+    apply C!_trans (K!_left dia_duality!)
+    apply C!_trans ?_ (K!_right dia_duality!)
+    apply contra!
+    apply axiomK'!
+    apply nec!
+    apply contra!
+    exact ih
 
 def diaOrInst₂ : 𝓢 ⊢ ◇ψ ➝ ◇(φ ⋎ ψ) := by
-  apply C_trans (K_left diaDuality);
-  apply C_trans ?h (K_right diaDuality);
-  apply contra;
-  apply axiomK';
-  apply nec;
-  apply contra;
-  exact or₂;
+  apply C_trans (K_left diaDuality)
+  apply C_trans ?h (K_right diaDuality)
+  apply contra
+  apply axiomK'
+  apply nec
+  apply contra
+  exact or₂
 @[simp] lemma dia_or_inst₂! : 𝓢 ⊢! ◇ψ ➝ ◇(φ ⋎ ψ) := ⟨diaOrInst₂⟩
 
 -- TODO: `multidiaOrInst₂`
 @[simp] lemma multidia_or_inst₂! : 𝓢 ⊢! ◇^[n]ψ ➝ ◇^[n](φ ⋎ ψ) := by
   induction n with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    suffices 𝓢 ⊢! ◇◇^[n]ψ ➝ ◇◇^[n](φ ⋎ ψ) by simpa;
-    apply C!_trans (K!_left dia_duality!);
-    apply C!_trans ?_ (K!_right dia_duality!);
-    apply contra!;
-    apply axiomK'!;
-    apply nec!;
-    apply contra!;
-    exact ih;
+    suffices 𝓢 ⊢! ◇◇^[n]ψ ➝ ◇◇^[n](φ ⋎ ψ) by simpa
+    apply C!_trans (K!_left dia_duality!)
+    apply C!_trans ?_ (K!_right dia_duality!)
+    apply contra!
+    apply axiomK'!
+    apply nec!
+    apply contra!
+    exact ih
 
 def collect_dia_or : 𝓢 ⊢ ◇φ ⋎ ◇ψ ➝ ◇(φ ⋎ ψ) := left_A_intro diaOrInst₁ diaOrInst₂
 @[simp] lemma collect_dia_or! : 𝓢 ⊢! ◇φ ⋎ ◇ψ ➝ ◇(φ ⋎ ψ) := ⟨collect_dia_or⟩
@@ -459,42 +459,42 @@ def collect_multidia_or! : 𝓢 ⊢! ◇^[n]φ ⋎ ◇^[n]ψ ➝ ◇^[n](φ ⋎ 
 @[simp]
 lemma distribute_multidia_or! : 𝓢 ⊢! ◇^[n](φ ⋎ ψ) ➝ ◇^[n]φ ⋎ ◇^[n]ψ := by
   induction n with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    suffices 𝓢 ⊢! ◇◇^[n](φ ⋎ ψ) ➝ ◇◇^[n]φ ⋎ ◇◇^[n]ψ by simpa [Dia.multidia_succ];
-    apply C!_trans (K!_left dia_duality!);
-    apply CN!_of_CN!_left;
-    apply C!_trans CNAKNN!;
+    suffices 𝓢 ⊢! ◇◇^[n](φ ⋎ ψ) ➝ ◇◇^[n]φ ⋎ ◇◇^[n]ψ by simpa [Dia.multidia_succ]
+    apply C!_trans (K!_left dia_duality!)
+    apply CN!_of_CN!_left
+    apply C!_trans CNAKNN!
     suffices 𝓢 ⊢! □(∼◇^[n]φ ⋏ ∼◇^[n]ψ) ➝ □(∼◇^[n](φ ⋎ ψ)) by
-      apply C!_trans ?_ this;
-      apply C!_trans ?_ collect_box_and!;
-      apply CKK!_of_C!_of_C!;
+      apply C!_trans ?_ this
+      apply C!_trans ?_ collect_box_and!
+      apply CKK!_of_C!_of_C!
       repeat {
-        apply C!_trans ?_ (K!_right $ box_duality!);
-        apply contra!;
-        apply diaK'!;
-        exact dne!;
-      };
-    apply axiomK'!;
-    apply nec!;
-    apply C!_trans CKNNNA! ?_;
-    apply contra!;
-    exact ih;
+        apply C!_trans ?_ (K!_right $ box_duality!)
+        apply contra!
+        apply diaK'!
+        exact dne!
+      }
+    apply axiomK'!
+    apply nec!
+    apply C!_trans CKNNNA! ?_
+    apply contra!
+    exact ih
 @[simp] lemma distribute_dia_or! : 𝓢 ⊢! ◇(φ ⋎ ψ) ➝ ◇φ ⋎ ◇ψ := distribute_multidia_or! (n := 1)
 
 @[simp]
 lemma not_dia_bot : 𝓢 ⊢! ∼◇^[n]⊥ := by
-  refine contra! (K!_right $ multidia_iff! iff_not_bot_top!) ⨀ ?_;
-  . apply multibox_duality'!.mp multiboxverum!;
+  refine contra! (K!_right $ multidia_iff! iff_not_bot_top!) ⨀ ?_
+  . apply multibox_duality'!.mp multiboxverum!
 
 -- TODO: `distributeMultidiaAnd!` is computable but it's too slow, so leave it.
 @[simp] lemma distribute_multidia_and!: 𝓢 ⊢! ◇^[n](φ ⋏ ψ) ➝ ◇^[n]φ ⋏ ◇^[n]ψ := by
   suffices h : 𝓢 ⊢! ∼(□^[n](∼(φ ⋏ ψ))) ➝ ∼(□^[n](∼φ)) ⋏ ∼(□^[n](∼ψ)) by
-    exact C!_trans (C!_trans (K!_left multidia_duality!) h) $ CKK!_of_C!_of_C! (K!_right multidia_duality!) (K!_right multidia_duality!);
-  apply FiniteContext.deduct'!;
-  apply KNN!_of_NA!;
-  apply FiniteContext.deductInv'!;
-  apply contra!;
+    exact C!_trans (C!_trans (K!_left multidia_duality!) h) $ CKK!_of_C!_of_C! (K!_right multidia_duality!) (K!_right multidia_duality!)
+  apply FiniteContext.deduct'!
+  apply KNN!_of_NA!
+  apply FiniteContext.deductInv'!
+  apply contra!
   apply C!_trans collect_multibox_or! (imply_multibox_distribute'! CANNNK!)
 
 @[simp] lemma distribute_dia_and! : 𝓢 ⊢! ◇(φ ⋏ ψ) ➝ ◇φ ⋏ ◇ψ := distribute_multidia_and! (n := 1)
@@ -504,23 +504,23 @@ lemma distribute_dia_and'! (h : 𝓢 ⊢! ◇(φ ⋏ ψ)) : 𝓢 ⊢! ◇φ ⋏ 
 
 -- TODO: move
 lemma neg_congruence! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ∼φ ⭤ ∼ψ := by
-  apply E!_intro;
-  . apply contra! $ C_of_E_mpr! h;
-  . apply contra! $ C_of_E_mp! h;
+  apply E!_intro
+  . apply contra! $ C_of_E_mpr! h
+  . apply contra! $ C_of_E_mp! h
 
 
 omit [DecidableEq F] in
 lemma box_regularity! (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! □φ ➝ □ψ := by
-  apply ?_ ⨀ nec! h;
-  simp;
+  apply ?_ ⨀ nec! h
+  simp
 
 
 -- TODO: move
 omit [DecidableEq F] in
 lemma box_congruence! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! □φ ⭤ □ψ := by
   apply E!_intro
-  . apply box_regularity!; exact C_of_E_mp! h;
-  . apply box_regularity!; exact C_of_E_mpr! h;
+  . apply box_regularity!; exact C_of_E_mp! h
+  . apply box_regularity!; exact C_of_E_mpr! h
 
 -- TODO
 noncomputable instance : Entailment.RE 𝓢 where
@@ -529,16 +529,16 @@ noncomputable instance : Entailment.RE 𝓢 where
 -- TODO: move
 omit [DecidableEq F] in
 lemma E!_replace (h₁ : 𝓢 ⊢! φ₁ ⭤ ψ₁) (h₂ : 𝓢 ⊢! φ₂ ⭤ ψ₂) (h₃ : 𝓢 ⊢! φ₁ ⭤ φ₂) : 𝓢 ⊢! ψ₁ ⭤ ψ₂ := by
-  apply E!_intro;
-  . apply C!_replace (C_of_E_mpr! h₁) (C_of_E_mp! h₂) (C_of_E_mp! h₃);
-  . apply C!_replace (C_of_E_mpr! h₂) (C_of_E_mp! h₁) (C_of_E_mpr! h₃);
+  apply E!_intro
+  . apply C!_replace (C_of_E_mpr! h₁) (C_of_E_mp! h₂) (C_of_E_mp! h₃)
+  . apply C!_replace (C_of_E_mpr! h₂) (C_of_E_mp! h₁) (C_of_E_mpr! h₃)
 
 lemma dia_congruence! (h : 𝓢 ⊢! φ ⭤ ψ) : 𝓢 ⊢! ◇φ ⭤ ◇ψ := by
-  apply E!_replace (E!_symm $ dia_duality!) (E!_symm $ dia_duality!);
-  apply neg_congruence!;
-  apply box_congruence!;
-  apply neg_congruence!;
-  exact h;
+  apply E!_replace (E!_symm $ dia_duality!) (E!_symm $ dia_duality!)
+  apply neg_congruence!
+  apply box_congruence!
+  apply neg_congruence!
+  exact h
 
 section List
 
@@ -547,12 +547,12 @@ variable {Γ : List F}
 @[simp]
 lemma distribute_multidia_disj! : 𝓢 ⊢! ◇^[n]⋁Γ ➝ ⋁(Γ.multidia n) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => apply C_of_N; simp only [List.disj₂_nil, not_dia_bot];
-  | hsingle => simp;
+  | hnil => apply C_of_N; simp only [List.disj₂_nil, not_dia_bot]
+  | hsingle => simp
   | hcons φ Γ h ih =>
     suffices 𝓢 ⊢! ◇^[n](φ ⋎ ⋁Γ) ➝ (◇^[n]φ ⋎ ⋁(Γ.multidia n)) by
-      simpa [List.multidia, List.disj₂_cons_nonempty h, List.disj₂_cons_nonempty (List.multidia_nonempty h)];
-    exact C!_trans distribute_multidia_or! $ CAA!_of_C!_right ih;
+      simpa [List.multidia, List.disj₂_cons_nonempty h, List.disj₂_cons_nonempty (List.multidia_nonempty h)]
+    exact C!_trans distribute_multidia_or! $ CAA!_of_C!_right ih
 
 @[simp]
 lemma distribute_dia_disj! : 𝓢 ⊢! ◇⋁Γ ➝ ⋁(Γ.dia) := by simpa using distribute_multidia_disj! (n := 1)
@@ -561,16 +561,16 @@ lemma distribute_dia_disj! : 𝓢 ⊢! ◇⋁Γ ➝ ⋁(Γ.dia) := by simpa usin
 @[simp] lemma iff_conjmultidia_multidiaconj! : 𝓢 ⊢! ◇^[n](⋀Γ) ➝ ⋀(Γ.multidia n) := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ h ih =>
-    simp_all only [ne_eq, not_false_eq_true, List.conj₂_cons_nonempty];
+    simp_all only [ne_eq, not_false_eq_true, List.conj₂_cons_nonempty]
     exact C!_trans distribute_multidia_and! $ by
-      apply deduct'!;
-      apply Conj₂!_iff_forall_provable.mpr;
-      intro ψ hq;
-      simp only [List.mem_cons] at hq;
-      rcases hq with (rfl | hψ);
-      . exact K!_left id!;
-      . obtain ⟨ξ, hξ, rfl⟩ := List.exists_multidia_of_mem_multidia hψ;
-        exact (Conj₂!_iff_forall_provable.mp $ (of'! ih) ⨀ (K!_right $ id!)) _ hψ;
+      apply deduct'!
+      apply Conj₂!_iff_forall_provable.mpr
+      intro ψ hq
+      simp only [List.mem_cons] at hq
+      rcases hq with (rfl | hψ)
+      . exact K!_left id!
+      . obtain ⟨ξ, hξ, rfl⟩ := List.exists_multidia_of_mem_multidia hψ
+        exact (Conj₂!_iff_forall_provable.mp $ (of'! ih) ⨀ (K!_right $ id!)) _ hψ
   | _ => simp
 
 end List
@@ -582,13 +582,13 @@ variable {Γ : Finset F}
 
 @[simp]
 lemma distribute_multidia_fdisj! : 𝓢 ⊢! ◇^[n]Γ.disj ➝ (Γ.multidia n).disj := by
-  refine C!_replace ?_ ?_ (distribute_multidia_disj! (n := n) (Γ := Γ.toList));
-  . apply CMultidiaMultidia_of_C;
-    simp;
+  refine C!_replace ?_ ?_ (distribute_multidia_disj! (n := n) (Γ := Γ.toList))
+  . apply CMultidiaMultidia_of_C
+    simp
   . apply left_Disj₂!_intro
-    intro φ hφ;
-    apply right_Fdisj!_intro;
-    exact Finset.mem_multidia_of_toList_multibox hφ;
+    intro φ hφ
+    apply right_Fdisj!_intro
+    exact Finset.mem_multidia_of_toList_multibox hφ
 
 @[simp] lemma distribute_dia_fdisj! : 𝓢 ⊢! ◇Γ.disj ➝ (Γ.dia).disj := distribute_multidia_fdisj! (n := 1)
 
@@ -599,25 +599,25 @@ end Finset
 section
 
 noncomputable def lemma_Grz₁ : 𝓢 ⊢ □φ ➝ □(□((φ ⋏ (□φ ➝ □□φ)) ➝ □(φ ⋏ (□φ ➝ □□φ))) ➝ (φ ⋏ (□φ ➝ □□φ))) := by
-  let ψ := φ ⋏ (□φ ➝ □□φ);
+  let ψ := φ ⋏ (□φ ➝ □□φ)
   have    : 𝓢 ⊢ ((□φ ➝ □□φ) ➝ □φ) ➝ □φ := peirce
-  have    : 𝓢 ⊢ (φ ➝ ((□φ ➝ □□φ) ➝ □φ)) ➝ (φ ➝ □φ) := CCC_of_C_right this;
-  have d₁ : 𝓢 ⊢ (ψ ➝ □φ) ➝ φ ➝ □φ := C_trans (K_left $ ECKCC φ (□φ ➝ □□φ) (□φ)) this;
-  have    : 𝓢 ⊢ ψ ➝ φ := and₁;
-  have    : 𝓢 ⊢ □ψ ➝ □φ := implyBoxDistribute' this;
-  have d₂ : 𝓢 ⊢ (ψ ➝ □ψ) ➝ (ψ ➝ □φ) := CCC_of_C_right this;
-  have    : 𝓢 ⊢ (ψ ➝ □ψ) ➝ φ ➝ □φ := C_trans d₂ d₁;
-  have    : 𝓢 ⊢ □(ψ ➝ □ψ) ➝ □(φ ➝ □φ) := implyBoxDistribute' this;
-  have    : 𝓢 ⊢ □(ψ ➝ □ψ) ➝ (□φ ➝ □□φ) := C_trans this axiomK;
-  have    : 𝓢 ⊢ (φ ➝ □(ψ ➝ □ψ)) ➝ (φ ➝ (□φ ➝ □□φ)) := CCC_of_C_right this;
+  have    : 𝓢 ⊢ (φ ➝ ((□φ ➝ □□φ) ➝ □φ)) ➝ (φ ➝ □φ) := CCC_of_C_right this
+  have d₁ : 𝓢 ⊢ (ψ ➝ □φ) ➝ φ ➝ □φ := C_trans (K_left $ ECKCC φ (□φ ➝ □□φ) (□φ)) this
+  have    : 𝓢 ⊢ ψ ➝ φ := and₁
+  have    : 𝓢 ⊢ □ψ ➝ □φ := implyBoxDistribute' this
+  have d₂ : 𝓢 ⊢ (ψ ➝ □ψ) ➝ (ψ ➝ □φ) := CCC_of_C_right this
+  have    : 𝓢 ⊢ (ψ ➝ □ψ) ➝ φ ➝ □φ := C_trans d₂ d₁
+  have    : 𝓢 ⊢ □(ψ ➝ □ψ) ➝ □(φ ➝ □φ) := implyBoxDistribute' this
+  have    : 𝓢 ⊢ □(ψ ➝ □ψ) ➝ (□φ ➝ □□φ) := C_trans this axiomK
+  have    : 𝓢 ⊢ (φ ➝ □(ψ ➝ □ψ)) ➝ (φ ➝ (□φ ➝ □□φ)) := CCC_of_C_right this
   have    : 𝓢 ⊢ φ ➝ (□(ψ ➝ □ψ) ➝ (φ ⋏ (□φ ➝ □□φ))) := by
-    apply deduct';
-    apply deduct;
-    apply K_intro;
-    . exact FiniteContext.byAxm;
-    . exact (of this) ⨀ (C_of_conseq FiniteContext.byAxm) ⨀ (FiniteContext.byAxm);
-  have    : 𝓢 ⊢ φ ➝ (□(ψ ➝ □ψ) ➝ ψ) := this;
-  exact implyBoxDistribute' this;
+    apply deduct'
+    apply deduct
+    apply K_intro
+    . exact FiniteContext.byAxm
+    . exact (of this) ⨀ (C_of_conseq FiniteContext.byAxm) ⨀ (FiniteContext.byAxm)
+  have    : 𝓢 ⊢ φ ➝ (□(ψ ➝ □ψ) ➝ ψ) := this
+  exact implyBoxDistribute' this
 
 lemma lemma_Grz₁! : 𝓢 ⊢! (□φ ➝ □(□((φ ⋏ (□φ ➝ □□φ)) ➝ □(φ ⋏ (□φ ➝ □□φ))) ➝ (φ ⋏ (□φ ➝ □□φ)))) := ⟨lemma_Grz₁⟩
 
@@ -629,80 +629,80 @@ section Boxlt
 variable {n m : ℕ}
 
 lemma boxlt_lt_succ! : 𝓢 ⊢! (□^≤[n + 1] φ) ➝ (□^≤[n] φ) := by
-  apply CFconjFconj!_of_provable;
-  intro ψ hψ;
-  simp only [Finset.mem_image, Finset.mem_range] at hψ;
-  obtain ⟨i, hi, rfl⟩ := hψ;
+  apply CFconjFconj!_of_provable
+  intro ψ hψ
+  simp only [Finset.mem_image, Finset.mem_range] at hψ
+  obtain ⟨i, hi, rfl⟩ := hψ
   apply Context.by_axm!
-  simp only [Finset.coe_image, Finset.coe_range, Set.mem_image, Set.mem_Iio];
-  use i;
-  constructor;
-  . omega;
-  . simp;
+  simp only [Finset.coe_image, Finset.coe_range, Set.mem_image, Set.mem_Iio]
+  use i
+  constructor
+  . omega
+  . simp
 
 lemma boxlt_lt_add! : 𝓢 ⊢! (□^≤[n + m] φ) ➝ (□^≤[n] φ) := by
   induction m with
-  | zero => simp;
+  | zero => simp
   | succ m ih =>
-    rw [(show n + (m + 1) = n + m + 1 by rfl)];
-    apply C!_trans boxlt_lt_succ! ih;
+    rw [(show n + (m + 1) = n + m + 1 by rfl)]
+    apply C!_trans boxlt_lt_succ! ih
 
 lemma boxlt_lt! (h : n ≥ m) : 𝓢 ⊢! (□^≤[n] φ) ➝ (□^≤[m] φ) := by
-  convert boxlt_lt_add! (𝓢 := 𝓢) (n := m) (m := n - m) (φ := φ);
-  omega;
+  convert boxlt_lt_add! (𝓢 := 𝓢) (n := m) (m := n - m) (φ := φ)
+  omega
 
 lemma E_boxlt_succ! : 𝓢 ⊢! (□^≤[n + 1] φ) ⭤ (□^≤[n] φ) ⋏ (□^[(n + 1)] φ) := by
-  apply E!_intro;
-  . apply FConj_DT.mpr;
-    apply K!_intro;
-    . apply FConj_DT.mp;
-      apply boxlt_lt!;
-      omega;
-    . apply Context.by_axm!;
-      simp only [Finset.coe_image, Finset.coe_range, Box.multibox_succ, Set.mem_image, Set.mem_Iio];
-      use n + 1;
-      constructor;
-      . omega;
-      . simp;
-  . suffices 𝓢 ⊢! (□^≤[n]φ) ⋏ (Finset.conj {(□^[(n + 1)]φ)}) ➝ (□^≤[n + 1]φ) by simpa using this;
-    convert CKFconjFconjUnion! (𝓢 := 𝓢) (Γ := Finset.range (n + 1) |>.image (λ i => □^[i] φ)) (Δ := {(□^[(n + 1)]φ)});
-    ext ψ;
-    simp only [Finset.mem_image, Finset.mem_range, Box.multibox_succ, Finset.mem_union, Finset.mem_singleton];
-    constructor;
-    . rintro ⟨k, hk, rfl⟩;
-      by_cases ha : k = n + 1;
-      . right;
-        subst ha;
-        simp;
-      . left;
-        use k;
-        constructor;
-        . omega;
-        . simp;
-    . rintro (⟨k, hk, rfl⟩ | rfl);
-      . use k;
-        constructor;
-        . omega;
-        . simp;
-      . use (n + 1);
-        constructor;
-        . omega;
-        . simp;
+  apply E!_intro
+  . apply FConj_DT.mpr
+    apply K!_intro
+    . apply FConj_DT.mp
+      apply boxlt_lt!
+      omega
+    . apply Context.by_axm!
+      simp only [Finset.coe_image, Finset.coe_range, Box.multibox_succ, Set.mem_image, Set.mem_Iio]
+      use n + 1
+      constructor
+      . omega
+      . simp
+  . suffices 𝓢 ⊢! (□^≤[n]φ) ⋏ (Finset.conj {(□^[(n + 1)]φ)}) ➝ (□^≤[n + 1]φ) by simpa using this
+    convert CKFconjFconjUnion! (𝓢 := 𝓢) (Γ := Finset.range (n + 1) |>.image (λ i => □^[i] φ)) (Δ := {(□^[(n + 1)]φ)})
+    ext ψ
+    simp only [Finset.mem_image, Finset.mem_range, Box.multibox_succ, Finset.mem_union, Finset.mem_singleton]
+    constructor
+    . rintro ⟨k, hk, rfl⟩
+      by_cases ha : k = n + 1
+      . right
+        subst ha
+        simp
+      . left
+        use k
+        constructor
+        . omega
+        . simp
+    . rintro (⟨k, hk, rfl⟩ | rfl)
+      . use k
+        constructor
+        . omega
+        . simp
+      . use (n + 1)
+        constructor
+        . omega
+        . simp
 
 lemma boxlt_regularity! (h : 𝓢 ⊢! φ ➝ ψ) : 𝓢 ⊢! (□^≤[n] φ) ➝ (□^≤[n] ψ) := by
   induction n with
-  | zero => simpa;
+  | zero => simpa
   | succ n ih =>
     suffices 𝓢 ⊢! ((□^≤[n]φ) ⋏ (□^[(n + 1)]φ)) ➝ ((□^≤[n]ψ) ⋏ (□^[(n + 1)]ψ)) by
-      apply C!_replace ?_ ?_ this;
-      . apply C_of_E_mp! E_boxlt_succ!;
-      . apply C_of_E_mpr! E_boxlt_succ!;
-    apply CKK!_of_C!_of_C! ih $ imply_multibox_distribute'! h;
+      apply C!_replace ?_ ?_ this
+      . apply C_of_E_mp! E_boxlt_succ!
+      . apply C_of_E_mpr! E_boxlt_succ!
+    apply CKK!_of_C!_of_C! ih $ imply_multibox_distribute'! h
 
 -- TODO: better name
 lemma boxlt_fconj_regularity_of_subset {Γ Δ : Finset _} (hs : Γ ⊆ Δ) : 𝓢 ⊢! (□^≤[n]Δ.conj) ➝ □^≤[n]Γ.conj := by
-  apply boxlt_regularity!;
-  apply CFConj_FConj!_of_subset hs;
+  apply boxlt_regularity!
+  apply CFConj_FConj!_of_subset hs
 
 end Boxlt
 
@@ -713,46 +713,46 @@ namespace Context
 variable {X : Set F}
 
 lemma provable_iff_boxed : (X.box) *⊢[𝓢]! φ ↔ ∃ Δ : List F, (∀ ψ ∈ Δ.box, ψ ∈ X.box) ∧ (Δ.box) ⊢[𝓢]! φ := by
-  constructor;
-  . intro h;
-    obtain ⟨Γ,sΓ, hΓ⟩ := Context.provable_iff.mp h;
-    use Γ.prebox;
-    constructor;
-    . rintro ψ hψ;
-      apply sΓ ψ;
-      obtain ⟨ξ, hξ, rfl⟩ := List.exists_box_of_mem_box hψ;
-      exact List.mem_of_mem_multiboxFilter hψ;
-    . apply FiniteContext.provable_iff.mpr;
-      apply C!_trans ?_ (FiniteContext.provable_iff.mp hΓ);
-      apply CConj₂Conj₂!_of_subset;
-      intro ψ hψ;
-      obtain ⟨ξ, hξ, rfl⟩ := sΓ ψ hψ;
-      apply List.mem_multiboxFilter_of_mem;
-      assumption;
-  . rintro ⟨Δ, hΔ, h⟩;
-    apply Context.provable_iff.mpr;
-    use Δ.box;
+  constructor
+  . intro h
+    obtain ⟨Γ,sΓ, hΓ⟩ := Context.provable_iff.mp h
+    use Γ.prebox
+    constructor
+    . rintro ψ hψ
+      apply sΓ ψ
+      obtain ⟨ξ, hξ, rfl⟩ := List.exists_box_of_mem_box hψ
+      exact List.mem_of_mem_multiboxFilter hψ
+    . apply FiniteContext.provable_iff.mpr
+      apply C!_trans ?_ (FiniteContext.provable_iff.mp hΓ)
+      apply CConj₂Conj₂!_of_subset
+      intro ψ hψ
+      obtain ⟨ξ, hξ, rfl⟩ := sΓ ψ hψ
+      apply List.mem_multiboxFilter_of_mem
+      assumption
+  . rintro ⟨Δ, hΔ, h⟩
+    apply Context.provable_iff.mpr
+    use Δ.box
 
 lemma nec! {Γ : Set F} (h : Γ *⊢[𝓢]! φ) : Γ.box *⊢[𝓢]! □φ := by
-  apply Context.provable_iff.mpr;
-  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff.mp h;
-  have : Δ.box ⊢[𝓢]! □φ := contextual_nec! hΔ₂;
-  use Δ.box;
-  constructor;
-  . intro ψ hψ;
-    obtain ⟨ψ, hψ, rfl⟩ := List.exists_box_of_mem_box hψ;
-    simp_all;
-  . assumption;
+  apply Context.provable_iff.mpr
+  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff.mp h
+  have : Δ.box ⊢[𝓢]! □φ := contextual_nec! hΔ₂
+  use Δ.box
+  constructor
+  . intro ψ hψ
+    obtain ⟨ψ, hψ, rfl⟩ := List.exists_box_of_mem_box hψ
+    simp_all
+  . assumption
 
 lemma box_regularity! (h : Γ *⊢[𝓢]! φ ➝ ψ) : Γ.box *⊢[𝓢]! □φ ➝ □ψ := by
-  have H₁ := Context.nec! h;
-  have H₂ : Γ.box *⊢[𝓢]! □(φ ➝ ψ) ➝ (□φ ➝ □ψ) := by simp;
-  exact H₂ ⨀ H₁;
+  have H₁ := Context.nec! h
+  have H₂ : Γ.box *⊢[𝓢]! □(φ ➝ ψ) ➝ (□φ ➝ □ψ) := by simp
+  exact H₂ ⨀ H₁
 
 lemma box_congruence! (h : Γ *⊢[𝓢]! φ ⭤ ψ) : Γ.box *⊢[𝓢]! □φ ⭤ □ψ := by
-  apply E!_intro;
-  . apply box_regularity!; exact C_of_E_mp! h;
-  . apply box_regularity!; exact C_of_E_mpr! h;
+  apply E!_intro
+  . apply box_regularity!; exact C_of_E_mp! h
+  . apply box_regularity!; exact C_of_E_mpr! h
 
 end Context
 

--- a/Foundation/Modal/Entailment/K4.lean
+++ b/Foundation/Modal/Entailment/K4.lean
@@ -9,12 +9,12 @@ variable {𝓢 : S} [Entailment.K4 𝓢]
 
 @[simp]
 lemma diaFour! : 𝓢 ⊢! ◇◇φ ➝ ◇φ := by
-  apply C!_replace diaDuality_mp! diaDuality_mpr!;
-  apply contra!;
-  suffices 𝓢 ⊢! □□(∼φ) ➝ □(∼◇φ) by apply C!_trans axiomFour! this;
-  apply axiomK'!;
-  apply nec!;
-  simp;
+  apply C!_replace diaDuality_mp! diaDuality_mpr!
+  apply contra!
+  suffices 𝓢 ⊢! □□(∼φ) ➝ □(∼◇φ) by apply C!_trans axiomFour! this
+  apply axiomK'!
+  apply nec!
+  simp
 lemma diaFour'! (h : 𝓢 ⊢! ◇◇φ) : 𝓢 ⊢! ◇φ := diaFour! ⨀ h
 
 def imply_BoxBoxdot_Box: 𝓢 ⊢  □⊡φ ➝ □φ := by
@@ -29,56 +29,56 @@ def imply_Box_BoxBoxdot' (h : 𝓢 ⊢ □φ) : 𝓢 ⊢ □⊡φ := imply_Box_B
 def imply_Box_BoxBoxdot'! (h : 𝓢 ⊢! □φ) : 𝓢 ⊢! □⊡φ := ⟨imply_Box_BoxBoxdot' h.some⟩
 
 def iff_Box_BoxBoxdot : 𝓢 ⊢ □φ ⭤ □⊡φ := by
-  apply E_intro;
+  apply E_intro
   . exact imply_Box_BoxBoxdot
-  . exact imply_BoxBoxdot_Box;
+  . exact imply_BoxBoxdot_Box
 @[simp] lemma iff_box_boxboxdot! : 𝓢 ⊢! □φ ⭤ □⊡φ := ⟨iff_Box_BoxBoxdot⟩
 
 def iff_Box_BoxdotBox : 𝓢 ⊢ □φ ⭤ ⊡□φ := by
-  apply E_intro;
+  apply E_intro
   . exact C_trans (right_K_intro (C_id _) axiomFour) (C_id _)
   . exact and₁
 @[simp] lemma iff_box_boxdotbox! : 𝓢 ⊢! □φ ⭤ ⊡□φ := ⟨iff_Box_BoxdotBox⟩
 
 def iff_Boxdot_BoxdotBoxdot : 𝓢 ⊢ ⊡φ ⭤ ⊡⊡φ := by
-  apply E_intro;
-  . exact right_K_intro (C_id _) (C_trans boxdotBox (K_left iff_Box_BoxBoxdot));
-  . exact and₁;
+  apply E_intro
+  . exact right_K_intro (C_id _) (C_trans boxdotBox (K_left iff_Box_BoxBoxdot))
+  . exact and₁
 @[simp] lemma iff_boxdot_boxdotboxdot : 𝓢 ⊢! ⊡φ ⭤ ⊡⊡φ := ⟨iff_Boxdot_BoxdotBoxdot⟩
 
 def boxdotAxiomFour : 𝓢 ⊢ ⊡φ ➝ ⊡⊡φ := K_left iff_Boxdot_BoxdotBoxdot
 @[simp] lemma boxdot_axiomFour! : 𝓢 ⊢! ⊡φ ➝ ⊡⊡φ := ⟨boxdotAxiomFour⟩
 
 lemma Context.multibox_2_in_context_to_box_finset {Γ : Finset F} (h : Γ.multibox 2 *⊢[𝓢]! φ) : Γ.box *⊢[𝓢]! φ := by
-  apply FConj_DT.mp;
-  refine C!_trans ?_ $ FConj_DT.mpr h;
-  apply CFconjFconj!_of_provable;
-  intro ξ hξ;
-  obtain ⟨ξ, h, rfl⟩ := Finset.exists_multibox_of_mem_multibox hξ;
-  apply axiomFour'!;
+  apply FConj_DT.mp
+  refine C!_trans ?_ $ FConj_DT.mpr h
+  apply CFconjFconj!_of_provable
+  intro ξ hξ
+  obtain ⟨ξ, h, rfl⟩ := Finset.exists_multibox_of_mem_multibox hξ
+  apply axiomFour'!
   apply Context.by_axm!
-  simpa using h;
+  simpa using h
 
 lemma Context.multibox_2_in_context_to_box {Γ : Set F} (h : Γ.multibox 2 *⊢[𝓢]! φ) : Γ.box *⊢[𝓢]! φ := by
-  apply Context.provable_iff_finset.mpr;
-  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff_finset.mp h;
-  use Δ.premultibox 2 |>.box;
-  constructor;
-  . intro ψ hψ;
-    simp at hψ;
-    obtain ⟨ψ, hψ, rfl⟩ := hψ;
-    have := hΔ₁ hψ;
-    simpa;
-  . apply Context.multibox_2_in_context_to_box_finset;
-    apply Context.weakening! ?_ hΔ₂;
-    intro ψ hψ;
-    have := hΔ₁ hψ;
-    simp at this;
-    obtain ⟨ψ, hψ, rfl⟩ := this;
-    simpa;
+  apply Context.provable_iff_finset.mpr
+  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff_finset.mp h
+  use Δ.premultibox 2 |>.box
+  constructor
+  . intro ψ hψ
+    simp at hψ
+    obtain ⟨ψ, hψ, rfl⟩ := hψ
+    have := hΔ₁ hψ
+    simpa
+  . apply Context.multibox_2_in_context_to_box_finset
+    apply Context.weakening! ?_ hΔ₂
+    intro ψ hψ
+    have := hΔ₁ hψ
+    simp at this
+    obtain ⟨ψ, hψ, rfl⟩ := this
+    simpa
 
 lemma Context.boxbox_in_context_to_box {Γ : Set F} (h : Γ.box.box *⊢[𝓢]! φ) : Γ.box *⊢[𝓢]! φ := by
-  rw [(show Γ.box.box = Γ.multibox 2 by ext; simp)] at h;
-  apply Context.multibox_2_in_context_to_box h;
+  rw [(show Γ.box.box = Γ.multibox 2 by ext; simp)] at h
+  apply Context.multibox_2_in_context_to_box h
 
 end LO.Modal.Entailment

--- a/Foundation/Modal/Entailment/K4Hen.lean
+++ b/Foundation/Modal/Entailment/K4Hen.lean
@@ -16,7 +16,7 @@ namespace K4Hen
 variable [Entailment.K4Hen 𝓢]
 
 instance : HenkinRule 𝓢 where
-  henkin h := (K_left h) ⨀ (axiomHen ⨀ nec h);
+  henkin h := (K_left h) ⨀ (axiomHen ⨀ nec h)
 
 end K4Hen
 

--- a/Foundation/Modal/Entailment/K4Henkin.lean
+++ b/Foundation/Modal/Entailment/K4Henkin.lean
@@ -16,7 +16,7 @@ namespace K4Henkin
 variable [Entailment.K4Henkin 𝓢]
 
 instance : LoebRule 𝓢 where
-  loeb h := h ⨀ (henkin $ E_intro (axiomK' $ nec h) axiomFour);
+  loeb h := h ⨀ (henkin $ E_intro (axiomK' $ nec h) axiomFour)
 
 end K4Henkin
 

--- a/Foundation/Modal/Entailment/K4Loeb.lean
+++ b/Foundation/Modal/Entailment/K4Loeb.lean
@@ -16,15 +16,15 @@ namespace K4Loeb
 variable [Entailment.K4Loeb 𝓢]
 
 protected def axiomL : 𝓢 ⊢ Axioms.L φ := by
-  dsimp [Axioms.L];
-  generalize e : □(□φ ➝ φ) ➝ □φ = ψ;
-  have d₁ : [□(□φ ➝ φ), □ψ] ⊢[𝓢] □□(□φ ➝ φ) ➝ □□φ := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
-  have d₂ : [□(□φ ➝ φ), □ψ] ⊢[𝓢] □□φ ➝ □φ := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
-  have d₃ : 𝓢 ⊢ □(□φ ➝ φ) ➝ □□(□φ ➝ φ) := axiomFour;
+  dsimp [Axioms.L]
+  generalize e : □(□φ ➝ φ) ➝ □φ = ψ
+  have d₁ : [□(□φ ➝ φ), □ψ] ⊢[𝓢] □□(□φ ➝ φ) ➝ □□φ := FiniteContext.weakening (by aesop) $ deductInv' axiomK
+  have d₂ : [□(□φ ➝ φ), □ψ] ⊢[𝓢] □□φ ➝ □φ := FiniteContext.weakening (by aesop) $ deductInv' axiomK
+  have d₃ : 𝓢 ⊢ □(□φ ➝ φ) ➝ □□(□φ ➝ φ) := axiomFour
   have : 𝓢 ⊢ □ψ ➝ ψ := by
-    nth_rw 2 [←e]; apply deduct'; apply deduct;
-    exact d₂ ⨀ (d₁ ⨀ ((of d₃) ⨀ (FiniteContext.byAxm)));
-  exact loeb this;
+    nth_rw 2 [←e]; apply deduct'; apply deduct
+    exact d₂ ⨀ (d₁ ⨀ ((of d₃) ⨀ (FiniteContext.byAxm)))
+  exact loeb this
 instance : HasAxiomL 𝓢 := ⟨fun _ ↦ K4Loeb.axiomL⟩
 
 end K4Loeb

--- a/Foundation/Modal/Entailment/KP.lean
+++ b/Foundation/Modal/Entailment/KP.lean
@@ -10,12 +10,12 @@ variable {𝓢 : S} [Entailment.KP 𝓢]
 namespace KP
 
 protected def axiomD [HasDiaDuality 𝓢] : 𝓢 ⊢ Axioms.D φ := by
-  have : 𝓢 ⊢ φ ➝ (∼φ ➝ ⊥) := C_trans dni (K_left negEquiv);
-  have : 𝓢 ⊢ □φ ➝ □(∼φ ➝ ⊥) := implyBoxDistribute' this;
-  have : 𝓢 ⊢ □φ ➝ (□(∼φ) ➝ □⊥) := C_trans this axiomK;
-  have : 𝓢 ⊢ □φ ➝ (∼□⊥ ➝ ∼□(∼φ)) := C_trans this CCCNN;
-  have : 𝓢 ⊢ □φ ➝ ∼□(∼φ) := C_swap this ⨀ axiomP;
-  exact C_trans this (K_right diaDuality);
+  have : 𝓢 ⊢ φ ➝ (∼φ ➝ ⊥) := C_trans dni (K_left negEquiv)
+  have : 𝓢 ⊢ □φ ➝ □(∼φ ➝ ⊥) := implyBoxDistribute' this
+  have : 𝓢 ⊢ □φ ➝ (□(∼φ) ➝ □⊥) := C_trans this axiomK
+  have : 𝓢 ⊢ □φ ➝ (∼□⊥ ➝ ∼□(∼φ)) := C_trans this CCCNN
+  have : 𝓢 ⊢ □φ ➝ ∼□(∼φ) := C_swap this ⨀ axiomP
+  exact C_trans this (K_right diaDuality)
 instance : HasAxiomD 𝓢 := ⟨fun _ ↦ KP.axiomD⟩
 
 end KP

--- a/Foundation/Modal/Entailment/KT.lean
+++ b/Foundation/Modal/Entailment/KT.lean
@@ -14,8 +14,8 @@ namespace KT
 variable [Entailment.KT 𝓢]
 
 def axiomDiaTc : 𝓢 ⊢ φ ➝ ◇φ := by
-  apply C_trans ?_ (K_right diaDuality);
-  exact C_trans dni $ contra axiomT;
+  apply C_trans ?_ (K_right diaDuality)
+  exact C_trans dni $ contra axiomT
 instance : HasAxiomDiaTc 𝓢 := ⟨fun _ ↦ KT.axiomDiaTc⟩
 
 protected def axiomP : 𝓢 ⊢ ∼□⊥ := N_of_CO axiomT
@@ -46,11 +46,11 @@ variable [Entailment.KT 𝓢]
 omit [DecidableEq F] in
 @[simp] lemma reduce_box_in_CAnt! : 𝓢 ⊢! □^[(i + n)]φ ➝ □^[i]φ := by
   induction n with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    simp only [show (i + (n + 1)) = (i + n) + 1 by omega, Box.multibox_succ];
-    apply C!_trans ?_ ih;
-    apply axiomT!;
+    simp only [show (i + (n + 1)) = (i + n) + 1 by omega, Box.multibox_succ]
+    apply C!_trans ?_ ih
+    apply axiomT!
 
 end
 

--- a/Foundation/Modal/Entailment/KTc.lean
+++ b/Foundation/Modal/Entailment/KTc.lean
@@ -18,9 +18,9 @@ protected def axiomFive : 𝓢 ⊢ ◇φ ➝ □◇φ := axiomTc
 instance : HasAxiomFive 𝓢 := ⟨fun _ ↦ KTc.axiomFive⟩
 
 protected def axiomDiaT : 𝓢 ⊢ ◇φ ➝ φ := by
-  apply C_trans (K_left diaDuality) ?_;
-  apply CN_of_CN_left;
-  exact axiomTc;
+  apply C_trans (K_left diaDuality) ?_
+  apply CN_of_CN_left
+  exact axiomTc
 instance : HasAxiomDiaT 𝓢 := ⟨fun _ ↦ KTc.axiomDiaT⟩
 
 end KTc

--- a/Foundation/Modal/Entailment/S4.lean
+++ b/Foundation/Modal/Entailment/S4.lean
@@ -9,14 +9,14 @@ variable {S F : Type*} [BasicModalLogicalConnective F] [DecidableEq F] [Entailme
 variable {𝓢 : S} [Entailment.S4 𝓢]
 
 def iff_box_boxdot : 𝓢 ⊢ □φ ⭤ ⊡φ := by
-  apply E_intro;
-  . exact right_K_intro (axiomT) (C_id _);
-  . exact and₂;
+  apply E_intro
+  . exact right_K_intro (axiomT) (C_id _)
+  . exact and₂
 @[simp] lemma iff_box_boxdot! : 𝓢 ⊢! □φ ⭤ ⊡φ := ⟨iff_box_boxdot⟩
 
 def iff_dia_diadot : 𝓢 ⊢ ◇φ ⭤ ⟐φ := by
-  apply E_intro;
-  . exact or₂;
+  apply E_intro
+  . exact or₂
   . exact left_A_intro diaTc (C_id _)
 @[simp] lemma iff_dia_diadot! : 𝓢 ⊢! ◇φ ⭤ ⟐φ := ⟨iff_dia_diadot⟩
 

--- a/Foundation/Modal/Entailment/S5.lean
+++ b/Foundation/Modal/Entailment/S5.lean
@@ -10,17 +10,17 @@ variable {𝓢 : S} [Entailment.S5 𝓢]
 
 -- MEMO: need more simple proof
 def diabox_box : 𝓢 ⊢ ◇□φ ➝ □φ := by
-  have : 𝓢 ⊢ ◇(∼φ) ➝ □◇(∼φ) := axiomFive;
-  have : 𝓢 ⊢ ∼□◇(∼φ) ➝ ∼◇(∼φ) := contra this;
-  have : 𝓢 ⊢ ∼□◇(∼φ) ➝ □φ := C_trans this boxDuality_mpr;
-  refine C_trans ?_ this;
+  have : 𝓢 ⊢ ◇(∼φ) ➝ □◇(∼φ) := axiomFive
+  have : 𝓢 ⊢ ∼□◇(∼φ) ➝ ∼◇(∼φ) := contra this
+  have : 𝓢 ⊢ ∼□◇(∼φ) ➝ □φ := C_trans this boxDuality_mpr
+  refine C_trans ?_ this
   refine C_trans diaDuality_mp $ ?_
-  apply contra;
-  apply implyBoxDistribute';
-  refine C_trans diaDuality_mp ?_;
-  apply contra;
-  apply implyBoxDistribute';
-  apply dni;
+  apply contra
+  apply implyBoxDistribute'
+  refine C_trans diaDuality_mp ?_
+  apply contra
+  apply implyBoxDistribute'
+  apply dni
 @[simp] lemma diabox_box! : 𝓢 ⊢! ◇□φ ➝ □φ := ⟨diabox_box⟩
 
 def diabox_box' (h : 𝓢 ⊢ ◇□φ) : 𝓢 ⊢ □φ := diabox_box ⨀ h

--- a/Foundation/Modal/Entailment/S5Grz.lean
+++ b/Foundation/Modal/Entailment/S5Grz.lean
@@ -10,17 +10,17 @@ variable {S F : Type*} [BasicModalLogicalConnective F] [Entailment F S]
 variable {𝓢 : S} [DecidableEq F] [Entailment.S5Grz 𝓢]
 
 protected def S5Grz.diaT : 𝓢 ⊢ ◇φ ➝ φ := by
-  have : 𝓢 ⊢ (φ ➝ □φ) ➝ (∼□φ ➝ ∼φ) := CCCNN;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ □(∼□φ ➝ ∼φ) := implyBoxDistribute' this;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (□(∼□φ) ➝ □(∼φ)) := C_trans this axiomK;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (∼□(∼φ) ➝ ∼□(∼□φ)) := C_trans this CCCNN;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ ◇□φ) := C_trans this lem₁_diaT_of_S5Grz;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ □φ) := C_trans this $ CCC_of_C_right diabox_box;
-  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ φ) := C_trans this $ CCC_of_C_right axiomT;
-  have : 𝓢 ⊢ ◇φ ➝ □(φ ➝ □φ) ➝ φ := C_swap this;
-  have : 𝓢 ⊢ □◇φ ➝ □(□(φ ➝ □φ) ➝ φ) := implyBoxDistribute' this;
-  have : 𝓢 ⊢ □◇φ ➝ φ := C_trans this axiomGrz;
-  exact C_trans axiomFive this;
+  have : 𝓢 ⊢ (φ ➝ □φ) ➝ (∼□φ ➝ ∼φ) := CCCNN
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ □(∼□φ ➝ ∼φ) := implyBoxDistribute' this
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (□(∼□φ) ➝ □(∼φ)) := C_trans this axiomK
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (∼□(∼φ) ➝ ∼□(∼□φ)) := C_trans this CCCNN
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ ◇□φ) := C_trans this lem₁_diaT_of_S5Grz
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ □φ) := C_trans this $ CCC_of_C_right diabox_box
+  have : 𝓢 ⊢ □(φ ➝ □φ) ➝ (◇φ ➝ φ) := C_trans this $ CCC_of_C_right axiomT
+  have : 𝓢 ⊢ ◇φ ➝ □(φ ➝ □φ) ➝ φ := C_swap this
+  have : 𝓢 ⊢ □◇φ ➝ □(□(φ ➝ □φ) ➝ φ) := implyBoxDistribute' this
+  have : 𝓢 ⊢ □◇φ ➝ φ := C_trans this axiomGrz
+  exact C_trans axiomFive this
 
 instance : HasAxiomDiaT 𝓢 := ⟨fun _ ↦ S5Grz.diaT⟩
 instance : Entailment.KTc' 𝓢 where

--- a/Foundation/Modal/Entailment/Triv.lean
+++ b/Foundation/Modal/Entailment/Triv.lean
@@ -9,12 +9,12 @@ variable {S F : Type*} [BasicModalLogicalConnective F] [DecidableEq F] [Entailme
 variable {𝓢 : S} [Entailment.Triv 𝓢]
 
 noncomputable instance : HasAxiomGrz 𝓢 := ⟨by
-  intro φ;
-  have : 𝓢 ⊢ φ ➝ □φ := axiomTc;
-  have d₁ := nec this;
-  have d₂ : 𝓢 ⊢ □(φ ➝ □φ) ➝ ((□(φ ➝ □φ)) ➝ φ) ➝ φ := CCC;
-  have := d₂ ⨀ d₁;
-  exact C_trans axiomT this;
+  intro φ
+  have : 𝓢 ⊢ φ ➝ □φ := axiomTc
+  have d₁ := nec this
+  have d₂ : 𝓢 ⊢ □(φ ➝ □φ) ➝ ((□(φ ➝ □φ)) ➝ φ) ➝ φ := CCC
+  have := d₂ ⨀ d₁
+  exact C_trans axiomT this
 ⟩
 
 end LO.Modal.Entailment

--- a/Foundation/Modal/Entailment/Ver.lean
+++ b/Foundation/Modal/Entailment/Ver.lean
@@ -8,11 +8,11 @@ variable {S F : Type*} [BasicModalLogicalConnective F] [DecidableEq F] [Entailme
 variable {𝓢 : S} [Entailment.Ver 𝓢]
 
 def bot_of_dia : 𝓢 ⊢ ◇φ ➝ ⊥ := by
-  have : 𝓢 ⊢ ∼◇φ ➝ (◇φ ➝ ⊥) := K_left $ negEquiv (𝓢 := 𝓢) (φ := ◇φ);
+  have : 𝓢 ⊢ ∼◇φ ➝ (◇φ ➝ ⊥) := K_left $ negEquiv (𝓢 := 𝓢) (φ := ◇φ)
   exact this ⨀ (contra (K_left diaDuality) ⨀ by
-    apply dni';
-    apply axiomVer;
-  );
+    apply dni'
+    apply axiomVer
+  )
 lemma bot_of_dia! : 𝓢 ⊢! ◇φ ➝ ⊥ := ⟨bot_of_dia⟩
 
 def bot_of_dia' (h : 𝓢 ⊢ ◇φ) : 𝓢 ⊢ ⊥ := bot_of_dia ⨀ h

--- a/Foundation/Modal/Formula.lean
+++ b/Foundation/Modal/Formula.lean
@@ -121,7 +121,7 @@ lemma falsum_eq : (falsum : Formula α) = ⊥ := rfl
 
 @[simp] lemma imp_inj (φ₁ ψ₁ φ₂ ψ₂ : Formula α) : φ₁ ➝ φ₂ = ψ₁ ➝ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Arrow.arrow]
 
-@[simp] lemma neg_inj (φ ψ : Formula α) : ∼φ = ∼ψ ↔ φ = ψ := by simp [NegAbbrev.neg];
+@[simp] lemma neg_inj (φ ψ : Formula α) : ∼φ = ∼ψ ↔ φ = ψ := by simp [NegAbbrev.neg]
 
 /-
 instance : ModalDeMorgan (Formula α) where
@@ -189,7 +189,7 @@ def hasDecEq : (φ ψ : Formula α) → Decidable (φ = ψ)
     { simp; try { exact isFalse not_false }; try { exact isTrue trivial } }
   | atom a, ψ => by
     cases ψ <;> try { simp; exact isFalse not_false }
-    simp; exact decEq _ _;
+    simp; exact decEq _ _
   | φ ➝ ψ, χ => by
     cases χ using cases' <;> try { simp; exact isFalse not_false }
     case himp φ' ψ' =>
@@ -256,19 +256,19 @@ def negated : Formula α → Bool
 
 @[simp]
 lemma negated_imp : (φ ➝ ψ).negated ↔ (ψ = ⊥) := by
-  simp [negated];
-  split;
-  . simp_all [Formula.imp_eq]; rfl;
-  . simp_all [Formula.imp_eq]; simpa;
+  simp [negated]
+  split
+  . simp_all [Formula.imp_eq]; rfl
+  . simp_all [Formula.imp_eq]; simpa
 
 lemma negated_iff [DecidableEq α] : φ.negated ↔ ∃ ψ, φ = ∼ψ := by
   induction φ using Formula.cases_neg with
-  | himp => simp [negated_imp, NegAbbrev.neg];
+  | himp => simp [negated_imp, NegAbbrev.neg]
   | _ => simp [negated]
 
 lemma not_negated_iff [DecidableEq α] : ¬φ.negated ↔ ∀ ψ, φ ≠ ∼ψ := by
   induction φ using Formula.cases_neg with
-  | himp => simp [negated_imp, NegAbbrev.neg];
+  | himp => simp [negated_imp, NegAbbrev.neg]
   | _ => simp [negated]
 
 @[elab_as_elim]
@@ -326,7 +326,7 @@ def ofNat : ℕ → Option (Formula α)
     | _ => none
 
 lemma ofNat_toNat : ∀ (φ : Formula α), ofNat (toNat φ) = some φ
-  | atom a  => by simp [toNat, ofNat, Nat.unpair_pair, encodek];
+  | atom a  => by simp [toNat, ofNat, Nat.unpair_pair, encodek]
   | ⊥       => by simp [toNat, ofNat]
   | □φ      => by simp [toNat, ofNat, ofNat_toNat φ]
   | φ ➝ ψ   => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
@@ -428,80 +428,80 @@ variable [DecidableEq α] {φ ψ χ ξ : Formula α}
 protected lemma mem_imp (h : (ψ ➝ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
   induction φ with
   | himp ψ χ ihψ ihχ =>
-    simp only [subformulas, Finset.mem_insert, imp_inj, Finset.mem_union] at h;
-    rcases h with ⟨rfl, rfl⟩ | h | h;
-    . simp_all [subformulas];
-    . simp_all [subformulas];
-    . simp_all [subformulas];
-  | _ => simp_all [subformulas];
+    simp only [subformulas, Finset.mem_insert, imp_inj, Finset.mem_union] at h
+    rcases h with ⟨rfl, rfl⟩ | h | h
+    . simp_all [subformulas]
+    . simp_all [subformulas]
+    . simp_all [subformulas]
+  | _ => simp_all [subformulas]
 
 @[grind ⇒]
 protected lemma mem_box (h : □ψ ∈ φ.subformulas) : ψ ∈ φ.subformulas := by
   induction φ with
   | hbox ψ ihψ =>
-    simp only [subformulas, Finset.mem_insert, Box.box_injective'] at h;
-    rcases h with rfl | h <;> simp_all [subformulas];
+    simp only [subformulas, Finset.mem_insert, Box.box_injective'] at h
+    rcases h with rfl | h <;> simp_all [subformulas]
   | himp ψ χ ihψ ihχ =>
-    simp_all only [subformulas, Finset.mem_insert, reduceCtorEq, Finset.mem_union, false_or];
-    grind;
-  | _ => simp_all [subformulas];
+    simp_all only [subformulas, Finset.mem_insert, reduceCtorEq, Finset.mem_union, false_or]
+    grind
+  | _ => simp_all [subformulas]
 
 @[grind ⇒]
 protected lemma mem_neg (h : (∼ψ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ ⊥ ∈ φ.subformulas := subformulas.mem_imp h
 
 @[grind ⇒]
 protected lemma mem_and (h : (ψ ⋏ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
-  simp [LukasiewiczAbbrev.and] at h;
-  grind;
+  simp [LukasiewiczAbbrev.and] at h
+  grind
 
 @[grind ⇒]
 protected lemma mem_or (h : (ψ ⋎ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
-  simp [LukasiewiczAbbrev.or] at h;
-  grind;
+  simp [LukasiewiczAbbrev.or] at h
+  grind
 
-example {_ : φ ∈ φ.subformulas} : φ ∈ φ.subformulas := by grind;
+example {_ : φ ∈ φ.subformulas} : φ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
-example {_ : □ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind;
-example {_ : ∼ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind;
-example {_ : ∼ψ ∈ φ.subformulas} : ⊥ ∈ φ.subformulas := by grind;
+example {_ : □ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
+example {_ : ∼ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
+example {_ : ∼ψ ∈ φ.subformulas} : ⊥ ∈ φ.subformulas := by grind
 example {_ : ψ ⋏ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ⋎ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
-example {_ : ψ ⋏ (ψ ⋎ □(□χ ➝ ξ)) ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind;
+example {_ : ψ ⋏ (ψ ⋎ □(□χ ➝ ξ)) ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
 
 lemma complexity_lower (h : ψ ∈ φ.subformulas) : ψ.complexity ≤ φ.complexity := by
   induction φ using Formula.rec' with
-  | hfalsum => simp_all [subformulas, complexity];
-  | hatom => simp_all [subformulas, complexity];
+  | hfalsum => simp_all [subformulas, complexity]
+  | hatom => simp_all [subformulas, complexity]
   | hbox φ ihφ =>
-    simp only [subformulas, Finset.mem_insert] at h;
-    rcases h with rfl | h;
-    . rfl;
-    . simp_all [complexity];
-      omega;
+    simp only [subformulas, Finset.mem_insert] at h
+    rcases h with rfl | h
+    . rfl
+    . simp_all [complexity]
+      omega
   | himp φ₁ φ₂ ihφ₁ ihφ₂ =>
-    simp only [subformulas, Finset.mem_insert, Finset.mem_union] at h;
-    rcases h with rfl | h | h;
-    . rfl;
-    . simp [complexity];
-      have := ihφ₁ h;
-      omega;
-    . simp [complexity];
-      have := ihφ₂ h;
-      omega;
+    simp only [subformulas, Finset.mem_insert, Finset.mem_union] at h
+    rcases h with rfl | h | h
+    . rfl
+    . simp [complexity]
+      have := ihφ₁ h
+      omega
+    . simp [complexity]
+      have := ihφ₂ h
+      omega
 
 lemma subset_of_mem (hψ : ψ ∈ φ.subformulas) : (ψ.subformulas ⊆ φ.subformulas) := by
-  intro ξ hξ;
+  intro ξ hξ
   induction ψ with
-  | hatom => simp_all [Formula.subformulas];
-  | hfalsum => simp_all [Formula.subformulas];
+  | hatom => simp_all [Formula.subformulas]
+  | hfalsum => simp_all [Formula.subformulas]
   | himp ψ₁ ψ₂ ihψ₁ ihψ₂ =>
-    simp only [subformulas, Finset.mem_insert, Finset.mem_union] at hξ;
-    rcases hξ with rfl | hξ | hξ <;> grind;
+    simp only [subformulas, Finset.mem_insert, Finset.mem_union] at hξ
+    rcases hξ with rfl | hξ | hξ <;> grind
   | hbox ψ ihψ =>
-    simp only [subformulas, Finset.mem_insert] at hξ;
-    rcases hξ with rfl | hξ <;> grind;
+    simp only [subformulas, Finset.mem_insert] at hξ
+    rcases hξ with rfl | hξ <;> grind
 
 end Formula.subformulas
 
@@ -513,19 +513,19 @@ namespace FormulaSet.SubformulaClosed
 variable {α} [DecidableEq α] {φ ψ : Formula α} {Γ : FormulaSet α}
 
 lemma of_mem_imp₁ (h : SubformulaClosed Γ) : φ ➝ ψ ∈ Γ → φ ∈ Γ := by
-  intro hφψ;
-  apply @h _ hφψ;
-  simp [Formula.subformulas];
+  intro hφψ
+  apply @h _ hφψ
+  simp [Formula.subformulas]
 
 lemma of_mem_imp₂ (h : SubformulaClosed Γ) : φ ➝ ψ ∈ Γ → ψ ∈ Γ := by
-  intro hφψ;
-  apply @h _ hφψ;
-  simp [Formula.subformulas];
+  intro hφψ
+  apply @h _ hφψ
+  simp [Formula.subformulas]
 
 lemma of_mem_box (h : SubformulaClosed Γ) : □φ ∈ Γ → φ ∈ Γ := by
-  intro hφ;
-  apply @h _ hφ;
-  simp [Formula.subformulas];
+  intro hφ
+  apply @h _ hφ
+  simp [Formula.subformulas]
 
 end FormulaSet.SubformulaClosed
 
@@ -594,7 +594,7 @@ end Formula.subst
 abbrev Substitution.id {α} : Substitution α := λ a => .atom a
 
 @[simp]
-lemma Formula.subst.def_id {φ : Formula α} : φ⟦.id⟧ = φ := by induction φ <;> simp_all;
+lemma Formula.subst.def_id {φ : Formula α} : φ⟦.id⟧ = φ := by induction φ <;> simp_all
 
 
 def Substitution.comp (s₁ s₂ : Substitution α) : Substitution α := λ a => (s₁ a)⟦s₂⟧
@@ -602,7 +602,7 @@ infixr:80 " ∘ " => Substitution.comp
 
 @[simp]
 lemma Formula.subst.def_comp {s₁ s₂ : Substitution α} {φ : Formula α} : φ⟦s₁ ∘ s₂⟧ = φ⟦s₁⟧⟦s₂⟧ := by
-  induction φ <;> simp_all [Substitution.comp];
+  induction φ <;> simp_all [Substitution.comp]
 
 
 class SubstitutionClosed (S : Set (Formula α)) where
@@ -612,11 +612,11 @@ class SubstitutionClosed (S : Set (Formula α)) where
 def ZeroSubstitution (α) := {s : Substitution α // ∀ {a : α}, ((.atom a)⟦s⟧).letterless }
 
 lemma Formula.letterless_zeroSubst {φ : Formula α} {s : ZeroSubstitution α} : (φ⟦s.1⟧).letterless := by
-  induction φ <;> simp [Formula.letterless, *];
-  case hatom => exact s.2;
+  induction φ <;> simp [Formula.letterless, *]
+  case hatom => exact s.2
 
 lemma Formula.toModalFormula.letterless {φ : Propositional.Formula α} (h : φ.letterless) : φ.toModalFormula.letterless := by
-  induction φ using Propositional.Formula.rec' <;> simp_all [Propositional.Formula.letterless, Formula.letterless];
+  induction φ using Propositional.Formula.rec' <;> simp_all [Propositional.Formula.letterless, Formula.letterless]
 
 instance : Coe (Propositional.ZeroSubstitution α) (Modal.ZeroSubstitution α) := ⟨λ ⟨s, p⟩ => ⟨λ φ => s φ, λ {_} => Formula.toModalFormula.letterless p⟩⟩
 
@@ -636,7 +636,7 @@ def atoms : Formula α → Finset α
   | φ ➝ ψ => φ.atoms ∪ ψ.atoms
 
 lemma iff_mem_atoms_mem_subformula {a : α} {φ : Formula α} : (a ∈ φ.atoms) ↔ (atom a ∈ φ.subformulas) := by
-  induction φ <;> simp_all [atoms, subformulas];
+  induction φ <;> simp_all [atoms, subformulas]
 
 section
 
@@ -646,32 +646,32 @@ def freshAtom (φ : Formula ℕ) : ℕ := if h : φ.atoms.Nonempty then φ.atoms
 
 lemma le_max_atoms_of_mem_atoms {a : ℕ} (ha : a ∈ φ.atoms) : a ≤ φ.atoms.max' (⟨a, ha⟩) := by
   induction φ with
-  | hfalsum => simp [atoms] at ha;
-  | hatom b => simp [atoms] at ha ⊢; omega;
-  | hbox φ ihφ => apply ihφ; simpa using ha;
+  | hfalsum => simp [atoms] at ha
+  | hatom b => simp [atoms] at ha ⊢; omega
+  | hbox φ ihφ => apply ihφ; simpa using ha
   | himp φ ψ ihφ ihψ =>
-    rcases (show a ∈ φ.atoms ∨ a ∈ ψ.atoms by simpa [atoms] using ha) with (hφ | hψ);
-    . by_cases hψ : ψ.atoms.Nonempty;
-      . simp [atoms, Finset.max'_union ⟨_, hφ⟩ hψ, ihφ hφ];
-      . simp [atoms, Finset.not_nonempty_iff_eq_empty.mp hψ, ihφ hφ];
-    . by_cases hφ : φ.atoms.Nonempty;
-      . simp [atoms, Finset.max'_union hφ ⟨_, hψ⟩, ihψ hψ];
-      . simp [atoms, Finset.not_nonempty_iff_eq_empty.mp hφ, ihψ hψ];
+    rcases (show a ∈ φ.atoms ∨ a ∈ ψ.atoms by simpa [atoms] using ha) with (hφ | hψ)
+    . by_cases hψ : ψ.atoms.Nonempty
+      . simp [atoms, Finset.max'_union ⟨_, hφ⟩ hψ, ihφ hφ]
+      . simp [atoms, Finset.not_nonempty_iff_eq_empty.mp hψ, ihφ hφ]
+    . by_cases hφ : φ.atoms.Nonempty
+      . simp [atoms, Finset.max'_union hφ ⟨_, hψ⟩, ihψ hψ]
+      . simp [atoms, Finset.not_nonempty_iff_eq_empty.mp hφ, ihψ hψ]
 
 lemma le_max_atoms_freshAtom (h : φ.atoms.Nonempty) : Finset.max' φ.atoms h < φ.freshAtom := by
-  simp only [freshAtom, Finset.max'_lt_iff];
-  intro a ha;
-  split;
-  . have := le_max_atoms_of_mem_atoms ha;
-    omega;
-  . exfalso;
-    have : φ.atoms.Nonempty := ⟨a, ha⟩;
-    contradiction;
+  simp only [freshAtom, Finset.max'_lt_iff]
+  intro a ha
+  split
+  . have := le_max_atoms_of_mem_atoms ha
+    omega
+  . exfalso
+    have : φ.atoms.Nonempty := ⟨a, ha⟩
+    contradiction
 
 lemma ne_freshAtom_of_mem_subformulas (h : atom a ∈ φ.subformulas) : φ.freshAtom ≠ a := by
-  by_contra hC; subst hC;
-  apply Nat.not_lt.mpr $ le_max_atoms_of_mem_atoms $ iff_mem_atoms_mem_subformula.mpr h;
-  apply le_max_atoms_freshAtom;
+  by_contra hC; subst hC
+  apply Nat.not_lt.mpr $ le_max_atoms_of_mem_atoms $ iff_mem_atoms_mem_subformula.mpr h
+  apply le_max_atoms_freshAtom
 
 end
 

--- a/Foundation/Modal/Hilbert/GL_K4Loeb_K4Henkin_K4Hen.lean
+++ b/Foundation/Modal/Hilbert/GL_K4Loeb_K4Henkin_K4Hen.lean
@@ -15,43 +15,43 @@ lemma Hilbert.equiv_Normal_WithLoeb
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HL ⊢! φ)
   (provable_HL : ∀ φ ∈ HL.axiomInstances, HN ⊢! φ)
   : HN ≊ HL := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
-  suffices HN ⊢! φ ↔ HL ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq];
-  constructor;
-  . intro h;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
+  suffices HN ⊢! φ ↔ HL ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq]
+  constructor
+  . intro h
     induction h using Hilbert.Normal.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
     | @axm ψ s h =>
-      apply provable_HN;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
-  . intro h;
+      apply provable_HN
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
+  . intro h
     induction h using Hilbert.WithLoeb.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
-    | loeb ihφ => apply Entailment.loeb! ihφ;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
+    | loeb ihφ => apply Entailment.loeb! ihφ
     | @axm ψ s h =>
-      apply provable_HL;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
+      apply provable_HL
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
 
 lemma Hilbert.equiv_logic_Normal_WithLoeb
   {HN : Hilbert.Normal α} {HL : Hilbert.WithLoeb α} [LoebRule HN]
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HL ⊢! φ)
   (provable_HL : ∀ φ ∈ HL.axiomInstances, HN ⊢! φ)
   : HN.logic ≊ HL.logic := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
-  suffices HN ⊢! φ ↔ HL ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq];
-  exact Entailment.Equiv.iff.mp (Hilbert.equiv_Normal_WithLoeb provable_HN provable_HL) φ;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
+  suffices HN ⊢! φ ↔ HL ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq]
+  exact Entailment.Equiv.iff.mp (Hilbert.equiv_Normal_WithLoeb provable_HN provable_HL) φ
 
 
 lemma Hilbert.equiv_Normal_WithHenkin
@@ -60,33 +60,33 @@ lemma Hilbert.equiv_Normal_WithHenkin
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HH ⊢! φ)
   (provable_HH : ∀ φ ∈ HH.axiomInstances, HN ⊢! φ)
   : HN ≊ HH := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
-  suffices HN ⊢! φ ↔ HH ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq];
-  constructor;
-  . intro h;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
+  suffices HN ⊢! φ ↔ HH ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq]
+  constructor
+  . intro h
     induction h using Hilbert.Normal.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
     | @axm ψ s h =>
-      apply provable_HN;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
-  . intro h;
+      apply provable_HN
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
+  . intro h
     induction h using Hilbert.WithHenkin.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
-    | henkin ihφ => apply Entailment.henkin! ihφ;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
+    | henkin ihφ => apply Entailment.henkin! ihφ
     | @axm ψ s h =>
-      apply provable_HH;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
+      apply provable_HH
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
 
 lemma Hilbert.equiv_logic_Normal_WithHenkin
   {HN : Hilbert.Normal α} {HH : Hilbert.WithHenkin α}
@@ -94,10 +94,10 @@ lemma Hilbert.equiv_logic_Normal_WithHenkin
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HH ⊢! φ)
   (provable_HH : ∀ φ ∈ HH.axiomInstances, HN ⊢! φ)
   : HN.logic ≊ HH.logic := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
-  suffices HN ⊢! φ ↔ HH ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq];
-  exact Entailment.Equiv.iff.mp (Hilbert.equiv_Normal_WithHenkin provable_HN provable_HH) φ;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
+  suffices HN ⊢! φ ↔ HH ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq]
+  exact Entailment.Equiv.iff.mp (Hilbert.equiv_Normal_WithHenkin provable_HN provable_HH) φ
 
 
 
@@ -108,65 +108,65 @@ theorem provable_GL_TFAE : [
   Hilbert.K4Hen ⊢! φ
 ].TFAE := by
   tfae_have 1 → 2 := by
-    intro h;
+    intro h
     induction h using Hilbert.Normal.rec! with
-    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
+    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
   tfae_have 2 → 3 := by
-    clear * -;
-    intro h;
+    clear * -
+    intro h
     induction h using Hilbert.WithLoeb.rec! with
-    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | loeb ihφ => exact loeb! ihφ;
-    | _ => simp;
+    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | loeb ihφ => exact loeb! ihφ
+    | _ => simp
   tfae_have 3 → 4 := by
-    clear * -;
-    intro h;
+    clear * -
+    intro h
     induction h using Hilbert.WithHenkin.rec! with
-    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | henkin ihφ => exact henkin! ihφ;
-    | _ => simp;
+    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | henkin ihφ => exact henkin! ihφ
+    | _ => simp
   tfae_have 4 → 1 := by
-    clear * -;
-    intro h;
+    clear * -
+    intro h
     induction h using Hilbert.Normal.rec! with
-    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  tfae_finish;
+    | axm _ h => rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, rfl⟩) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  tfae_finish
 
 
 instance : Modal.GL ≊ Modal.K4Loeb := by
-  apply Entailment.Equiv.iff.mpr;
+  apply Entailment.Equiv.iff.mpr
   simp only [
     Hilbert.Normal.iff_logic_provable_provable,
     Hilbert.WithLoeb.iff_logic_provable_provable
-  ];
-  intro φ;
-  apply provable_GL_TFAE.out 0 1;
+  ]
+  intro φ
+  apply provable_GL_TFAE.out 0 1
 
 instance : Modal.GL ≊ Modal.K4Henkin := by
-  apply Entailment.Equiv.iff.mpr;
+  apply Entailment.Equiv.iff.mpr
   simp only [
     Hilbert.Normal.iff_logic_provable_provable,
     Hilbert.WithHenkin.iff_logic_provable_provable
-  ];
-  intro φ;
-  apply provable_GL_TFAE.out 0 2;
+  ]
+  intro φ
+  apply provable_GL_TFAE.out 0 2
 
 instance : Modal.GL ≊ Modal.K4Hen := by
-  apply Entailment.Equiv.iff.mpr;
+  apply Entailment.Equiv.iff.mpr
   simp only [
     Hilbert.Normal.iff_logic_provable_provable,
-  ];
-  intro φ;
-  apply provable_GL_TFAE.out 0 3;
+  ]
+  intro φ
+  apply provable_GL_TFAE.out 0 3
 
 end LO.Modal

--- a/Foundation/Modal/Hilbert/Minimal/Basic.lean
+++ b/Foundation/Modal/Hilbert/Minimal/Basic.lean
@@ -22,11 +22,11 @@ variable {H H₁ H₂ : Hilbert.WithRE α} {φ ψ : Formula α}
 abbrev axiomInstances (H : Hilbert.WithRE α) : Set (Formula α) := { φ⟦s⟧ | (φ ∈ H.axioms) (s : Substitution α) }
 
 lemma mem_axiomInstances_of_mem_axioms {φ} (h : φ ∈ H.axioms) : φ ∈ H.axiomInstances := by
-  use φ;
-  constructor;
-  . assumption;
-  . use Substitution.id;
-    simp;
+  use φ
+  constructor
+  . assumption
+  . use Substitution.id
+    simp
 
 inductive Deduction (H : Hilbert.WithRE α) : (Formula α) → Type u
   | axm {φ} (s : Substitution _) : φ ∈ H.axioms → Deduction H (φ⟦s⟧)
@@ -40,7 +40,7 @@ instance : Entailment (Formula α) (Hilbert.WithRE α) := ⟨Deduction⟩
 
 def Deduction.axm' {H : Hilbert.WithRE α} {φ} (h : φ ∈ H.axioms) : Deduction H φ := by
   rw [(show φ = φ⟦.id⟧ by simp)]
-  apply Deduction.axm _ h;
+  apply Deduction.axm _ h
 
 section
 
@@ -63,14 +63,14 @@ protected lemma rec!
   (imply₂   : ∀ {φ ψ χ}, motive (Axioms.Imply₂ φ ψ χ) $ by simp)
   (ec       : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ by simp)
   : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
-  rintro φ ⟨d⟩;
+  rintro φ ⟨d⟩
   induction d with
-  | axm s h => apply axm s h;
-  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ;
+  | axm s h => apply axm s h
+  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ
   | re hφψ ihφψ => apply re ihφψ
   | imply₁ φ ψ => apply imply₁
   | imply₂ φ ψ χ => apply imply₂
-  | ec φ ψ => apply ec;
+  | ec φ ψ => apply ec
 
 lemma axm! {φ} (s) (h : φ ∈ H.axioms) : H ⊢! (φ⟦s⟧) := ⟨.axm s h⟩
 
@@ -78,25 +78,25 @@ lemma axm'! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := by simpa using axm! Substi
 
 lemma subst! {φ} (s) (h : H ⊢! φ) : H ⊢! (φ⟦s⟧) := by
   induction h using WithRE.rec! with
-  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h;
-  | @re φ ψ h => apply re!; simpa;
-  | _ => simp;
+  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h
+  | @re φ ψ h => apply re!; simpa
+  | _ => simp
 
 lemma weakerThan_of_provable_axioms (hs : H₂ ⊢!* H₁.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ h;
+  apply weakerThan_iff.mpr
+  intro φ h
   induction h using WithRE.rec! with
-  | @axm φ s h => apply subst!; apply @hs φ h;
-  | @re φ ψ h => apply re!; simpa;
-  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂;
-  | _ => simp;
+  | @axm φ s h => apply subst!; apply @hs φ h
+  | @re φ ψ h => apply re!; simpa
+  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂
+  | _ => simp
 
 lemma weakerThan_of_subset_axioms (hs : H₁.axioms ⊆ H₂.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_of_provable_axioms;
-  intro φ h;
-  apply axm'!;
-  exact hs h;
+  apply weakerThan_of_provable_axioms
+  intro φ h
+  apply axm'!
+  exact hs h
 
 end
 
@@ -106,35 +106,35 @@ section
 abbrev logic (H : Hilbert.WithRE α) : Logic α := Entailment.theory H
 
 @[simp high]
-lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [Entailment.theory, Logic.iff_provable];
+lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [Entailment.theory, Logic.iff_provable]
 
 instance [H₁ ⪯ H₂] : H₁.logic ⪯ H₂.logic := by
-  apply weakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply WeakerThan.wk;
-  infer_instance;
+  apply weakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply WeakerThan.wk
+  infer_instance
 
 instance [H₁ ⪱ H₂] : H₁.logic ⪱ H₂.logic := by
-  apply strictlyWeakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable];
-  apply strictlyWeakerThan_iff.mp;
-  infer_instance;
+  apply strictlyWeakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable]
+  apply strictlyWeakerThan_iff.mp
+  infer_instance
 
 instance [H₁ ≊ H₂] : H₁.logic ≊ H₂.logic := by
-  apply Equiv.iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply Equiv.iff.mp;
-  infer_instance;
+  apply Equiv.iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply Equiv.iff.mp
+  infer_instance
 
 instance [h : Incomparable H₁ H₂]
   : Incomparable H₁.logic H₂.logic := by
-  apply Incomparable.of_unprovable;
-  . obtain ⟨φ, hφ⟩ := Entailment.not_weakerThan_iff.mp h.notWT₁;
-    use φ;
-    simpa;
-  . obtain ⟨φ, hφ⟩ := Entailment.not_weakerThan_iff.mp h.notWT₂;
-    use φ;
-    simpa;
+  apply Incomparable.of_unprovable
+  . obtain ⟨φ, hφ⟩ := Entailment.not_weakerThan_iff.mp h.notWT₁
+    use φ
+    simpa
+  . obtain ⟨φ, hφ⟩ := Entailment.not_weakerThan_iff.mp h.notWT₂
+    use φ
+    simpa
 
 end
 
@@ -146,8 +146,8 @@ variable [DecidableEq α]
 class HasM (H : Hilbert.WithRE α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_m : Axioms.M (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_m : Axioms.M (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasM] : Entailment.HasAxiomM H where
   M φ ψ := by
@@ -157,14 +157,14 @@ instance [H.HasM] : Entailment.HasAxiomM H where
         if (HasM.p H) = b then φ
         else if (HasM.q H) = b then ψ
         else (.atom b))
-      HasM.mem_m;
+      HasM.mem_m
 
 
 class HasC (H : Hilbert.WithRE α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_c : Axioms.C (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_c : Axioms.C (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasC] : Entailment.HasAxiomC H where
   C φ ψ := by
@@ -174,21 +174,21 @@ instance [H.HasC] : Entailment.HasAxiomC H where
         if (HasC.p H) = b then φ
         else if (HasC.q H) = b then ψ
         else (.atom b))
-      HasC.mem_c;
+      HasC.mem_c
 
 
 class HasN (H : Hilbert.WithRE α) where
-  mem_n : Axioms.N ∈ H.axioms := by tauto;
+  mem_n : Axioms.N ∈ H.axioms := by tauto
 
 instance [H.HasN] : Entailment.HasAxiomN H where
-  N := by apply Deduction.axm'; simp [HasN.mem_n];
+  N := by apply Deduction.axm'; simp [HasN.mem_n]
 
 
 class HasK (H : Hilbert.WithRE α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
   K φ ψ := by
@@ -198,48 +198,48 @@ instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
         if (HasK.p H) = b then φ
         else if (HasK.q H) = b then ψ
         else (.atom b))
-      HasK.mem_K;
+      HasK.mem_K
 
 
 class HasT (H : Hilbert.WithRE α) where
   p : α
-  mem_T : Axioms.T (.atom p) ∈ H.axioms := by tauto;
+  mem_T : Axioms.T (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasT] : Entailment.HasAxiomT H where
   T φ := by
     simpa using Deduction.axm
       (φ := Axioms.T (.atom (HasT.p H)))
       (s := λ b => if (HasT.p H) = b then φ else (.atom b))
-      HasT.mem_T;
+      HasT.mem_T
 
 class HasD (H : Hilbert.WithRE α) where
   p : α
-  mem_D : Axioms.D (.atom p) ∈ H.axioms := by tauto;
+  mem_D : Axioms.D (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasD] : Entailment.HasAxiomD H where
   D φ := by
     simpa using Deduction.axm
       (φ := Axioms.D (.atom (HasD.p H)))
       (s := λ b => if (HasD.p H) = b then φ else (.atom b))
-      HasD.mem_D;
+      HasD.mem_D
 
 class HasP (H : Hilbert.WithRE α) where
-  mem_P : Axioms.P ∈ H.axioms := by tauto;
+  mem_P : Axioms.P ∈ H.axioms := by tauto
 
 instance [H.HasP] : Entailment.HasAxiomP H where
-  P := by simpa using Deduction.axm' (h := HasP.mem_P);
+  P := by simpa using Deduction.axm' (h := HasP.mem_P)
 
 
 class HasFour (H : Hilbert.WithRE α) where
   p : α
-  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto;
+  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasFour] : Entailment.HasAxiomFour H where
   Four φ := by
     simpa using Deduction.axm
       (φ := Axioms.Four (.atom (HasFour.p H)))
       (s := λ b => if (HasFour.p H) = b then φ else (.atom b))
-      HasFour.mem_Four;
+      HasFour.mem_Four
 
 end
 

--- a/Foundation/Modal/Hilbert/Minimal_Normal.lean
+++ b/Foundation/Modal/Hilbert/Minimal_Normal.lean
@@ -12,33 +12,33 @@ lemma Hilbert.equiv_WithRE_Normal
   (provable_HE : ∀ φ ∈ HE.axiomInstances, HN ⊢! φ)
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HE ⊢! φ)
   : HE ≊ HN := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
   suffices HE ⊢! φ ↔ HN ⊢! φ by
-    simpa [Entailment.theory, Set.mem_setOf_eq];
-  constructor;
-  . intro h;
+    simpa [Entailment.theory, Set.mem_setOf_eq]
+  constructor
+  . intro h
     induction h using Hilbert.WithRE.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | re h => apply re! h;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | re h => apply re! h
     | @axm ψ s h =>
-      apply provable_HE;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
-  . intro h;
+      apply provable_HE
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
+  . intro h
     induction h using Hilbert.Normal.rec! with
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
     | @axm ψ s h =>
-      apply provable_HN;
-      use ψ;
-      constructor;
-      . assumption;
-      . use s;
-    | _ => simp;
+      apply provable_HN
+      use ψ
+      constructor
+      . assumption
+      . use s
+    | _ => simp
 
 lemma Hilbert.equiv_logic_WithRE_Normal
   {HE : Hilbert.WithRE α} {HN : Hilbert.Normal α}
@@ -46,24 +46,24 @@ lemma Hilbert.equiv_logic_WithRE_Normal
   (provable_HE : ∀ φ ∈ HE.axiomInstances, HN ⊢! φ)
   (provable_HN : ∀ φ ∈ HN.axiomInstances, HE ⊢! φ)
   : HE.logic ≊ HN.logic := by
-  apply Entailment.Equiv.iff.mpr;
-  intro φ;
-  suffices HE ⊢! φ ↔ HN ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq];
-  exact Entailment.Equiv.iff.mp (Hilbert.equiv_WithRE_Normal provable_HE provable_HN) φ;
+  apply Entailment.Equiv.iff.mpr
+  intro φ
+  suffices HE ⊢! φ ↔ HN ⊢! φ by simpa [Entailment.theory, Set.mem_setOf_eq]
+  exact Entailment.Equiv.iff.mp (Hilbert.equiv_WithRE_Normal provable_HE provable_HN) φ
 
 instance : 𝐄𝐌𝐂𝐍 ≊ Modal.K := by
-  apply Hilbert.equiv_logic_WithRE_Normal;
-  . rintro _ ⟨φ, (rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp;
-  . rintro _ ⟨φ, rfl, ⟨_, rfl⟩⟩; simp;
+  apply Hilbert.equiv_logic_WithRE_Normal
+  . rintro _ ⟨φ, (rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp
+  . rintro _ ⟨φ, rfl, ⟨_, rfl⟩⟩; simp
 
 instance : 𝐄𝐌𝐂𝐍𝐓 ≊ Modal.KT := by
-  apply Hilbert.equiv_logic_WithRE_Normal;
-  . rintro _ ⟨φ, (rfl | rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp;
-  . rintro _ ⟨φ, (rfl | rfl), ⟨_, rfl⟩⟩ <;> simp;
+  apply Hilbert.equiv_logic_WithRE_Normal
+  . rintro _ ⟨φ, (rfl | rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp
+  . rintro _ ⟨φ, (rfl | rfl), ⟨_, rfl⟩⟩ <;> simp
 
 instance : 𝐄𝐌𝐂𝐍𝐓𝟒 ≊ Modal.S4 := by
-  apply Hilbert.equiv_logic_WithRE_Normal;
-  . rintro _ ⟨φ, (rfl | rfl | rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp;
-  . rintro _ ⟨φ, (rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp;
+  apply Hilbert.equiv_logic_WithRE_Normal
+  . rintro _ ⟨φ, (rfl | rfl | rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp
+  . rintro _ ⟨φ, (rfl | rfl | rfl), ⟨_, rfl⟩⟩ <;> simp
 
 end LO.Modal

--- a/Foundation/Modal/Hilbert/NNFormula.lean
+++ b/Foundation/Modal/Hilbert/NNFormula.lean
@@ -14,173 +14,173 @@ open
 
 lemma iff_neg {φ : NNFormula _} : Hilbert.K ⊢! ∼(φ.toFormula) ⭤ (∼φ).toFormula := by
   induction φ using NNFormula.rec' with
-  | hNatom a => apply K!_intro <;> simp;
+  | hNatom a => apply K!_intro <;> simp
   | hAnd φ ψ ihφ ihψ =>
-    apply K!_intro;
-    . apply deduct'!;
-      apply A!_replace $ ANN!_of_NK! $ show [∼(φ.toFormula ⋏ ψ.toFormula)] ⊢[Hilbert.K]! ∼(φ.toFormula ⋏ ψ.toFormula) by simp;
-      . apply of'! $ K!_left ihφ;
-      . apply of'! $ K!_left ihψ;
-    . apply deduct'!;
-      apply NK!_of_ANN!;
-      apply A!_replace $ show [(∼φ).toFormula ⋎ (∼ψ).toFormula] ⊢[Hilbert.K]! (∼φ).toFormula ⋎ (∼ψ).toFormula by simp;
-      . apply of'! $ K!_right ihφ;
-      . apply of'! $ K!_right ihψ;
+    apply K!_intro
+    . apply deduct'!
+      apply A!_replace $ ANN!_of_NK! $ show [∼(φ.toFormula ⋏ ψ.toFormula)] ⊢[Hilbert.K]! ∼(φ.toFormula ⋏ ψ.toFormula) by simp
+      . apply of'! $ K!_left ihφ
+      . apply of'! $ K!_left ihψ
+    . apply deduct'!
+      apply NK!_of_ANN!
+      apply A!_replace $ show [(∼φ).toFormula ⋎ (∼ψ).toFormula] ⊢[Hilbert.K]! (∼φ).toFormula ⋎ (∼ψ).toFormula by simp
+      . apply of'! $ K!_right ihφ
+      . apply of'! $ K!_right ihψ
   | hOr φ ψ ihφ ihψ =>
-    apply K!_intro;
-    . apply deduct'!;
-      apply K!_replace $ KNN!_of_NA! $ show [∼(φ.toFormula ⋎ ψ.toFormula)] ⊢[Hilbert.K]! (∼(φ.toFormula ⋎ ψ.toFormula)) by simp;
-      . apply of'! $ K!_left ihφ;
-      . apply of'! $ K!_left ihψ;
-    . apply deduct'!;
-      apply NA!_of_KNN!;
-      apply K!_replace $ show [(∼φ).toFormula ⋏ (∼ψ).toFormula] ⊢[Hilbert.K]! (∼φ).toFormula ⋏ (∼ψ).toFormula by simp;
-      . apply of'! $ K!_right ihφ;
-      . apply of'! $ K!_right ihψ;
+    apply K!_intro
+    . apply deduct'!
+      apply K!_replace $ KNN!_of_NA! $ show [∼(φ.toFormula ⋎ ψ.toFormula)] ⊢[Hilbert.K]! (∼(φ.toFormula ⋎ ψ.toFormula)) by simp
+      . apply of'! $ K!_left ihφ
+      . apply of'! $ K!_left ihψ
+    . apply deduct'!
+      apply NA!_of_KNN!
+      apply K!_replace $ show [(∼φ).toFormula ⋏ (∼ψ).toFormula] ⊢[Hilbert.K]! (∼φ).toFormula ⋏ (∼ψ).toFormula by simp
+      . apply of'! $ K!_right ihφ
+      . apply of'! $ K!_right ihψ
   | hBox φ ih =>
-    apply K!_intro;
-    . apply C!_trans ?_ $ K!_right $ dia_duality!;
-      apply contra!;
-      apply axiomK'!;
-      apply nec!;
-      apply CN!_of_CN!_left;
-      exact K!_left ih;
-    . apply CN!_of_CN!_right;
-      apply C!_trans (K!_left $ box_duality!) ?_
-      apply contra!;
-      apply diaK'!;
-      exact K!_right ih;
-  | hDia φ ih =>
-    apply K!_intro;
-    . apply C!_trans ?_ (K!_right $ box_duality!);
-      apply contra!;
-      apply diaK'!;
-      apply CN!_of_CN!_left;
-      exact K!_left ih;
+    apply K!_intro
+    . apply C!_trans ?_ $ K!_right $ dia_duality!
+      apply contra!
+      apply axiomK'!
+      apply nec!
+      apply CN!_of_CN!_left
+      exact K!_left ih
     . apply CN!_of_CN!_right
-      apply C!_trans (K!_left $ dia_duality!) ?_;
-      apply contra!;
-      apply axiomK'!;
-      apply nec!;
-      exact K!_right ih;
-  | _ => simp;
+      apply C!_trans (K!_left $ box_duality!) ?_
+      apply contra!
+      apply diaK'!
+      exact K!_right ih
+  | hDia φ ih =>
+    apply K!_intro
+    . apply C!_trans ?_ (K!_right $ box_duality!)
+      apply contra!
+      apply diaK'!
+      apply CN!_of_CN!_left
+      exact K!_left ih
+    . apply CN!_of_CN!_right
+      apply C!_trans (K!_left $ dia_duality!) ?_
+      apply contra!
+      apply axiomK'!
+      apply nec!
+      exact K!_right ih
+  | _ => simp
 
 lemma exists_iff {φ} : ∃ ψ : NNFormula _, Hilbert.K ⊢! φ ⭤ ψ.toFormula := by
   induction φ with
-  | hatom a => use (.atom a); simp;
-  | hfalsum => use ⊥; simp;
+  | hatom a => use (.atom a); simp
+  | hfalsum => use ⊥; simp
   | himp φ ψ ihφ ihψ =>
-    obtain ⟨φ', hφ'⟩ := ihφ;
-    obtain ⟨ψ', hψ'⟩ := ihψ;
-    use φ' ➝ ψ';
-    apply K!_intro;
-    . apply deduct'!;
-      apply A!_replace $ AN!_of_C! (show [φ ➝ ψ] ⊢[Hilbert.K]! φ ➝ ψ by simp;);
-      . apply of'!;
+    obtain ⟨φ', hφ'⟩ := ihφ
+    obtain ⟨ψ', hψ'⟩ := ihψ
+    use φ' ➝ ψ'
+    apply K!_intro
+    . apply deduct'!
+      apply A!_replace $ AN!_of_C! (show [φ ➝ ψ] ⊢[Hilbert.K]! φ ➝ ψ by simp;)
+      . apply of'!
         exact C!_trans (contra! $ (K!_right $ hφ')) $ K!_left iff_neg
-      . exact of'! $ K!_left hψ';
-    . apply left_A!_intro;
-      . apply C!_trans (C!_trans (K!_right $ iff_neg) (contra! $ K!_left hφ'));
-        exact CNC!;
-      . exact C!_trans (K!_right $ hψ') imply₁!;
+      . exact of'! $ K!_left hψ'
+    . apply left_A!_intro
+      . apply C!_trans (C!_trans (K!_right $ iff_neg) (contra! $ K!_left hφ'))
+        exact CNC!
+      . exact C!_trans (K!_right $ hψ') imply₁!
   | hbox φ ihφ =>
-    obtain ⟨ψ, ih⟩ := ihφ;
-    use □ψ;
-    apply box_iff! ih;
+    obtain ⟨ψ, ih⟩ := ihφ
+    use □ψ
+    apply box_iff! ih
 
 lemma exists_of_provable {φ} (h : Hilbert.K ⊢! φ) : ∃ ψ : NNFormula _, Hilbert.K ⊢! ψ.toFormula := by
-  obtain ⟨ψ, h₂⟩ := exists_iff (φ := φ);
-  use ψ;
-  exact K!_left h₂ ⨀ h;
+  obtain ⟨ψ, h₂⟩ := exists_iff (φ := φ)
+  use ψ
+  exact K!_left h₂ ⨀ h
 
 /-
 lemma exists_CNFPart_list {φ : NNFormula _} (φ_CNFP : φ.isModalCNFPart)
   : ∃ Γ : List { φ : NNFormula ℕ // φ.isPrebox ∨ φ.isPredia ∨ φ.degree = 0 }, Hilbert.K ⊢! φ.toFormula ⭤ ⋁(Γ.map (·.1)) := by
   induction φ using NNFormula.rec' with
-  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp;
-  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp;
-  | hVerum => use [⟨⊤, by tauto⟩]; simp;
-  | hFalsum => use [⟨⊥, by tauto⟩]; simp;
-  | hBox φ ih => use [⟨(□φ), by tauto⟩]; simp;
-  | hDia φ ih => use [⟨(◇φ), by tauto⟩]; simp;
+  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp
+  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp
+  | hVerum => use [⟨⊤, by tauto⟩]; simp
+  | hFalsum => use [⟨⊥, by tauto⟩]; simp
+  | hBox φ ih => use [⟨(□φ), by tauto⟩]; simp
+  | hDia φ ih => use [⟨(◇φ), by tauto⟩]; simp
   | hAnd φ ψ ihφ ihψ =>
     obtain ⟨hφ, hψ⟩ : φ.degree = 0 ∧ ψ.degree = 0 := by
       simpa [NNFormula.isPrebox, NNFormula.isPredia, NNFormula.isModalCNFPart, NNFormula.degree]
-      using φ_CNFP;
-    obtain ⟨Γ, hΓ⟩ := ihφ $ NNFormula.isModalCNFPart.of_degree_zero hφ;
-    obtain ⟨Δ, hΔ⟩ := ihψ $ NNFormula.isModalCNFPart.of_degree_zero hψ;
-    use Γ ++ Δ;
-    apply K!_intro;
-    . sorry;
-    . sorry;
+      using φ_CNFP
+    obtain ⟨Γ, hΓ⟩ := ihφ $ NNFormula.isModalCNFPart.of_degree_zero hφ
+    obtain ⟨Δ, hΔ⟩ := ihψ $ NNFormula.isModalCNFPart.of_degree_zero hψ
+    use Γ ++ Δ
+    apply K!_intro
+    . sorry
+    . sorry
   | hOr φ ψ ihφ ihψ =>
-    obtain ⟨hφ, hψ⟩ := φ_CNFP;
-    obtain ⟨Γ, hΓ⟩ := ihφ hφ;
-    obtain ⟨Δ, hΔ⟩ := ihψ hψ;
-    use Γ ++ Δ;
-    simp only [List.map_append, List.map_subtype];
-    apply K!_intro;
-    . apply left_A!_intro;
-      . apply C!_trans (K!_left hΓ) ?_;
+    obtain ⟨hφ, hψ⟩ := φ_CNFP
+    obtain ⟨Γ, hΓ⟩ := ihφ hφ
+    obtain ⟨Δ, hΔ⟩ := ihψ hψ
+    use Γ ++ Δ
+    simp only [List.map_append, List.map_subtype]
+    apply K!_intro
+    . apply left_A!_intro
+      . apply C!_trans (K!_left hΓ) ?_
         apply C!_trans ?_ (K!_right EDisj₂AppendADisj₂Disj₂!)
-        simp;
-      . apply C!_trans (K!_left hΔ) ?_;
+        simp
+      . apply C!_trans (K!_left hΔ) ?_
         apply C!_trans ?_ (K!_right EDisj₂AppendADisj₂Disj₂!)
-        simp;
-    . apply C!_trans (K!_left EDisj₂AppendADisj₂Disj₂!) ?_;
-      apply CAA!_of_C!_of_C!;
-      . simpa using K!_right hΓ;
-      . simpa using K!_right hΔ;
+        simp
+    . apply C!_trans (K!_left EDisj₂AppendADisj₂Disj₂!) ?_
+      apply CAA!_of_C!_of_C!
+      . simpa using K!_right hΓ
+      . simpa using K!_right hΔ
 
 lemma exists_CNFPart_list {φ : NNFormula _} (φ_CNFP : φ.isModalCNFPart)
   : ∃ Γ : List { φ : NNFormula ℕ // φ.isPrebox ∨ φ.isPredia ∨ φ.degree = 0 }, Hilbert.K ⊢! φ.toFormula ⭤ ⋁(Γ.map (·.1)) := by
   induction φ using NNFormula.rec' with
-  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp;
-  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp;
-  | hVerum => use [⟨⊤, by tauto⟩]; simp;
-  | hFalsum => use [⟨⊥, by tauto⟩]; simp;
-  | hBox φ ih => use [⟨(□φ), by tauto⟩]; simp;
-  | hDia φ ih => use [⟨(◇φ), by tauto⟩]; simp;
+  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp
+  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp
+  | hVerum => use [⟨⊤, by tauto⟩]; simp
+  | hFalsum => use [⟨⊥, by tauto⟩]; simp
+  | hBox φ ih => use [⟨(□φ), by tauto⟩]; simp
+  | hDia φ ih => use [⟨(◇φ), by tauto⟩]; simp
   | hAnd φ ψ ihφ ihψ =>
     obtain ⟨hφ, hψ⟩ : φ.degree = 0 ∧ ψ.degree = 0 := by
       simpa [NNFormula.isPrebox, NNFormula.isPredia, NNFormula.isModalCNFPart, NNFormula.degree]
-      using φ_CNFP;
-    obtain ⟨Γ, hΓ⟩ := ihφ $ NNFormula.isModalCNFPart.of_degree_zero hφ;
-    obtain ⟨Δ, hΔ⟩ := ihψ $ NNFormula.isModalCNFPart.of_degree_zero hψ;
+      using φ_CNFP
+    obtain ⟨Γ, hΓ⟩ := ihφ $ NNFormula.isModalCNFPart.of_degree_zero hφ
+    obtain ⟨Δ, hΔ⟩ := ihψ $ NNFormula.isModalCNFPart.of_degree_zero hψ
     use List.zipWith
       (λ ⟨ξ₁, hξ₁⟩ ⟨ξ₂, hξ₂⟩ => ⟨
         ξ₁ ⋏ ξ₂,
-        by sorry;
+        by sorry
       ⟩)
-      Γ Δ;
-    sorry;
+      Γ Δ
+    sorry
   | hOr φ ψ ihφ ihψ =>
-    obtain ⟨hφ, hψ⟩ := φ_CNFP;
-    obtain ⟨Γ, hΓ⟩ := ihφ hφ;
-    obtain ⟨Δ, hΔ⟩ := ihψ hψ;
-    sorry;
+    obtain ⟨hφ, hψ⟩ := φ_CNFP
+    obtain ⟨Γ, hΓ⟩ := ihφ hφ
+    obtain ⟨Δ, hΔ⟩ := ihψ hψ
+    sorry
 -/
 
 /-
 lemma exists_CNF_list {φ : NNFormula _} (φ_CNF : φ.isModalCNF)
   : ∃ Γ : List { φ : NNFormula ℕ // φ.isModalCNFPart }, Hilbert.K ⊢! (φ.toFormula ⭤ ⋀(Γ.map (·.1))) := by
   induction φ using NNFormula.rec' with
-  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp;
-  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp;
-  | hVerum => use []; simp;
-  | hFalsum => use [⟨⊥, by tauto⟩]; simp;
-  | hBox φ ih => use [⟨(□φ), by simpa⟩]; simp;
-  | hDia φ ih => use [⟨(◇φ), by simpa⟩]; simp;
+  | hAtom a => use [⟨(NNFormula.atom a), by tauto⟩]; simp
+  | hNatom a => use [⟨(NNFormula.natom a), by tauto⟩]; simp
+  | hVerum => use []; simp
+  | hFalsum => use [⟨⊥, by tauto⟩]; simp
+  | hBox φ ih => use [⟨(□φ), by simpa⟩]; simp
+  | hDia φ ih => use [⟨(◇φ), by simpa⟩]; simp
   | hAnd φ ψ ihφ ihψ =>
-    obtain ⟨Γ, hΓ⟩ := ihφ φ_CNF.1;
-    obtain ⟨Δ, hΔ⟩ := ihψ φ_CNF.2;
-    use Γ ++ Δ;
-    sorry;
+    obtain ⟨Γ, hΓ⟩ := ihφ φ_CNF.1
+    obtain ⟨Δ, hΔ⟩ := ihψ φ_CNF.2
+    use Γ ++ Δ
+    sorry
   | hOr φ ψ ihφ ihψ =>
-    obtain ⟨Γ, hΓ⟩ : ∃ Γ : NNFormula.ModalCNFPartList ℕ, (φ ⋎ ψ) = ⋁(Γ.map (·.1)) := φ_CNF;
-    rw [hΓ];
+    obtain ⟨Γ, hΓ⟩ : ∃ Γ : NNFormula.ModalCNFPartList ℕ, (φ ⋎ ψ) = ⋁(Γ.map (·.1)) := φ_CNF
+    rw [hΓ]
 
-    sorry;
+    sorry
 
 
 theorem exists_CNF_DNF {φ : NNFormula _}
@@ -188,44 +188,44 @@ theorem exists_CNF_DNF {φ : NNFormula _}
     (∃ ξ : NNFormula _, ξ.isModalDNF ∧ Hilbert.K ⊢! φ.toFormula ⭤ ξ.toFormula)
   := by
   induction φ using NNFormula.rec' with
-  | hAtom a => constructor <;> { use (.atom a); simp; };
+  | hAtom a => constructor <;> { use (.atom a); simp; }
   | hNatom a => constructor <;> { use (.natom a); simp; }
   | hVerum => constructor <;> { use ⊤; simp; }
   | hFalsum => constructor <;> { use ⊥; simp; }
   | hBox φ ih => constructor <;> { use (□φ); simp; }
   | hDia φ ih => constructor <;> { use (◇φ); simp; }
   | hAnd φ ψ ihφ ihψ =>
-    obtain ⟨⟨φ₁, φ₁_CNF, hφ₁⟩, ⟨φ₂, φ₂_DNF, hφ₂⟩⟩ := ihφ;
-    obtain ⟨⟨ψ₁, ψ₁_CNF, hψ₁⟩, ⟨ψ₂, ψ₂_DNF, hψ₂⟩⟩ := ihψ;
-    constructor;
-    . use (φ₁ ⋏ ψ₁);
-      constructor;
-      . tauto;
-      . apply K!_intro;
+    obtain ⟨⟨φ₁, φ₁_CNF, hφ₁⟩, ⟨φ₂, φ₂_DNF, hφ₂⟩⟩ := ihφ
+    obtain ⟨⟨ψ₁, ψ₁_CNF, hψ₁⟩, ⟨ψ₂, ψ₂_DNF, hψ₂⟩⟩ := ihψ
+    constructor
+    . use (φ₁ ⋏ ψ₁)
+      constructor
+      . tauto
+      . apply K!_intro
         . apply CKK!_of_C!_of_C!
-          . exact K!_left hφ₁;
-          . exact K!_left hψ₁;
-        . apply CKK!_of_C!_of_C!;
-          . exact K!_right hφ₁;
-          . exact K!_right hψ₁;
-    . obtain ⟨Γ, hΓ⟩ := exists_CNF_list φ₁_CNF;
-      obtain ⟨Δ, hΔ⟩ := exists_CNF_list ψ₁_CNF;
-      sorry;
+          . exact K!_left hφ₁
+          . exact K!_left hψ₁
+        . apply CKK!_of_C!_of_C!
+          . exact K!_right hφ₁
+          . exact K!_right hψ₁
+    . obtain ⟨Γ, hΓ⟩ := exists_CNF_list φ₁_CNF
+      obtain ⟨Δ, hΔ⟩ := exists_CNF_list ψ₁_CNF
+      sorry
   | hOr φ ψ ihφ ihψ =>
-    obtain ⟨⟨φ₁, φ₁_CNF, hφ₁⟩, ⟨φ₂, φ₂_DNF, hφ₂⟩⟩ := ihφ;
-    obtain ⟨⟨ψ₁, ψ₁_CNF, hψ₁⟩, ⟨ψ₂, ψ₂_DNF, hψ₂⟩⟩ := ihψ;
-    constructor;
-    . sorry;
-    . use (φ₂ ⋎ ψ₂);
-      constructor;
-      . tauto;
-      . apply K!_intro;
+    obtain ⟨⟨φ₁, φ₁_CNF, hφ₁⟩, ⟨φ₂, φ₂_DNF, hφ₂⟩⟩ := ihφ
+    obtain ⟨⟨ψ₁, ψ₁_CNF, hψ₁⟩, ⟨ψ₂, ψ₂_DNF, hψ₂⟩⟩ := ihψ
+    constructor
+    . sorry
+    . use (φ₂ ⋎ ψ₂)
+      constructor
+      . tauto
+      . apply K!_intro
         . apply CAA!_of_C!_of_C!
-          . exact K!_left hφ₂;
-          . exact K!_left hψ₂;
-        . apply CAA!_of_C!_of_C!;
-          . exact K!_right hφ₂;
-          . exact K!_right hψ₂;
+          . exact K!_left hφ₂
+          . exact K!_left hψ₂
+        . apply CAA!_of_C!_of_C!
+          . exact K!_right hφ₂
+          . exact K!_right hψ₂
 -/
 
 lemma exists_CNF (φ : NNFormula _)

--- a/Foundation/Modal/Hilbert/Normal/Basic.lean
+++ b/Foundation/Modal/Hilbert/Normal/Basic.lean
@@ -21,11 +21,11 @@ variable {H H₁ H₂ : Hilbert.Normal α} {φ ψ : Formula α}
 abbrev axiomInstances (H : Hilbert.Normal α) : Set (Formula α) := { φ⟦s⟧ | (φ ∈ H.axioms) (s : Substitution α) }
 
 lemma mem_axiomInstances_of_mem_axioms {φ} (h : φ ∈ H.axioms) : φ ∈ H.axiomInstances := by
-  use φ;
-  constructor;
-  . assumption;
-  . use Substitution.id;
-    simp;
+  use φ
+  constructor
+  . assumption
+  . use Substitution.id
+    simp
 
 inductive Deduction (H : Hilbert.Normal α) : (Formula α) → Type u
   | axm {φ} (s : Substitution _) : φ ∈ H.axioms → Deduction H (φ⟦s⟧)
@@ -39,7 +39,7 @@ instance : Entailment (Formula α) (Hilbert.Normal α) := ⟨Deduction⟩
 
 def Deduction.axm' {H : Hilbert.Normal α} {φ} (h : φ ∈ H.axioms) : Deduction H φ := by
   rw [(show φ = φ⟦.id⟧ by simp)]
-  apply Deduction.axm _ h;
+  apply Deduction.axm _ h
 
 section
 
@@ -65,14 +65,14 @@ protected lemma rec!
   (imply₂   : ∀ {φ ψ χ}, motive (Axioms.Imply₂ φ ψ χ) $ by simp)
   (ec       : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ by simp)
   : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
-  rintro φ ⟨d⟩;
+  rintro φ ⟨d⟩
   induction d with
-  | axm s h => apply axm s h;
-  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ;
+  | axm s h => apply axm s h
+  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ
   | nec hφψ ihφ => apply nec ihφ
   | imply₁ φ ψ => apply imply₁
   | imply₂ φ ψ χ => apply imply₂
-  | ec φ ψ => apply ec;
+  | ec φ ψ => apply ec
 
 lemma axm! {φ} (s) (h : φ ∈ H.axioms) : H ⊢! (φ⟦s⟧) := ⟨.axm s h⟩
 
@@ -80,25 +80,25 @@ lemma axm'! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := by simpa using axm! Substi
 
 lemma subst! {φ} (s) (h : H ⊢! φ) : H ⊢! (φ⟦s⟧) := by
   induction h using Normal.rec! with
-  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h;
-  | @nec φ h => apply nec!; simpa;
-  | _ => simp;
+  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h
+  | @nec φ h => apply nec!; simpa
+  | _ => simp
 
 lemma weakerThan_of_provable_axioms (hs : H₂ ⊢!* H₁.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ h;
+  apply weakerThan_iff.mpr
+  intro φ h
   induction h using Normal.rec! with
-  | @axm φ s h => apply subst!; apply @hs φ h;
-  | @nec φ h => apply nec!; simpa;
-  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂;
-  | _ => simp;
+  | @axm φ s h => apply subst!; apply @hs φ h
+  | @nec φ h => apply nec!; simpa
+  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂
+  | _ => simp
 
 lemma weakerThan_of_subset_axioms (hs : H₁.axioms ⊆ H₂.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_of_provable_axioms;
-  intro φ h;
-  apply axm'!;
-  exact hs h;
+  apply weakerThan_of_provable_axioms
+  intro φ h
+  apply axm'!
+  exact hs h
 
 end
 
@@ -108,50 +108,50 @@ section
 abbrev logic (H : Hilbert.Normal α) : Logic α := Entailment.theory H
 
 @[simp high]
-lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [Entailment.theory, Logic.iff_provable];
+lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [Entailment.theory, Logic.iff_provable]
 
 instance : Entailment.Lukasiewicz H.logic where
   mdp hφψ hφ := by
-    replace hφψ := hφψ.1;
-    replace hφ := hφ.1;
-    simp_all only [theory, Set.mem_setOf_eq];
-    constructor;
-    exact hφψ ⨀ hφ;
-  imply₁ _ _ := by constructor; simp [Entailment.theory];
-  imply₂ _ _ _ := by constructor; simp [Entailment.theory];
-  elimContra _ _ := by constructor; simp [Entailment.theory];
+    replace hφψ := hφψ.1
+    replace hφ := hφ.1
+    simp_all only [theory, Set.mem_setOf_eq]
+    constructor
+    exact hφψ ⨀ hφ
+  imply₁ _ _ := by constructor; simp [Entailment.theory]
+  imply₂ _ _ _ := by constructor; simp [Entailment.theory]
+  elimContra _ _ := by constructor; simp [Entailment.theory]
 
 instance : Entailment.Necessitation H.logic where
   nec hφ := by
-    replace hφ := hφ.1;
-    simp only [theory, Set.mem_setOf_eq];
-    constructor;
-    exact nec! hφ;
+    replace hφ := hφ.1
+    simp only [theory, Set.mem_setOf_eq]
+    constructor
+    exact nec! hφ
 
 instance [H₁ ⪯ H₂] : H₁.logic ⪯ H₂.logic := by
-  apply weakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply WeakerThan.wk;
-  infer_instance;
+  apply weakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply WeakerThan.wk
+  infer_instance
 
 instance [H₁ ⪱ H₂] : H₁.logic ⪱ H₂.logic := by
-  apply strictlyWeakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable];
-  apply strictlyWeakerThan_iff.mp;
-  infer_instance;
+  apply strictlyWeakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable]
+  apply strictlyWeakerThan_iff.mp
+  infer_instance
 
 instance [H₁ ≊ H₂] : H₁.logic ≊ H₂.logic := by
-  apply Equiv.iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply Equiv.iff.mp;
-  infer_instance;
+  apply Equiv.iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply Equiv.iff.mp
+  infer_instance
 
 instance [Entailment.Consistent H] : Entailment.Consistent H.logic where
   not_inconsistent := by
     simp only [Inconsistent, iff_logic_provable_provable, not_forall]
-    use ⊥;
-    apply Entailment.Consistent.not_bot;
-    infer_instance;
+    use ⊥
+    apply Entailment.Consistent.not_bot
+    infer_instance
 
 end
 
@@ -163,8 +163,8 @@ variable [DecidableEq α]
 class HasK (H : Hilbert.Normal α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasK] : Entailment.HasAxiomK H where
   K φ ψ := by
@@ -174,104 +174,104 @@ instance [H.HasK] : Entailment.HasAxiomK H where
         if (HasK.p H) = b then φ
         else if (HasK.q H) = b then ψ
         else (.atom b))
-      HasK.mem_K;
+      HasK.mem_K
 
 instance [H.HasK] : H.logic.IsNormal where
-  K φ ψ := by constructor; simp [Entailment.theory];
+  K φ ψ := by constructor; simp [Entailment.theory]
   subst s hφ := by
-    replace hφ := hφ.1;
-    constructor;
-    simp_all only [theory, Set.mem_setOf_eq];
-    apply subst! s hφ;
+    replace hφ := hφ.1
+    constructor
+    simp_all only [theory, Set.mem_setOf_eq]
+    apply subst! s hφ
 
 
 class HasT (H : Hilbert.Normal α) where
   p : α
-  mem_T : Axioms.T (.atom p) ∈ H.axioms := by tauto;
+  mem_T : Axioms.T (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasT] : Entailment.HasAxiomT H where
   T φ := by
     simpa using Deduction.axm
       (φ := Axioms.T (.atom (HasT.p H)))
       (s := λ b => if (HasT.p H) = b then φ else (.atom b))
-      HasT.mem_T;
+      HasT.mem_T
 
 class HasB (H : Hilbert.Normal α) where
   p : α
-  mem_B : Axioms.B (.atom p) ∈ H.axioms := by tauto;
+  mem_B : Axioms.B (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasB] : Entailment.HasAxiomB H where
   B φ := by
     simpa using Deduction.axm
       (φ := Axioms.B (.atom (HasB.p H)))
       (s := λ b => if (HasB.p H) = b then φ else (.atom b))
-      HasB.mem_B;
+      HasB.mem_B
 
 
 class HasD (H : Hilbert.Normal α) where
   p : α
-  mem_D : Axioms.D (.atom p) ∈ H.axioms := by tauto;
+  mem_D : Axioms.D (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasD] : Entailment.HasAxiomD H where
   D φ := by
     simpa using Deduction.axm
       (φ := Axioms.D (.atom (HasD.p H)))
       (s := λ b => if (HasD.p H) = b then φ else (.atom b))
-      HasD.mem_D;
+      HasD.mem_D
 
 
 class HasP (H : Hilbert.Normal α) where
-  mem_P : Axioms.P ∈ H.axioms := by tauto;
+  mem_P : Axioms.P ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasP] : Entailment.HasAxiomP H where
   P := by
     simpa using Deduction.axm
       (φ := Axioms.P)
       (s := .id)
-      HasP.mem_P;
+      HasP.mem_P
 
 
 class HasFour (H : Hilbert.Normal α) where
   p : α
-  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto;
+  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasFour] : Entailment.HasAxiomFour H where
   Four φ := by
     simpa using Deduction.axm
       (φ := Axioms.Four (.atom (HasFour.p H)))
       (s := λ b => if (HasFour.p H) = b then φ else (.atom b))
-      HasFour.mem_Four;
+      HasFour.mem_Four
 
 
 class HasFive (H : Hilbert.Normal α) where
   p : α
-  mem_Five : Axioms.Five (.atom p) ∈ H.axioms := by tauto;
+  mem_Five : Axioms.Five (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasFive] : Entailment.HasAxiomFive H where
   Five φ := by
     simpa using Deduction.axm
       (φ := Axioms.Five (.atom (HasFive.p H)))
       (s := λ b => if (HasFive.p H) = b then φ else (.atom b))
-      HasFive.mem_Five;
+      HasFive.mem_Five
 
 
 class HasPoint2 (H : Hilbert.Normal α) where
   p : α
-  mem_Point2 : Axioms.Point2 (.atom p) ∈ H.axioms := by tauto;
+  mem_Point2 : Axioms.Point2 (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasPoint2] : Entailment.HasAxiomPoint2 H where
   Point2 φ := by
     simpa using Deduction.axm
       (φ := Axioms.Point2 (.atom (HasPoint2.p H)))
       (s := λ b => if (HasPoint2.p H) = b then φ else (.atom b))
-      HasPoint2.mem_Point2;
+      HasPoint2.mem_Point2
 
 
 class HasWeakPoint2 (H : Hilbert.Normal α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_WeakPoint2 : Axioms.WeakPoint2 (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_WeakPoint2 : Axioms.WeakPoint2 (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasWeakPoint2] : Entailment.HasAxiomWeakPoint2 H where
   WeakPoint2 φ ψ := by
@@ -281,14 +281,14 @@ instance [H.HasWeakPoint2] : Entailment.HasAxiomWeakPoint2 H where
         if (HasWeakPoint2.p H) = b then φ
         else if (HasWeakPoint2.q H) = b then ψ
         else (.atom b))
-      HasWeakPoint2.mem_WeakPoint2;
+      HasWeakPoint2.mem_WeakPoint2
 
 
 class HasPoint3 (H : Hilbert.Normal α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_Point3 : Axioms.Point3 (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_Point3 : Axioms.Point3 (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasPoint3] : Entailment.HasAxiomPoint3 H where
   Point3 φ ψ := by
@@ -298,14 +298,14 @@ instance [H.HasPoint3] : Entailment.HasAxiomPoint3 H where
         if (HasPoint3.p H) = b then φ
         else if (HasPoint3.q H) = b then ψ
         else (.atom b))
-      HasPoint3.mem_Point3;
+      HasPoint3.mem_Point3
 
 
 class HasWeakPoint3 (H : Hilbert.Normal α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_WeakPoint3 : Axioms.WeakPoint3 (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_WeakPoint3 : Axioms.WeakPoint3 (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasWeakPoint3] : Entailment.HasAxiomWeakPoint3 H where
   WeakPoint3 φ ψ := by
@@ -315,123 +315,123 @@ instance [H.HasWeakPoint3] : Entailment.HasAxiomWeakPoint3 H where
         if (HasWeakPoint3.p H) = b then φ
         else if (HasWeakPoint3.q H) = b then ψ
         else (.atom b))
-      HasWeakPoint3.mem_WeakPoint3;
+      HasWeakPoint3.mem_WeakPoint3
 
 
 class HasPoint4 (H : Hilbert.Normal α) where
   p : α
-  mem_Point4 : Axioms.Point4 (.atom p) ∈ H.axioms := by tauto;
+  mem_Point4 : Axioms.Point4 (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasPoint4] : Entailment.HasAxiomPoint4 H where
   Point4 φ := by
     simpa using Deduction.axm
       (φ := Axioms.Point4 (.atom (HasPoint4.p H)))
       (s := λ b => if (HasPoint4.p H) = b then φ else (.atom b))
-      HasPoint4.mem_Point4;
+      HasPoint4.mem_Point4
 
 
 class HasL (H : Hilbert.Normal α) where
   p : α
-  mem_L : Axioms.L (.atom p) ∈ H.axioms := by tauto;
+  mem_L : Axioms.L (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasL] : Entailment.HasAxiomL H where
   L φ := by
     simpa using Deduction.axm
       (φ := Axioms.L (.atom (HasL.p H)))
       (s := λ b => if (HasL.p H) = b then φ else (.atom b))
-      HasL.mem_L;
+      HasL.mem_L
 
 
 class HasZ (H : Hilbert.Normal α) where
   p : α
-  mem_Z : Axioms.Z (.atom p) ∈ H.axioms := by tauto;
+  mem_Z : Axioms.Z (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasZ] : Entailment.HasAxiomZ H where
   Z φ := by
     simpa using Deduction.axm
       (φ := Axioms.Z (.atom (HasZ.p H)))
       (s := λ b => if (HasZ.p H) = b then φ else (.atom b))
-      HasZ.mem_Z;
+      HasZ.mem_Z
 
 
 class HasGrz (H : Hilbert.Normal α) where
   p : α
-  mem_Grz : Axioms.Grz (.atom p) ∈ H.axioms := by tauto;
+  mem_Grz : Axioms.Grz (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasGrz] : Entailment.HasAxiomGrz H where
   Grz φ := by
     simpa using Deduction.axm
       (φ := Axioms.Grz (.atom (HasGrz.p H)))
       (s := λ b => if (HasGrz.p H) = b then φ else (.atom b))
-      HasGrz.mem_Grz;
+      HasGrz.mem_Grz
 
 
 class HasDum (H : Hilbert.Normal α) where
   p : α
-  mem_Dum : Axioms.Dum (.atom p) ∈ H.axioms := by tauto;
+  mem_Dum : Axioms.Dum (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasDum] : Entailment.HasAxiomDum H where
   Dum φ := by
     simpa using Deduction.axm
       (φ := Axioms.Dum (.atom (HasDum.p H)))
       (s := λ b => if (HasDum.p H) = b then φ else (.atom b))
-      HasDum.mem_Dum;
+      HasDum.mem_Dum
 
 
 class HasTc (H : Hilbert.Normal α) where
   p : α
-  mem_Tc : Axioms.Tc (.atom p) ∈ H.axioms := by tauto;
+  mem_Tc : Axioms.Tc (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasTc] : Entailment.HasAxiomTc H where
   Tc φ := by
     simpa using Deduction.axm
       (φ := Axioms.Tc (.atom (HasTc.p H)))
       (s := λ b => if (HasTc.p H) = b then φ else (.atom b))
-      HasTc.mem_Tc;
+      HasTc.mem_Tc
 
 
 class HasVer (H : Hilbert.Normal α) where
   p : α
-  mem_Ver : Axioms.Ver (.atom p) ∈ H.axioms := by tauto;
+  mem_Ver : Axioms.Ver (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasVer] : Entailment.HasAxiomVer H where
   Ver φ := by
     simpa using Deduction.axm
       (φ := Axioms.Ver (.atom (HasVer.p H)))
       (s := λ b => if (HasVer.p H) = b then φ else (.atom b))
-      HasVer.mem_Ver;
+      HasVer.mem_Ver
 
 
 class HasHen (H : Hilbert.Normal α) where
   p : α
-  mem_Hen : Axioms.Hen (.atom p) ∈ H.axioms := by tauto;
+  mem_Hen : Axioms.Hen (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasHen] : Entailment.HasAxiomHen H where
   Hen φ := by
     simpa using Deduction.axm
       (φ := Axioms.Hen (.atom (HasHen.p H)))
       (s := λ b => if (HasHen.p H) = b then φ else (.atom b))
-      HasHen.mem_Hen;
+      HasHen.mem_Hen
 
 
 
 class HasMcK (H : Hilbert.Normal α) where
   p : α
-  mem_M : Axioms.McK (.atom p) ∈ H.axioms := by tauto;
+  mem_M : Axioms.McK (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasMcK] : Entailment.HasAxiomMcK H where
   McK φ := by
     simpa using Deduction.axm
       (φ := Axioms.McK (.atom (HasMcK.p H)))
       (s := λ b => if (HasMcK.p H) = b then φ else (.atom b))
-      HasMcK.mem_M;
+      HasMcK.mem_M
 
 
 class HasMk (H : Hilbert.Normal α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_Mk : Axioms.Mk (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_Mk : Axioms.Mk (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [H.HasMk] : Entailment.HasAxiomMk H where
   Mk φ ψ := by
@@ -441,31 +441,31 @@ instance [H.HasMk] : Entailment.HasAxiomMk H where
         if (HasMk.p H) = b then φ
         else if (HasMk.q H) = b then ψ
         else (.atom b))
-      HasMk.mem_Mk;
+      HasMk.mem_Mk
 
 
 class HasH1 (H : Hilbert.Normal α) where
   p : α
-  mem_H1 : Axioms.H (.atom p) ∈ H.axioms := by tauto;
+  mem_H1 : Axioms.H (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasH1] : Entailment.HasAxiomH H where
   H1 φ := by
     simpa using Deduction.axm
       (φ := Axioms.H (.atom (HasH1.p H)))
       (s := λ b => if (HasH1.p H) = b then φ else (.atom b))
-      HasH1.mem_H1;
+      HasH1.mem_H1
 
 
 class HasGeach (g) (H : Hilbert.Normal α) where
   p : α
-  mem_Geach : Axioms.Geach g (.atom p) ∈ H.axioms := by tauto;
+  mem_Geach : Axioms.Geach g (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasGeach g] : Entailment.HasAxiomGeach g H where
   Geach φ := by
     simpa using Deduction.axm
       (φ := Axioms.Geach g (.atom (HasGeach.p g H)))
       (s := λ b => if (HasGeach.p g H) = b then φ else (.atom b))
-      HasGeach.mem_Geach;
+      HasGeach.mem_Geach
 
 end
 
@@ -487,27 +487,27 @@ instance : Hilbert.K.HasK where p := 0; q := 1
 instance : Entailment.K (Hilbert.K) where
 
 instance [L.IsNormal] : Modal.K ⪯ L := by
-  constructor;
-  intro φ;
-  suffices Hilbert.K ⊢! φ → L ⊢! φ by simpa [theory, Set.mem_setOf_eq, Set.setOf_mem_eq];
-  intro hφ;
+  constructor
+  intro φ
+  suffices Hilbert.K ⊢! φ → L ⊢! φ by simpa [theory, Set.mem_setOf_eq, Set.setOf_mem_eq]
+  intro hφ
   induction hφ using Hilbert.Normal.rec! with
-  | axm s h => rcases h with rfl; simp;
-  | nec hφ => apply nec! hφ;
+  | axm s h => rcases h with rfl; simp
+  | nec hφ => apply nec! hφ
   | mdp hφψ hφ => exact mdp! hφψ hφ
-  | imply₁ | imply₂ | ec => simp;
+  | imply₁ | imply₂ | ec => simp
 
 
 protected abbrev Hilbert.KT : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0)}⟩
 protected abbrev KT := Hilbert.KT.logic
-instance : (Hilbert.KT).HasK where p := 0; q := 1;
+instance : (Hilbert.KT).HasK where p := 0; q := 1
 instance : (Hilbert.KT).HasT where p := 0
 instance : Entailment.KT (Hilbert.KT) where
 
 
 protected abbrev Hilbert.KD : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0)}⟩
 protected abbrev KD := Hilbert.KD.logic
-instance : (Hilbert.KD).HasK where p := 0; q := 1;
+instance : (Hilbert.KD).HasK where p := 0; q := 1
 instance : (Hilbert.KD).HasD where p := 0
 instance : Entailment.KD (Hilbert.KD) where
 
@@ -520,24 +520,24 @@ instance : Entailment.KP (Hilbert.KP) where
 
 
 instance : Hilbert.KP ≊ Hilbert.KD := by
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl) <;> simp;
-  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl) <;> simp;
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl) <;> simp
+  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl) <;> simp
 
 instance : Modal.KP ≊ Modal.KD := inferInstance
 
 
 protected abbrev Hilbert.KB : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.B (.atom 0)}⟩
 protected abbrev KB := Hilbert.KB.logic
-instance : (Hilbert.KB).HasK where p := 0; q := 1;
+instance : (Hilbert.KB).HasK where p := 0; q := 1
 instance : (Hilbert.KB).HasB where p := 0
 instance : Entailment.KB (Hilbert.KB) where
 
 
 protected abbrev Hilbert.KDB : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0), Axioms.B (.atom 0)}⟩
 protected abbrev KDB := Hilbert.KDB.logic
-instance : (Hilbert.KDB).HasK where p := 0; q := 1;
+instance : (Hilbert.KDB).HasK where p := 0; q := 1
 instance : (Hilbert.KDB).HasD where p := 0
 instance : (Hilbert.KDB).HasB where p := 0
 instance : Entailment.KDB (Hilbert.KDB) where
@@ -545,7 +545,7 @@ instance : Entailment.KDB (Hilbert.KDB) where
 
 protected abbrev Hilbert.KTB : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.B (.atom 0)}⟩
 protected abbrev KTB := Hilbert.KTB.logic
-instance : (Hilbert.KTB).HasK where p := 0; q := 1;
+instance : (Hilbert.KTB).HasK where p := 0; q := 1
 instance : (Hilbert.KTB).HasT where p := 0
 instance : (Hilbert.KTB).HasB where p := 0
 instance : Entailment.KTB (Hilbert.KTB) where
@@ -553,27 +553,27 @@ instance : Entailment.KTB (Hilbert.KTB) where
 
 protected abbrev Hilbert.KMcK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.McK (.atom 0)}⟩
 protected abbrev KMcK := Hilbert.KMcK.logic
-instance : (Hilbert.KMcK).HasK where p := 0; q := 1;
+instance : (Hilbert.KMcK).HasK where p := 0; q := 1
 instance : (Hilbert.KMcK).HasMcK where p := 0
 instance : Entailment.KMcK (Hilbert.KMcK) where
-instance : Hilbert.K ⪯ Hilbert.KMcK := weakerThan_of_subset_axioms $ by simp;
+instance : Hilbert.K ⪯ Hilbert.KMcK := weakerThan_of_subset_axioms $ by simp
 
 
 protected abbrev Hilbert.K4 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0)}⟩
 protected abbrev K4 := Hilbert.K4.logic
-instance : (Hilbert.K4).HasK where p := 0; q := 1;
+instance : (Hilbert.K4).HasK where p := 0; q := 1
 instance : (Hilbert.K4).HasFour where p := 0
 instance : Entailment.K4 (Hilbert.K4) where
 
 
 protected abbrev Hilbert.K4McK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.McK (.atom 0)}⟩
 protected abbrev K4McK := Hilbert.K4McK.logic
-instance : (Hilbert.K4McK).HasK where p := 0; q := 1;
+instance : (Hilbert.K4McK).HasK where p := 0; q := 1
 instance : (Hilbert.K4McK).HasFour where p := 0
 instance : (Hilbert.K4McK).HasMcK where p := 0
 instance : Entailment.K4McK (Hilbert.K4McK) where
 
-instance : Hilbert.K ⪯ Hilbert.K4McK := weakerThan_of_subset_axioms $ by simp;
+instance : Hilbert.K ⪯ Hilbert.K4McK := weakerThan_of_subset_axioms $ by simp
 
 noncomputable instance [Entailment.K H] [Hilbert.K4McK ⪯ H] : Entailment.K4McK H where
   Four _ := Entailment.WeakerThan.pbl (𝓢 := Hilbert.K4McK) (by simp) |>.some
@@ -583,22 +583,22 @@ noncomputable instance [Entailment.K H] [Hilbert.K4McK ⪯ H] : Entailment.K4McK
 
 protected abbrev Hilbert.K4Point2 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.WeakPoint2 (.atom 0) (.atom 1)}⟩
 protected abbrev K4Point2 := Hilbert.K4Point2.logic
-instance : (Hilbert.K4Point2).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Point2).HasK where p := 0; q := 1
 instance : (Hilbert.K4Point2).HasFour where p := 0
-instance : (Hilbert.K4Point2).HasWeakPoint2 where p := 0; q := 1;
+instance : (Hilbert.K4Point2).HasWeakPoint2 where p := 0; q := 1
 instance : Entailment.K4Point2 (Hilbert.K4Point2) where
 
 protected abbrev Hilbert.K4Point3 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.WeakPoint3 (.atom 0) (.atom 1)}⟩
 protected abbrev K4Point3 := Hilbert.K4Point3.logic
-instance : (Hilbert.K4Point3).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Point3).HasK where p := 0; q := 1
 instance : (Hilbert.K4Point3).HasFour where p := 0
-instance : (Hilbert.K4Point3).HasWeakPoint3 where p := 0; q := 1;
+instance : (Hilbert.K4Point3).HasWeakPoint3 where p := 0; q := 1
 instance : Entailment.K4Point3 (Hilbert.K4Point3) where
 
 
 protected abbrev Hilbert.KT4B : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.B (.atom 0)}⟩
 protected abbrev KT4B := Hilbert.KT4B.logic
-instance : (Hilbert.KT4B).HasK where p := 0; q := 1;
+instance : (Hilbert.KT4B).HasK where p := 0; q := 1
 instance : (Hilbert.KT4B).HasT where p := 0
 instance : (Hilbert.KT4B).HasFour where p := 0
 instance : (Hilbert.KT4B).HasB where p := 0
@@ -607,7 +607,7 @@ instance : Entailment.KT4B (Hilbert.KT4B) where
 
 protected abbrev Hilbert.K45 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.Five (.atom 0)}⟩
 protected abbrev K45 := Hilbert.K45.logic
-instance : (Hilbert.K45).HasK where p := 0; q := 1;
+instance : (Hilbert.K45).HasK where p := 0; q := 1
 instance : (Hilbert.K45).HasFour where p := 0
 instance : (Hilbert.K45).HasFive where p := 0
 instance : Entailment.K45 (Hilbert.K45) where
@@ -615,7 +615,7 @@ instance : Entailment.K45 (Hilbert.K45) where
 
 protected abbrev Hilbert.KD4 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0), Axioms.Four (.atom 0)}⟩
 protected abbrev KD4 := Hilbert.KD4.logic
-instance : (Hilbert.KD4).HasK where p := 0; q := 1;
+instance : (Hilbert.KD4).HasK where p := 0; q := 1
 instance : (Hilbert.KD4).HasD where p := 0
 instance : (Hilbert.KD4).HasFour where p := 0
 instance : Entailment.KD4 (Hilbert.KD4) where
@@ -623,7 +623,7 @@ instance : Entailment.KD4 (Hilbert.KD4) where
 
 protected abbrev Hilbert.KD5 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0), Axioms.Five (.atom 0)}⟩
 protected abbrev KD5 := Hilbert.KD5.logic
-instance : (Hilbert.KD5).HasK where p := 0; q := 1;
+instance : (Hilbert.KD5).HasK where p := 0; q := 1
 instance : (Hilbert.KD5).HasD where p := 0
 instance : (Hilbert.KD5).HasFive where p := 0
 instance : Entailment.KD5 (Hilbert.KD5) where
@@ -631,7 +631,7 @@ instance : Entailment.KD5 (Hilbert.KD5) where
 
 protected abbrev Hilbert.KD45 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0), Axioms.Four (.atom 0), Axioms.Five (.atom 0)}⟩
 protected abbrev KD45 := Hilbert.KD45.logic
-instance : (Hilbert.KD45).HasK where p := 0; q := 1;
+instance : (Hilbert.KD45).HasK where p := 0; q := 1
 instance : (Hilbert.KD45).HasD where p := 0
 instance : (Hilbert.KD45).HasFour where p := 0
 instance : (Hilbert.KD45).HasFive where p := 0
@@ -640,7 +640,7 @@ instance : Entailment.KD45 (Hilbert.KD45) where
 
 protected abbrev Hilbert.KB4 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.B (.atom 0), Axioms.Four (.atom 0)}⟩
 protected abbrev KB4 := Hilbert.KB4.logic
-instance : (Hilbert.KB4).HasK where p := 0; q := 1;
+instance : (Hilbert.KB4).HasK where p := 0; q := 1
 instance : (Hilbert.KB4).HasB where p := 0
 instance : (Hilbert.KB4).HasFour where p := 0
 instance : Entailment.KB4 (Hilbert.KB4) where
@@ -648,7 +648,7 @@ instance : Entailment.KB4 (Hilbert.KB4) where
 
 protected abbrev Hilbert.KB5 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.B (.atom 0), Axioms.Five (.atom 0)}⟩
 protected abbrev KB5 := Hilbert.KB5.logic
-instance : (Hilbert.KB5).HasK where p := 0; q := 1;
+instance : (Hilbert.KB5).HasK where p := 0; q := 1
 instance : (Hilbert.KB5).HasB where p := 0
 instance : (Hilbert.KB5).HasFive where p := 0
 instance : Entailment.KB5 (Hilbert.KB5) where
@@ -656,59 +656,59 @@ instance : Entailment.KB5 (Hilbert.KB5) where
 
 protected abbrev Hilbert.S4 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0)}⟩
 protected abbrev S4 := Hilbert.S4.logic
-instance : (Hilbert.S4).HasK where p := 0; q := 1;
+instance : (Hilbert.S4).HasK where p := 0; q := 1
 instance : (Hilbert.S4).HasT where p := 0
 instance : (Hilbert.S4).HasFour where p := 0
 instance : Entailment.S4 (Hilbert.S4) where
-instance : Hilbert.K4 ⪯ Hilbert.S4 := weakerThan_of_subset_axioms $ by simp;
+instance : Hilbert.K4 ⪯ Hilbert.S4 := weakerThan_of_subset_axioms $ by simp
 
 
 protected abbrev Hilbert.S4McK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.McK (.atom 0)}⟩
 protected abbrev S4McK := Hilbert.S4McK.logic
-instance : (Hilbert.S4McK).HasK where p := 0; q := 1;
+instance : (Hilbert.S4McK).HasK where p := 0; q := 1
 instance : (Hilbert.S4McK).HasT where p := 0
 instance : (Hilbert.S4McK).HasFour where p := 0
 instance : (Hilbert.S4McK).HasMcK where p := 0
 instance : Entailment.S4McK (Hilbert.S4McK) where
-instance : Hilbert.K4McK ⪯ Hilbert.S4McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4McK ⪯ Hilbert.S4McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.S4Point2McK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.McK (.atom 0), Axioms.Point2 (.atom 0)}⟩
 protected abbrev S4Point2McK := Hilbert.S4Point2McK.logic
-instance : (Hilbert.S4Point2McK).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point2McK).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point2McK).HasT where p := 0
 instance : (Hilbert.S4Point2McK).HasFour where p := 0
 instance : (Hilbert.S4Point2McK).HasMcK where p := 0
 instance : (Hilbert.S4Point2McK).HasPoint2 where p := 0
 instance : Entailment.S4Point2McK (Hilbert.S4Point2McK) where
-instance : Hilbert.K4McK ⪯ Hilbert.S4Point2McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4McK ⪯ Hilbert.S4Point2McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.S4Point3McK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.McK (.atom 0), Axioms.Point3 (.atom 0) (.atom 1)}⟩
 protected abbrev S4Point3McK := Hilbert.S4Point3McK.logic
-instance : (Hilbert.S4Point3McK).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point3McK).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point3McK).HasT where p := 0
 instance : (Hilbert.S4Point3McK).HasFour where p := 0
 instance : (Hilbert.S4Point3McK).HasMcK where p := 0
-instance : (Hilbert.S4Point3McK).HasPoint3 where p := 0; q := 1;
+instance : (Hilbert.S4Point3McK).HasPoint3 where p := 0; q := 1
 instance : Entailment.S4Point3McK (Hilbert.S4Point3McK) where
-instance : Hilbert.K4McK ⪯ Hilbert.S4Point3McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4McK ⪯ Hilbert.S4Point3McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.S4Point4McK : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.McK (.atom 0), Axioms.Point4 (.atom 0)}⟩
 protected abbrev S4Point4McK := Hilbert.S4Point4McK.logic
-instance : (Hilbert.S4Point4McK).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point4McK).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point4McK).HasT where p := 0
 instance : (Hilbert.S4Point4McK).HasFour where p := 0
 instance : (Hilbert.S4Point4McK).HasMcK where p := 0
 instance : (Hilbert.S4Point4McK).HasPoint4 where p := 0
 instance : Entailment.S4Point4McK (Hilbert.S4Point4McK) where
-instance : Hilbert.K4McK ⪯ Hilbert.S4Point4McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4McK ⪯ Hilbert.S4Point4McK := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.S4Point2 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Point2 (.atom 0)}⟩
 protected abbrev S4Point2 := Hilbert.S4Point2.logic
-instance : (Hilbert.S4Point2).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point2).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point2).HasT where p := 0
 instance : (Hilbert.S4Point2).HasFour where p := 0
 instance : (Hilbert.S4Point2).HasPoint2 where p := 0
@@ -717,16 +717,16 @@ instance : Entailment.S4Point2 (Hilbert.S4Point2) where
 
 protected abbrev Hilbert.S4Point3 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Point3 (.atom 0) (.atom 1)}⟩
 protected abbrev S4Point3 := Hilbert.S4Point3.logic
-instance : (Hilbert.S4Point3).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point3).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point3).HasT where p := 0
 instance : (Hilbert.S4Point3).HasFour where p := 0
-instance : (Hilbert.S4Point3).HasPoint3 where p := 0; q := 1;
+instance : (Hilbert.S4Point3).HasPoint3 where p := 0; q := 1
 instance : Entailment.S4Point3 (Hilbert.S4Point3) where
 
 
 protected abbrev Hilbert.S4Point4 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Point4 (.atom 0)}⟩
 protected abbrev S4Point4 := Hilbert.S4Point4.logic
-instance : (Hilbert.S4Point4).HasK where p := 0; q := 1;
+instance : (Hilbert.S4Point4).HasK where p := 0; q := 1
 instance : (Hilbert.S4Point4).HasT where p := 0
 instance : (Hilbert.S4Point4).HasFour where p := 0
 instance : (Hilbert.S4Point4).HasPoint4 where p := 0
@@ -735,14 +735,14 @@ instance : Entailment.S4Point4 (Hilbert.S4Point4) where
 
 protected abbrev Hilbert.K5 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Five (.atom 0)}⟩
 protected abbrev K5 := Hilbert.K5.logic
-instance : (Hilbert.K5).HasK where p := 0; q := 1;
+instance : (Hilbert.K5).HasK where p := 0; q := 1
 instance : (Hilbert.K5).HasFive where p := 0
 instance : Entailment.K5 (Hilbert.K5) where
 
 
 protected abbrev Hilbert.S5 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Five (.atom 0)}⟩
 protected abbrev S5 := Hilbert.S5.logic
-instance : (Hilbert.S5).HasK where p := 0; q := 1;
+instance : (Hilbert.S5).HasK where p := 0; q := 1
 instance : (Hilbert.S5).HasT where p := 0
 instance : (Hilbert.S5).HasFive where p := 0
 instance : Entailment.S5 (Hilbert.S5) where
@@ -750,31 +750,31 @@ instance : Entailment.S5 (Hilbert.S5) where
 
 protected abbrev Hilbert.GL : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.L (.atom 0)}⟩
 protected abbrev GL := Hilbert.GL.logic
-instance : (Hilbert.GL).HasK where p := 0; q := 1;
-instance : (Hilbert.GL).HasL where p := 0;
+instance : (Hilbert.GL).HasK where p := 0; q := 1
+instance : (Hilbert.GL).HasL where p := 0
 instance : Entailment.GL (Hilbert.GL) where
 
 
 protected abbrev Hilbert.GLPoint2 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.L (.atom 0), Axioms.WeakPoint2 (.atom 0) (.atom 1)}⟩
 protected abbrev GLPoint2 := Hilbert.GLPoint2.logic
-instance : (Hilbert.GLPoint2).HasK where p := 0; q := 1;
+instance : (Hilbert.GLPoint2).HasK where p := 0; q := 1
 instance : (Hilbert.GLPoint2).HasL where p := 0
-instance : (Hilbert.GLPoint2).HasWeakPoint2 where p := 0; q := 1;
+instance : (Hilbert.GLPoint2).HasWeakPoint2 where p := 0; q := 1
 instance : Entailment.GLPoint2 (Hilbert.GLPoint2) where
 instance : Hilbert.GL ⪯ Hilbert.GLPoint2 := weakerThan_of_subset_axioms $ by simp
 
 
 protected abbrev Hilbert.GLPoint3 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.L (.atom 0), Axioms.WeakPoint3 (.atom 0) (.atom 1)}⟩
 protected abbrev GLPoint3 := Hilbert.GLPoint3.logic
-instance : (Hilbert.GLPoint3).HasK where p := 0; q := 1;
+instance : (Hilbert.GLPoint3).HasK where p := 0; q := 1
 instance : (Hilbert.GLPoint3).HasL where p := 0
-instance : (Hilbert.GLPoint3).HasWeakPoint3 where p := 0; q := 1;
+instance : (Hilbert.GLPoint3).HasWeakPoint3 where p := 0; q := 1
 instance : Entailment.GLPoint3 (Hilbert.GLPoint3) where
 
 
 protected abbrev Hilbert.K4Z : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.Z (.atom 0)}⟩
 protected abbrev K4Z := Hilbert.K4Z.logic
-instance : (Hilbert.K4Z).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Z).HasK where p := 0; q := 1
 instance : (Hilbert.K4Z).HasFour where p := 0
 instance : (Hilbert.K4Z).HasZ where p := 0
 instance : Entailment.K4Z (Hilbert.K4Z) where
@@ -782,16 +782,16 @@ instance : Entailment.K4Z (Hilbert.K4Z) where
 instance : Hilbert.K4 ⪯ Hilbert.K4Z := weakerThan_of_subset_axioms $ by simp
 instance : Modal.K4 ⪯ Modal.K4Z := inferInstance
 
-instance : Hilbert.K4Z ⪯ Hilbert.GL := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4Z ⪯ Hilbert.GL := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 instance : Modal.K4Z ⪯ Modal.GL := inferInstance
 
 
 protected abbrev Hilbert.K4Point2Z : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.Z (.atom 0), Axioms.WeakPoint2 (.atom 0) (.atom 1)}⟩
 protected abbrev K4Point2Z := Hilbert.K4Point2Z.logic
-instance : (Hilbert.K4Point2Z).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Point2Z).HasK where p := 0; q := 1
 instance : (Hilbert.K4Point2Z).HasFour where p := 0
 instance : (Hilbert.K4Point2Z).HasZ where p := 0
-instance : (Hilbert.K4Point2Z).HasWeakPoint2 where p := 0; q := 1;
+instance : (Hilbert.K4Point2Z).HasWeakPoint2 where p := 0; q := 1
 instance : Entailment.K4Point2Z (Hilbert.K4Point2Z) where
 
 instance : Hilbert.K4Point2 ⪯ Hilbert.K4Point2Z := weakerThan_of_subset_axioms (by simp)
@@ -800,37 +800,37 @@ instance : Modal.K4Point2 ⪯ Modal.K4Point2Z := inferInstance
 instance : Hilbert.K4Z ⪯ Hilbert.K4Point2Z := weakerThan_of_subset_axioms (by simp)
 instance : Modal.K4Z ⪯ Modal.K4Point2Z := inferInstance
 
-instance : Hilbert.K4Point2Z ⪯ Hilbert.GLPoint2 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4Point2Z ⪯ Hilbert.GLPoint2 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.K4Point2Z ⪯ Modal.GLPoint2 := inferInstance
 
 
 protected abbrev Hilbert.K4Point3Z : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.Z (.atom 0), Axioms.WeakPoint3 (.atom 0) (.atom 1)}⟩
 protected abbrev K4Point3Z := Hilbert.K4Point3Z.logic
-instance : (Hilbert.K4Point3Z).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Point3Z).HasK where p := 0; q := 1
 instance : (Hilbert.K4Point3Z).HasFour where p := 0
 instance : (Hilbert.K4Point3Z).HasZ where p := 0
-instance : (Hilbert.K4Point3Z).HasWeakPoint3 where p := 0; q := 1;
+instance : (Hilbert.K4Point3Z).HasWeakPoint3 where p := 0; q := 1
 instance : Entailment.K4Point3Z (Hilbert.K4Point3Z) where
 
-instance : Hilbert.K4Point3 ⪯ Hilbert.K4Point3Z := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4Point3 ⪯ Hilbert.K4Point3Z := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 instance : Modal.K4Point3 ⪯ Modal.K4Point3Z := inferInstance
 
-instance : Hilbert.K4Z ⪯ Hilbert.K4Point3Z := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4Z ⪯ Hilbert.K4Point3Z := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 instance : Modal.K4Z ⪯ Modal.K4Point3Z := inferInstance
 
-instance : Hilbert.K4Point3Z ⪯ Hilbert.GLPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.K4Point3Z ⪯ Hilbert.GLPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.K4Point3Z ⪯ Modal.GLPoint3 := inferInstance
 
 
 protected abbrev Hilbert.KHen : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Hen (.atom 0)}⟩
 protected abbrev KHen := Hilbert.KHen.logic
-instance : (Hilbert.KHen).HasK where p := 0; q := 1;
-instance : (Hilbert.KHen).HasHen where p := 0;
+instance : (Hilbert.KHen).HasK where p := 0; q := 1
+instance : (Hilbert.KHen).HasHen where p := 0
 
 
 protected abbrev Hilbert.K4Hen : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0), Axioms.Hen (.atom 0)}⟩
 protected abbrev K4Hen := Hilbert.K4Hen.logic
-instance : (Hilbert.K4Hen).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Hen).HasK where p := 0; q := 1
 instance : (Hilbert.K4Hen).HasFour where p := 0
 instance : (Hilbert.K4Hen).HasHen where p := 0
 instance : Entailment.K4Hen (Hilbert.K4Hen) where
@@ -838,15 +838,15 @@ instance : Entailment.K4Hen (Hilbert.K4Hen) where
 
 protected abbrev Hilbert.Grz : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Grz (.atom 0)}⟩
 protected abbrev Grz := Hilbert.Grz.logic
-instance : (Hilbert.Grz).HasK where p := 0; q := 1;
+instance : (Hilbert.Grz).HasK where p := 0; q := 1
 instance : (Hilbert.Grz).HasGrz where p := 0
 instance : Entailment.Grz (Hilbert.Grz) where
-instance : Hilbert.KT ⪯ Hilbert.Grz := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl) <;> simp;
+instance : Hilbert.KT ⪯ Hilbert.Grz := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.GrzPoint2 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Grz (.atom 0), Axioms.Point2 (.atom 0)}⟩
 protected abbrev GrzPoint2 := Hilbert.GrzPoint2.logic
-instance : (Hilbert.GrzPoint2).HasK where p := 0; q := 1;
+instance : (Hilbert.GrzPoint2).HasK where p := 0; q := 1
 instance : (Hilbert.GrzPoint2).HasGrz where p := 0
 instance : (Hilbert.GrzPoint2).HasPoint2 where p := 0
 instance : Entailment.GrzPoint2 (Hilbert.GrzPoint2) where
@@ -854,30 +854,30 @@ instance : Entailment.GrzPoint2 (Hilbert.GrzPoint2) where
 
 protected abbrev Hilbert.GrzPoint3 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Grz (.atom 0), Axioms.Point3 (.atom 0) (.atom 1)}⟩
 protected abbrev GrzPoint3 := Hilbert.GrzPoint3.logic
-instance : (Hilbert.GrzPoint3).HasK where p := 0; q := 1;
+instance : (Hilbert.GrzPoint3).HasK where p := 0; q := 1
 instance : (Hilbert.GrzPoint3).HasGrz where p := 0
-instance : (Hilbert.GrzPoint3).HasPoint3 where p := 0; q := 1;
+instance : (Hilbert.GrzPoint3).HasPoint3 where p := 0; q := 1
 instance : Entailment.GrzPoint3 (Hilbert.GrzPoint3) where
 
 
 protected abbrev Hilbert.Dum : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Dum (.atom 0)}⟩
 protected abbrev Dum := Hilbert.Dum.logic
-instance : (Hilbert.Dum).HasK where p := 0; q := 1;
+instance : (Hilbert.Dum).HasK where p := 0; q := 1
 instance : (Hilbert.Dum).HasT where p := 0
 instance : (Hilbert.Dum).HasFour where p := 0
 instance : (Hilbert.Dum).HasDum where p := 0
 instance : Entailment.Dum (Hilbert.Dum) where
 
-instance : Hilbert.S4 ⪯ Hilbert.Dum := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp;
+instance : Hilbert.S4 ⪯ Hilbert.Dum := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl) <;> simp
 instance : Modal.S4 ⪯ Modal.Dum := inferInstance
 
-instance : Hilbert.Dum ⪯ Hilbert.Grz := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.Dum ⪯ Hilbert.Grz := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.Dum ⪯ Modal.Grz := inferInstance
 
 
 protected abbrev Hilbert.DumPoint2 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Dum (.atom 0), Axioms.Point2 (.atom 0)}⟩
 protected abbrev DumPoint2 := Hilbert.DumPoint2.logic
-instance : (Hilbert.DumPoint2).HasK where p := 0; q := 1;
+instance : (Hilbert.DumPoint2).HasK where p := 0; q := 1
 instance : (Hilbert.DumPoint2).HasT where p := 0
 instance : (Hilbert.DumPoint2).HasFour where p := 0
 instance : (Hilbert.DumPoint2).HasDum where p := 0
@@ -890,49 +890,49 @@ instance : Modal.Dum ⪯ Modal.DumPoint2 := inferInstance
 instance : Hilbert.S4Point2 ⪯ Hilbert.DumPoint2 := weakerThan_of_subset_axioms (by simp)
 instance : Modal.S4Point2 ⪯ Modal.DumPoint2 := inferInstance
 
-instance : Hilbert.DumPoint2 ⪯ Hilbert.GrzPoint2 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.DumPoint2 ⪯ Hilbert.GrzPoint2 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.DumPoint2 ⪯ Modal.GrzPoint2 := inferInstance
 
 
 protected abbrev Hilbert.DumPoint3 : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Four (.atom 0), Axioms.Dum (.atom 0), Axioms.Point3 (.atom 0) (.atom 1)}⟩
 protected abbrev DumPoint3 := Hilbert.DumPoint3.logic
-instance : (Hilbert.DumPoint3).HasK where p := 0; q := 1;
+instance : (Hilbert.DumPoint3).HasK where p := 0; q := 1
 instance : (Hilbert.DumPoint3).HasT where p := 0
 instance : (Hilbert.DumPoint3).HasFour where p := 0
 instance : (Hilbert.DumPoint3).HasDum where p := 0
-instance : (Hilbert.DumPoint3).HasPoint3 where p := 0; q := 1;
+instance : (Hilbert.DumPoint3).HasPoint3 where p := 0; q := 1
 instance : Entailment.DumPoint3 (Hilbert.DumPoint3) where
 
 instance : Hilbert.Dum ⪯ Hilbert.DumPoint3 := weakerThan_of_subset_axioms (by simp)
 instance : Modal.Dum ⪯ Modal.DumPoint3 := inferInstance
 
-instance : Hilbert.S4Point3 ⪯ Hilbert.DumPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.S4Point3 ⪯ Hilbert.DumPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.S4Point3 ⪯ Modal.DumPoint3 := inferInstance
 
-instance : Hilbert.DumPoint3 ⪯ Hilbert.GrzPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp;
+instance : Hilbert.DumPoint3 ⪯ Hilbert.GrzPoint3 := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl | rfl | rfl | rfl) <;> simp
 instance : Modal.DumPoint3 ⪯ Modal.GrzPoint3 := inferInstance
 
 
 protected abbrev Hilbert.KTc : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Tc (.atom 0)}⟩
 protected abbrev KTc := Hilbert.KTc.logic
-instance : (Hilbert.KTc).HasK where p := 0; q := 1;
+instance : (Hilbert.KTc).HasK where p := 0; q := 1
 instance : (Hilbert.KTc).HasTc where p := 0
 instance : Entailment.KTc (Hilbert.KTc) where
 
 
 protected abbrev Hilbert.KD4Point3Z : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.D (.atom 0), Axioms.Four (.atom 0), Axioms.WeakPoint3 (.atom 0) (.atom 1), Axioms.Z (.atom 0)}⟩
 protected abbrev KD4Point3Z := Hilbert.KD4Point3Z.logic
-instance : (Hilbert.KD4Point3Z).HasK where p := 0; q := 1;
+instance : (Hilbert.KD4Point3Z).HasK where p := 0; q := 1
 instance : (Hilbert.KD4Point3Z).HasD where p := 0
 instance : (Hilbert.KD4Point3Z).HasFour where p := 0
-instance : (Hilbert.KD4Point3Z).HasWeakPoint3 where p := 0; q := 1;
+instance : (Hilbert.KD4Point3Z).HasWeakPoint3 where p := 0; q := 1
 instance : (Hilbert.KD4Point3Z).HasZ where p := 0
 instance : Entailment.KD4Point3Z (Hilbert.KD4Point3Z) where
 
 
 protected abbrev Hilbert.KTMk : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Mk (.atom 0) (.atom 1)}⟩
 protected abbrev KTMk := Hilbert.KTMk.logic
-instance : (Hilbert.KTMk).HasK where p := 0; q := 1;
+instance : (Hilbert.KTMk).HasK where p := 0; q := 1
 instance : (Hilbert.KTMk).HasT where p := 0
 instance : (Hilbert.KTMk).HasMk where p := 0; q := 1
 instance : Entailment.KTMk (Hilbert.KTMk) where
@@ -945,7 +945,7 @@ protected abbrev Hilbert.S4H : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.at
 -/
 protected abbrev S4H := Hilbert.S4H.logic
 
-instance : (Hilbert.S4H).HasK where p := 0; q := 1;
+instance : (Hilbert.S4H).HasK where p := 0; q := 1
 instance : (Hilbert.S4H).HasT where p := 0
 instance : (Hilbert.S4H).HasFour where p := 0
 instance : (Hilbert.S4H).HasH1 where p := 0
@@ -958,33 +958,33 @@ protected abbrev N := Hilbert.N.logic
 
 protected abbrev Hilbert.Ver : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Ver (.atom 0)}⟩
 protected abbrev Ver := Hilbert.Ver.logic
-instance : (Hilbert.Ver).HasK where p := 0; q := 1;
+instance : (Hilbert.Ver).HasK where p := 0; q := 1
 instance : (Hilbert.Ver).HasVer where p := 0
 instance : Entailment.Ver (Hilbert.Ver) where
 
 
 protected abbrev Hilbert.Triv : Hilbert.Normal ℕ := ⟨{ Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Tc (.atom 0)}⟩
 protected abbrev Triv := Hilbert.Triv.logic
-instance : (Hilbert.Triv).HasK where p := 0; q := 1;
+instance : (Hilbert.Triv).HasK where p := 0; q := 1
 instance : (Hilbert.Triv).HasT where p := 0
 instance : (Hilbert.Triv).HasTc where p := 0
 instance : Entailment.Triv (Hilbert.Triv) where
-instance : Hilbert.K4 ⪯ Hilbert.Triv := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl) <;> simp;
+instance : Hilbert.K4 ⪯ Hilbert.Triv := weakerThan_of_provable_axioms $ by rintro φ (rfl | rfl) <;> simp
 
 
 protected abbrev Hilbert.S5Grz : Hilbert.Normal ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.T (.atom 0), Axioms.Five (.atom 0), Axioms.Grz (.atom 0)}⟩
 protected abbrev S5Grz : Logic ℕ := Hilbert.S5Grz.logic
-instance : (Hilbert.S5Grz).HasK where p := 0; q := 1;
+instance : (Hilbert.S5Grz).HasK where p := 0; q := 1
 instance : (Hilbert.S5Grz).HasT where p := 0
 instance : (Hilbert.S5Grz).HasFive where p := 0
 instance : (Hilbert.S5Grz).HasGrz where p := 0
 instance : Entailment.S5Grz (Hilbert.S5Grz) where
 
 instance : Hilbert.S5Grz ≊ Hilbert.Triv := by
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl | rfl | rfl) <;> simp;
-  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl | rfl) <;> simp;
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl | rfl | rfl) <;> simp
+  . apply weakerThan_of_provable_axioms; rintro φ (rfl | rfl | rfl) <;> simp
 instance : Modal.S5Grz ≊ Modal.Triv := inferInstance
 
 

--- a/Foundation/Modal/Hilbert/WithHenkin/Basic.lean
+++ b/Foundation/Modal/Hilbert/WithHenkin/Basic.lean
@@ -17,11 +17,11 @@ variable {H H₁ H₂ : Hilbert.WithHenkin α} {φ ψ : Formula α}
 abbrev axiomInstances (H : Hilbert.WithHenkin α) : Set (Formula α) := { φ⟦s⟧ | (φ ∈ H.axioms) (s : Substitution α) }
 
 lemma mem_axiomInstances_of_mem_axioms {φ} (h : φ ∈ H.axioms) : φ ∈ H.axiomInstances := by
-  use φ;
-  constructor;
-  . assumption;
-  . use Substitution.id;
-    simp;
+  use φ
+  constructor
+  . assumption
+  . use Substitution.id
+    simp
 
 inductive Deduction (H : Hilbert.WithHenkin α) : (Formula α) → Type u
   | axm {φ} (s : Substitution _) : φ ∈ H.axioms → Deduction H (φ⟦s⟧)
@@ -36,7 +36,7 @@ instance : Entailment (Formula α) (Hilbert.WithHenkin α) := ⟨Deduction⟩
 
 def Deduction.axm' {H : Hilbert.WithHenkin α} {φ} (h : φ ∈ H.axioms) : Deduction H φ := by
   rw [(show φ = φ⟦.id⟧ by simp)]
-  apply Deduction.axm _ h;
+  apply Deduction.axm _ h
 
 section
 
@@ -62,15 +62,15 @@ protected lemma rec!
   (imply₂   : ∀ {φ ψ χ}, motive (Axioms.Imply₂ φ ψ χ) $ by simp)
   (ec       : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ by simp)
   : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
-  rintro φ ⟨d⟩;
+  rintro φ ⟨d⟩
   induction d with
-  | axm s h => apply axm s h;
-  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ;
+  | axm s h => apply axm s h
+  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ
   | nec hφψ ihφ => apply nec ihφ
   | henkin hφψ ihφψ => apply henkin ihφψ
   | imply₁ φ ψ => apply imply₁
   | imply₂ φ ψ χ => apply imply₂
-  | ec φ ψ => apply ec;
+  | ec φ ψ => apply ec
 
 lemma axm! {φ} (s) (h : φ ∈ H.axioms) : H ⊢! (φ⟦s⟧) := ⟨.axm s h⟩
 
@@ -78,27 +78,27 @@ lemma axm'! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := by simpa using axm! Substi
 
 lemma subst! {φ} (s) (h : H ⊢! φ) : H ⊢! (φ⟦s⟧) := by
   induction h using WithHenkin.rec! with
-  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h;
-  | @henkin φ ψ h => apply henkin!; simpa;
-  | @nec φ h => apply nec!; simpa;
-  | _ => simp;
+  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h
+  | @henkin φ ψ h => apply henkin!; simpa
+  | @nec φ h => apply nec!; simpa
+  | _ => simp
 
 lemma weakerThan_of_provable_axioms (hs : H₂ ⊢!* H₁.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ h;
+  apply weakerThan_iff.mpr
+  intro φ h
   induction h using WithHenkin.rec! with
-  | @axm φ s h => apply subst!; apply @hs φ h;
-  | @henkin φ ψ h => apply henkin!; simpa;
-  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂;
-  | @nec φ h => apply nec!; simpa;
-  | _ => simp;
+  | @axm φ s h => apply subst!; apply @hs φ h
+  | @henkin φ ψ h => apply henkin!; simpa
+  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂
+  | @nec φ h => apply nec!; simpa
+  | _ => simp
 
 lemma weakerThan_of_subset_axioms (hs : H₁.axioms ⊆ H₂.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_of_provable_axioms;
-  intro φ h;
-  apply axm'!;
-  exact hs h;
+  apply weakerThan_of_provable_axioms
+  intro φ h
+  apply axm'!
+  exact hs h
 
 end
 
@@ -108,25 +108,25 @@ section
 abbrev logic (H : Hilbert.WithHenkin α) : Logic α := Entailment.theory H
 
 @[simp high]
-lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [logic, Entailment.theory, Set.mem_setOf_eq];
+lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [logic, Entailment.theory, Set.mem_setOf_eq]
 
 instance [H₁ ⪯ H₂] : H₁.logic ⪯ H₂.logic := by
-  apply weakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply WeakerThan.wk;
-  infer_instance;
+  apply weakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply WeakerThan.wk
+  infer_instance
 
 instance [H₁ ⪱ H₂] : H₁.logic ⪱ H₂.logic := by
-  apply strictlyWeakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable];
-  apply strictlyWeakerThan_iff.mp;
-  infer_instance;
+  apply strictlyWeakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable]
+  apply strictlyWeakerThan_iff.mp
+  infer_instance
 
 instance [H₁ ≊ H₂] : H₁.logic ≊ H₂.logic := by
-  apply Equiv.iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply Equiv.iff.mp;
-  infer_instance;
+  apply Equiv.iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply Equiv.iff.mp
+  infer_instance
 
 end
 
@@ -138,8 +138,8 @@ variable [DecidableEq α]
 class HasK (H : Hilbert.WithHenkin α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
   K φ ψ := by
@@ -149,19 +149,19 @@ instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
         if (HasK.p H) = b then φ
         else if (HasK.q H) = b then ψ
         else (.atom b))
-      HasK.mem_K;
+      HasK.mem_K
 
 
 class HasFour (H : Hilbert.WithHenkin α) where
   p : α
-  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto;
+  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasFour] : Entailment.HasAxiomFour H where
   Four φ := by
     simpa using Deduction.axm
       (φ := Axioms.Four (.atom (HasFour.p H)))
       (s := λ b => if (HasFour.p H) = b then φ else (.atom b))
-      HasFour.mem_Four;
+      HasFour.mem_Four
 
 end
 
@@ -172,7 +172,7 @@ end Hilbert
 
 protected abbrev Hilbert.K4Henkin : Hilbert.WithHenkin ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0)}⟩
 protected abbrev K4Henkin := Hilbert.K4Henkin.logic
-instance : (Hilbert.K4Henkin).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Henkin).HasK where p := 0; q := 1
 instance : (Hilbert.K4Henkin).HasFour where p := 0
 instance : Entailment.K4Henkin (Hilbert.K4Henkin) where
 

--- a/Foundation/Modal/Hilbert/WithLoeb/Basic.lean
+++ b/Foundation/Modal/Hilbert/WithLoeb/Basic.lean
@@ -17,11 +17,11 @@ variable {H H₁ H₂ : Hilbert.WithLoeb α} {φ ψ : Formula α}
 abbrev axiomInstances (H : Hilbert.WithLoeb α) : Set (Formula α) := { φ⟦s⟧ | (φ ∈ H.axioms) (s : Substitution α) }
 
 lemma mem_axiomInstances_of_mem_axioms {φ} (h : φ ∈ H.axioms) : φ ∈ H.axiomInstances := by
-  use φ;
-  constructor;
-  . assumption;
-  . use Substitution.id;
-    simp;
+  use φ
+  constructor
+  . assumption
+  . use Substitution.id
+    simp
 
 inductive Deduction (H : Hilbert.WithLoeb α) : (Formula α) → Type u
   | axm {φ} (s : Substitution _) : φ ∈ H.axioms → Deduction H (φ⟦s⟧)
@@ -36,7 +36,7 @@ instance : Entailment (Formula α) (Hilbert.WithLoeb α) := ⟨Deduction⟩
 
 def Deduction.axm' {H : Hilbert.WithLoeb α} {φ} (h : φ ∈ H.axioms) : Deduction H φ := by
   rw [(show φ = φ⟦.id⟧ by simp)]
-  apply Deduction.axm _ h;
+  apply Deduction.axm _ h
 
 section
 
@@ -62,15 +62,15 @@ protected lemma rec!
   (imply₂   : ∀ {φ ψ χ}, motive (Axioms.Imply₂ φ ψ χ) $ by simp)
   (ec       : ∀ {φ ψ}, motive (Axioms.ElimContra φ ψ) $ by simp)
   : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
-  rintro φ ⟨d⟩;
+  rintro φ ⟨d⟩
   induction d with
-  | axm s h => apply axm s h;
-  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ;
+  | axm s h => apply axm s h
+  | mdp hφψ hφ ihφψ ihφ => apply mdp ihφψ ihφ
   | nec hφψ ihφ => apply nec ihφ
   | loeb hφψ ihφψ => apply loeb ihφψ
   | imply₁ φ ψ => apply imply₁
   | imply₂ φ ψ χ => apply imply₂
-  | ec φ ψ => apply ec;
+  | ec φ ψ => apply ec
 
 lemma axm! {φ} (s) (h : φ ∈ H.axioms) : H ⊢! (φ⟦s⟧) := ⟨.axm s h⟩
 
@@ -78,27 +78,27 @@ lemma axm'! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := by simpa using axm! Substi
 
 lemma subst! {φ} (s) (h : H ⊢! φ) : H ⊢! (φ⟦s⟧) := by
   induction h using WithLoeb.rec! with
-  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h;
-  | @loeb φ ψ h => apply loeb!; simpa;
-  | @nec φ h => apply nec!; simpa;
-  | _ => simp;
+  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h
+  | @loeb φ ψ h => apply loeb!; simpa
+  | @nec φ h => apply nec!; simpa
+  | _ => simp
 
 lemma weakerThan_of_provable_axioms (hs : H₂ ⊢!* H₁.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ h;
+  apply weakerThan_iff.mpr
+  intro φ h
   induction h using WithLoeb.rec! with
-  | @axm φ s h => apply subst!; apply @hs φ h;
-  | @loeb φ ψ h => apply loeb!; simpa;
-  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂;
-  | @nec φ h => apply nec!; simpa;
-  | _ => simp;
+  | @axm φ s h => apply subst!; apply @hs φ h
+  | @loeb φ ψ h => apply loeb!; simpa
+  | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂
+  | @nec φ h => apply nec!; simpa
+  | _ => simp
 
 lemma weakerThan_of_subset_axioms (hs : H₁.axioms ⊆ H₂.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_of_provable_axioms;
-  intro φ h;
-  apply axm'!;
-  exact hs h;
+  apply weakerThan_of_provable_axioms
+  intro φ h
+  apply axm'!
+  exact hs h
 
 end
 
@@ -108,25 +108,25 @@ section
 abbrev logic (H : Hilbert.WithLoeb α) : Logic α := Entailment.theory H
 
 @[simp high]
-lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [logic, Entailment.theory, Set.mem_setOf_eq];
+lemma iff_logic_provable_provable : H.logic ⊢! φ ↔ H ⊢! φ := by simp [logic, Entailment.theory, Set.mem_setOf_eq]
 
 instance [H₁ ⪯ H₂] : H₁.logic ⪯ H₂.logic := by
-  apply weakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply WeakerThan.wk;
-  infer_instance;
+  apply weakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply WeakerThan.wk
+  infer_instance
 
 instance [H₁ ⪱ H₂] : H₁.logic ⪱ H₂.logic := by
-  apply strictlyWeakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable];
-  apply strictlyWeakerThan_iff.mp;
-  infer_instance;
+  apply strictlyWeakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable]
+  apply strictlyWeakerThan_iff.mp
+  infer_instance
 
 instance [H₁ ≊ H₂] : H₁.logic ≊ H₂.logic := by
-  apply Equiv.iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply Equiv.iff.mp;
-  infer_instance;
+  apply Equiv.iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply Equiv.iff.mp
+  infer_instance
 
 end
 
@@ -138,8 +138,8 @@ variable [DecidableEq α]
 class HasK (H : Hilbert.WithLoeb α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by trivial;
-  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by trivial
+  mem_K : Axioms.K (.atom p) (.atom q) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
   K φ ψ := by
@@ -149,19 +149,19 @@ instance [DecidableEq α] [H.HasK] : Entailment.HasAxiomK H where
         if (HasK.p H) = b then φ
         else if (HasK.q H) = b then ψ
         else (.atom b))
-      HasK.mem_K;
+      HasK.mem_K
 
 
 class HasFour (H : Hilbert.WithLoeb α) where
   p : α
-  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto;
+  mem_Four : Axioms.Four (.atom p) ∈ H.axioms := by tauto
 
 instance [H.HasFour] : Entailment.HasAxiomFour H where
   Four φ := by
     simpa using Deduction.axm
       (φ := Axioms.Four (.atom (HasFour.p H)))
       (s := λ b => if (HasFour.p H) = b then φ else (.atom b))
-      HasFour.mem_Four;
+      HasFour.mem_Four
 
 end
 
@@ -172,7 +172,7 @@ end Hilbert
 
 protected abbrev Hilbert.K4Loeb : Hilbert.WithLoeb ℕ := ⟨{Axioms.K (.atom 0) (.atom 1), Axioms.Four (.atom 0)}⟩
 protected abbrev K4Loeb := Hilbert.K4Loeb.logic
-instance : (Hilbert.K4Loeb).HasK where p := 0; q := 1;
+instance : (Hilbert.K4Loeb).HasK where p := 0; q := 1
 instance : (Hilbert.K4Loeb).HasFour where p := 0
 instance : Entailment.K4Loeb (Hilbert.K4Loeb) where
 

--- a/Foundation/Modal/Kripke/AxiomGeach.lean
+++ b/Foundation/Modal/Kripke/AxiomGeach.lean
@@ -21,9 +21,9 @@ protected abbrev IsReflexive (F : Frame) := _root_.IsRefl _ F
 
 @[simp]
 instance [F.IsGeachConvergent ⟨0, 0, 1, 0⟩] : F.IsReflexive where
-  refl := by simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 0, 1, 0⟩);
+  refl := by simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 0, 1, 0⟩)
 instance [F.IsReflexive] : F.IsGeachConvergent ⟨0, 0, 1, 0⟩ where
-  gconv x y z Rxy Rxz := by simp_all;
+  gconv x y z Rxy Rxz := by simp_all
 
 protected abbrev IsSerial (F : Frame) := _root_.IsSerial F.Rel
 
@@ -31,11 +31,11 @@ lemma serial [F.IsSerial] : ∀ x : F, ∃ y, x ≺ y := IsSerial.serial
 
 @[simp]
 instance [F.IsGeachConvergent ⟨0, 0, 1, 1⟩] : F.IsSerial where
-  serial := by simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 0, 1, 1⟩);
+  serial := by simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 0, 1, 1⟩)
 instance [F.IsSerial] : F.IsGeachConvergent ⟨0, 0, 1, 1⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, and_self];
-    subst Rxz;
+    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, and_self]
+    subst Rxz
     apply _root_.IsSerial.serial
 
 
@@ -46,15 +46,15 @@ lemma trans [F.IsTransitive] : ∀ {x y z : F.World}, x ≺ y → y ≺ z → x 
 @[simp]
 instance [F.IsGeachConvergent ⟨0, 2, 1, 0⟩] : F.IsTransitive where
   trans := by
-    rintro x y z;
+    rintro x y z
     have : ∀ x y z : F, x = y → ∀ (u : F.World), x ≺ u → u ≺ z → y ≺ z := by
-      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 2, 1, 0⟩);
-    apply this x x z rfl y;
+      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 2, 1, 0⟩)
+    apply this x x z rfl y
 instance [F.IsTransitive] : F.IsGeachConvergent ⟨0, 2, 1, 0⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_right'];
-    subst Rxy;
-    obtain ⟨y, Rxy, Ryz⟩ := Rxz;
+    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_right']
+    subst Rxy
+    obtain ⟨y, Rxy, Ryz⟩ := Rxz
     exact IsTrans.trans _ _ _ Rxy Ryz
 
 
@@ -66,13 +66,13 @@ lemma symm [F.IsSymmetric] : ∀ {x y : F.World}, x ≺ y → y ≺ x := by appl
 instance [F.IsGeachConvergent ⟨0, 1, 0, 1⟩] : F.IsSymmetric where
   symm x y := by
     have : ∀ x y z : F, x = y → x ≺ z → z ≺ y := by
-      simpa using IsGeachConvergent.gconv (g := ⟨0, 1, 0, 1⟩) (F := F);
-    apply @this x x y rfl;
+      simpa using IsGeachConvergent.gconv (g := ⟨0, 1, 0, 1⟩) (F := F)
+    apply @this x x y rfl
 instance [F.IsSymmetric] : F.IsGeachConvergent ⟨0, 1, 0, 1⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_left'];
-    subst Rxy;
-    exact _root_.IsSymm.symm _ _ Rxz;
+    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_left']
+    subst Rxy
+    exact _root_.IsSymm.symm _ _ Rxz
 
 
 protected abbrev IsEuclidean (F : Frame) := _root_.IsRightEuclidean F.Rel
@@ -83,11 +83,11 @@ lemma eucl [F.IsEuclidean] : ∀ {x y z : F.World}, x ≺ y → x ≺ z → y �
 instance [F.IsGeachConvergent ⟨1, 1, 0, 1⟩] : F.IsEuclidean where
   reucl x y z Rxy Rxz := by
     have : ∀ x y z : F, x ≺ y → x ≺ z → z ≺ y := by
-      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨1, 1, 0, 1⟩);
-    apply this x z y Rxz Rxy;
+      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨1, 1, 0, 1⟩)
+    apply this x z y Rxz Rxy
 instance [F.IsEuclidean] : F.IsGeachConvergent ⟨1, 1, 0, 1⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right, exists_eq_left'];
+    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right, exists_eq_left']
     exact IsRightEuclidean.reucl Rxz Rxy
 
 
@@ -98,12 +98,12 @@ lemma ps_convergent [F.IsPiecewiseStronglyConvergent] : ∀ {x y z : F.World}, x
 
 @[simp]
 instance [F.IsGeachConvergent ⟨1, 1, 1, 1⟩] : F.IsPiecewiseStronglyConvergent where
-  ps_convergent := by simpa using IsGeachConvergent.gconv (g := ⟨1, 1, 1, 1⟩) (F := F);
+  ps_convergent := by simpa using IsGeachConvergent.gconv (g := ⟨1, 1, 1, 1⟩) (F := F)
 instance [F.IsPiecewiseStronglyConvergent] : F.IsGeachConvergent ⟨1, 1, 1, 1⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right];
-    obtain ⟨u, Ryu, Rzu⟩ := IsPiecewiseStronglyConvergent.ps_convergent Rxy Rxz;
-    use u;
+    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right]
+    obtain ⟨u, Ryu, Rzu⟩ := IsPiecewiseStronglyConvergent.ps_convergent Rxy Rxz
+    use u
 
 
 protected abbrev IsCoreflexive (F : Frame) := _root_.IsCoreflexive F.Rel
@@ -114,13 +114,13 @@ lemma corefl [F.IsCoreflexive] : ∀ {x y : F.World}, x ≺ y → x = y := by ap
 instance [F.IsGeachConvergent ⟨0, 1, 0, 0⟩] : F.IsCoreflexive where
   corefl x y Rxy := by
     have : ∀ x y z : F, x = y → x ≺ z → z = y := by
-      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 1, 0, 0⟩);
-    apply this x x y rfl Rxy |>.symm;
+      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 1, 0, 0⟩)
+    apply this x x y rfl Rxy |>.symm
 instance [F.IsCoreflexive] : F.IsGeachConvergent ⟨0, 1, 0, 0⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_left'];
-    subst Rxy;
-    exact F.corefl Rxz |>.symm;
+    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_left']
+    subst Rxy
+    exact F.corefl Rxz |>.symm
 
 
 protected class IsFunctional (F : Frame) where
@@ -131,12 +131,12 @@ lemma functional [F.IsFunctional] : ∀ {x y z : F.World}, x ≺ y → x ≺ z �
 instance [F.IsGeachConvergent ⟨1, 1, 0, 0⟩] : F.IsFunctional where
   functional x y z Rxy Rxz := by
     have : ∀ x y z : F, x ≺ y → x ≺ z → z = y := by
-      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨1, 1, 0, 0⟩);
-    exact this x y z Rxy Rxz |>.symm;
+      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨1, 1, 0, 0⟩)
+    exact this x y z Rxy Rxz |>.symm
 instance [F.IsFunctional] : F.IsGeachConvergent ⟨1, 1, 0, 0⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right, exists_eq_left'];
-    apply IsFunctional.functional Rxy Rxz |>.symm;
+    simp_all only [HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right, exists_eq_left']
+    apply IsFunctional.functional Rxy Rxz |>.symm
 
 
 protected class IsDense (F : Frame) where
@@ -147,14 +147,14 @@ lemma dense [F.IsDense] : ∀ {x y : F.World}, x ≺ y → ∃ u, x ≺ u ∧ u 
 instance [F.IsGeachConvergent ⟨0, 1, 2, 0⟩] : F.IsDense where
   dense x y Rxy := by
     have : ∀ x y z : F, x = y → x ≺ z → ∃ u, y ≺ u ∧ u ≺ z := by
-      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 1, 2, 0⟩);
-    apply this x x y rfl Rxy;
+      simpa using IsGeachConvergent.gconv (F := F) (g := ⟨0, 1, 2, 0⟩)
+    apply this x x y rfl Rxy
 instance [F.IsDense] : F.IsGeachConvergent ⟨0, 1, 2, 0⟩ where
   gconv x y z Rxy Rxz := by
-    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_right'];
-    subst Rxy;
-    obtain ⟨u, Ryu, Rzu⟩ := IsDense.dense Rxz;
-    use u;
+    simp_all only [HRel.Iterate.iff_zero, HRel.Iterate.iff_succ, exists_eq_right, exists_eq_right']
+    subst Rxy
+    obtain ⟨u, Ryu, Rzu⟩ := IsDense.dense Rxz
+    use u
 
 
 protected class IsPreorder (F : Frame) extends F.IsReflexive, F.IsTransitive
@@ -166,9 +166,9 @@ end Frame
 
 
 instance : whitepoint.IsGeachConvergent g := ⟨by
-  rintro x y z Rxy Rxz;
-  use ();
-  constructor <;> . apply HRel.Iterate.true_any; tauto;
+  rintro x y z Rxy Rxz
+  use ()
+  constructor <;> . apply HRel.Iterate.true_any; tauto
 ⟩
 instance : whitepoint.IsPreorder where
 
@@ -179,16 +179,16 @@ open Formula (atom)
 open Formula.Kripke
 
 lemma validate_axiomGeach_of_isGeachConvergent (g) [F.IsGeachConvergent g] : F ⊧ (Axioms.Geach g (.atom 0)) := by
-  rintro V x h;
-  apply Satisfies.multibox_def.mpr;
-  obtain ⟨y, Rxy, hbp⟩ := Satisfies.multidia_def.mp h;
-  intro z Rxz;
-  apply Satisfies.multidia_def.mpr;
-  obtain ⟨u, Ryu, Rzu⟩ := Frame.IsGeachConvergent.gconv Rxy Rxz;
-  use u;
-  constructor;
-  . assumption;
-  . exact (Satisfies.multibox_def.mp hbp) Ryu;
+  rintro V x h
+  apply Satisfies.multibox_def.mpr
+  obtain ⟨y, Rxy, hbp⟩ := Satisfies.multidia_def.mp h
+  intro z Rxz
+  apply Satisfies.multidia_def.mpr
+  obtain ⟨u, Ryu, Rzu⟩ := Frame.IsGeachConvergent.gconv Rxy Rxz
+  use u
+  constructor
+  . assumption
+  . exact (Satisfies.multibox_def.mp hbp) Ryu
 
 lemma validate_AxiomT_of_reflexive [refl : F.IsReflexive] : F ⊧ (Axioms.T (.atom 0)) := validate_axiomGeach_of_isGeachConvergent ⟨0, 0, 1, 0⟩
 lemma validate_AxiomD_of_serial [ser : F.IsSerial] : F ⊧ (Axioms.D (.atom 0)) := validate_axiomGeach_of_isGeachConvergent ⟨0, 0, 1, 1⟩
@@ -200,54 +200,54 @@ lemma validate_AxiomTc_of_coreflexive [corefl : F.IsCoreflexive] : F ⊧ (Axioms
 
 
 lemma isGeachConvergent_of_validate_axiomGeach {g} (h : F ⊧ (Axioms.Geach g (.atom 0))) : F.IsGeachConvergent g := ⟨by
-  rintro x y z Rxy Rxz;
-  let V : Kripke.Valuation F := λ v _ => y ≺^[g.m] v;
+  rintro x y z Rxy Rxz
+  let V : Kripke.Valuation F := λ v _ => y ≺^[g.m] v
   have : Satisfies ⟨F, V⟩ x (□^[g.j](◇^[g.n](.atom 0)))  := h V x $ by
-    apply Satisfies.multidia_def.mpr;
-    use y;
-    constructor;
-    . assumption;
-    . apply Satisfies.multibox_def.mpr;
-      aesop;
-  replace : Satisfies ⟨F, V⟩ z (◇^[g.n]Formula.atom 0) := Satisfies.multibox_def.mp this Rxz;
-  obtain ⟨u, Rzu, Ryu⟩ := Satisfies.multidia_def.mp this;
-  exact ⟨u, Ryu, Rzu⟩;
+    apply Satisfies.multidia_def.mpr
+    use y
+    constructor
+    . assumption
+    . apply Satisfies.multibox_def.mpr
+      aesop
+  replace : Satisfies ⟨F, V⟩ z (◇^[g.n]Formula.atom 0) := Satisfies.multibox_def.mp this Rxz
+  obtain ⟨u, Rzu, Ryu⟩ := Satisfies.multidia_def.mp this
+  exact ⟨u, Ryu, Rzu⟩
 ⟩
 
 lemma reflexive_of_validate_AxiomT (h : F ⊧ (Axioms.T (.atom 0))) : F.IsReflexive := by
-  suffices F.IsGeachConvergent ⟨0, 0, 1, 0⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨0, 0, 1, 0⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma transitive_of_validate_AxiomFour (h : F ⊧ (Axioms.Four (.atom 0))) : F.IsTransitive := by
-  suffices F.IsGeachConvergent ⟨0, 2, 1, 0⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨0, 2, 1, 0⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma euclidean_of_validate_AxiomFive (h : F ⊧ (Axioms.Five (.atom 0))) : F.IsEuclidean := by
-  suffices F.IsGeachConvergent ⟨1, 1, 0, 1⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨1, 1, 0, 1⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma symmetric_of_validate_AxiomB (h : F ⊧ (Axioms.B (.atom 0))) : F.IsSymmetric := by
-  suffices F.IsGeachConvergent ⟨0, 1, 0, 1⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨0, 1, 0, 1⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma serial_of_validate_AxiomD (h : F ⊧ (Axioms.D (.atom 0))) : F.IsSerial := by
-  suffices F.IsGeachConvergent ⟨0, 0, 1, 1⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨0, 0, 1, 1⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma coreflexive_of_validate_AxiomTc (h : F ⊧ (Axioms.Tc (.atom 0))) : F.IsCoreflexive := by
-  suffices F.IsGeachConvergent ⟨0, 1, 0, 0⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨0, 1, 0, 0⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 lemma confluent_of_validate_AxiomPoint2 (h : F ⊧ (Axioms.Point2 (.atom 0))) : F.IsPiecewiseStronglyConvergent := by
-  suffices F.IsGeachConvergent ⟨1, 1, 1, 1⟩ by infer_instance;
-  apply isGeachConvergent_of_validate_axiomGeach;
-  simpa;
+  suffices F.IsGeachConvergent ⟨1, 1, 1, 1⟩ by infer_instance
+  apply isGeachConvergent_of_validate_axiomGeach
+  simpa
 
 end definability
 
@@ -263,25 +263,25 @@ open MaximalConsistentTableau
 open canonicalModel
 
 instance [Entailment.HasAxiomGeach g 𝓢] : (canonicalFrame 𝓢).IsGeachConvergent g := ⟨by
-  rintro x y z Rxy Rxz;
+  rintro x y z Rxy Rxz
   have ⟨u, hu⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨y.1.1.premultibox g.m, z.1.2.premultidia g.n⟩) $ by
-    rintro Γ Δ hΓ hΔ;
-    by_contra! hC;
-    have hγ : □^[g.m](Γ.conj) ∈ y.1.1 := y.mdp_mem₁_provable collect_multibox_fconj! $ iff_mem₁_fconj.mpr (by simpa using hΓ);
-    have hδ : ◇^[g.n](Δ.disj) ∈ z.1.2 := mdp_mem₂_provable distribute_multidia_fdisj! $ iff_mem₂_fdisj.mpr (by simpa using hΔ);
-    generalize Γ.conj = γ at hγ hC;
-    generalize Δ.disj = δ at hδ hC;
-    have : 𝓢 ⊢! □^[g.m]γ ➝ □^[g.m]δ := imply_multibox_distribute'! hC;
-    have : □^[g.m]δ ∈ y.1.1 := mdp_mem₁_provable this hγ;
-    have : ◇^[g.i](□^[g.m]δ) ∈ x.1.1 := def_multirel_multidia_mem₁.mp Rxy this;
-    have : □^[g.j](◇^[g.n]δ) ∈ x.1.1 := mdp_mem₁_provable axiomGeach! this;
-    have : ◇^[g.n]δ ∈ z.1.1 := def_multirel_multibox_mem₁.mp Rxz this;
-    have : ◇^[g.n]δ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr this;
-    contradiction;
-  use u;
-  constructor;
-  . apply def_multirel_multibox_mem₁.mpr; apply hu.1;
-  . apply def_multirel_multidia_mem₂.mpr; apply hu.2;
+    rintro Γ Δ hΓ hΔ
+    by_contra! hC
+    have hγ : □^[g.m](Γ.conj) ∈ y.1.1 := y.mdp_mem₁_provable collect_multibox_fconj! $ iff_mem₁_fconj.mpr (by simpa using hΓ)
+    have hδ : ◇^[g.n](Δ.disj) ∈ z.1.2 := mdp_mem₂_provable distribute_multidia_fdisj! $ iff_mem₂_fdisj.mpr (by simpa using hΔ)
+    generalize Γ.conj = γ at hγ hC
+    generalize Δ.disj = δ at hδ hC
+    have : 𝓢 ⊢! □^[g.m]γ ➝ □^[g.m]δ := imply_multibox_distribute'! hC
+    have : □^[g.m]δ ∈ y.1.1 := mdp_mem₁_provable this hγ
+    have : ◇^[g.i](□^[g.m]δ) ∈ x.1.1 := def_multirel_multidia_mem₁.mp Rxy this
+    have : □^[g.j](◇^[g.n]δ) ∈ x.1.1 := mdp_mem₁_provable axiomGeach! this
+    have : ◇^[g.n]δ ∈ z.1.1 := def_multirel_multibox_mem₁.mp Rxz this
+    have : ◇^[g.n]δ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr this
+    contradiction
+  use u
+  constructor
+  . apply def_multirel_multibox_mem₁.mpr; apply hu.1
+  . apply def_multirel_multidia_mem₂.mpr; apply hu.2
 ⟩
 
 instance [Entailment.HasAxiomT 𝓢] : (canonicalFrame 𝓢).IsReflexive := by simp

--- a/Foundation/Modal/Kripke/AxiomGrz.lean
+++ b/Foundation/Modal/Kripke/AxiomGrz.lean
@@ -25,198 +25,198 @@ instance [F.IsFinite] [F.IsTransitive] [F.IsAntisymmetric] : F.IsWeaklyConverseW
 
 
 lemma validate_AxiomGrz_of_refl_trans_wcwf [F.IsReflexive] [F.IsTransitive] [F.IsWeaklyConverseWellFounded] : F ⊧ (Axioms.Grz (.atom 0)) := by
-  intro V;
-  let M : Model := ⟨F, V⟩;
-  let X := { x | Satisfies M x (□(□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0))) ∧ ¬(Satisfies M x (.atom 0)) };
-  let Y := { x | Satisfies M x (□(□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0))) ∧ ¬(Satisfies M x (□(.atom 0))) ∧ (Satisfies ⟨F, V⟩ x (.atom 0)) };
-  have : (X ∩ Y) = ∅ := by aesop;
+  intro V
+  let M : Model := ⟨F, V⟩
+  let X := { x | Satisfies M x (□(□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0))) ∧ ¬(Satisfies M x (.atom 0)) }
+  let Y := { x | Satisfies M x (□(□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0))) ∧ ¬(Satisfies M x (□(.atom 0))) ∧ (Satisfies ⟨F, V⟩ x (.atom 0)) }
+  have : (X ∩ Y) = ∅ := by aesop
 
   suffices ∀ x ∈ X ∪ Y, ∃ y ∈ X ∪ Y, (IrreflGen F.Rel) x y by
     have : (X ∪ Y) = ∅ := by
-      by_contra hC;
+      by_contra hC
       obtain ⟨z, z_sub, hz⟩ := F.wcwf.has_max (X ∪ Y) $ by
-        exact Set.nonempty_iff_ne_empty.mpr hC;
-      obtain ⟨x, x_sub, hx⟩ := this z z_sub;
-      exact hz x x_sub hx;
-    have : X = ∅ := by tauto_set;
+        exact Set.nonempty_iff_ne_empty.mpr hC
+      obtain ⟨x, x_sub, hx⟩ := this z z_sub
+      exact hz x x_sub hx
+    have : X = ∅ := by tauto_set
     -- TODO: need more refactor
-    have := Set.not_nonempty_iff_eq_empty.mpr this;
-    have := Set.nonempty_def.not.mp this;
-    push_neg at this;
-    simpa [X] using this;
+    have := Set.not_nonempty_iff_eq_empty.mpr this
+    have := Set.nonempty_def.not.mp this
+    push_neg at this
+    simpa [X] using this
 
-  rintro w (⟨hw₁, hw₂⟩ | ⟨hw₁, hw₂, hw₃⟩);
-  . have : Satisfies M w (□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0)) := hw₁ w (IsRefl.refl w);
-    have : ¬Satisfies M w (□(atom 0 ➝ □atom 0)) := not_imp_not.mpr this hw₂;
-    obtain ⟨x, Rwx, hx, ⟨y, Rxy, hy⟩⟩ := by simpa [Satisfies] using this;
-    use x;
-    constructor;
-    . right;
-      refine ⟨?_, ?_, by assumption⟩;
-      . intro z Rxz hz;
-        exact hw₁ z (IsTrans.trans _ _ _ Rwx Rxz) hz;
-      . simp [Satisfies];
-        use y;
-    . constructor;
-      . assumption;
-      . by_contra hC;
-        subst hC;
-        simp [Satisfies] at hw₂;
-        contradiction;
-  . obtain ⟨x, Rwx, hx⟩ := by simpa [Satisfies] using hw₂;
-    use x;
-    constructor;
-    . left;
-      refine ⟨?_, (by assumption)⟩;
-      . intro y Rxy hy;
-        exact hw₁ _ (IsTrans.trans _ _ _ Rwx Rxy) hy;
-    . constructor;
-      . assumption;
-      . by_contra hC;
-        subst hC;
+  rintro w (⟨hw₁, hw₂⟩ | ⟨hw₁, hw₂, hw₃⟩)
+  . have : Satisfies M w (□((.atom 0) ➝ □(.atom 0)) ➝ (.atom 0)) := hw₁ w (IsRefl.refl w)
+    have : ¬Satisfies M w (□(atom 0 ➝ □atom 0)) := not_imp_not.mpr this hw₂
+    obtain ⟨x, Rwx, hx, ⟨y, Rxy, hy⟩⟩ := by simpa [Satisfies] using this
+    use x
+    constructor
+    . right
+      refine ⟨?_, ?_, by assumption⟩
+      . intro z Rxz hz
+        exact hw₁ z (IsTrans.trans _ _ _ Rwx Rxz) hz
+      . simp [Satisfies]
+        use y
+    . constructor
+      . assumption
+      . by_contra hC
+        subst hC
+        simp [Satisfies] at hw₂
+        contradiction
+  . obtain ⟨x, Rwx, hx⟩ := by simpa [Satisfies] using hw₂
+    use x
+    constructor
+    . left
+      refine ⟨?_, (by assumption)⟩
+      . intro y Rxy hy
+        exact hw₁ _ (IsTrans.trans _ _ _ Rwx Rxy) hy
+    . constructor
+      . assumption
+      . by_contra hC
+        subst hC
         simp [Satisfies] at hw₃
-        contradiction;
+        contradiction
 
 lemma validate_AxiomGrz_of_finite_strict_preorder [F.IsFinite] [F.IsPartialOrder] : F ⊧ (Axioms.Grz (.atom 0)) := validate_AxiomGrz_of_refl_trans_wcwf
 
 
 lemma validate_AxiomT_AxiomFour_of_validate_Grz (h : F ⊧ Axioms.Grz (.atom 0)) : F ⊧ □(.atom 0) ➝ ((.atom 0) ⋏ □□(.atom 0)) := by
-  let ψ : Formula _ := (.atom 0) ⋏ (□(.atom 0) ➝ □□(.atom 0));
-  intro V x;
-  simp only [Axioms.Grz, ValidOnFrame.models_iff, ValidOnFrame, ValidOnModel.iff_models, ValidOnModel] at h;
+  let ψ : Formula _ := (.atom 0) ⋏ (□(.atom 0) ➝ □□(.atom 0))
+  intro V x
+  simp only [Axioms.Grz, ValidOnFrame.models_iff, ValidOnFrame, ValidOnModel.iff_models, ValidOnModel] at h
   suffices Satisfies { toFrame := F, Val := V } x (□(.atom 0) ➝ ψ) by
-    intro h₁;
-    have h₂ := Satisfies.and_def.mp $ this h₁;
-    apply Satisfies.and_def.mpr;
-    constructor;
-    . exact h₂.1;
-    . exact h₂.2 h₁;
-  intro h₁;
-  have h₂ : Satisfies ⟨F, V⟩ x (□(atom 0) ➝ □(□(ψ ➝ □ψ) ➝ ψ)) := (Sound.sound (𝓢 := Hilbert.K) (𝓜 := FrameClass.K) lemma_Grz₁!) (by trivial) V x;
-  have h₃ : Satisfies ⟨F, V⟩ x (□(□(ψ ➝ □ψ) ➝ ψ) ➝ ψ) := Satisfies.iff_subst_self (s := λ a => if a = 0 then ψ else a) |>.mp $ h _ _;
-  exact h₃ $ h₂ $ h₁;
+    intro h₁
+    have h₂ := Satisfies.and_def.mp $ this h₁
+    apply Satisfies.and_def.mpr
+    constructor
+    . exact h₂.1
+    . exact h₂.2 h₁
+  intro h₁
+  have h₂ : Satisfies ⟨F, V⟩ x (□(atom 0) ➝ □(□(ψ ➝ □ψ) ➝ ψ)) := (Sound.sound (𝓢 := Hilbert.K) (𝓜 := FrameClass.K) lemma_Grz₁!) (by trivial) V x
+  have h₃ : Satisfies ⟨F, V⟩ x (□(□(ψ ➝ □ψ) ➝ ψ) ➝ ψ) := Satisfies.iff_subst_self (s := λ a => if a = 0 then ψ else a) |>.mp $ h _ _
+  exact h₃ $ h₂ $ h₁
 
 lemma validate_AxiomT_of_validate_AxiomGrz (h : F ⊧ Axioms.Grz (.atom 0)) : F ⊧ (Axioms.T (.atom 0)) := by
-  intro V x hx;
-  exact Satisfies.and_def.mp (validate_AxiomT_AxiomFour_of_validate_Grz h V x hx) |>.1;
+  intro V x hx
+  exact Satisfies.and_def.mp (validate_AxiomT_AxiomFour_of_validate_Grz h V x hx) |>.1
 
 lemma validate_AxiomFour_of_validate_AxiomGrz (h : F ⊧ Axioms.Grz (.atom 0)) : F ⊧ (Axioms.Four (.atom 0))  := by
-  intro V x hx;
-  exact Satisfies.and_def.mp (validate_AxiomT_AxiomFour_of_validate_Grz h V x hx) |>.2;
+  intro V x hx
+  exact Satisfies.and_def.mp (validate_AxiomT_AxiomFour_of_validate_Grz h V x hx) |>.2
 
 lemma reflexive_of_validate_AxiomGrz (h : F ⊧ Axioms.Grz (.atom 0)) : F.IsReflexive := by
-  apply reflexive_of_validate_AxiomT;
-  exact validate_AxiomT_of_validate_AxiomGrz h;
+  apply reflexive_of_validate_AxiomT
+  exact validate_AxiomT_of_validate_AxiomGrz h
 
 lemma transitive_of_validate_AxiomGrz (h : F ⊧ Axioms.Grz (.atom 0)) : F.IsTransitive := by
-  apply transitive_of_validate_AxiomFour;
-  exact validate_AxiomFour_of_validate_AxiomGrz h;
+  apply transitive_of_validate_AxiomFour
+  exact validate_AxiomFour_of_validate_AxiomGrz h
 
 lemma WCWF_of_validate_AxiomGrz (h : F ⊧ Axioms.Grz (.atom 0)) : F.IsWeaklyConverseWellFounded where
   wcwf := by
-    have := reflexive_of_validate_AxiomGrz h;
-    have := transitive_of_validate_AxiomGrz h;
+    have := reflexive_of_validate_AxiomGrz h
+    have := transitive_of_validate_AxiomGrz h
 
-    revert h;
-    contrapose;
-    intro hWCWF;
+    revert h
+    contrapose
+    intro hWCWF
 
-    replace hWCWF := ConverseWellFounded.iff_has_max.not.mp hWCWF;
-    push_neg at hWCWF;
-    obtain ⟨f, hf⟩ := dependent_choice hWCWF; clear hWCWF;
-    simp only [IrreflGen, ne_eq] at hf;
-    apply ValidOnFrame.not_of_exists_valuation_world;
+    replace hWCWF := ConverseWellFounded.iff_has_max.not.mp hWCWF
+    push_neg at hWCWF
+    obtain ⟨f, hf⟩ := dependent_choice hWCWF; clear hWCWF
+    simp only [IrreflGen, ne_eq] at hf
+    apply ValidOnFrame.not_of_exists_valuation_world
     by_cases H : ∀ j₁ j₂, (j₁ < j₂ → f j₂ ≠ f j₁)
-    . use (λ v _ => ∀ i, v ≠ f (2 * i)), (f 0);
+    . use (λ v _ => ∀ i, v ≠ f (2 * i)), (f 0)
       apply Classical.not_imp.mpr
-      constructor;
+      constructor
       . suffices Satisfies ⟨F, _⟩ (f 0) (□(∼(.atom 0) ➝ ∼(□((.atom 0) ➝ □(.atom 0))))) by
-          intro x hx;
-          exact not_imp_not.mp $ this _ hx;
+          intro x hx
+          exact not_imp_not.mp $ this _ hx
         suffices ∀ y, f 0 ≺ y → ∀ j, y = f (2 * j) → ∃ x, y ≺ x ∧ (∀ i, ¬x = f (2 * i)) ∧ ∃ z, x ≺ z ∧ ∃ x, z = f (2 * x) by
-          simpa [Satisfies];
-        rintro v h0v j rfl;
-        use f (2 * j + 1);
-        refine ⟨?_, ?_, f ((2 * j) + 2), ?_, ?_⟩;
-        . apply hf _ |>.1;
-        . intro i;
-          rcases (lt_trichotomy i j) with (hij | rfl | hij);
-          . apply H;
-            omega;
-          . apply H;
-            omega;
-          . apply @H _ _ ?_ |>.symm;
-            omega;
-        . apply hf _ |>.1;
-        . use (j + 1);
-          rfl;
-      . suffices ∃ x, f 0 = f (2 * x) by simpa [Satisfies];
-        use 0;
-    . push_neg at H;
-      obtain ⟨j, k, ljk, ejk⟩ := H;
-      let V : Valuation F := (λ v _ => v ≠ f j);
-      use V, (f j);
-      apply Classical.not_imp.mpr;
-      constructor;
+          simpa [Satisfies]
+        rintro v h0v j rfl
+        use f (2 * j + 1)
+        refine ⟨?_, ?_, f ((2 * j) + 2), ?_, ?_⟩
+        . apply hf _ |>.1
+        . intro i
+          rcases (lt_trichotomy i j) with (hij | rfl | hij)
+          . apply H
+            omega
+          . apply H
+            omega
+          . apply @H _ _ ?_ |>.symm
+            omega
+        . apply hf _ |>.1
+        . use (j + 1)
+          rfl
+      . suffices ∃ x, f 0 = f (2 * x) by simpa [Satisfies]
+        use 0
+    . push_neg at H
+      obtain ⟨j, k, ljk, ejk⟩ := H
+      let V : Valuation F := (λ v _ => v ≠ f j)
+      use V, (f j)
+      apply Classical.not_imp.mpr
+      constructor
       . have : Satisfies ⟨F, V⟩ (f (j + 1)) (∼((.atom 0) ➝ □(.atom 0))) := by
-          suffices f (j + 1) ≠ f j ∧ f (j + 1) ≺ f j by simp_all [Satisfies, V];
-          constructor;
-          . exact Ne.symm $ (hf j).2;
-          . rw [←ejk];
+          suffices f (j + 1) ≠ f j ∧ f (j + 1) ≺ f j by simp_all [Satisfies, V]
+          constructor
+          . exact Ne.symm $ (hf j).2
+          . rw [←ejk]
             have H : ∀ {x y : ℕ}, x < y → F.Rel (f x) (f y) := by
-              intro x y hxy;
+              intro x y hxy
               induction hxy with
-              | refl => exact (hf x).1;
-              | step _ ih => exact F.trans ih (hf _).1;
-            by_cases h : j + 1 = k;
-            . subst_vars; simp;
-            . have : j + 1 < k := by omega;
-              exact H this;
-        intro x hx;
-        contrapose;
+              | refl => exact (hf x).1
+              | step _ ih => exact F.trans ih (hf _).1
+            by_cases h : j + 1 = k
+            . subst_vars; simp
+            . have : j + 1 < k := by omega
+              exact H this
+        intro x hx
+        contrapose
         have : Satisfies ⟨F, V⟩ (f j) (□(∼(.atom 0) ➝ ∼□((.atom 0) ➝ □(.atom 0)))) := by
-          simp_all [Satisfies, V];
-          rintro x hx rfl;
-          use f (j + 1);
-          refine ⟨(hf j).1, Ne.symm $ (hf j).2, this.2⟩;
-        exact this _ hx;
-      . simp [Satisfies, V];
+          simp_all [Satisfies, V]
+          rintro x hx rfl
+          use f (j + 1)
+          refine ⟨(hf j).1, Ne.symm $ (hf j).2, this.2⟩
+        exact this _ hx
+      . simp [Satisfies, V]
 
 /-
 protected instance FrameClass.trans_wcwf.definability
 : FrameClass.trans_wcwf.DefinedByFormula (Axioms.Grz (.atom 0)) := ⟨by
-  intro F;
-  constructor;
-  . rintro ⟨hRefl, hTrans, hWCWF⟩;
-    suffices ValidOnFrame F (Axioms.Grz (.atom 0)) by simpa;
-    apply validate_Grz_of_refl_trans_wcwf <;> assumption;
-  . rintro h;
-    replace h : ValidOnFrame F (Axioms.Grz (.atom 0)) := by simpa using h;
-    refine ⟨?_, ?_, ?_⟩;
-    . exact reflexive_of_validate_Grz h;
-    . exact transitive_of_validate_Grz h;
-    . exact WCWF_of_validate_Grz h;
+  intro F
+  constructor
+  . rintro ⟨hRefl, hTrans, hWCWF⟩
+    suffices ValidOnFrame F (Axioms.Grz (.atom 0)) by simpa
+    apply validate_Grz_of_refl_trans_wcwf <;> assumption
+  . rintro h
+    replace h : ValidOnFrame F (Axioms.Grz (.atom 0)) := by simpa using h
+    refine ⟨?_, ?_, ?_⟩
+    . exact reflexive_of_validate_Grz h
+    . exact transitive_of_validate_Grz h
+    . exact WCWF_of_validate_Grz h
 ⟩
 
 protected instance FrameClass.finite_strict_preorder.definability
   : FrameClass.finite_strict_preorder.DefinedByFormula (Axioms.Grz (.atom 0)) := ⟨by
-  intro F;
-  constructor;
-  . rintro ⟨hRefl, hTrans, hAntisymm⟩;
-    suffices F ⊧ (Axioms.Grz (.atom 0)) by simpa;
-    apply validate_Grz_of_refl_trans_wcwf;
-    . assumption;
-    . assumption;
-    . apply WCWF_of_finite_trans_antisymm;
-      . exact F.world_finite;
-      . assumption;
-      . assumption;
-  . rintro h;
-    replace h : F ⊧ (Axioms.Grz (.atom 0)) := by simpa using h;
-    refine ⟨?_, ?_, ?_⟩;
-    . exact reflexive_of_validate_Grz h;
-    . exact transitive_of_validate_Grz h;
-    . exact antisymm_of_WCWF $ WCWF_of_validate_Grz h;
+  intro F
+  constructor
+  . rintro ⟨hRefl, hTrans, hAntisymm⟩
+    suffices F ⊧ (Axioms.Grz (.atom 0)) by simpa
+    apply validate_Grz_of_refl_trans_wcwf
+    . assumption
+    . assumption
+    . apply WCWF_of_finite_trans_antisymm
+      . exact F.world_finite
+      . assumption
+      . assumption
+  . rintro h
+    replace h : F ⊧ (Axioms.Grz (.atom 0)) := by simpa using h
+    refine ⟨?_, ?_, ?_⟩
+    . exact reflexive_of_validate_Grz h
+    . exact transitive_of_validate_Grz h
+    . exact antisymm_of_WCWF $ WCWF_of_validate_Grz h
 ⟩
 -/
 

--- a/Foundation/Modal/Kripke/AxiomH.lean
+++ b/Foundation/Modal/Kripke/AxiomH.lean
@@ -21,25 +21,25 @@ class Frame.IsDetourFree (F : Frame) : Prop where
 lemma Frame.detour_free [F.IsDetourFree] : ∀ {x u y : F}, x ≺ u → u ≺ y → (u = x ∨ u = y) := IsDetourFree.detour_free
 
 lemma Frame.not_exists_detour [F.IsDetourFree] {x y : F} : ¬∃ u, u ≠ x ∧ u ≠ y ∧ x ≺ u ∧ u ≺ y := by
-  by_contra! hC;
-  obtain ⟨u, nexy, neuy, Rxy, Ruy⟩ := hC;
-  rcases F.detour_free Rxy Ruy with (rfl | rfl) <;> contradiction;
+  by_contra! hC
+  obtain ⟨u, nexy, neuy, Rxy, Ruy⟩ := hC
+  rcases F.detour_free Rxy Ruy with (rfl | rfl) <;> contradiction
 
 lemma Frame.IsDetourFree.of_not_exists_detour (h : ∀ {x y : F}, ¬∃ u, u ≠ x ∧ u ≠ y ∧ x ≺ u ∧ u ≺ y) : Frame.IsDetourFree F := by
-  constructor;
-  rintro x y u Rxu Ruy;
-  contrapose! h;
-  use x, u, y;
-  tauto;
+  constructor
+  rintro x y u Rxu Ruy
+  contrapose! h
+  use x, u, y
+  tauto
 
 instance [F.IsFinite] [F.IsDetourFree] : F.IsAntisymmetric := by
-  constructor;
-  intro x y Rxy Ryx;
-  rcases F.detour_free Rxy Ryx with rfl | rfl <;> trivial;
+  constructor
+  intro x y Rxy Ryx
+  rcases F.detour_free Rxy Ryx with rfl | rfl <;> trivial
 
 instance {r : F.World} [F.IsDetourFree] : (F↾r).IsDetourFree := ⟨by
   rintro ⟨x, (rfl | Rrx)⟩ ⟨u, (rfl | Rru)⟩ ⟨y, (rfl | Rry)⟩ Rxu Ruy <;>
-  rcases F.detour_free Rxu Ruy with h | h <;> simp_all;
+  rcases F.detour_free Rxu Ruy with h | h <;> simp_all
 ⟩
 
 end
@@ -49,32 +49,32 @@ section definability
 instance : whitepoint.IsDetourFree := ⟨by tauto⟩
 
 lemma validate_axiomH_of_isDetourFree [F.IsDetourFree] : F ⊧ (Axioms.H (.atom 0)) := by
-  have := @F.detour_free _;
-  contrapose! this;
+  have := @F.detour_free _
+  contrapose! this
 
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not this;
-  replace h := Satisfies.not_imp_def.mp h;
-  have ⟨h₁, h₂⟩ := h;
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not this
+  replace h := Satisfies.not_imp_def.mp h
+  have ⟨h₁, h₂⟩ := h
 
-  replace h₂ := Satisfies.not_box_def.mp h₂;
-  obtain ⟨u, Rxu, h₂⟩ := h₂;
-  replace ⟨h₂, h₃⟩ := Satisfies.not_imp_def.mp h₂;
-  obtain ⟨y, Ruy, h₂⟩ := Satisfies.dia_def.mp h₂;
+  replace h₂ := Satisfies.not_box_def.mp h₂
+  obtain ⟨u, Rxu, h₂⟩ := h₂
+  replace ⟨h₂, h₃⟩ := Satisfies.not_imp_def.mp h₂
+  obtain ⟨y, Ruy, h₂⟩ := Satisfies.dia_def.mp h₂
 
-  use x, u, y;
+  use x, u, y
   refine ⟨Rxu, Ruy, ?_, ?_⟩ <;>
-  . by_contra hC;
-    subst hC;
-    tauto;
+  . by_contra hC
+    subst hC
+    tauto
 
 lemma isDetourFree_of_validate_axiomH (h : F ⊧ (Axioms.H (.atom 0))) : F.IsDetourFree := by
-  constructor;
-  contrapose! h;
-  rcases h with ⟨x, u, y, Rxu, Ruy, neux, neuy⟩;
-  apply ValidOnFrame.not_of_exists_valuation_world;
-  use λ w _ => w ≠ u, x;
-  simp [Satisfies];
-  tauto;
+  constructor
+  contrapose! h
+  rcases h with ⟨x, u, y, Rxu, Ruy, neux, neuy⟩
+  apply ValidOnFrame.not_of_exists_valuation_world
+  use λ w _ => w ≠ u, x
+  simp [Satisfies]
+  tauto
 
 end definability
 
@@ -94,24 +94,24 @@ open MaximalConsistentTableau
 namespace Canonical
 
 instance [Entailment.HasAxiomH 𝓢] : (canonicalFrame 𝓢).IsDetourFree := ⟨by
-  rintro x u y Rxu Ruy;
-  by_contra! hC;
-  obtain ⟨neux, neuy⟩ := hC;
+  rintro x u y Rxu Ruy
+  by_contra! hC
+  obtain ⟨neux, neuy⟩ := hC
 
-  obtain ⟨φ, hφu, hφx⟩ := exists₂₁_of_ne neux;
-  obtain ⟨ψ, hψu, hψy⟩ := exists₂₁_of_ne neuy;
+  obtain ⟨φ, hφu, hφx⟩ := exists₂₁_of_ne neux
+  obtain ⟨ψ, hψu, hψy⟩ := exists₂₁_of_ne neuy
 
   suffices φ ⋎ ψ ∈ u.1.1 by
-    apply neither ⟨this, iff_mem₂_or.mpr $ ?_⟩;
-    tauto;
+    apply neither ⟨this, iff_mem₂_or.mpr $ ?_⟩
+    tauto
 
   have : □(◇(φ ⋎ ψ) ➝ φ ⋎ ψ) ∈ x.1.1 := mdp_mem₁_provable axiomH! $ by
-    apply iff_mem₁_or.mpr;
-    tauto;
-  apply iff_mem₁_imp'.mp $ def_rel_box_mem₁.mp Rxu this;
-  apply def_rel_dia_mem₁.mp Ruy;
-  apply iff_mem₁_or.mpr;
-  tauto;
+    apply iff_mem₁_or.mpr
+    tauto
+  apply iff_mem₁_imp'.mp $ def_rel_box_mem₁.mp Rxu this
+  apply def_rel_dia_mem₁.mp Ruy
+  apply iff_mem₁_or.mpr
+  tauto
 ⟩
 
 end Canonical

--- a/Foundation/Modal/Kripke/AxiomL.lean
+++ b/Foundation/Modal/Kripke/AxiomL.lean
@@ -19,110 +19,110 @@ instance [F.IsFinite] [F.IsTransitive] [F.IsIrreflexive] : F.IsConverseWellFound
 
 
 lemma validate_AxiomL_of_trans_cwf [F.IsTransitive] [F.IsConverseWellFounded] : F ⊧ (Axioms.L (.atom 0)) := by
-  rintro V w;
-  apply Satisfies.imp_def.mpr;
-  contrapose;
-  intro h;
-  obtain ⟨x, Rwx, h⟩ := by simpa using Satisfies.box_def.not.mp h;
+  rintro V w
+  apply Satisfies.imp_def.mpr
+  contrapose
+  intro h
+  obtain ⟨x, Rwx, h⟩ := by simpa using Satisfies.box_def.not.mp h
   obtain ⟨m, ⟨⟨Rwm, hm⟩, hm₂⟩⟩ := F.cwf.has_min ({ x | w ≺ x ∧ ¬(Satisfies ⟨F, V⟩ x (.atom 0)) }) $ by
-    use x;
-    tauto;
-  replace hm₂ : ∀ x, w ≺ x → ¬Satisfies ⟨F, V⟩ x (.atom 0) → ¬m ≺ x := by simpa using hm₂;
-  apply Satisfies.not_box_def.mpr;
-  use m;
-  constructor;
-  . assumption;
-  . apply Satisfies.not_imp_def.mpr;
-    constructor;
-    . intro n rmn;
-      apply not_imp_not.mp $ hm₂ n (IsTrans.trans _ _ _ Rwm rmn);
-      exact rmn;
-    . assumption;
+    use x
+    tauto
+  replace hm₂ : ∀ x, w ≺ x → ¬Satisfies ⟨F, V⟩ x (.atom 0) → ¬m ≺ x := by simpa using hm₂
+  apply Satisfies.not_box_def.mpr
+  use m
+  constructor
+  . assumption
+  . apply Satisfies.not_imp_def.mpr
+    constructor
+    . intro n rmn
+      apply not_imp_not.mp $ hm₂ n (IsTrans.trans _ _ _ Rwm rmn)
+      exact rmn
+    . assumption
 
 lemma validate_AxiomL_of_finite_trans_irrefl [F.IsFinite] [F.IsTransitive] [F.IsIrreflexive] : F ⊧ (Axioms.L (.atom 0)) := validate_AxiomL_of_trans_cwf
 
 lemma isTransitive_of_validate_axiomL (h : F ⊧ (Axioms.L (.atom 0))) : F.IsTransitive where
   trans := by
-    revert h;
-    contrapose!;
-    intro hT;
-    obtain ⟨w, v, Rwv, u, Rvu, nRwu⟩ := by simpa [Transitive] using hT;
-    apply ValidOnFrame.not_of_exists_valuation_world;
-    use (λ w _ => w ≠ v ∧ w ≠ u), w;
-    apply Satisfies.imp_def.not.mpr;
-    push_neg;
-    constructor;
-    . intro x Rwx hx;
-      by_cases exv : x = v;
-      . subst x;
-        simpa using Satisfies.atom_def.mp $ @hx u Rvu;
-      . apply Satisfies.atom_def.mpr;
-        constructor;
-        . assumption;
-        . by_contra hC;
-          subst x;
-          contradiction;
-    . apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use v;
-      constructor;
-      . assumption;
-      . simp [Semantics.Realize, Satisfies];
+    revert h
+    contrapose!
+    intro hT
+    obtain ⟨w, v, Rwv, u, Rvu, nRwu⟩ := by simpa [Transitive] using hT
+    apply ValidOnFrame.not_of_exists_valuation_world
+    use (λ w _ => w ≠ v ∧ w ≠ u), w
+    apply Satisfies.imp_def.not.mpr
+    push_neg
+    constructor
+    . intro x Rwx hx
+      by_cases exv : x = v
+      . subst x
+        simpa using Satisfies.atom_def.mp $ @hx u Rvu
+      . apply Satisfies.atom_def.mpr
+        constructor
+        . assumption
+        . by_contra hC
+          subst x
+          contradiction
+    . apply Satisfies.box_def.not.mpr
+      push_neg
+      use v
+      constructor
+      . assumption
+      . simp [Semantics.Realize, Satisfies]
 
 lemma isConverseWellFounded_of_validate_axiomL (h : F ⊧ (Axioms.L (.atom 0))) : F.IsConverseWellFounded where
   cwf := by
-    revert h;
-    contrapose;
-    intro hCF;
-    obtain ⟨X, ⟨x, _⟩, hX₂⟩ := by simpa using ConverseWellFounded.iff_has_max.not.mp hCF;
-    apply ValidOnFrame.not_of_exists_valuation_world;
-    use (λ w _ => w ∉ X), x;
-    apply Satisfies.imp_def.not.mpr;
-    push_neg;
-    constructor;
-    . intro y Rxy;
+    revert h
+    contrapose
+    intro hCF
+    obtain ⟨X, ⟨x, _⟩, hX₂⟩ := by simpa using ConverseWellFounded.iff_has_max.not.mp hCF
+    apply ValidOnFrame.not_of_exists_valuation_world
+    use (λ w _ => w ∉ X), x
+    apply Satisfies.imp_def.not.mpr
+    push_neg
+    constructor
+    . intro y Rxy
       by_cases hys : y ∈ X
-      . obtain ⟨z, _, Rxz⟩ := hX₂ y hys;
-        intro hy;
-        have : z ∉ X := by simpa using Satisfies.atom_def.mp $ hy z Rxz;
-        contradiction;
-      . intro _;
-        apply Satisfies.atom_def.mpr;
-        simpa;
-    . obtain ⟨y, _, _⟩ := hX₂ x (by assumption);
-      apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use y;
-      constructor;
-      . assumption;
-      . simpa [Semantics.Realize, Satisfies];
+      . obtain ⟨z, _, Rxz⟩ := hX₂ y hys
+        intro hy
+        have : z ∉ X := by simpa using Satisfies.atom_def.mp $ hy z Rxz
+        contradiction
+      . intro _
+        apply Satisfies.atom_def.mpr
+        simpa
+    . obtain ⟨y, _, _⟩ := hX₂ x (by assumption)
+      apply Satisfies.box_def.not.mpr
+      push_neg
+      use y
+      constructor
+      . assumption
+      . simpa [Semantics.Realize, Satisfies]
 
 /-
 protected instance FrameClass.transitive_cwf.definability : FrameClass.trans_cwf.DefinedByFormula (Axioms.L (.atom 0)) := ⟨by
-  intro F;
-  constructor;
-  . simpa using validate_L_of_trans_and_cwf;
-  . intro h;
-    constructor;
-    . apply trans_of_validate_L; simp_all;
-    . apply cwf_of_validate_L; simp_all;
+  intro F
+  constructor
+  . simpa using validate_L_of_trans_and_cwf
+  . intro h
+    constructor
+    . apply trans_of_validate_L; simp_all
+    . apply cwf_of_validate_L; simp_all
 ⟩
 
 protected instance FrameClass.finite_trans_irrefl.definability : FrameClass.finite_trans_irrefl.DefinedByFormula (Axioms.L (.atom 0)) := ⟨by
-  intro F;
-  constructor;
-  . rintro ⟨hTrans, hIrrefl⟩ φ ⟨_, rfl⟩;
-    apply validate_L_of_trans_and_cwf;
-    . assumption;
-    . apply Finite.converseWellFounded_of_trans_irrefl';
-      . exact F.world_finite;
-      . assumption;
-      . assumption;
-  . intro h;
-    refine ⟨?_, ?_⟩;
-    . apply trans_of_validate_L; simpa using h;
-    . intro w;
-      simpa using ConverseWellFounded.iff_has_max.mp (cwf_of_validate_L (by simpa using h)) {w} (by simp);
+  intro F
+  constructor
+  . rintro ⟨hTrans, hIrrefl⟩ φ ⟨_, rfl⟩
+    apply validate_L_of_trans_and_cwf
+    . assumption
+    . apply Finite.converseWellFounded_of_trans_irrefl'
+      . exact F.world_finite
+      . assumption
+      . assumption
+  . intro h
+    refine ⟨?_, ?_⟩
+    . apply trans_of_validate_L; simpa using h
+    . intro w
+      simpa using ConverseWellFounded.iff_has_max.mp (cwf_of_validate_L (by simpa using h)) {w} (by simp)
 ⟩
 -/
 

--- a/Foundation/Modal/Kripke/AxiomMcK.lean
+++ b/Foundation/Modal/Kripke/AxiomMcK.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.Preorder.Finite
 namespace LO.Modal
 
 @[simp]
-lemma eq_box_toSet_toSet_box {F : Type*} [Box F] [DecidableEq F] {s : Finset F} : s.toSet.box = s.box.toSet := by ext φ; simp;
+lemma eq_box_toSet_toSet_box {F : Type*} [Box F] [DecidableEq F] {s : Finset F} : s.toSet.box = s.box.toSet := by ext φ; simp
 
 
 namespace Logic.K
@@ -22,60 +22,60 @@ open Formula.Kripke
 variable {φ ψ : Formula _}
 
 lemma axiomMcK_DiaCDiaBox! : Hilbert.K ⊢! (□◇φ ➝ ◇□φ) ⭤ ◇(◇φ ➝ □φ) := by
-  apply Complete.complete (𝓜 := Kripke.FrameClass.K);
-  intro F _ V x;
-  apply Satisfies.iff_def.mpr;
-  constructor;
-  . intro h;
-    apply Satisfies.dia_def.mpr;
-    by_cases hx : Satisfies _ x (□◇φ);
-    . obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp $ h hx;
-      use y;
-      constructor;
-      . assumption;
-      . tauto;
-    . have := Satisfies.box_def.not.mp hx;
-      push_neg at this;
-      obtain ⟨y, Rxy, hy⟩ := this;
-      use y;
-      constructor;
-      . assumption;
-      . intro h;
-        contradiction;
-  . intro hx₁ hx₂;
-    obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₁;
-    apply Satisfies.dia_def.mpr;
-    use y;
+  apply Complete.complete (𝓜 := Kripke.FrameClass.K)
+  intro F _ V x
+  apply Satisfies.iff_def.mpr
+  constructor
+  . intro h
+    apply Satisfies.dia_def.mpr
+    by_cases hx : Satisfies _ x (□◇φ)
+    . obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp $ h hx
+      use y
+      constructor
+      . assumption
+      . tauto
+    . have := Satisfies.box_def.not.mp hx
+      push_neg at this
+      obtain ⟨y, Rxy, hy⟩ := this
+      use y
+      constructor
+      . assumption
+      . intro h
+        contradiction
+  . intro hx₁ hx₂
+    obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₁
+    apply Satisfies.dia_def.mpr
+    use y
     constructor
-    . assumption;
-    . exact hy $ hx₂ _ Rxy;
+    . assumption
+    . exact hy $ hx₂ _ Rxy
 
 lemma CKDiaBoxDiaK! : Hilbert.K ⊢! (◇φ ⋏ □ψ) ➝ ◇(φ ⋏ ψ) := by
-  apply Complete.complete (𝓜 := Kripke.FrameClass.K);
-  intro F _ V x hx;
-  have ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx;
-  have ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₁;
-  apply Satisfies.dia_def.mpr;
-  use y;
-  constructor;
-  . assumption;
-  . apply Satisfies.and_def.mpr;
-    constructor;
+  apply Complete.complete (𝓜 := Kripke.FrameClass.K)
+  intro F _ V x hx
+  have ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx
+  have ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₁
+  apply Satisfies.dia_def.mpr
+  use y
+  constructor
+  . assumption
+  . apply Satisfies.and_def.mpr
+    constructor
     . assumption
-    . apply hx₂ _ Rxy;
+    . apply hx₂ _ Rxy
 
 lemma CKBoxDiaDiaK! : Hilbert.K ⊢! (□φ ⋏ ◇ψ) ➝ ◇(φ ⋏ ψ) := by
-  apply Complete.complete (𝓜 := Kripke.FrameClass.K);
-  intro F _ V x hx;
-  have ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx;
-  have ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₂;
-  apply Satisfies.dia_def.mpr;
-  use y;
-  constructor;
-  . assumption;
-  . apply Satisfies.and_def.mpr;
-    constructor;
-    . apply hx₁ _ Rxy;
+  apply Complete.complete (𝓜 := Kripke.FrameClass.K)
+  intro F _ V x hx
+  have ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx
+  have ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp hx₂
+  apply Satisfies.dia_def.mpr
+  use y
+  constructor
+  . assumption
+  . apply Satisfies.and_def.mpr
+    constructor
+    . apply hx₁ _ Rxy
     . assumption
 
 end Logic.K
@@ -99,27 +99,27 @@ lemma DiaCDiaBox! : Hilbert.K4McK ⊢! ◇(◇φ ➝ □φ) :=
 
 lemma DiaConjCDiabox {Γ : List _} (hΓ : Γ ≠ []) : Hilbert.K4McK ⊢! ◇(Γ.map (λ φ => ◇φ ➝ □φ)).conj := by
   induction Γ using List.induction_with_singleton with
-  | hnil => tauto;
+  | hnil => tauto
   | hsingle φ =>
-    apply diaK''! ?_ $ DiaCDiaBox! (φ := φ);
-    apply right_K!_intro <;> simp;
+    apply diaK''! ?_ $ DiaCDiaBox! (φ := φ)
+    apply right_K!_intro <;> simp
   | hcons φ Γ _ ih =>
     have : Hilbert.K4McK ⊢! ◇□(◇φ ➝ □φ) ⋏ □◇(List.map (fun φ ↦ (◇φ ➝ □φ)) Γ).conj := by
-      apply K!_intro;
-      . exact axiomMcK! ⨀ (nec! DiaCDiaBox!);
-      . exact nec! $ ih $ by assumption;
-    have : Hilbert.K4McK ⊢! ◇(□(◇φ ➝ □φ) ⋏ ◇(List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := DiaK!_of_CKBoxDia this;
-    replace : Hilbert.K4McK ⊢! ◇◇((◇φ ➝ □φ) ⋏ (List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := diaK''! CKBoxDiaDiaK! this;
-    replace : Hilbert.K4McK ⊢! ◇((◇φ ➝ □φ) ⋏ (List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := diaFour'! this;
-    exact this;
+      apply K!_intro
+      . exact axiomMcK! ⨀ (nec! DiaCDiaBox!)
+      . exact nec! $ ih $ by assumption
+    have : Hilbert.K4McK ⊢! ◇(□(◇φ ➝ □φ) ⋏ ◇(List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := DiaK!_of_CKBoxDia this
+    replace : Hilbert.K4McK ⊢! ◇◇((◇φ ➝ □φ) ⋏ (List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := diaK''! CKBoxDiaDiaK! this
+    replace : Hilbert.K4McK ⊢! ◇((◇φ ➝ □φ) ⋏ (List.map (fun φ ↦ ◇φ ➝ □φ) Γ).conj) := diaFour'! this
+    exact this
 
 lemma DiaFconjCDiabox {Γ : Finset _} (hΓ : Γ ≠ ∅) : Hilbert.K4McK ⊢! ◇(Γ.image (λ φ => ◇φ ➝ □φ)).conj := by
-  apply diaK''! ?_ (h₂ := DiaConjCDiabox (Γ := Γ.toList) ?_);
-  . apply right_Fconj!_intro;
-    intro ψ hψ;
-    apply left_Conj!_intro;
-    simpa using hψ;
-  . simpa;
+  apply diaK''! ?_ (h₂ := DiaConjCDiabox (Γ := Γ.toList) ?_)
+  . apply right_Fconj!_intro
+    intro ψ hψ
+    apply left_Conj!_intro
+    simpa using hψ
+  . simpa
 
 end Logic.K4McK
 
@@ -137,9 +137,9 @@ class Frame.SatisfiesMcKinseyCondition (F : Frame) where
 lemma Frame.mckinsey [F.SatisfiesMcKinseyCondition] : ∀ x : F, ∃ y, x ≺ y ∧ ∀ z, y ≺ z → y = z := SatisfiesMcKinseyCondition.mckinsey
 
 instance : whitepoint.SatisfiesMcKinseyCondition := ⟨by
-  intro x;
-  use x;
-  tauto;
+  intro x
+  use x
+  tauto
 ⟩
 
 section definability
@@ -148,24 +148,24 @@ open Formula (atom)
 open Formula.Kripke
 
 lemma validate_axiomMcK_of_satisfiesMcKinseyCondition [F.SatisfiesMcKinseyCondition] : F ⊧ (Axioms.McK (.atom 0)) := by
-  have := Frame.SatisfiesMcKinseyCondition.mckinsey (F := F);
-  revert this;
-  contrapose!;
-  intro h;
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h;
-  have ⟨h₁, h₂⟩ := Satisfies.not_imp_def.mp h;
-  use x;
-  intro y Rxy;
-  obtain ⟨z, Ryz, hz⟩ := Satisfies.dia_def.mp $ h₁ _ Rxy;
-  obtain ⟨w, Ryw, h₂⟩ := Satisfies.not_box_def.mp $ (Satisfies.not_dia_def.mp h₂) y Rxy;
-  by_cases eyz : y = z;
-  . subst eyz;
-    use w;
-    constructor;
-    . assumption;
-    . by_contra hC; subst hC;
-      contradiction;
-  . tauto;
+  have := Frame.SatisfiesMcKinseyCondition.mckinsey (F := F)
+  revert this
+  contrapose!
+  intro h
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h
+  have ⟨h₁, h₂⟩ := Satisfies.not_imp_def.mp h
+  use x
+  intro y Rxy
+  obtain ⟨z, Ryz, hz⟩ := Satisfies.dia_def.mp $ h₁ _ Rxy
+  obtain ⟨w, Ryw, h₂⟩ := Satisfies.not_box_def.mp $ (Satisfies.not_dia_def.mp h₂) y Rxy
+  by_cases eyz : y = z
+  . subst eyz
+    use w
+    constructor
+    . assumption
+    . by_contra hC; subst hC
+      contradiction
+  . tauto
 
 end definability
 
@@ -182,76 +182,76 @@ namespace Canonical
 
 open Classical in
 instance [Hilbert.K4McK ⪯ H] : (canonicalFrame H).SatisfiesMcKinseyCondition := ⟨by
-  rintro x;
+  rintro x
   have ⟨y, hy⟩ := lindenbaum (𝓢 := H) (t₀ := ⟨x.1.1.prebox ∪ Set.univ.image (λ φ => ◇φ ➝ □φ), ∅⟩) $ by
-    intro Γ Δ hΓ hΔ;
+    intro Γ Δ hΓ hΔ
     suffices H ⊬ Γ.conj ➝ ⊥ by
-      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ;
-      subst hΔ;
-      simpa;
-    by_contra! hC;
-    replace hC := FConj_DT.mp hC;
+      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ
+      subst hΔ
+      simpa
+    by_contra! hC
+    replace hC := FConj_DT.mp hC
 
-    let Γ' := insert (◇⊤ ➝ □⊤) Γ;
-    replace hC : Γ'.toSet *⊢[H]! ⊥ := Context.weakening! (by simp [Γ']) hC;
+    let Γ' := insert (◇⊤ ➝ □⊤) Γ
+    replace hC : Γ'.toSet *⊢[H]! ⊥ := Context.weakening! (by simp [Γ']) hC
 
-    let Γ'₁ := { φ ∈ Γ' | φ ∈ x.1.1.prebox };
-    let Γ'₂ := { φ ∈ Γ' | ∃ ψ, ◇ψ ➝ □ψ = φ };
-    apply MaximalConsistentTableau.neither (t := x) (φ := ◇Γ'₂.conj);
-    constructor;
-    . apply iff_provable_mem₁.mp;
-      apply WeakerThan.pbl (𝓢 := Hilbert.K4McK);
+    let Γ'₁ := { φ ∈ Γ' | φ ∈ x.1.1.prebox }
+    let Γ'₂ := { φ ∈ Γ' | ∃ ψ, ◇ψ ➝ □ψ = φ }
+    apply MaximalConsistentTableau.neither (t := x) (φ := ◇Γ'₂.conj)
+    constructor
+    . apply iff_provable_mem₁.mp
+      apply WeakerThan.pbl (𝓢 := Hilbert.K4McK)
       convert Logic.K4McK.DiaFconjCDiabox (Γ := Γ'.preimage (λ φ => ◇φ ➝ □φ) (by simp [Set.InjOn])) ?_
-      . simp [Γ'₂, Finset.image_preimage];
+      . simp [Γ'₂, Finset.image_preimage]
       . simp [
           Γ',
           (show insert (◇⊤ ➝ □⊤) Γ = {◇⊤ ➝ □⊤} ∪ Γ by ext; simp),
           (show Finset.preimage {◇⊤ ➝ □⊤} (fun φ ↦ ◇φ ➝ □φ) (by simp [Set.InjOn]) = {(⊤ : Formula ℕ)} by ext; simp),
-        ];
+        ]
     . replace hC : (Γ'₁ ∪ Γ'₂).toSet *⊢[H]! ⊥ := by
-        convert hC;
-        ext φ;
-        simp only [Set.mem_preimage, Function.iterate_one, Finset.mem_union, Finset.mem_filter, Finset.mem_insert, Γ'₁, Γ', Γ'₂];
-        constructor;
-        . tauto;
-        . rintro (rfl | h);
-          . tauto;
-          . have := hΓ h;
-            simp at this ⊢;
-            tauto;
-      replace hC : Γ'₁.toSet.box *⊢[H]! □(∼Γ'₂.conj) := Context.nec! $ N!_iff_CO!.mpr $ FConj_DT'.mpr hC;
-      replace hC : Γ'₁.box.toSet *⊢[H]! □(∼Γ'₂.conj) := by convert hC; simp;
+        convert hC
+        ext φ
+        simp only [Set.mem_preimage, Function.iterate_one, Finset.mem_union, Finset.mem_filter, Finset.mem_insert, Γ'₁, Γ', Γ'₂]
+        constructor
+        . tauto
+        . rintro (rfl | h)
+          . tauto
+          . have := hΓ h
+            simp at this ⊢
+            tauto
+      replace hC : Γ'₁.toSet.box *⊢[H]! □(∼Γ'₂.conj) := Context.nec! $ N!_iff_CO!.mpr $ FConj_DT'.mpr hC
+      replace hC : Γ'₁.box.toSet *⊢[H]! □(∼Γ'₂.conj) := by convert hC; simp
       replace hC : Γ'₁.box.toSet *⊢[H]! ∼◇(Γ'₂.conj) := by
-        apply FConj_DT.mp;
-        apply C!_trans $ FConj_DT.mpr hC;
-        simp;
-      apply iff_mem₁_neg.mp;
-      apply iff_provable_include₁.mp hC x;
-      intro _;
+        apply FConj_DT.mp
+        apply C!_trans $ FConj_DT.mpr hC
+        simp
+      apply iff_mem₁_neg.mp
+      apply iff_provable_include₁.mp hC x
+      intro _
       simp only [Set.mem_preimage, Function.iterate_one, Finset.coe_image, Finset.coe_filter,
-        Set.mem_image, Set.mem_setOf_eq, forall_exists_index, and_imp, Γ'₁];
-      rintro χ hχ _ rfl;
-      assumption;
+        Set.mem_image, Set.mem_setOf_eq, forall_exists_index, and_imp, Γ'₁]
+      rintro χ hχ _ rfl
+      assumption
   have Rxy : (canonicalFrame H).Rel x y := by
-    dsimp [canonicalFrame];
-    trans (x.1.1.prebox ∪ Set.univ.image (λ φ => ◇φ ➝ □φ));
-    . apply Set.subset_union_left;
-    . simpa using hy;
-  by_cases hy : ∃ z, (canonicalFrame H).Rel y z;
-  . obtain ⟨z, Ryz⟩ := hy;
-    use z;
-    constructor;
-    . exact (canonicalFrame H).trans Rxy Ryz;
-    . intro u Rzu;
-      by_contra! ezu;
-      obtain ⟨ξ, hξ₁, hξ₂⟩ := exists₁₂_of_ne ezu;
-      have : □ξ ∈ y.1.1 := iff_mem₁_imp'.mp (by apply hy.1; simp) $ def_rel_dia_mem₁.mp Ryz hξ₁;
-      have : ξ ∈ u.1.1 := def_rel_box_mem₁.mp ((canonicalFrame H).trans Ryz Rzu) this;
-      exact iff_not_mem₂_mem₁.mpr this hξ₂;
-  . use y;
-    constructor;
-    . assumption;
-    . tauto;
+    dsimp [canonicalFrame]
+    trans (x.1.1.prebox ∪ Set.univ.image (λ φ => ◇φ ➝ □φ))
+    . apply Set.subset_union_left
+    . simpa using hy
+  by_cases hy : ∃ z, (canonicalFrame H).Rel y z
+  . obtain ⟨z, Ryz⟩ := hy
+    use z
+    constructor
+    . exact (canonicalFrame H).trans Rxy Ryz
+    . intro u Rzu
+      by_contra! ezu
+      obtain ⟨ξ, hξ₁, hξ₂⟩ := exists₁₂_of_ne ezu
+      have : □ξ ∈ y.1.1 := iff_mem₁_imp'.mp (by apply hy.1; simp) $ def_rel_dia_mem₁.mp Ryz hξ₁
+      have : ξ ∈ u.1.1 := def_rel_box_mem₁.mp ((canonicalFrame H).trans Ryz Rzu) this
+      exact iff_not_mem₂_mem₁.mpr this hξ₂
+  . use y
+    constructor
+    . assumption
+    . tauto
 ⟩
 
 end Canonical

--- a/Foundation/Modal/Kripke/AxiomMk.lean
+++ b/Foundation/Modal/Kripke/AxiomMk.lean
@@ -14,31 +14,31 @@ class Frame.SatisfiesMakinsonCondition (F : Frame) where
 lemma Frame.makinson [F.SatisfiesMakinsonCondition] : ∀ x : F, ∃ y, x ≺ y ∧ y ≺ x ∧ (∀ z, y ≺^[2] z → x ≺ z) := SatisfiesMakinsonCondition.makinson
 
 instance : whitepoint.SatisfiesMakinsonCondition := ⟨by
-  intro x;
-  use x;
-  tauto;
+  intro x
+  use x
+  tauto
 ⟩
 
 section definability
 
 lemma validate_axiomMk_of_satisfiesMakinsonCondition [F.SatisfiesMakinsonCondition] : F ⊧ (Axioms.Mk (.atom 0) (.atom 1)) := by
-  intro V x hx;
-  replace ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx;
-  obtain ⟨y, Rxy, Ryx, hz⟩ := Frame.makinson x;
-  apply Satisfies.dia_def.mpr;
-  use y;
-  constructor;
-  . assumption;
-  . apply Satisfies.and_def.mpr;
-    constructor;
-    . suffices Satisfies ⟨F, V⟩ y (□^[2](.atom 0)) by simpa using this;
+  intro V x hx
+  replace ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx
+  obtain ⟨y, Rxy, Ryx, hz⟩ := Frame.makinson x
+  apply Satisfies.dia_def.mpr
+  use y
+  constructor
+  . assumption
+  . apply Satisfies.and_def.mpr
+    constructor
+    . suffices Satisfies ⟨F, V⟩ y (□^[2](.atom 0)) by simpa using this
       apply Satisfies.multibox_def.mpr
-      intro z Ryz;
-      apply hx₁;
-      apply hz;
-      exact Ryz;
-    . apply Satisfies.dia_def.mpr;
-      use x;
+      intro z Ryz
+      apply hx₁
+      apply hz
+      exact Ryz
+    . apply Satisfies.dia_def.mpr
+      use x
 
 end definability
 
@@ -56,42 +56,42 @@ namespace Canonical
 
 open Classical in
 instance [Entailment.HasAxiomT 𝓢] [Entailment.HasAxiomMk 𝓢] : (canonicalFrame 𝓢).SatisfiesMakinsonCondition := ⟨by
-  sorry;
+  sorry
   /-
-  rintro x;
+  rintro x
   obtain ⟨y, hy⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨x.1.1.prebox, x.1.2.box ∪ x.1.2.dia⟩) $ by
-    rintro Γ Δ hΓ hΔ;
-    by_contra! hC;
-    let Δ₁ := { φ ∈ Δ | φ ∈ x.1.2.box };
-    let Δ₂ := { φ ∈ Δ | φ ∈ x.1.2.dia };
+    rintro Γ Δ hΓ hΔ
+    by_contra! hC
+    let Δ₁ := { φ ∈ Δ | φ ∈ x.1.2.box }
+    let Δ₂ := { φ ∈ Δ | φ ∈ x.1.2.dia }
     have eΔ : Δ = Δ₁ ∪ Δ₂ := by
-      ext φ;
-      simp only [Set.mem_image, Function.iterate_one, Finset.mem_union, Finset.mem_filter, Δ₁, Δ₂];
-      constructor;
-      . rintro h;
-        rcases hΔ h with h₁ | h₂ <;> tauto;
-      . tauto;
-    rw [eΔ] at hC;
-    have : 𝓢 ⊢! Γ.conj ➝ Δ₁.disj ⋎ Δ₂.disj := C!_trans hC CFdisjUnionAFdisj;
+      ext φ
+      simp only [Set.mem_image, Function.iterate_one, Finset.mem_union, Finset.mem_filter, Δ₁, Δ₂]
+      constructor
+      . rintro h
+        rcases hΔ h with h₁ | h₂ <;> tauto
+      . tauto
+    rw [eΔ] at hC
+    have : 𝓢 ⊢! Γ.conj ➝ Δ₁.disj ⋎ Δ₂.disj := C!_trans hC CFdisjUnionAFdisj
     have : 𝓢 ⊢! □Γ.prebox.conj ➝ Δ₁.disj ⋎ Δ₂.disj := C!_trans (by
-      apply right_Fconj!_intro;
-      intro φ hφ;
-      have := hΓ hφ;
-      simp at this;
+      apply right_Fconj!_intro
+      intro φ hφ
+      have := hΓ hφ
+      simp at this
       sorry
-    ) this;
-    sorry;
-  use y;
-  refine ⟨?_, ?_, ?_⟩;
-  . exact hy.1;
-  . apply def_rel_box_mem₂.mpr;
-    intro φ hφ;
-    exact @hy.2 (□φ) (by left; simpa);
-  . rintro z Ryz;
-    apply def_rel_dia_mem₂.mpr;
-    intro φ hφ;
-    apply def_multirel_multidia_mem₂.mp Ryz;
-    exact @hy.2 (◇◇φ) (by simpa);
+    ) this
+    sorry
+  use y
+  refine ⟨?_, ?_, ?_⟩
+  . exact hy.1
+  . apply def_rel_box_mem₂.mpr
+    intro φ hφ
+    exact @hy.2 (□φ) (by left; simpa)
+  . rintro z Ryz
+    apply def_rel_dia_mem₂.mpr
+    intro φ hφ
+    apply def_multirel_multidia_mem₂.mp Ryz
+    exact @hy.2 (◇◇φ) (by simpa)
   -/
 ⟩
 

--- a/Foundation/Modal/Kripke/AxiomPoint3.lean
+++ b/Foundation/Modal/Kripke/AxiomPoint3.lean
@@ -22,7 +22,7 @@ end Frame
 
 
 instance : whitepoint.IsPiecewiseStronglyConnected where
-  ps_connected := by tauto;
+  ps_connected := by tauto
 
 
 section definability
@@ -31,30 +31,30 @@ open Formula (atom)
 open Formula.Kripke
 
 lemma validate_axiomPoint3_of_isPiecewiseStronglyConnected [F.IsPiecewiseStronglyConnected] : F ⊧ (Axioms.Point3 (.atom 0) (.atom 1)) := by
-  rintro V x;
-  apply Satisfies.or_def.mpr;
+  rintro V x
+  apply Satisfies.or_def.mpr
   suffices
     (∀ y, x ≺ y → (∀ z, y ≺ z → V z 0) → V y 1) ∨
     (∀ y, x ≺ y → (∀ z, y ≺ z → V z 1) → V y 0)
-    by simpa [Semantics.Realize, Satisfies];
-  by_contra hC;
-  push_neg at hC;
-  obtain ⟨⟨y, Rxy, hp, hnq⟩, ⟨z, Rxz, hq, hnp⟩⟩ := hC;
-  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz with (Ryz | Rzy);
-  . have := hp z Ryz; contradiction;
-  . have := hq y Rzy; contradiction;
+    by simpa [Semantics.Realize, Satisfies]
+  by_contra hC
+  push_neg at hC
+  obtain ⟨⟨y, Rxy, hp, hnq⟩, ⟨z, Rxz, hq, hnp⟩⟩ := hC
+  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz with (Ryz | Rzy)
+  . have := hp z Ryz; contradiction
+  . have := hq y Rzy; contradiction
 
 lemma isPiecewiseStronglyConnected_of_validate_axiomPoint3 (h : F ⊧ (Axioms.Point3 (.atom 0) (.atom 1))) : F.IsPiecewiseStronglyConnected where
   ps_connected := by
-    dsimp [PiecewiseStronglyConnected];
-    revert h;
-    contrapose!;
-    rintro ⟨x, y, z, Rxy, Rxz, nRyz, nRzy⟩;
-    apply ValidOnFrame.not_of_exists_valuation_world;
-    use (λ w a => match a with | 0 => y ≺ w | 1 => z ≺ w | _ => False), x;
+    dsimp [PiecewiseStronglyConnected]
+    revert h
+    contrapose!
+    rintro ⟨x, y, z, Rxy, Rxz, nRyz, nRzy⟩
+    apply ValidOnFrame.not_of_exists_valuation_world
+    use (λ w a => match a with | 0 => y ≺ w | 1 => z ≺ w | _ => False), x
     suffices ∃ y', x ≺ y' ∧ (∀ z', y' ≺ z' → y ≺ z') ∧ ¬z ≺ y' ∧ (∃ z', x ≺ z' ∧ (∀ y, z' ≺ y → z ≺ y) ∧ ¬y ≺ z') by
-      simpa [Semantics.Realize, Satisfies];
-    refine ⟨y, Rxy, by tauto, nRzy, z, Rxz, by tauto, nRyz⟩;
+      simpa [Semantics.Realize, Satisfies]
+    refine ⟨y, Rxy, by tauto, nRzy, z, Rxz, by tauto, nRyz⟩
 
 end definability
 
@@ -71,33 +71,33 @@ open canonicalModel
 
 instance [Entailment.HasAxiomPoint3 𝓢] : (canonicalFrame 𝓢).IsPiecewiseStronglyConnected where
   ps_connected := by
-    rintro x y z Rxy Rxz;
-    by_contra hC;
-    push_neg at hC;
-    rcases hC with ⟨nRyz, nRzy⟩;
-    obtain ⟨φ, hφy, hφz⟩ := Set.not_subset.mp nRyz;
-    obtain ⟨ψ, hψz, hψy⟩ := Set.not_subset.mp nRzy;
-    apply x.neither (φ := □(□φ ➝ ψ) ⋎ □(□ψ ➝ φ));
-    constructor;
-    . exact iff_provable_mem₁.mp axiomPoint3! x;
-    . apply iff_mem₂_or.mpr;
-      constructor;
-      . apply iff_mem₂_box.mpr;
-        use y;
-        constructor;
-        . exact Rxy;
-        . apply iff_mem₂_imp.mpr;
-          constructor;
-          . simpa using hφy;
-          . exact iff_not_mem₁_mem₂.mp hψy;
-      . apply iff_mem₂_box.mpr;
-        use z;
-        constructor;
-        . exact Rxz;
-        . apply iff_mem₂_imp.mpr;
-          constructor;
-          . simpa using hψz;
-          . exact iff_not_mem₁_mem₂.mp hφz;
+    rintro x y z Rxy Rxz
+    by_contra hC
+    push_neg at hC
+    rcases hC with ⟨nRyz, nRzy⟩
+    obtain ⟨φ, hφy, hφz⟩ := Set.not_subset.mp nRyz
+    obtain ⟨ψ, hψz, hψy⟩ := Set.not_subset.mp nRzy
+    apply x.neither (φ := □(□φ ➝ ψ) ⋎ □(□ψ ➝ φ))
+    constructor
+    . exact iff_provable_mem₁.mp axiomPoint3! x
+    . apply iff_mem₂_or.mpr
+      constructor
+      . apply iff_mem₂_box.mpr
+        use y
+        constructor
+        . exact Rxy
+        . apply iff_mem₂_imp.mpr
+          constructor
+          . simpa using hφy
+          . exact iff_not_mem₁_mem₂.mp hψy
+      . apply iff_mem₂_box.mpr
+        use z
+        constructor
+        . exact Rxz
+        . apply iff_mem₂_imp.mpr
+          constructor
+          . simpa using hψz
+          . exact iff_not_mem₁_mem₂.mp hφz
 
 end canonicality
 

--- a/Foundation/Modal/Kripke/AxiomPoint4.lean
+++ b/Foundation/Modal/Kripke/AxiomPoint4.lean
@@ -15,17 +15,17 @@ class SatisfiesSobocinskiCondition (F : Kripke.Frame) where
 
 instance [F.SatisfiesSobocinskiCondition] : F.IsPiecewiseStronglyConnected where
   ps_connected := by
-    intro x y z Rxy Rxz;
-    by_cases exy : x = y;
-    . subst exy;
-      tauto;
-    . right;
-      exact SatisfiesSobocinskiCondition.sobocinski (by simpa) Rxy Rxz;
+    intro x y z Rxy Rxz
+    by_cases exy : x = y
+    . subst exy
+      tauto
+    . right
+      exact SatisfiesSobocinskiCondition.sobocinski (by simpa) Rxy Rxz
 
 instance [F.IsEuclidean] : F.SatisfiesSobocinskiCondition where
   sobocinski := by
-    intro x y z _ Rxy Rxz;
-    exact IsRightEuclidean.reucl Rxz Rxy;
+    intro x y z _ Rxy Rxz
+    exact IsRightEuclidean.reucl Rxz Rxy
 
 end Frame
 
@@ -41,44 +41,44 @@ open Formula.Kripke
 variable {F : Kripke.Frame}
 
 private lemma validate_axiomPoint4_of_sobocinskiCondition : (∀ ⦃x y z : F⦄, x ≠ y → x ≺ y → x ≺ z → z ≺ y) → F ⊧ (Axioms.Point4 (.atom 0)) := by
-  contrapose!;
-  intro h;
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h;
+  contrapose!
+  intro h
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h
 
-  replace h := Satisfies.not_imp_def.mp h;
-  have ⟨h₁, h₂⟩ := h;
-  replace h₂ := Satisfies.not_imp_def.mp h₂;
-  replace ⟨h₂, h₃⟩ := h₂;
+  replace h := Satisfies.not_imp_def.mp h
+  have ⟨h₁, h₂⟩ := h
+  replace h₂ := Satisfies.not_imp_def.mp h₂
+  replace ⟨h₂, h₃⟩ := h₂
 
-  replace h₁ := Satisfies.dia_def.mp h₁;
-  obtain ⟨z, Rxz, hz⟩ := h₁;
+  replace h₁ := Satisfies.dia_def.mp h₁
+  obtain ⟨z, Rxz, hz⟩ := h₁
 
-  replace h₃ := Satisfies.not_box_def.mp h₃;
-  obtain ⟨y, Rxy, hy⟩ := h₃;
+  replace h₃ := Satisfies.not_box_def.mp h₃
+  obtain ⟨y, Rxy, hy⟩ := h₃
 
-  use x, y, z;
-  refine ⟨?_, Rxy, Rxz, ?_⟩;
-  . by_contra hC; subst hC; contradiction;
-  . by_contra hC; apply hy; apply hz; assumption;
+  use x, y, z
+  refine ⟨?_, Rxy, Rxz, ?_⟩
+  . by_contra hC; subst hC; contradiction
+  . by_contra hC; apply hy; apply hz; assumption
 
 lemma validate_axiomPoint4_of_satisfiesSobocinskiCondition [F.SatisfiesSobocinskiCondition] : F ⊧ (Axioms.Point4 (.atom 0)) :=
   validate_axiomPoint4_of_sobocinskiCondition Frame.SatisfiesSobocinskiCondition.sobocinski
 
 lemma sobocinskiCondition_of_validate_axiomPoint4 (h : F ⊧ (Axioms.Point4 (.atom 0))) : F.SatisfiesSobocinskiCondition where
   sobocinski := by
-    revert h;
-    contrapose!;
-    rintro ⟨x, y, z, nexy, Rxy, Rxz, Rzy⟩;
-    apply ValidOnFrame.not_of_exists_valuation_world;
+    revert h
+    contrapose!
+    rintro ⟨x, y, z, nexy, Rxy, Rxz, Rzy⟩
+    apply ValidOnFrame.not_of_exists_valuation_world
     suffices ∃ V : Valuation F, ∃ x z, x ≺ z ∧ (∀ w, z ≺ w → V w 0) ∧ V x 0 ∧ ∃ y, x ≺ y ∧ ¬V y 0 by
-      simpa [Axioms.Point4, Satisfies];
-    use (λ w _ => w = x ∨ z ≺ w), x, z;
-    refine ⟨?_, ?_, ?_, ?_⟩;
-    . assumption;
-    . tauto;
-    . tauto;
-    . use y;
-      tauto;
+      simpa [Axioms.Point4, Satisfies]
+    use (λ w _ => w = x ∨ z ≺ w), x, z
+    refine ⟨?_, ?_, ?_, ?_⟩
+    . assumption
+    . tauto
+    . tauto
+    . use y
+      tauto
 
 end definability
 
@@ -96,23 +96,23 @@ open canonicalModel
 open MaximalConsistentTableau
 
 instance [Entailment.K 𝓢] [Entailment.HasAxiomPoint4 𝓢] : (canonicalFrame 𝓢).SatisfiesSobocinskiCondition := ⟨by
-  intro x y z nexy Rxy Rxz;
-  obtain ⟨φ, hφ₁, hφ₂⟩ := exists₁₂_of_ne nexy;
-  apply def_rel_box_mem₁.mpr;
-  intro ψ hψ;
+  intro x y z nexy Rxy Rxz
+  obtain ⟨φ, hφ₁, hφ₂⟩ := exists₁₂_of_ne nexy
+  apply def_rel_box_mem₁.mpr
+  intro ψ hψ
   have : (φ ⋎ ψ) ➝ □(φ ⋎ ψ) ∈ x.1.1 := mdp_mem₁_provable axiomPoint4! $ def_rel_dia_mem₁.mp Rxz $ mdp_mem₁_provable (by
-    apply imply_box_distribute'!;
-    simp;
-  ) hψ;
+    apply imply_box_distribute'!
+    simp
+  ) hψ
   have : □(φ ⋎ ψ) ∈ x.1.1 := iff_mem₁_imp'.mp this $ by
-    apply iff_mem₁_or.mpr;
-    left;
-    tauto;
-  rcases iff_mem₁_or.mp $ (iff_mem₁_box.mp this) Rxy with (_ | _);
-  . exfalso;
-    apply y.neither (φ := φ);
-    constructor <;> assumption;
-  . assumption;
+    apply iff_mem₁_or.mpr
+    left
+    tauto
+  rcases iff_mem₁_or.mp $ (iff_mem₁_box.mp this) Rxy with (_ | _)
+  . exfalso
+    apply y.neither (φ := φ)
+    constructor <;> assumption
+  . assumption
 ⟩
 
 end canonicality

--- a/Foundation/Modal/Kripke/AxiomVer.lean
+++ b/Foundation/Modal/Kripke/AxiomVer.lean
@@ -12,20 +12,20 @@ variable {F : Frame}
 protected abbrev Frame.IsIsolated (F : Frame) := _root_.IsIsolated F.Rel
 
 instance : blackpoint.IsIsolated where
-  isolated := by tauto;
+  isolated := by tauto
 
 section definability
 
 lemma validate_AxiomVer_of_isIsolated {F : Frame} [F.IsIsolated] : F ⊧ (Axioms.Ver (.atom 0)) := by
-  intro V x y Rxy;
-  exfalso;
-  exact IsIsolated.isolated Rxy;
+  intro V x y Rxy
+  exfalso
+  exact IsIsolated.isolated Rxy
 
 lemma isIsolated_of_validate_AxiomVer {F : Frame} (h : F ⊧ (Axioms.Ver (.atom 0))) : F.IsIsolated where
   isolated := by
-    intro x y Rxy;
-    have := h (λ _ _ => False) x y Rxy;
-    simp [Formula.Kripke.Satisfies] at this;
+    intro x y Rxy
+    have := h (λ _ _ => False) x y Rxy
+    simp [Formula.Kripke.Satisfies] at this
 
 
 end definability
@@ -42,9 +42,9 @@ open canonicalModel
 
 instance [Entailment.HasAxiomVer 𝓢] : (canonicalFrame 𝓢).IsIsolated where
   isolated := by
-    intro x y Rxy;
+    intro x y Rxy
     have : (canonicalModel 𝓢) ⊧ □⊥ := iff_valid_on_canonicalModel_deducible.mpr axiomVer!
-    exact this x _ Rxy;
+    exact this x _ Rxy
 
 end canonicality
 

--- a/Foundation/Modal/Kripke/AxiomWeakPoint2.lean
+++ b/Foundation/Modal/Kripke/AxiomWeakPoint2.lean
@@ -29,39 +29,39 @@ open Formula (atom)
 open Formula.Kripke
 
 lemma validate_WeakPoint2_of_weakConfluent [F.IsPiecewiseConvergent] : F ⊧ (Axioms.WeakPoint2 (.atom 0) (.atom 1)) := by
-  rintro V x;
-  apply Satisfies.imp_def.mpr;
+  rintro V x
+  apply Satisfies.imp_def.mpr
   suffices
     ∀ y, x ≺ y → (∀ u, y ≺ u → V u 0) → V y 1 →
     ∀ z, x ≺ z → (∀ u, z ≺ u → ¬V u 0) → V z 1
-    by simpa [Semantics.Realize, Satisfies];
-  intro y Rxy h₁ hy₁ z Rxz h₂;
-  by_contra hC;
+    by simpa [Semantics.Realize, Satisfies]
+  intro y Rxy h₁ hy₁ z Rxz h₂
+  by_contra hC
   have nyz : y ≠ z := by
-    by_contra hC;
-    subst hC;
-    contradiction;
-  obtain ⟨u, Ryu, Rzu⟩ := IsPiecewiseConvergent.p_convergent Rxy Rxz nyz;
-  have : V u 0 := h₁ _ Ryu;
-  have : ¬V u 0 := h₂ _ Rzu;
-  contradiction;
+    by_contra hC
+    subst hC
+    contradiction
+  obtain ⟨u, Ryu, Rzu⟩ := IsPiecewiseConvergent.p_convergent Rxy Rxz nyz
+  have : V u 0 := h₁ _ Ryu
+  have : ¬V u 0 := h₂ _ Rzu
+  contradiction
 
 lemma isPiecewiseConvergent_of_validate_axiomWeakPoint2 (h : F ⊧ (Axioms.WeakPoint2 (.atom 0) (.atom 1))) : F.IsPiecewiseConvergent where
   p_convergent := by
-    dsimp [PiecewiseConvergent];
-    revert h;
-    contrapose!;
-    rintro ⟨x, y, z, Rxy, Rxz, nyz, hu⟩;
-    apply ValidOnFrame.not_of_exists_valuation_world;
-    use (λ w a => match a with | 0 => y ≺ w | 1 => w = y | _ => False), x;
+    dsimp [PiecewiseConvergent]
+    revert h
+    contrapose!
+    rintro ⟨x, y, z, Rxy, Rxz, nyz, hu⟩
+    apply ValidOnFrame.not_of_exists_valuation_world
+    use (λ w a => match a with | 0 => y ≺ w | 1 => w = y | _ => False), x
     suffices x ≺ y ∧ ∃ z, x ≺ z ∧ (∀ u, z ≺ u → ¬y ≺ u) ∧ ¬z = y by
-      simpa [Satisfies, Semantics.Realize];
-    refine ⟨Rxy, z, Rxz, ?_, by tauto⟩;
-    . intro u;
-      contrapose;
-      push_neg;
-      intro Ryu;
-      exact hu u Ryu;
+      simpa [Satisfies, Semantics.Realize]
+    refine ⟨Rxy, z, Rxz, ?_, by tauto⟩
+    . intro u
+      contrapose
+      push_neg
+      intro Ryu
+      exact hu u Ryu
 
 end definability
 
@@ -78,36 +78,36 @@ open canonicalModel
 
 instance [Entailment.HasAxiomWeakPoint2 𝓢] : (canonicalFrame 𝓢).IsPiecewiseConvergent where
   p_convergent := by
-    rintro x y z Rxy Rxz eyz;
+    rintro x y z Rxy Rxz eyz
     have ⟨u, hu⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨y.1.1.prebox, z.1.2.predia⟩) $ by
-      rintro Γ Δ hΓ hΔ;
-      by_contra hC;
-      have hγ : □(Γ.conj) ∈ y.1.1 := y.mdp_mem₁_provable collect_box_fconj! $ iff_mem₁_fconj.mpr (by simpa using hΓ);
-      have hδ : ◇(Δ.disj) ∈ z.1.2 := mdp_mem₂_provable distribute_dia_fdisj! $ iff_mem₂_fdisj.mpr (by simpa using hΔ);
-      generalize Γ.conj = γ₁ at hγ hC;
-      generalize Δ.disj = δ₁ at hδ hC;
-      obtain ⟨δ₂, hδ₂₁, hδ₂₂⟩ := exists₁₂_of_ne eyz;
+      rintro Γ Δ hΓ hΔ
+      by_contra hC
+      have hγ : □(Γ.conj) ∈ y.1.1 := y.mdp_mem₁_provable collect_box_fconj! $ iff_mem₁_fconj.mpr (by simpa using hΓ)
+      have hδ : ◇(Δ.disj) ∈ z.1.2 := mdp_mem₂_provable distribute_dia_fdisj! $ iff_mem₂_fdisj.mpr (by simpa using hΔ)
+      generalize Γ.conj = γ₁ at hγ hC
+      generalize Δ.disj = δ₁ at hδ hC
+      obtain ⟨δ₂, hδ₂₁, hδ₂₂⟩ := exists₁₂_of_ne eyz
 
-      have : 𝓢 ⊢! □γ₁ ➝ □δ₁ := imply_box_distribute'! hC;
-      have : 𝓢 ⊢! □γ₁ ⋏ δ₂ ➝ □δ₁ ⋏ δ₂ := CKK!_of_C! this;
+      have : 𝓢 ⊢! □γ₁ ➝ □δ₁ := imply_box_distribute'! hC
+      have : 𝓢 ⊢! □γ₁ ⋏ δ₂ ➝ □δ₁ ⋏ δ₂ := CKK!_of_C! this
       have : □δ₁ ⋏ δ₂ ∈ y.1.1 := mdp_mem₁_provable this $ by
-        apply iff_mem₁_and.mpr; constructor <;> assumption;
-      have : ◇(□δ₁ ⋏ δ₂) ∈ x.1.1 := def_rel_dia_mem₁.mp Rxy this;
-      have : □(◇δ₁ ⋎ δ₂) ∈ x.1.1 := mdp_mem₁_provable axiomWeakPoint2! this;
-      have : ◇δ₁ ⋎ δ₂ ∈ z.1.1 := def_rel_box_mem₁.mp Rxz this;
-      rcases iff_mem₁_or.mp this with (hδ₁ | hδ₂);
-      . have : ◇δ₁ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr hδ₁;
-        contradiction;
-      . have : δ₂ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr hδ₂;
-        contradiction;
-    use u;
-    constructor;
-    . apply def_rel_box_mem₁.mpr;
-      intro φ hφ;
-      apply hu.1 hφ;
-    . apply def_rel_dia_mem₂.mpr;
-      intro φ hφ;
-      apply hu.2 hφ;
+        apply iff_mem₁_and.mpr; constructor <;> assumption
+      have : ◇(□δ₁ ⋏ δ₂) ∈ x.1.1 := def_rel_dia_mem₁.mp Rxy this
+      have : □(◇δ₁ ⋎ δ₂) ∈ x.1.1 := mdp_mem₁_provable axiomWeakPoint2! this
+      have : ◇δ₁ ⋎ δ₂ ∈ z.1.1 := def_rel_box_mem₁.mp Rxz this
+      rcases iff_mem₁_or.mp this with (hδ₁ | hδ₂)
+      . have : ◇δ₁ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr hδ₁
+        contradiction
+      . have : δ₂ ∉ z.1.2 := iff_not_mem₂_mem₁.mpr hδ₂
+        contradiction
+    use u
+    constructor
+    . apply def_rel_box_mem₁.mpr
+      intro φ hφ
+      apply hu.1 hφ
+    . apply def_rel_dia_mem₂.mpr
+      intro φ hφ
+      apply hu.2 hφ
 
 end canonicality
 

--- a/Foundation/Modal/Kripke/AxiomWeakPoint3.lean
+++ b/Foundation/Modal/Kripke/AxiomWeakPoint3.lean
@@ -16,9 +16,9 @@ abbrev IsPiecewiseConnected (F : Frame) := _root_.IsPiecewiseConnected F.Rel
 
 lemma IsPiecewiseConnected.mk' (p_connected' : ∀ {x y z : F.World}, x ≺ y → x ≺ z → y ≠ z → y ≺ z ∨ z ≺ y) : F.IsPiecewiseConnected where
   p_connected := by
-    intro x y z Rxy Rxz;
-    suffices y ≠ z → y ≺ z ∨ z ≺ y by tauto;
-    apply p_connected' <;> tauto;
+    intro x y z Rxy Rxz
+    suffices y ≠ z → y ≺ z ∨ z ≺ y by tauto
+    apply p_connected' <;> tauto
 
 lemma p_connected [F.IsPiecewiseConnected] {x y z : F.World} : x ≺ y → x ≺ z → y ≺ z ∨ y = z ∨ z ≺ y := by apply IsPiecewiseConnected.p_connected
 lemma p_connected' [F.IsPiecewiseConnected] {x y z : F.World} : x ≺ y → x ≺ z → y ≠ z → y ≺ z ∨ z ≺ y := IsPiecewiseConnected.p_connected'
@@ -35,37 +35,37 @@ open Formula (atom)
 open Formula.Kripke
 
 lemma validate_WeakPoint3_of_weakConnected [F.IsPiecewiseConnected] : F ⊧ (Axioms.WeakPoint3 (.atom 0) (.atom 1)) := by
-  rintro V x;
-  apply Satisfies.or_def.mpr;
+  rintro V x
+  apply Satisfies.or_def.mpr
   suffices
     (∀ (y : F.World), x ≺ y → V y 0 → (∀ (x : F.World), y ≺ x → V x 0) → V y 1) ∨
     (∀ (y : F.World), x ≺ y → V y 1 → (∀ (x : F.World), y ≺ x → V x 1) → V y 0)
-    by simpa [Semantics.Realize, Satisfies];
-  by_contra hC;
-  push_neg at hC;
-  obtain ⟨⟨y, Rxy, hy0, hz, nhy1⟩, ⟨z, Rxz, hz1, hy, nhz0⟩⟩ := hC;
+    by simpa [Semantics.Realize, Satisfies]
+  by_contra hC
+  push_neg at hC
+  obtain ⟨⟨y, Rxy, hy0, hz, nhy1⟩, ⟨z, Rxz, hz1, hy, nhz0⟩⟩ := hC
   have nyz : y ≠ z := by
-    by_contra hC;
-    subst hC;
-    contradiction;
-  rcases IsPiecewiseConnected.p_connected' Rxy Rxz nyz with (Ryz | Rzy);
-  . apply nhz0; exact hz _ Ryz;
-  . apply nhy1; exact hy _ Rzy;
+    by_contra hC
+    subst hC
+    contradiction
+  rcases IsPiecewiseConnected.p_connected' Rxy Rxz nyz with (Ryz | Rzy)
+  . apply nhz0; exact hz _ Ryz
+  . apply nhy1; exact hy _ Rzy
 
 lemma isPiecewiseConnected_of_validate_axiomWeakPoint3 (h : F ⊧ (Axioms.WeakPoint3 (.atom 0) (.atom 1))) : F.IsPiecewiseConnected where
   p_connected := by
-    dsimp [PiecewiseConnected];
-    revert h;
-    contrapose!;
-    rintro ⟨x, y, z, Rxy, Rxz, nRyz, nyz, nRzy⟩;
-    apply ValidOnFrame.not_of_exists_valuation_world;
-    use (λ w a => match a with | 0 => w = y ∨ y ≺ w | 1 => w = z ∨ z ≺ w | _ => True), x;
+    dsimp [PiecewiseConnected]
+    revert h
+    contrapose!
+    rintro ⟨x, y, z, Rxy, Rxz, nRyz, nyz, nRzy⟩
+    apply ValidOnFrame.not_of_exists_valuation_world
+    use (λ w a => match a with | 0 => w = y ∨ y ≺ w | 1 => w = z ∨ z ≺ w | _ => True), x
     suffices
       ∃ w, x ≺ w ∧ (w = y ∨ y ≺ w) ∧ (∀ (v : F.World), w ≺ v → ¬v = y → y ≺ v) ∧ ¬w = z ∧ ¬z ≺ w ∧
       ∃ w, x ≺ w ∧ (w = z ∨ z ≺ w) ∧ (∀ (v : F.World), w ≺ v → ¬v = z → z ≺ v) ∧ ¬w = y ∧ ¬y ≺ w by
-      simpa [Semantics.Realize, Satisfies];
-    refine ⟨y, Rxy, ?_, ?_, ?_, ?_, z, Rxz, ?_, ?_, ?_, ?_⟩;
-    all_goals tauto;
+      simpa [Semantics.Realize, Satisfies]
+    refine ⟨y, Rxy, ?_, ?_, ?_, ?_, z, Rxz, ?_, ?_, ?_, ?_⟩
+    all_goals tauto
 
 end definability
 
@@ -82,63 +82,63 @@ open canonicalModel
 
 instance [Entailment.HasAxiomWeakPoint3 𝓢] : (canonicalFrame 𝓢).IsPiecewiseConnected where
   p_connected := by
-    rintro x y z Rxy Rxz;
-    by_contra! hC;
-    rcases hC with ⟨nRyz, neyz, nRzy⟩;
+    rintro x y z Rxy Rxz
+    by_contra! hC
+    rcases hC with ⟨nRyz, neyz, nRzy⟩
 
-    obtain ⟨φ₁, hφ₁y, hφ₁z⟩ := Set.not_subset.mp nRyz;
-    replace hφ₁y : □φ₁ ∈ y.1.1 := by simpa using hφ₁y;
-    replace hφ₁z : φ₁ ∈ z.1.2 := iff_not_mem₁_mem₂.mp hφ₁z;
-    obtain ⟨φ₂, hφ₂y, hφ₂z⟩ := exists₁₂_of_ne neyz;
-    let φ := φ₁ ⋎ φ₂;
+    obtain ⟨φ₁, hφ₁y, hφ₁z⟩ := Set.not_subset.mp nRyz
+    replace hφ₁y : □φ₁ ∈ y.1.1 := by simpa using hφ₁y
+    replace hφ₁z : φ₁ ∈ z.1.2 := iff_not_mem₁_mem₂.mp hφ₁z
+    obtain ⟨φ₂, hφ₂y, hφ₂z⟩ := exists₁₂_of_ne neyz
+    let φ := φ₁ ⋎ φ₂
 
-    obtain ⟨ψ₁, hψz, hψy⟩ := Set.not_subset.mp nRzy;
-    replace hψ₁z : □ψ₁ ∈ z.1.1 := by simpa using hψz;
-    replace hψ₁y : ψ₁ ∈ y.1.2 := iff_not_mem₁_mem₂.mp hψy;
-    obtain ⟨ψ₂, hψ₂z, hψ₂y⟩ := exists₂₁_of_ne neyz;
-    let ψ := ψ₁ ⋎ ψ₂;
+    obtain ⟨ψ₁, hψz, hψy⟩ := Set.not_subset.mp nRzy
+    replace hψ₁z : □ψ₁ ∈ z.1.1 := by simpa using hψz
+    replace hψ₁y : ψ₁ ∈ y.1.2 := iff_not_mem₁_mem₂.mp hψy
+    obtain ⟨ψ₂, hψ₂z, hψ₂y⟩ := exists₂₁_of_ne neyz
+    let ψ := ψ₁ ⋎ ψ₂
 
-    apply x.neither (φ := □(⊡φ ➝ ψ) ⋎ □(⊡ψ ➝ φ));
-    constructor;
-    . exact iff_provable_mem₁.mp axiomWeakPoint3! x;
-    . apply iff_mem₂_or.mpr;
-      constructor;
-      . apply iff_mem₂_box.mpr;
-        use y;
-        constructor;
-        . assumption;
-        . apply iff_mem₂_imp.mpr;
-          constructor;
-          . apply iff_mem₁_and.mpr;
-            constructor;
-            . apply iff_mem₁_or.mpr; tauto;
+    apply x.neither (φ := □(⊡φ ➝ ψ) ⋎ □(⊡ψ ➝ φ))
+    constructor
+    . exact iff_provable_mem₁.mp axiomWeakPoint3! x
+    . apply iff_mem₂_or.mpr
+      constructor
+      . apply iff_mem₂_box.mpr
+        use y
+        constructor
+        . assumption
+        . apply iff_mem₂_imp.mpr
+          constructor
+          . apply iff_mem₁_and.mpr
+            constructor
+            . apply iff_mem₁_or.mpr; tauto
             . apply iff_mem₁_box.mpr
-              intro u Ryu;
-              apply iff_mem₁_or.mpr;
-              left;
-              exact Ryu hφ₁y;
-          . apply iff_mem₂_or.mpr;
-            constructor;
-            . assumption;
-            . assumption;
-      . apply iff_mem₂_box.mpr;
-        use z;
-        constructor;
-        . assumption;
-        . apply iff_mem₂_imp.mpr;
-          constructor;
-          . apply iff_mem₁_and.mpr;
-            constructor;
-            . apply iff_mem₁_or.mpr; tauto;
+              intro u Ryu
+              apply iff_mem₁_or.mpr
+              left
+              exact Ryu hφ₁y
+          . apply iff_mem₂_or.mpr
+            constructor
+            . assumption
+            . assumption
+      . apply iff_mem₂_box.mpr
+        use z
+        constructor
+        . assumption
+        . apply iff_mem₂_imp.mpr
+          constructor
+          . apply iff_mem₁_and.mpr
+            constructor
+            . apply iff_mem₁_or.mpr; tauto
             . apply iff_mem₁_box.mpr
-              intro u Rzu;
-              apply iff_mem₁_or.mpr;
-              left;
-              exact Rzu hψ₁z;
-          . apply iff_mem₂_or.mpr;
-            constructor;
-            . assumption;
-            . assumption;
+              intro u Rzu
+              apply iff_mem₁_or.mpr
+              left
+              exact Rzu hψ₁z
+          . apply iff_mem₂_or.mpr
+            constructor
+            . assumption
+            . assumption
 
 end canonicality
 

--- a/Foundation/Modal/Kripke/Balloon.lean
+++ b/Foundation/Modal/Kripke/Balloon.lean
@@ -19,48 +19,48 @@ lemma rfl_in_envelope (hx : x ∈ e) : x ≺ x := Cluster.refl_of_mem_non_degene
 
 /-- Every point in balloon can see all points in envelope. -/
 lemma covered_in_envelope (x : F.World) : ∀ t ∈ e, x ≺ t := by
-  obtain ⟨t₁, rfl⟩ := Quotient.exists_rep e;
-  intro t₂ ht₂;
-  replace ht₂ := Cluster.mem_iff₂.mp ht₂;
-  rcases ht₂ with rfl | ⟨Rt₁₂, Rt₂₁⟩;
-  . by_cases ext₁ : (⟦x⟧ : Cluster F) = ⟦t₁⟧;
-    . simp only [Quotient.eq] at ext₁;
-      rcases ext₁ with rfl | ⟨Rxt₁, Rtx₁⟩;
-      . exact rfl_in_envelope (by tauto);
-      . assumption;
-    . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁;
-      exact this.1;
-  . by_cases ext₁ : (⟦x⟧ : Cluster F) = ⟦t₁⟧;
-    . rcases Cluster.iff_eq_cluster.mp ext₁ with rfl | ⟨Rxt₁, Rtx₁⟩;
-      . assumption;
-      . exact _root_.trans Rxt₁ Rt₁₂;
-    . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁;
-      exact _root_.trans this.1 Rt₁₂;
+  obtain ⟨t₁, rfl⟩ := Quotient.exists_rep e
+  intro t₂ ht₂
+  replace ht₂ := Cluster.mem_iff₂.mp ht₂
+  rcases ht₂ with rfl | ⟨Rt₁₂, Rt₂₁⟩
+  . by_cases ext₁ : (⟦x⟧ : Cluster F) = ⟦t₁⟧
+    . simp only [Quotient.eq] at ext₁
+      rcases ext₁ with rfl | ⟨Rxt₁, Rtx₁⟩
+      . exact rfl_in_envelope (by tauto)
+      . assumption
+    . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁
+      exact this.1
+  . by_cases ext₁ : (⟦x⟧ : Cluster F) = ⟦t₁⟧
+    . rcases Cluster.iff_eq_cluster.mp ext₁ with rfl | ⟨Rxt₁, Rtx₁⟩
+      . assumption
+      . exact _root_.trans Rxt₁ Rt₁₂
+    . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁
+      exact _root_.trans this.1 Rt₁₂
 
 /-- Every points from enverope is in enverope. -/
 lemma in_envelope_of_in_envelope (hx : x ∈ e) : ∀ {y}, x ≺ y → y ∈ e := by
-  obtain ⟨t, rfl⟩ := Quotient.exists_rep e;
-  intro y Rxy;
-  apply Cluster.mem_iff₂.mpr;
-  by_cases t = y;
-  . tauto;
-  . right;
-    replace hx := Cluster.mem_iff₂.mp hx;
-    rcases hx with rfl | ⟨Rtx, Rxt⟩;
-    . constructor;
-      . exact Rxy;
-      . apply covered_in_envelope (e := ⟦t⟧);
-        tauto;
-    . constructor;
-      . exact _root_.trans Rtx Rxy;
-      . apply covered_in_envelope (e := ⟦t⟧);
-        tauto;
+  obtain ⟨t, rfl⟩ := Quotient.exists_rep e
+  intro y Rxy
+  apply Cluster.mem_iff₂.mpr
+  by_cases t = y
+  . tauto
+  . right
+    replace hx := Cluster.mem_iff₂.mp hx
+    rcases hx with rfl | ⟨Rtx, Rxt⟩
+    . constructor
+      . exact Rxy
+      . apply covered_in_envelope (e := ⟦t⟧)
+        tauto
+    . constructor
+      . exact _root_.trans Rtx Rxy
+      . apply covered_in_envelope (e := ⟦t⟧)
+        tauto
 
 end Frame.IsBalloon
 
 /-- In finite strict total ordered frame, `□φ` is not valid at x, farthest point from `x` exists s.t. not validate `φ` and validate `□φ`. -/
 lemma farthermost_point_of_not_box {M : Kripke.Model} [IsStrictOrder _ M.toFrame] {x : M} (h : ¬x ⊧ □φ) : ∃ y, x ≺ y ∧ ¬y ⊧ φ ∧ y ⊧ □φ := by
-  sorry;
+  sorry
 
 open
   Formula.Kripke
@@ -68,33 +68,33 @@ open
 in
 lemma balooon_validates_axiomZ
   {F : Frame} [F.IsTransitive] {e : Cluster F} [F.IsBalloon e] : F ⊧ (Axioms.Z (.atom 0)) := by
-  intro V x;
-  suffices ¬(Satisfies _ x (□(□(.atom 0) ➝ (.atom 0)))) ∨ ¬(Satisfies _ x (◇□(.atom 0))) ∨ (Satisfies _ x (□(.atom 0))) by tauto;
-  by_cases h : Satisfies _ x (□(.atom 0));
-  . right; right; assumption;
-  . obtain ⟨y, Rxy, hy, hy_far⟩ := farthermost_point_of_not_box h;
-    by_cases hxT : x ∈ e;
-    . right; left;
-      apply Satisfies.dia_def.not.mpr;
-      push_neg;
-      intro z Rxz;
-      apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use y;
-      constructor;
-      . have hzT : z ∈ e := in_envelope_of_in_envelope hxT Rxz;
-        rcases Cluster.mem_same_cluster hxT hzT with rfl | ⟨Rzx, Rxz⟩;
-        . assumption;
-        . exact _root_.trans Rzx Rxy;
-      . assumption;
-    . left;
-      apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use y;
-      constructor;
-      . assumption;
+  intro V x
+  suffices ¬(Satisfies _ x (□(□(.atom 0) ➝ (.atom 0)))) ∨ ¬(Satisfies _ x (◇□(.atom 0))) ∨ (Satisfies _ x (□(.atom 0))) by tauto
+  by_cases h : Satisfies _ x (□(.atom 0))
+  . right; right; assumption
+  . obtain ⟨y, Rxy, hy, hy_far⟩ := farthermost_point_of_not_box h
+    by_cases hxT : x ∈ e
+    . right; left
+      apply Satisfies.dia_def.not.mpr
+      push_neg
+      intro z Rxz
+      apply Satisfies.box_def.not.mpr
+      push_neg
+      use y
+      constructor
+      . have hzT : z ∈ e := in_envelope_of_in_envelope hxT Rxz
+        rcases Cluster.mem_same_cluster hxT hzT with rfl | ⟨Rzx, Rxz⟩
+        . assumption
+        . exact _root_.trans Rzx Rxy
+      . assumption
+    . left
+      apply Satisfies.box_def.not.mpr
+      push_neg
+      use y
+      constructor
+      . assumption
       . apply Satisfies.imp_def₂.not.mpr
-        push_neg;
-        tauto;
+        push_neg
+        tauto
 
 end LO.Modal.Kripke

--- a/Foundation/Modal/Kripke/Basic.lean
+++ b/Foundation/Modal/Kripke/Basic.lean
@@ -50,14 +50,14 @@ section
 def whitepoint : Frame := ⟨Unit, λ _ _ => True⟩
 
 instance : Finite whitepoint.World := by
-  dsimp [whitepoint];
+  dsimp [whitepoint]
   infer_instance
 
 def blackpoint : Frame := ⟨Unit, λ _ _ => False⟩
 
 instance : Finite blackpoint.World := by
-  dsimp [blackpoint];
-  infer_instance;
+  dsimp [blackpoint]
+  infer_instance
 instance : IsIrrefl _ blackpoint.Rel := by tauto
 instance : IsTrans _ blackpoint.Rel := ⟨by tauto⟩
 instance : IsStrictOrder _ blackpoint.Rel where
@@ -95,299 +95,299 @@ variable {M : Kripke.Model} {x : M.World} {φ ψ : Formula ℕ}
 
 @[simp] protected lemma iff_models : x ⊧ φ ↔ Kripke.Satisfies M x φ := iff_of_eq rfl
 
-@[simp] lemma atom_def : x ⊧ atom a ↔ M x a := by simp [Satisfies];
+@[simp] lemma atom_def : x ⊧ atom a ↔ M x a := by simp [Satisfies]
 
-protected lemma bot_def : ¬x ⊧ ⊥ := by simp [Satisfies];
+protected lemma bot_def : ¬x ⊧ ⊥ := by simp [Satisfies]
 
-protected lemma imp_def : x ⊧ φ ➝ ψ ↔ (x ⊧ φ) → (x ⊧ ψ) := by tauto;
-protected lemma not_imp_def : ¬(x ⊧ φ ➝ ψ) ↔ (x ⊧ φ) ∧ ¬(x ⊧ ψ) := by constructor <;> . contrapose!; tauto;
+protected lemma imp_def : x ⊧ φ ➝ ψ ↔ (x ⊧ φ) → (x ⊧ ψ) := by tauto
+protected lemma not_imp_def : ¬(x ⊧ φ ➝ ψ) ↔ (x ⊧ φ) ∧ ¬(x ⊧ ψ) := by constructor <;> . contrapose!; tauto
 
-protected lemma imp_def₂ : x ⊧ φ ➝ ψ ↔ ¬x ⊧ φ ∨ x ⊧ ψ := by tauto;
+protected lemma imp_def₂ : x ⊧ φ ➝ ψ ↔ ¬x ⊧ φ ∨ x ⊧ ψ := by tauto
 
-protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies]; tauto;
+protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies]; tauto
 
-protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies];
+protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies]
 
-protected lemma not_def : x ⊧ ∼φ ↔ ¬(x ⊧ φ) := by simp [Satisfies];
+protected lemma not_def : x ⊧ ∼φ ↔ ¬(x ⊧ φ) := by simp [Satisfies]
 
-protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies];
+protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies]
 
-protected lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺ y → y ⊧ φ := by simp [Satisfies];
-protected lemma not_box_def : ¬x ⊧ □φ ↔ (∃ y, x ≺ y ∧ ¬y ⊧ φ) := by simp [Satisfies];
+protected lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺ y → y ⊧ φ := by simp [Satisfies]
+protected lemma not_box_def : ¬x ⊧ □φ ↔ (∃ y, x ≺ y ∧ ¬y ⊧ φ) := by simp [Satisfies]
 
-protected lemma dia_def : x ⊧ ◇φ ↔ ∃ y, x ≺ y ∧ y ⊧ φ := by simp [Satisfies];
-protected lemma not_dia_def : ¬x ⊧ ◇φ ↔ ∀ y, x ≺ y → ¬(y ⊧ φ) := by simp [Satisfies];
+protected lemma dia_def : x ⊧ ◇φ ↔ ∃ y, x ≺ y ∧ y ⊧ φ := by simp [Satisfies]
+protected lemma not_dia_def : ¬x ⊧ ◇φ ↔ ∀ y, x ≺ y → ¬(y ⊧ φ) := by simp [Satisfies]
 
 protected instance : Semantics.Tarski (M.World) where
-  realize_top := λ _ => Satisfies.top_def;
-  realize_bot := λ _ => Satisfies.bot_def;
-  realize_imp := Satisfies.imp_def;
-  realize_not := Satisfies.not_def;
-  realize_or := Satisfies.or_def;
-  realize_and := Satisfies.and_def;
+  realize_top := λ _ => Satisfies.top_def
+  realize_bot := λ _ => Satisfies.bot_def
+  realize_imp := Satisfies.imp_def
+  realize_not := Satisfies.not_def
+  realize_or := Satisfies.or_def
+  realize_and := Satisfies.and_def
 
-lemma iff_def : x ⊧ φ ⭤ ψ ↔ (x ⊧ φ ↔ x ⊧ ψ) := by simp [Satisfies];
+lemma iff_def : x ⊧ φ ⭤ ψ ↔ (x ⊧ φ ↔ x ⊧ ψ) := by simp [Satisfies]
 
-@[simp] lemma negneg_def : x ⊧ ∼∼φ ↔ x ⊧ φ := by simp;
+@[simp] lemma negneg_def : x ⊧ ∼∼φ ↔ x ⊧ φ := by simp
 
 lemma multibox_dn : x ⊧ □^[n](∼∼φ) ↔ x ⊧ □^[n]φ := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    suffices x ⊧ (□□^[n](∼∼φ)) ↔ x ⊧ (□□^[n]φ) by simpa;
-    constructor;
-    . intro h y Rxy;
-      exact ih.mp $ (h y Rxy);
-    . intro h y Rxy;
-      exact ih.mpr $ (h y Rxy);
+    suffices x ⊧ (□□^[n](∼∼φ)) ↔ x ⊧ (□□^[n]φ) by simpa
+    constructor
+    . intro h y Rxy
+      exact ih.mp $ (h y Rxy)
+    . intro h y Rxy
+      exact ih.mpr $ (h y Rxy)
 
 lemma box_dn : x ⊧ □(∼∼φ) ↔ x ⊧ □φ := multibox_dn (n := 1)
 
 lemma multidia_dn : x ⊧ ◇^[n](∼∼φ) ↔ x ⊧ ◇^[n]φ := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    suffices x ⊧ (◇◇^[n](∼∼φ)) ↔ x ⊧ (◇◇^[n]φ) by simpa;
-    constructor;
-    . intro h;
-      obtain ⟨y, Rxy, h⟩ := Satisfies.dia_def.mp h;
-      apply Satisfies.dia_def.mpr;
-      use y;
-      constructor;
-      . exact Rxy;
-      . exact ih.mp h;
-    . intro h;
-      obtain ⟨y, Rxy, h⟩ := Satisfies.dia_def.mp h;
-      apply Satisfies.dia_def.mpr;
-      use y;
-      constructor;
-      . exact Rxy;
-      . exact ih.mpr h;
+    suffices x ⊧ (◇◇^[n](∼∼φ)) ↔ x ⊧ (◇◇^[n]φ) by simpa
+    constructor
+    . intro h
+      obtain ⟨y, Rxy, h⟩ := Satisfies.dia_def.mp h
+      apply Satisfies.dia_def.mpr
+      use y
+      constructor
+      . exact Rxy
+      . exact ih.mp h
+    . intro h
+      obtain ⟨y, Rxy, h⟩ := Satisfies.dia_def.mp h
+      apply Satisfies.dia_def.mpr
+      use y
+      constructor
+      . exact Rxy
+      . exact ih.mpr h
 
 lemma dia_dn : x ⊧ ◇(∼∼φ) ↔ x ⊧ ◇φ := multidia_dn (n := 1)
 
 lemma multibox_def : x ⊧ □^[n]φ ↔ ∀ {y}, x ≺^[n] y → y ⊧ φ := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    constructor;
-    . rintro h y ⟨z, Rxz, Rzy⟩;
-      replace h : ∀ y, x ≺ y → y ⊧ □^[n]φ := Satisfies.box_def.mp $ by simpa using h;
-      exact (ih.mp $ h _ Rxz) Rzy;
-    . suffices (∀ {y z}, x ≺ z → z ≺^[n] y → Satisfies M y φ) → x ⊧ (□□^[n]φ) by simpa;
-      intro h y Rxy;
-      apply ih.mpr;
-      intro z Ryz;
-      exact h Rxy Ryz;
+    constructor
+    . rintro h y ⟨z, Rxz, Rzy⟩
+      replace h : ∀ y, x ≺ y → y ⊧ □^[n]φ := Satisfies.box_def.mp $ by simpa using h
+      exact (ih.mp $ h _ Rxz) Rzy
+    . suffices (∀ {y z}, x ≺ z → z ≺^[n] y → Satisfies M y φ) → x ⊧ (□□^[n]φ) by simpa
+      intro h y Rxy
+      apply ih.mpr
+      intro z Ryz
+      exact h Rxy Ryz
 
 lemma multidia_def : x ⊧ ◇^[n]φ ↔ ∃ y, x ≺^[n] y ∧ y ⊧ φ := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    constructor;
-    . intro h;
-      replace h : x ⊧ (◇◇^[n]φ) := by simpa using h;
-      obtain ⟨y, Rxy, hv⟩ := Satisfies.dia_def.mp h;
-      obtain ⟨x, Ryx, hx⟩ := ih.mp hv;
-      use x;
-      constructor;
-      . use y;
-      . assumption;
-    . rintro ⟨y, ⟨z, Rxz, Rzy⟩, hy⟩;
-      suffices x ⊧ ◇◇^[n]φ by simpa;
-      apply Satisfies.dia_def.mpr;
-      use z;
-      constructor;
-      . assumption;
-      . apply ih.mpr;
-        use y;
+    constructor
+    . intro h
+      replace h : x ⊧ (◇◇^[n]φ) := by simpa using h
+      obtain ⟨y, Rxy, hv⟩ := Satisfies.dia_def.mp h
+      obtain ⟨x, Ryx, hx⟩ := ih.mp hv
+      use x
+      constructor
+      . use y
+      . assumption
+    . rintro ⟨y, ⟨z, Rxz, Rzy⟩, hy⟩
+      suffices x ⊧ ◇◇^[n]φ by simpa
+      apply Satisfies.dia_def.mpr
+      use z
+      constructor
+      . assumption
+      . apply ih.mpr
+        use y
 
 lemma disj_def : x ⊧ ⋁Γ ↔ ∃ φ ∈ Γ, x ⊧ φ := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ hΓ ih =>
-    suffices x ⊧ φ ∨ x ⊧ ⋁Γ ↔ x ⊧ φ ∨ ∃ a ∈ Γ, x ⊧ a by simp [List.disj₂_cons_nonempty hΓ];
-    constructor;
+    suffices x ⊧ φ ∨ x ⊧ ⋁Γ ↔ x ⊧ φ ∨ ∃ a ∈ Γ, x ⊧ a by simp [List.disj₂_cons_nonempty hΓ]
+    constructor
     . rintro (_ | h)
-      . tauto;
-      . right; exact ih.mp h;
-    . rintro (_ | h);
-      . tauto;
-      . right; exact ih.mpr h;
-  | _ => simp;
+      . tauto
+      . right; exact ih.mp h
+    . rintro (_ | h)
+      . tauto
+      . right; exact ih.mpr h
+  | _ => simp
 
-lemma conj₁_def {Γ : List _} : x ⊧ Γ.conj ↔ ∀ φ ∈ Γ, x ⊧ φ := by induction Γ <;> simp;
+lemma conj₁_def {Γ : List _} : x ⊧ Γ.conj ↔ ∀ φ ∈ Γ, x ⊧ φ := by induction Γ <;> simp
 
 lemma conj_def : x ⊧ ⋀Γ ↔ ∀ φ ∈ Γ, x ⊧ φ := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ hΓ ih =>
-    suffices (x ⊧ φ ∧ x ⊧ ⋀Γ) ↔ (x ⊧ φ ∧ ∀ φ ∈ Γ, x ⊧ φ) by simp [List.conj₂_cons_nonempty hΓ];
-    constructor;
-    . intro ⟨_, hΓ⟩;
-      constructor;
-      . assumption;
-      . exact ih.mp hΓ;
-    . intro ⟨_, hΓ⟩;
-      constructor;
-      . assumption;
-      . apply ih.mpr hΓ;
-  | _ => simp;
+    suffices (x ⊧ φ ∧ x ⊧ ⋀Γ) ↔ (x ⊧ φ ∧ ∀ φ ∈ Γ, x ⊧ φ) by simp [List.conj₂_cons_nonempty hΓ]
+    constructor
+    . intro ⟨_, hΓ⟩
+      constructor
+      . assumption
+      . exact ih.mp hΓ
+    . intro ⟨_, hΓ⟩
+      constructor
+      . assumption
+      . apply ih.mpr hΓ
+  | _ => simp
 
 lemma fconj_def {Γ : Finset _} : x ⊧ Γ.conj ↔ ∀ φ ∈ Γ, x ⊧ φ := by
-  simp only [Semantics.realize_finset_conj];
+  simp only [Semantics.realize_finset_conj]
 
 lemma fdisj_def {Γ : Finset _} : x ⊧ Γ.disj ↔ ∃ φ ∈ Γ, x ⊧ φ := by
-  simp only [Semantics.realize_finset_disj];
+  simp only [Semantics.realize_finset_disj]
 
-lemma trans (hpq : x ⊧ φ ➝ ψ) (hqr : x ⊧ ψ ➝ χ) : x ⊧ φ ➝ χ := by simp_all;
+lemma trans (hpq : x ⊧ φ ➝ ψ) (hqr : x ⊧ ψ ➝ χ) : x ⊧ φ ➝ χ := by simp_all
 
-lemma mdp (hpq : x ⊧ φ ➝ ψ) (hp : x ⊧ φ) : x ⊧ ψ := by simp_all;
+lemma mdp (hpq : x ⊧ φ ➝ ψ) (hp : x ⊧ φ) : x ⊧ ψ := by simp_all
 
 
 lemma intro_neg_semiequiv (h : x ⊧ φ → x ⊧ ψ) : x ⊧ ∼ψ → x ⊧ ∼φ := by
-  contrapose;
-  simp_all [Satisfies];
+  contrapose
+  simp_all [Satisfies]
 
 lemma intro_multibox_semiequiv (h : ∀ y, x ≺^[n] y → y ⊧ φ → y ⊧ ψ) : x ⊧ □^[n]φ → x ⊧ □^[n]ψ := by
   induction n generalizing x with
-  | zero => simp_all;
+  | zero => simp_all
   | succ n ih =>
-    intro hφ;
-    apply Satisfies.multibox_def.mpr;
-    rintro y ⟨z, Rxz, Rzy⟩;
-    replace hφ : x ⊧ □□^[n]φ := by simpa using hφ;
-    refine Satisfies.multibox_def.mp (@ih z ?_ (Satisfies.box_def.mp hφ z Rxz)) Rzy;
-    . intro w Rzw;
-      apply h w;
-      use z;
+    intro hφ
+    apply Satisfies.multibox_def.mpr
+    rintro y ⟨z, Rxz, Rzy⟩
+    replace hφ : x ⊧ □□^[n]φ := by simpa using hφ
+    refine Satisfies.multibox_def.mp (@ih z ?_ (Satisfies.box_def.mp hφ z Rxz)) Rzy
+    . intro w Rzw
+      apply h w
+      use z
 
 lemma intro_box_semiequiv (h : ∀ y, x ≺ y → y ⊧ φ → y ⊧ ψ) : x ⊧ □φ → x ⊧ □ψ := by
-  apply intro_multibox_semiequiv (n := 1);
-  simpa;
+  apply intro_multibox_semiequiv (n := 1)
+  simpa
 
 lemma intro_multidia_semiequiv (h : ∀ y, x ≺^[n] y → y ⊧ φ → y ⊧ ψ) : x ⊧ ◇^[n]φ → x ⊧ ◇^[n]ψ := by
   induction n generalizing x with
-  | zero => simp_all;
+  | zero => simp_all
   | succ n ih =>
-    simp only [Dia.multidia_succ];
-    apply intro_neg_semiequiv;
-    apply intro_box_semiequiv;
-    intro y Rxy;
-    apply intro_neg_semiequiv;
-    apply ih;
-    intro z Ryz;
-    apply h;
-    use y;
+    simp only [Dia.multidia_succ]
+    apply intro_neg_semiequiv
+    apply intro_box_semiequiv
+    intro y Rxy
+    apply intro_neg_semiequiv
+    apply ih
+    intro z Ryz
+    apply h
+    use y
 
 lemma intro_dia_semiequiv (h : ∀ y, x ≺ y → y ⊧ φ → y ⊧ ψ) : x ⊧ ◇φ → x ⊧ ◇ψ := by
-  apply intro_multidia_semiequiv (n := 1);
-  simpa;
+  apply intro_multidia_semiequiv (n := 1)
+  simpa
 
 
 lemma intro_negEquiv (h : x ⊧ φ ↔ x ⊧ ψ) : x ⊧ ∼φ ↔ x ⊧ ∼ψ := by
-  constructor;
-  . apply intro_neg_semiequiv $ h.mpr;
-  . apply intro_neg_semiequiv $ h.mp;
+  constructor
+  . apply intro_neg_semiequiv $ h.mpr
+  . apply intro_neg_semiequiv $ h.mp
 
 lemma intro_multibox_equiv (h : ∀ y, x ≺^[n] y → (y ⊧ φ ↔ y ⊧ ψ)) : x ⊧ □^[n]φ ↔ x ⊧ □^[n]ψ := by
-  constructor;
-  . apply intro_multibox_semiequiv; intro y Rxy; apply h y Rxy |>.mp;
-  . apply intro_multibox_semiequiv; intro y Rxy; apply h y Rxy |>.mpr;
+  constructor
+  . apply intro_multibox_semiequiv; intro y Rxy; apply h y Rxy |>.mp
+  . apply intro_multibox_semiequiv; intro y Rxy; apply h y Rxy |>.mpr
 
 lemma intro_box_equiv (h : ∀ y, x ≺ y → (y ⊧ φ ↔ y ⊧ ψ)) : x ⊧ □φ ↔ x ⊧ □ψ := by
-  apply intro_multibox_equiv (n := 1);
-  simpa;
+  apply intro_multibox_equiv (n := 1)
+  simpa
 
 lemma intro_multidia_equiv (h : ∀ y, x ≺^[n] y → (y ⊧ φ ↔ y ⊧ ψ)) : x ⊧ ◇^[n]φ ↔ x ⊧ ◇^[n]ψ := by
-  constructor;
-  . apply intro_multidia_semiequiv; intro y Rxy; apply h y Rxy |>.mp;
-  . apply intro_multidia_semiequiv; intro y Rxy; apply h y Rxy |>.mpr;
+  constructor
+  . apply intro_multidia_semiequiv; intro y Rxy; apply h y Rxy |>.mp
+  . apply intro_multidia_semiequiv; intro y Rxy; apply h y Rxy |>.mpr
 
 lemma intro_dia_equiv (h : ∀ y, x ≺ y → (y ⊧ φ ↔ y ⊧ ψ)) : x ⊧ ◇φ ↔ x ⊧ ◇ψ := by
-  apply intro_multidia_equiv (n := 1);
-  simpa;
+  apply intro_multidia_equiv (n := 1)
+  simpa
 
 
-lemma dia_dual : x ⊧ ◇φ ↔ x ⊧ ∼□(∼φ) := by simp [Satisfies];
+lemma dia_dual : x ⊧ ◇φ ↔ x ⊧ ∼□(∼φ) := by simp [Satisfies]
 
 lemma multidia_dual : x ⊧ ◇^[n]φ ↔ x ⊧ ∼□^[n](∼φ) := by
   induction n generalizing x with
-  | zero => simp;
+  | zero => simp
   | succ n ih =>
-    constructor;
-    . intro h;
-      replace h : x ⊧ ◇◇^[n]φ := by simpa using h;
-      obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp h;
-      suffices ¬x ⊧ (□□^[n](∼φ)) by simpa;
-      apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply Satisfies.not_def.mp;
-        apply ih.mp;
-        exact hy;
-    . intro h;
-      replace h : ¬x ⊧ (□□^[n](∼φ)) := by simpa using h;
-      suffices x ⊧ ◇◇^[n]φ by simpa;
-      apply Satisfies.dia_def.mpr;
-      have := Satisfies.box_def.not.mp h;
-      push_neg at this;
-      obtain ⟨y, Rxy, hy⟩ := this;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply ih.mpr;
-        exact Satisfies.not_def.mpr hy;
+    constructor
+    . intro h
+      replace h : x ⊧ ◇◇^[n]φ := by simpa using h
+      obtain ⟨y, Rxy, hy⟩ := Satisfies.dia_def.mp h
+      suffices ¬x ⊧ (□□^[n](∼φ)) by simpa
+      apply Satisfies.box_def.not.mpr
+      push_neg
+      use y
+      constructor
+      . exact Rxy
+      . apply Satisfies.not_def.mp
+        apply ih.mp
+        exact hy
+    . intro h
+      replace h : ¬x ⊧ (□□^[n](∼φ)) := by simpa using h
+      suffices x ⊧ ◇◇^[n]φ by simpa
+      apply Satisfies.dia_def.mpr
+      have := Satisfies.box_def.not.mp h
+      push_neg at this
+      obtain ⟨y, Rxy, hy⟩ := this
+      use y
+      constructor
+      . exact Rxy
+      . apply ih.mpr
+        exact Satisfies.not_def.mpr hy
 
-lemma box_dual : x ⊧ □φ ↔ x ⊧ ∼◇(∼φ) := by simp [Satisfies];
+lemma box_dual : x ⊧ □φ ↔ x ⊧ ∼◇(∼φ) := by simp [Satisfies]
 
 lemma multibox_dual : x ⊧ □^[n]φ ↔ x ⊧ ∼◇^[n](∼φ) := by
-  constructor;
-  . contrapose;
-    intro h;
+  constructor
+  . contrapose
+    intro h
     exact
       multibox_dn.not.mp
       $ Satisfies.not_def.mp
       $ multidia_dual.mp
       $ negneg_def.mp
       $ Satisfies.not_def.mpr h
-  . contrapose;
-    intro h;
-    apply Satisfies.not_def.mp;
-    apply negneg_def.mpr;
-    apply multidia_dual.mpr;
-    apply Satisfies.not_def.mpr;
-    apply multibox_dn.not.mpr;
-    exact h;
+  . contrapose
+    intro h
+    apply Satisfies.not_def.mp
+    apply negneg_def.mpr
+    apply multidia_dual.mpr
+    apply Satisfies.not_def.mpr
+    apply multibox_dn.not.mpr
+    exact h
 
-lemma not_imp : ¬(x ⊧ φ ➝ ψ) ↔ x ⊧ φ ⋏ ∼ψ := by simp [Satisfies];
+lemma not_imp : ¬(x ⊧ φ ➝ ψ) ↔ x ⊧ φ ⋏ ∼ψ := by simp [Satisfies]
 
 lemma iff_subst_self {x : F.World} (s : Substitution ℕ) :
-  letI U : Kripke.Valuation F := λ w a => Satisfies ⟨F, V⟩ w ((atom a)⟦s⟧);
+  letI U : Kripke.Valuation F := λ w a => Satisfies ⟨F, V⟩ w ((atom a)⟦s⟧)
   Satisfies ⟨F, U⟩ x φ ↔ Satisfies ⟨F, V⟩ x (φ⟦s⟧) := by
   induction φ generalizing x with
-  | hatom a => simp [Satisfies];
-  | hfalsum => simp [Satisfies];
+  | hatom a => simp [Satisfies]
+  | hfalsum => simp [Satisfies]
   | hbox φ ih =>
-    constructor;
-    . intro hbφ y Rxy;
-      apply ih.mp;
-      exact hbφ y Rxy;
-    . intro hbφ y Rxy;
-      apply ih.mpr;
-      exact hbφ y Rxy;
+    constructor
+    . intro hbφ y Rxy
+      apply ih.mp
+      exact hbφ y Rxy
+    . intro hbφ y Rxy
+      apply ih.mpr
+      exact hbφ y Rxy
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro hφψ hφ;
-      apply ihψ.mp;
-      apply hφψ;
-      apply ihφ.mpr;
-      exact hφ;
-    . intro hφψs hφ;
-      apply ihψ.mpr;
-      apply hφψs;
-      apply ihφ.mp;
-      exact hφ;
+    constructor
+    . intro hφψ hφ
+      apply ihψ.mp
+      apply hφψ
+      apply ihφ.mpr
+      exact hφ
+    . intro hφψs hφ
+      apply ihψ.mpr
+      apply hφψs
+      apply ihφ.mp
+      exact hφ
 
 end Satisfies
 
@@ -402,53 +402,53 @@ instance semantics : Semantics (Formula ℕ) (Kripke.Model) := ⟨fun M ↦ Form
 
 variable {M : Kripke.Model} {φ ψ χ : Formula ℕ}
 
-protected lemma bot_def : ¬M ⊧ ⊥ := by simp [Kripke.ValidOnModel];
+protected lemma bot_def : ¬M ⊧ ⊥ := by simp [Kripke.ValidOnModel]
 
-protected lemma top_def : M ⊧ ⊤ := by simp [Kripke.ValidOnModel];
+protected lemma top_def : M ⊧ ⊤ := by simp [Kripke.ValidOnModel]
 
 instance : Semantics.Bot (Kripke.Model) where
-  realize_bot := λ _ => ValidOnModel.bot_def;
+  realize_bot := λ _ => ValidOnModel.bot_def
 
 instance : Semantics.Top (Kripke.Model) where
-  realize_top := λ _ => ValidOnModel.top_def;
+  realize_top := λ _ => ValidOnModel.top_def
 
 
 lemma iff_not_exists_world {M : Kripke.Model} : (¬M ⊧ φ) ↔ (∃ x : M.World, ¬x ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 
 alias ⟨exists_world_of_not, not_of_exists_world⟩ := iff_not_exists_world
 
 
 protected lemma mdp (hpq : M ⊧ φ ➝ ψ) (hp : M ⊧ φ) : M ⊧ ψ := by
-  intro x;
-  exact (Satisfies.imp_def.mp $ hpq x) (hp x);
+  intro x
+  exact (Satisfies.imp_def.mp $ hpq x) (hp x)
 
 protected lemma nec (h : M ⊧ φ) : M ⊧ □φ := by
-  intro x y _;
-  exact h y;
+  intro x y _
+  exact h y
 
 lemma multinec (n) (h : M ⊧ φ) : M ⊧ □^[n]φ := by
   induction n with
-  | zero => tauto;
-  | succ n ih => simpa using ValidOnModel.nec ih;
+  | zero => tauto
+  | succ n ih => simpa using ValidOnModel.nec ih
 
-protected lemma imply₁ : M ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnModel]; tauto;
+protected lemma imply₁ : M ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnModel]; tauto
 
-protected lemma imply₂ : M ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnModel]; tauto;
+protected lemma imply₂ : M ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnModel]; tauto
 
-protected lemma elimContra : M ⊧ (Axioms.ElimContra φ ψ) := by simp [ValidOnModel, Satisfies]; tauto;
+protected lemma elimContra : M ⊧ (Axioms.ElimContra φ ψ) := by simp [ValidOnModel, Satisfies]; tauto
 
 protected lemma axiomK : M ⊧ (Axioms.K φ ψ)  := by
-  intro V;
-  apply Satisfies.imp_def.mpr;
-  intro hpq;
-  apply Satisfies.imp_def.mpr;
-  intro hp x Rxy;
-  replace hpq := Satisfies.imp_def.mp $ hpq x Rxy;
-  replace hp := hp x Rxy;
-  exact hpq hp;
+  intro V
+  apply Satisfies.imp_def.mpr
+  intro hpq
+  apply Satisfies.imp_def.mpr
+  intro hp x Rxy
+  replace hpq := Satisfies.imp_def.mp $ hpq x Rxy
+  replace hp := hp x Rxy
+  exact hpq hp
 
 end ValidOnModel
 
@@ -463,62 +463,62 @@ variable {F : Kripke.Frame}
 
 @[simp] protected lemma models_iff : F ⊧ φ ↔ Kripke.ValidOnFrame F φ := iff_of_eq rfl
 
-lemma models_set_iff : F ⊧* Φ ↔ ∀ φ ∈ Φ, F ⊧ φ := by simp [Semantics.realizeSet_iff];
+lemma models_set_iff : F ⊧* Φ ↔ ∀ φ ∈ Φ, F ⊧ φ := by simp [Semantics.realizeSet_iff]
 
-protected lemma top_def : F ⊧ ⊤ := by simp [ValidOnFrame];
+protected lemma top_def : F ⊧ ⊤ := by simp [ValidOnFrame]
 
-protected lemma bot_def : ¬F ⊧ ⊥ := by simp [ValidOnFrame];
+protected lemma bot_def : ¬F ⊧ ⊥ := by simp [ValidOnFrame]
 
 instance : Semantics.Top (Kripke.Frame) where
-  realize_top _ := ValidOnFrame.top_def;
+  realize_top _ := ValidOnFrame.top_def
 
 instance : Semantics.Bot (Kripke.Frame) where
   realize_bot _ := ValidOnFrame.bot_def
 
 lemma iff_not_exists_valuation : (¬F ⊧ φ) ↔ (∃ V : Kripke.Valuation F, ¬(⟨F, V⟩ : Kripke.Model) ⊧ φ) := by
-  simp [ValidOnFrame];
+  simp [ValidOnFrame]
 
 alias ⟨exists_valuation_of_not, not_of_exists_valuation⟩ := iff_not_exists_valuation
 
 lemma iff_not_exists_valuation_world : (¬F ⊧ φ) ↔ (∃ V : Kripke.Valuation F, ∃ x : (⟨F, V⟩ : Kripke.Model).World, ¬Satisfies _ x φ) := by
-  simp [ValidOnFrame, Satisfies, ValidOnModel, Semantics.Realize];
+  simp [ValidOnFrame, Satisfies, ValidOnModel, Semantics.Realize]
 
 alias ⟨exists_valuation_world_of_not, not_of_exists_valuation_world⟩ := iff_not_exists_valuation_world
 
 lemma iff_not_exists_model_world :  (¬F ⊧ φ) ↔ (∃ M : Kripke.Model, ∃ x : M.World, M.toFrame = F ∧ ¬(x ⊧ φ)) := by
-  constructor;
-  . intro h;
-    obtain ⟨V, x, h⟩ := iff_not_exists_valuation_world.mp h;
-    use ⟨F, V⟩, x;
-    tauto;
-  . rintro ⟨M, x, rfl, h⟩;
-    exact iff_not_exists_valuation_world.mpr ⟨M.Val, x, h⟩;
+  constructor
+  . intro h
+    obtain ⟨V, x, h⟩ := iff_not_exists_valuation_world.mp h
+    use ⟨F, V⟩, x
+    tauto
+  . rintro ⟨M, x, rfl, h⟩
+    exact iff_not_exists_valuation_world.mpr ⟨M.Val, x, h⟩
 
 alias ⟨exists_model_world_of_not, not_of_exists_model_world⟩ := iff_not_exists_model_world
 
 
 protected lemma mdp (hpq : F ⊧ φ ➝ ψ) (hp : F ⊧ φ) : F ⊧ ψ := by
-  intro V x;
-  exact (hpq V x) (hp V x);
+  intro V x
+  exact (hpq V x) (hp V x)
 
 protected lemma nec (h : F ⊧ φ) : F ⊧ □φ := by
-  intro V x y _;
-  exact h V y;
+  intro V x y _
+  exact h V y
 
 protected lemma subst (h : F ⊧ φ) : F ⊧ φ⟦s⟧ := by
-  by_contra hC;
-  replace hC := iff_not_exists_valuation_world.mp hC;
-  obtain ⟨V, ⟨x, hx⟩⟩ := hC;
-  apply Satisfies.iff_subst_self s |>.not.mpr hx;
-  exact h (λ w a => Satisfies ⟨F, V⟩ w (atom a⟦s⟧)) x;
+  by_contra hC
+  replace hC := iff_not_exists_valuation_world.mp hC
+  obtain ⟨V, ⟨x, hx⟩⟩ := hC
+  apply Satisfies.iff_subst_self s |>.not.mpr hx
+  exact h (λ w a => Satisfies ⟨F, V⟩ w (atom a⟦s⟧)) x
 
-protected lemma imply₁ : F ⊧ (Axioms.Imply₁ φ ψ) := by intro V; exact ValidOnModel.imply₁ (M := ⟨F, V⟩);
+protected lemma imply₁ : F ⊧ (Axioms.Imply₁ φ ψ) := by intro V; exact ValidOnModel.imply₁ (M := ⟨F, V⟩)
 
-protected lemma imply₂ : F ⊧ (Axioms.Imply₂ φ ψ χ) := by intro V; exact ValidOnModel.imply₂ (M := ⟨F, V⟩);
+protected lemma imply₂ : F ⊧ (Axioms.Imply₂ φ ψ χ) := by intro V; exact ValidOnModel.imply₂ (M := ⟨F, V⟩)
 
-protected lemma elimContra : F ⊧ (Axioms.ElimContra φ ψ) := by intro V; exact ValidOnModel.elimContra (M := ⟨F, V⟩);
+protected lemma elimContra : F ⊧ (Axioms.ElimContra φ ψ) := by intro V; exact ValidOnModel.elimContra (M := ⟨F, V⟩)
 
-protected lemma axiomK : F ⊧ (Axioms.K φ ψ) := by intro V; exact ValidOnModel.axiomK (M := ⟨F, V⟩);
+protected lemma axiomK : F ⊧ (Axioms.K φ ψ) := by intro V; exact ValidOnModel.axiomK (M := ⟨F, V⟩)
 
 end ValidOnFrame
 
@@ -541,27 +541,27 @@ section
 variable {C : FrameClass} {φ ψ χ : Formula ℕ}
 
 lemma iff_not_validOnFrameClass_exists_frame : (¬C ⊧ φ) ↔ (∃ F ∈ C, ¬F ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_frame_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_frame⟩ := iff_not_validOnFrameClass_exists_frame
 
 lemma iff_not_validOnFrameClass_exists_model : (¬C ⊧ φ) ↔ (∃ M : Kripke.Model, M.toFrame ∈ C ∧ ¬M ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_model_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_model⟩ := iff_not_validOnFrameClass_exists_model
 
 lemma iff_not_validOnFrameClass_exists_model_world : (¬C ⊧ φ) ↔ (∃ M : Kripke.Model, ∃ x : M.World, M.toFrame ∈ C ∧ ¬(x ⊧ φ)) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_model_world_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_model_world⟩ := iff_not_validOnFrameClass_exists_model_world
 
 lemma iff_not_validOnFrameClass_exists_valuation_world : (¬C ⊧ φ) ↔ (∃ F ∈ C, ∃ V, ∃ x, ¬(Formula.Kripke.Satisfies ⟨F, V⟩ x φ)) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_valuation_world_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_valuation_world⟩ := iff_not_validOnFrameClass_exists_valuation_world
 
 end
@@ -576,12 +576,12 @@ namespace FrameClass
 variable {C : FrameClass} {Γ : FormulaSet ℕ} {φ ψ χ : Formula ℕ}
 
 lemma validates_with_AxiomK_of_validates (hV : C ⊧* Γ) : C ⊧* (insert (Axioms.K (.atom 0) (.atom 1)) Γ) := by
-  constructor;
-  rintro φ (rfl | hφ);
-  . intro F _;
-    apply Formula.Kripke.ValidOnFrame.axiomK;
-  . apply hV.realize;
-    assumption;
+  constructor
+  rintro φ (rfl | hφ)
+  . intro F _
+    apply Formula.Kripke.ValidOnFrame.axiomK
+  . apply hV.realize
+    assumption
 
 end FrameClass
 

--- a/Foundation/Modal/Kripke/Closure.lean
+++ b/Foundation/Modal/Kripke/Closure.lean
@@ -71,7 +71,7 @@ instance [Finite F.World] : Finite (F^*).World := inferInstance
 
 instance : (F^*).IsPreorder where
 
-instance [F.IsSymmetric] : F^*.IsSymmetric where symm := by simp only; apply IsSymm.symm;
+instance [F.IsSymmetric] : F^*.IsSymmetric where symm := by simp only; apply IsSymm.symm
 
 instance [F.IsSymmetric] : F^*.IsEquivalence where
 

--- a/Foundation/Modal/Kripke/Cluster.lean
+++ b/Foundation/Modal/Kripke/Cluster.lean
@@ -19,23 +19,23 @@ section
 
 variable {F : Kripke.Frame} {x y z : F.World}
 
-instance : IsRefl _ (clusterEquiv F) := by tauto;
+instance : IsRefl _ (clusterEquiv F) := by tauto
 
 instance : IsSymm _ (clusterEquiv F) := ⟨by
-  rintro x y (rfl | ⟨Rxy, Ryx⟩);
-  . apply refl;
-  . right; exact ⟨Ryx, Rxy⟩;
+  rintro x y (rfl | ⟨Rxy, Ryx⟩)
+  . apply refl
+  . right; exact ⟨Ryx, Rxy⟩
 ⟩
 
 instance [F.IsTransitive] : IsTrans _ (clusterEquiv F) := ⟨by
-  rintro x y z (rfl | ⟨Rxy, Ryx⟩) (rfl | ⟨Ryz, Rzy⟩);
-  . apply refl;
-  . right; exact ⟨Ryz, Rzy⟩;
-  . right; exact ⟨Rxy, Ryx⟩;
-  . right;
-    constructor;
-    . exact _root_.trans Rxy Ryz;
-    . exact _root_.trans Rzy Ryx;
+  rintro x y z (rfl | ⟨Rxy, Ryx⟩) (rfl | ⟨Ryz, Rzy⟩)
+  . apply refl
+  . right; exact ⟨Ryz, Rzy⟩
+  . right; exact ⟨Rxy, Ryx⟩
+  . right
+    constructor
+    . exact _root_.trans Rxy Ryz
+    . exact _root_.trans Rzy Ryx
 ⟩
 
 instance [F.IsTransitive] : IsEquiv _ (clusterEquiv F) where
@@ -49,68 +49,68 @@ namespace Cluster
 variable {F : Frame} [F.IsTransitive] {x y : F.World} {C : Cluster F}
 
 instance [Finite F] : Finite (Cluster F) := Finite.of_surjective (λ x => ⟦x⟧) $ by
-  intro C;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep C;
-  use x;
+  intro C
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep C
+  use x
 
 @[simp]
 lemma iff_eq_cluster : (⟦x⟧ : Cluster F) = ⟦y⟧ ↔ (x = y ∨ (x ≺ y ∧ y ≺ x)) := by
-  simp only [Quotient.eq, clusterEquiv];
+  simp only [Quotient.eq, clusterEquiv]
 
 protected abbrev rel : HRel (Cluster F) := Quotient.lift₂ (λ x y => x ≺ y) $ by
-    rintro x₁ y₁ x₂ y₂ (rfl | ⟨Rx₁x₂, Rx₂x₁⟩) (rfl | ⟨Ry₁y₂, Ry₂y₁⟩);
-    . rfl;
-    . apply eq_iff_iff.mpr;
-      constructor;
-      . intro Rx₁y₁;
-        exact _root_.trans Rx₁y₁ Ry₁y₂;
-      . intro Rx₁y₂;
-        exact _root_.trans Rx₁y₂ Ry₂y₁;
-    . apply eq_iff_iff.mpr;
-      constructor;
-      . intro Rx₁y₁;
-        exact _root_.trans Rx₂x₁ Rx₁y₁;
-      . intro Rx₂y₁;
-        exact _root_.trans Rx₁x₂ Rx₂y₁;
-    . apply eq_iff_iff.mpr;
-      constructor;
-      . intro Rx₁y₁;
-        exact _root_.trans Rx₂x₁ $ _root_.trans Rx₁y₁ Ry₁y₂;
-      . intro Rx₂y₂;
-        exact _root_.trans (_root_.trans Rx₁x₂ Rx₂y₂) Ry₂y₁;
+    rintro x₁ y₁ x₂ y₂ (rfl | ⟨Rx₁x₂, Rx₂x₁⟩) (rfl | ⟨Ry₁y₂, Ry₂y₁⟩)
+    . rfl
+    . apply eq_iff_iff.mpr
+      constructor
+      . intro Rx₁y₁
+        exact _root_.trans Rx₁y₁ Ry₁y₂
+      . intro Rx₁y₂
+        exact _root_.trans Rx₁y₂ Ry₂y₁
+    . apply eq_iff_iff.mpr
+      constructor
+      . intro Rx₁y₁
+        exact _root_.trans Rx₂x₁ Rx₁y₁
+      . intro Rx₂y₁
+        exact _root_.trans Rx₁x₂ Rx₂y₁
+    . apply eq_iff_iff.mpr
+      constructor
+      . intro Rx₁y₁
+        exact _root_.trans Rx₂x₁ $ _root_.trans Rx₁y₁ Ry₁y₂
+      . intro Rx₂y₂
+        exact _root_.trans (_root_.trans Rx₁x₂ Rx₂y₂) Ry₂y₁
 local infix:50 " ≼ " => Cluster.rel
 
 instance : IsTrans (Cluster F) (· ≼ ·) := ⟨by
-  rintro X Y Z RXY RYZ;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-  obtain ⟨z, rfl⟩ := Quotient.exists_rep Z;
-  simp only [Cluster.rel, Quotient.lift_mk] at RXY RYZ;
-  apply _root_.trans RXY RYZ;
+  rintro X Y Z RXY RYZ
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+  obtain ⟨z, rfl⟩ := Quotient.exists_rep Z
+  simp only [Cluster.rel, Quotient.lift_mk] at RXY RYZ
+  apply _root_.trans RXY RYZ
 ⟩
 
 instance : IsAntisymm (Cluster F) (· ≼ ·) := ⟨by
-  rintro X Y RXY RYX;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-  simp only [Cluster.rel, Quotient.lift_mk] at RXY RYX;
-  apply iff_eq_cluster.mpr;
-  right;
-  tauto;
+  rintro X Y RXY RYX
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+  simp only [Cluster.rel, Quotient.lift_mk] at RXY RYX
+  apply iff_eq_cluster.mpr
+  right
+  tauto
 ⟩
 
 instance [F.IsReflexive] : IsRefl (Cluster F) (· ≼ ·)  := ⟨by
-  rintro X;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  simp only [Cluster.rel, Quotient.lift_mk];
-  apply IsRefl.refl;
+  rintro X
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  simp only [Cluster.rel, Quotient.lift_mk]
+  apply IsRefl.refl
 ⟩
 
 instance [IsTotal _ F] : IsTotal (Cluster F) (· ≼ ·) := ⟨by
-  rintro X Y;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-  rcases total_of (· ≺ ·) x y with Rxy | Rxy <;> tauto;
+  rintro X Y
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+  rcases total_of (· ≺ ·) x y with Rxy | Rxy <;> tauto
 ⟩
 
 
@@ -118,35 +118,35 @@ protected abbrev strict_rel : HRel (Cluster F) := λ X Y => X ≼ Y ∧ X ≠ Y
 local infix:50 " ≺ " => Cluster.strict_rel
 
 instance : IsTrans (Cluster F) (· ≺ ·) := ⟨by
-  rintro X Y Z ⟨RXY, _⟩ ⟨RYZ, _⟩;
-  constructor;
-  . exact _root_.trans RXY RYZ;
-  . by_contra hC;
-    subst hC;
-    have : X = Y := antisymm RXY RYZ;
-    contradiction;
+  rintro X Y Z ⟨RXY, _⟩ ⟨RYZ, _⟩
+  constructor
+  . exact _root_.trans RXY RYZ
+  . by_contra hC
+    subst hC
+    have : X = Y := antisymm RXY RYZ
+    contradiction
 ⟩
 
 instance : IsIrrefl (Cluster F) (· ≺ ·) := ⟨by
-  rintro X;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  simp [Cluster.strict_rel, Quotient.lift_mk];
+  rintro X
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  simp [Cluster.strict_rel, Quotient.lift_mk]
 ⟩
 
 instance : IsAsymm (Cluster F) (· ≺ ·) := ⟨by
-  intro X Y ⟨RXY, _⟩;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-  simp_all [Cluster.strict_rel, Quotient.lift_mk, clusterEquiv];
+  intro X Y ⟨RXY, _⟩
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+  simp_all [Cluster.strict_rel, Quotient.lift_mk, clusterEquiv]
 ⟩
 
 instance : IsStrictOrder (Cluster F) (· ≺ ·) where
 
 instance [IsTrichotomous _ F] : IsTrichotomous (Cluster F) (· ≺ ·) := ⟨by
-  rintro X Y;
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-  rcases (trichotomous (r := (· ≺ ·)) x y) with Rxy | rfl | Rxy <;> tauto;
+  rintro X Y
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+  obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+  rcases (trichotomous (r := (· ≺ ·)) x y) with Rxy | rfl | Rxy <;> tauto
 ⟩
 
 instance [IsTrichotomous _ F] : IsStrictTotalOrder (Cluster F) (· ≺ ·) where
@@ -157,145 +157,145 @@ instance : Membership (F.World) (Cluster F) := ⟨Cluster.mem⟩
 
 @[simp]
 lemma mem_iff : x ∈ C ↔ C = ⟦x⟧ := by
-  obtain ⟨c, rfl⟩ := Quotient.exists_rep C;
-  simp only [Quotient.eq, clusterEquiv, Cluster.mem, Membership.mem];
+  obtain ⟨c, rfl⟩ := Quotient.exists_rep C
+  simp only [Quotient.eq, clusterEquiv, Cluster.mem, Membership.mem]
 
 @[simp]
 lemma mem_iff₂ : x ∈ (⟦y⟧ : Cluster F) ↔ y = x ∨ y ≺ x ∧ x ≺ y := by
-  constructor;
-  . intro h;
-    replace h := mem_iff.mp h;
-    simpa using h;
-  . intro h;
-    apply mem_iff.mpr;
-    simpa using h;
+  constructor
+  . intro h
+    replace h := mem_iff.mp h
+    simpa using h
+  . intro h
+    apply mem_iff.mpr
+    simpa using h
 
 lemma mem_same_cluster (hx : x ∈ C) (hy : y ∈ C): y = x ∨ (y ≺ x ∧ x ≺ y) := by
-  obtain ⟨c, rfl⟩ := Quotient.exists_rep C;
-  replace hx := mem_iff₂.mp hx;
-  replace hy := mem_iff₂.mp hy;
+  obtain ⟨c, rfl⟩ := Quotient.exists_rep C
+  replace hx := mem_iff₂.mp hx
+  replace hy := mem_iff₂.mp hy
   rcases hx with rfl | ⟨Rcx, Rxc⟩ <;>
-  rcases hy with rfl | ⟨Rcy, Ryc⟩;
-  . tauto;
-  . tauto;
-  . tauto;
-  . right;
-    constructor;
-    . exact _root_.trans Ryc Rcx;
-    . exact _root_.trans Rxc Rcy;
+  rcases hy with rfl | ⟨Rcy, Ryc⟩
+  . tauto
+  . tauto
+  . tauto
+  . right
+    constructor
+    . exact _root_.trans Ryc Rcx
+    . exact _root_.trans Rxc Rcy
 
 lemma refl_in_cluster_of_more_than_one (h : ∃ x y, x ≠ y ∧ x ∈ C ∧ y ∈ C) : ∀ z, z ∈ C → z ≺ z := by
-  obtain ⟨c, rfl⟩ := Quotient.exists_rep C;
-  obtain ⟨x, y, hxy, hx, hy⟩ := h;
-  intro z hz;
-  simp only [mem_iff₂] at hx hy hz;
+  obtain ⟨c, rfl⟩ := Quotient.exists_rep C
+  obtain ⟨x, y, hxy, hx, hy⟩ := h
+  intro z hz
+  simp only [mem_iff₂] at hx hy hz
   rcases hx with rfl | ⟨Rcx, Rxc⟩ <;>
   rcases hy with rfl | ⟨Rcy, Ryc⟩ <;>
-  rcases hz with rfl | ⟨Rcz, Rzc⟩;
-  . contradiction;
-  . exact _root_.trans Rzc Rcz;
-  . exact _root_.trans Rcy Ryc;
-  . exact _root_.trans Rzc Rcz;
-  . exact _root_.trans Rcx Rxc;
-  . exact _root_.trans Rzc Rcz;
-  . exact _root_.trans Rcy Ryc;
-  . exact _root_.trans Rzc Rcz;
+  rcases hz with rfl | ⟨Rcz, Rzc⟩
+  . contradiction
+  . exact _root_.trans Rzc Rcz
+  . exact _root_.trans Rcy Ryc
+  . exact _root_.trans Rzc Rcz
+  . exact _root_.trans Rcx Rxc
+  . exact _root_.trans Rzc Rcz
+  . exact _root_.trans Rcy Ryc
+  . exact _root_.trans Rzc Rcz
 
 lemma refl_rel_of_more_than_one (h : ∃ x y, x ≠ y ∧ x ∈ C ∧ y ∈ C) : C ≼ C := by
-  obtain ⟨c, rfl⟩ := Quotient.exists_rep C;
-  apply refl_in_cluster_of_more_than_one h;
-  tauto;
+  obtain ⟨c, rfl⟩ := Quotient.exists_rep C
+  apply refl_in_cluster_of_more_than_one h
+  tauto
 
 def degenerate (C : Cluster F) := ¬C ≼ C
 
 lemma not_more_than_two_of_degenerate : C.degenerate → ¬∃ x y, x ≠ y ∧ x ∈ C ∧ y ∈ C := by
-  apply not_imp_not.mpr $ refl_rel_of_more_than_one;
+  apply not_imp_not.mpr $ refl_rel_of_more_than_one
 
 lemma degenerate_iff_exists_unique_irrefl_point : C.degenerate ↔ (∃! x, x ∈ C ∧ ¬x ≺ x) := by
-  obtain ⟨c, rfl⟩ := Quotient.exists_rep C;
-  constructor;
-  . intro h;
-    use c;
-    constructor;
-    . simpa;
-    . rintro x ⟨hx₁, hx₂⟩;
-      by_contra nexc;
-      have := not_more_than_two_of_degenerate h;
-      push_neg at this;
-      replace this := this c x (by tauto) (by tauto);
-      contradiction;
-  . rintro ⟨x, ⟨hx₁, hx₂⟩, hx₃⟩;
-    rcases (mem_iff₂.mp hx₁) with rfl | ⟨Rxy, Ryx⟩;
-    . apply hx₂;
-    . exfalso;
-      exact hx₂ $ _root_.trans Ryx Rxy;
+  obtain ⟨c, rfl⟩ := Quotient.exists_rep C
+  constructor
+  . intro h
+    use c
+    constructor
+    . simpa
+    . rintro x ⟨hx₁, hx₂⟩
+      by_contra nexc
+      have := not_more_than_two_of_degenerate h
+      push_neg at this
+      replace this := this c x (by tauto) (by tauto)
+      contradiction
+  . rintro ⟨x, ⟨hx₁, hx₂⟩, hx₃⟩
+    rcases (mem_iff₂.mp hx₁) with rfl | ⟨Rxy, Ryx⟩
+    . apply hx₂
+    . exfalso
+      exact hx₂ $ _root_.trans Ryx Rxy
 
 def simple (C : Cluster F) := ∃! x, x ∈ C ∧ x ≺ x
 
 lemma not_degenerate_of_simple (h : C.simple) : ¬C.degenerate := by
-  apply degenerate_iff_exists_unique_irrefl_point.not.mpr;
-  by_contra hC;
-  obtain ⟨x, hx⟩ := h;
-  obtain ⟨y, hy⟩ := hC;
-  obtain ⟨⟨hx₁, hx₂⟩, hx₃⟩ := hx;
-  obtain ⟨⟨hy₁, hy₂⟩, hy₃⟩ := hy;
-  by_cases exy : x = y;
-  . subst exy;
-    contradiction;
-  . exact hy₂ $ refl_in_cluster_of_more_than_one (by use x, y) y hy₁;
+  apply degenerate_iff_exists_unique_irrefl_point.not.mpr
+  by_contra hC
+  obtain ⟨x, hx⟩ := h
+  obtain ⟨y, hy⟩ := hC
+  obtain ⟨⟨hx₁, hx₂⟩, hx₃⟩ := hx
+  obtain ⟨⟨hy₁, hy₂⟩, hy₃⟩ := hy
+  by_cases exy : x = y
+  . subst exy
+    contradiction
+  . exact hy₂ $ refl_in_cluster_of_more_than_one (by use x, y) y hy₁
 
 lemma refl_in_simple (h : C.simple) (hx : x ∈ C) : x ≺ x := by
-  obtain ⟨y, ⟨hy, _⟩, _⟩ := h;
-  rcases mem_same_cluster hx hy with rfl | ⟨Rxy, Ryx⟩;
-  . assumption;
-  . exact _root_.trans Ryx Rxy;
+  obtain ⟨y, ⟨hy, _⟩, _⟩ := h
+  rcases mem_same_cluster hx hy with rfl | ⟨Rxy, Ryx⟩
+  . assumption
+  . exact _root_.trans Ryx Rxy
 
 def proper (C : Cluster F) := ∃ x y, x ≠ y ∧ x ∈ C ∧ y ∈ C
 
 lemma not_degenerate_of_proper (h : C.proper) : ¬C.degenerate := by
-  by_contra hC;
-  exact not_more_than_two_of_degenerate hC h;
+  by_contra hC
+  exact not_more_than_two_of_degenerate hC h
 
 lemma refl_in_proper (h : C.proper) (hx : x ∈ C) : x ≺ x := by
-  obtain ⟨y, z, hxy, hy, hz⟩ := h;
-  rcases mem_same_cluster hx hy with rfl | ⟨Rxy, Ryx⟩;
-  . rcases mem_same_cluster hy hz with rfl | ⟨Ryz, Rzy⟩;
-    . contradiction;
-    . exact _root_.trans Rzy Ryz;
-  . exact _root_.trans Ryx Rxy;
+  obtain ⟨y, z, hxy, hy, hz⟩ := h
+  rcases mem_same_cluster hx hy with rfl | ⟨Rxy, Ryx⟩
+  . rcases mem_same_cluster hy hz with rfl | ⟨Ryz, Rzy⟩
+    . contradiction
+    . exact _root_.trans Rzy Ryz
+  . exact _root_.trans Ryx Rxy
 
 lemma either_simple_or_proper_of_non_degenerate (h : ¬C.degenerate) : C.simple ∨ C.proper := by
-  obtain ⟨x, rfl⟩ := Quotient.exists_rep C;
-  by_cases ex : ∃ y, x ≠ y ∧ (⟦x⟧ : Cluster F) = ⟦y⟧;
-  . right;
-    obtain ⟨y, nexy, h⟩ := ex;
-    use x, y;
-    tauto;
-  . left;
-    use x;
-    constructor;
-    . simpa [degenerate] using h;
-    . rintro y ⟨hy₁, hy₂⟩;
-      simp only [ne_eq, Quotient.eq, not_exists, not_and] at ex;
-      replace hy₁ := iff_eq_cluster.mp hy₁;
-      rcases hy₁ with rfl | ⟨Rxy, Ryx⟩;
-      . tauto;
-      . apply not_imp_comm.mp (ex y) ?_ |>.symm;
-        push_neg;
-        dsimp [clusterEquiv];
-        tauto;
+  obtain ⟨x, rfl⟩ := Quotient.exists_rep C
+  by_cases ex : ∃ y, x ≠ y ∧ (⟦x⟧ : Cluster F) = ⟦y⟧
+  . right
+    obtain ⟨y, nexy, h⟩ := ex
+    use x, y
+    tauto
+  . left
+    use x
+    constructor
+    . simpa [degenerate] using h
+    . rintro y ⟨hy₁, hy₂⟩
+      simp only [ne_eq, Quotient.eq, not_exists, not_and] at ex
+      replace hy₁ := iff_eq_cluster.mp hy₁
+      rcases hy₁ with rfl | ⟨Rxy, Ryx⟩
+      . tauto
+      . apply not_imp_comm.mp (ex y) ?_ |>.symm
+        push_neg
+        dsimp [clusterEquiv]
+        tauto
 
 lemma refl_of_mem_non_degenerate (h : ¬C.degenerate) (hx : x ∈ C) : x ≺ x := by
-  rcases (either_simple_or_proper_of_non_degenerate h) with h | h;
-  . apply refl_in_simple h hx;
-  . apply refl_in_proper h hx;
+  rcases (either_simple_or_proper_of_non_degenerate h) with h | h
+  . apply refl_in_simple h hx
+  . apply refl_in_proper h hx
 
 theorem degenerate_or_simple_or_proper : C.degenerate ∨ C.simple ∨ C.proper := by
-  by_cases h : C.degenerate;
-  . left;
-    exact h;
-  . right;
-    exact either_simple_or_proper_of_non_degenerate h;
+  by_cases h : C.degenerate
+  . left
+    exact h
+  . right
+    exact either_simple_or_proper_of_non_degenerate h
 
 end Cluster
 
@@ -311,27 +311,27 @@ section
 variable {F : Frame} [F.IsTransitive]
 
 instance [Finite F] : Finite F.skeleton := by
-  dsimp only [Frame.skeleton];
-  infer_instance;
+  dsimp only [Frame.skeleton]
+  infer_instance
 
 instance : F.skeleton.IsTransitive := by
-  dsimp only [Frame.skeleton];
-  infer_instance;
+  dsimp only [Frame.skeleton]
+  infer_instance
 
 instance : F.skeleton.IsAntisymmetric :=  by
-  dsimp only [Frame.skeleton];
-  infer_instance;
+  dsimp only [Frame.skeleton]
+  infer_instance
 
 instance [F.IsReflexive] : F.skeleton.IsReflexive :=  by
-  dsimp only [Frame.skeleton];
-  infer_instance;
+  dsimp only [Frame.skeleton]
+  infer_instance
 
 instance [F.IsReflexive] : F.skeleton.IsPartialOrder where
 
 
 instance [IsTotal _ F] : IsTotal _ F.skeleton := by
-  dsimp only [Frame.skeleton];
-  infer_instance;
+  dsimp only [Frame.skeleton]
+  infer_instance
 
 instance [IsTotal _ F] : IsLinearOrder _ F.skeleton where
 
@@ -348,20 +348,20 @@ namespace Frame.strictSkelteon
 variable {F : Frame} [F.IsTransitive]
 
 instance [Finite F] : Finite F.strictSkelteon := by
-  dsimp only [Frame.strictSkelteon];
-  infer_instance;
+  dsimp only [Frame.strictSkelteon]
+  infer_instance
 
 instance : F.strictSkelteon.IsTransitive := by
-  dsimp only [Frame.strictSkelteon];
-  infer_instance;
+  dsimp only [Frame.strictSkelteon]
+  infer_instance
 
 instance : F.strictSkelteon.IsIrreflexive := by
-  dsimp only [Frame.strictSkelteon];
-  infer_instance;
+  dsimp only [Frame.strictSkelteon]
+  infer_instance
 
 instance [IsTrichotomous _ F] : IsTrichotomous _ F.strictSkelteon := by
-  dsimp only [Frame.strictSkelteon];
-  infer_instance;
+  dsimp only [Frame.strictSkelteon]
+  infer_instance
 
 instance [IsTrichotomous _ F] : IsStrictTotalOrder _ F.strictSkelteon where
 

--- a/Foundation/Modal/Kripke/Completeness.lean
+++ b/Foundation/Modal/Kripke/Completeness.lean
@@ -38,89 +38,89 @@ variable {t : (canonicalModel 𝓢).World}
 lemma truthlemma : ((φ ∈ t.1.1) ↔ t ⊧ φ) ∧ ((φ ∈ t.1.2) ↔ ¬t ⊧ φ) := by
   induction φ generalizing t with
   | hatom =>
-    simp_all only [Semantics.Realize, Satisfies, true_and];
-    exact iff_not_mem₁_mem₂.symm;
-  | hfalsum => simp [Semantics.Realize, Satisfies];
+    simp_all only [Semantics.Realize, Satisfies, true_and]
+    exact iff_not_mem₁_mem₂.symm
+  | hfalsum => simp [Semantics.Realize, Satisfies]
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . constructor;
-      . intro hφψ hφ;
-        rcases iff_mem₁_imp.mp hφψ with (hφ | hψ);
-        . have := ihφ.2.1 hφ; contradiction;
-        . exact ihψ.1.1 hψ;
-      . intro hφψ;
-        rcases Satisfies.imp_def₂.mp hφψ with (hφ | hψ);
-        . apply iff_mem₁_imp.mpr;
-          left;
-          exact ihφ.2.2 hφ;
-        . apply iff_mem₁_imp.mpr;
-          right;
-          exact ihψ.1.2 hψ;
-    . constructor;
-      . intro hφψ;
-        rcases iff_mem₂_imp.mp hφψ with ⟨hφ, hψ⟩;
-        apply Satisfies.imp_def₂.not.mpr;
-        push_neg;
-        constructor;
-        . exact ihφ.1.mp hφ;
-        . exact ihψ.2.mp hψ;
-      . intro hφψ;
-        apply iff_mem₂_imp.mpr;
-        replace hφψ := Satisfies.imp_def₂.not.mp hφψ;
-        push_neg at hφψ;
-        rcases hφψ with ⟨hφ, hψ⟩;
-        constructor;
-        . exact ihφ.1.mpr hφ;
-        . exact ihψ.2.mpr hψ;
+    constructor
+    . constructor
+      . intro hφψ hφ
+        rcases iff_mem₁_imp.mp hφψ with (hφ | hψ)
+        . have := ihφ.2.1 hφ; contradiction
+        . exact ihψ.1.1 hψ
+      . intro hφψ
+        rcases Satisfies.imp_def₂.mp hφψ with (hφ | hψ)
+        . apply iff_mem₁_imp.mpr
+          left
+          exact ihφ.2.2 hφ
+        . apply iff_mem₁_imp.mpr
+          right
+          exact ihψ.1.2 hψ
+    . constructor
+      . intro hφψ
+        rcases iff_mem₂_imp.mp hφψ with ⟨hφ, hψ⟩
+        apply Satisfies.imp_def₂.not.mpr
+        push_neg
+        constructor
+        . exact ihφ.1.mp hφ
+        . exact ihψ.2.mp hψ
+      . intro hφψ
+        apply iff_mem₂_imp.mpr
+        replace hφψ := Satisfies.imp_def₂.not.mp hφψ
+        push_neg at hφψ
+        rcases hφψ with ⟨hφ, hψ⟩
+        constructor
+        . exact ihφ.1.mpr hφ
+        . exact ihψ.2.mpr hψ
   | hbox φ ihφ =>
-    constructor;
-    . constructor;
-      . intro h t' Rtt';
-        apply ihφ.1.1;
-        exact iff_mem₁_box.mp h Rtt';
-      . intro h;
-        apply iff_mem₁_box.mpr;
-        intro t' Rtt';
-        apply ihφ.1.2;
-        exact h t' Rtt';
-    . constructor;
-      . intro h;
-        apply Satisfies.box_def.not.mpr;
-        push_neg;
-        obtain ⟨t', Rtt', ht'⟩ := iff_mem₂_box.mp h;
-        use t';
-        constructor;
-        . exact Rtt';
-        . exact ihφ.2.mp ht';
-      . intro h;
-        apply iff_mem₂_box.mpr;
-        replace h := Satisfies.box_def.not.mp h;
-        push_neg at h;
-        obtain ⟨t', Rtt', ht'⟩ := h;
-        use t';
-        constructor;
-        . exact Rtt';
-        . exact ihφ.2.mpr ht';
+    constructor
+    . constructor
+      . intro h t' Rtt'
+        apply ihφ.1.1
+        exact iff_mem₁_box.mp h Rtt'
+      . intro h
+        apply iff_mem₁_box.mpr
+        intro t' Rtt'
+        apply ihφ.1.2
+        exact h t' Rtt'
+    . constructor
+      . intro h
+        apply Satisfies.box_def.not.mpr
+        push_neg
+        obtain ⟨t', Rtt', ht'⟩ := iff_mem₂_box.mp h
+        use t'
+        constructor
+        . exact Rtt'
+        . exact ihφ.2.mp ht'
+      . intro h
+        apply iff_mem₂_box.mpr
+        replace h := Satisfies.box_def.not.mp h
+        push_neg at h
+        obtain ⟨t', Rtt', ht'⟩ := h
+        use t'
+        constructor
+        . exact Rtt'
+        . exact ihφ.2.mpr ht'
 
 lemma truthlemma₁ : (φ ∈ t.1.1) ↔ t ⊧ φ := truthlemma.1
 
 lemma truthlemma₂ : (φ ∈ t.1.2) ↔ ¬t ⊧ φ := truthlemma.2
 
 lemma iff_valid_on_canonicalModel_deducible : (canonicalModel 𝓢) ⊧ φ ↔ 𝓢 ⊢! φ := by
-  constructor;
-  . contrapose;
-    intro h;
+  constructor
+  . contrapose
+    intro h
     have : Tableau.Consistent 𝓢 (∅, {φ}) := by
-      apply Tableau.iff_consistent_empty_singleton₂ (𝓢 := 𝓢) (φ := φ) |>.mpr;
-      exact h;
-    obtain ⟨t, ht⟩ := lindenbaum this;
-    apply ValidOnModel.not_of_exists_world;
-    use t;
-    apply truthlemma₂.mp;
-    apply ht.2;
-    tauto_set;
-  . intro h t;
-    exact truthlemma₁.mp $ MaximalConsistentTableau.iff_provable_mem₁.mp h t;
+      apply Tableau.iff_consistent_empty_singleton₂ (𝓢 := 𝓢) (φ := φ) |>.mpr
+      exact h
+    obtain ⟨t, ht⟩ := lindenbaum this
+    apply ValidOnModel.not_of_exists_world
+    use t
+    apply truthlemma₂.mp
+    apply ht.2
+    tauto_set
+  . intro h t
+    exact truthlemma₁.mp $ MaximalConsistentTableau.iff_provable_mem₁.mp h t
 
 end lemmata
 
@@ -129,13 +129,13 @@ class Canonical (𝓢 : S) [Entailment.Consistent 𝓢] [Entailment.K 𝓢] (C :
   canonical : (Kripke.canonicalFrame 𝓢) ∈ C
 
 instance [Canonical 𝓢 C] : Complete 𝓢 C := ⟨by
-  contrapose;
-  intro h;
-  apply not_validOnFrameClass_of_exists_model;
-  use (canonicalModel 𝓢);
-  constructor;
-  . exact Canonical.canonical;
-  . exact iff_valid_on_canonicalModel_deducible.not.mpr h;
+  contrapose
+  intro h
+  apply not_validOnFrameClass_of_exists_model
+  use (canonicalModel 𝓢)
+  constructor
+  . exact Canonical.canonical
+  . exact iff_valid_on_canonicalModel_deducible.not.mpr h
 ⟩
 
 
@@ -145,64 +145,64 @@ open Formula.Kripke.Satisfies
 
 variable {x y : (canonicalModel 𝓢).World}
 
-lemma def_rel_box_mem₁ : x ≺ y ↔ x.1.1.prebox ⊆ y.1.1 := by simp [Frame.Rel'];
+lemma def_rel_box_mem₁ : x ≺ y ↔ x.1.1.prebox ⊆ y.1.1 := by simp [Frame.Rel']
 
 lemma def_rel_box_satisfies : x ≺ y ↔ ∀ {φ}, x ⊧ □φ → y ⊧ φ := by
-  constructor;
-  . intro h φ hφ;
-    exact truthlemma₁.mp $  def_rel_box_mem₁.mp h (truthlemma₁.mpr hφ);
-  . intro h;
-    apply def_rel_box_mem₁.mpr;
-    intro φ hφ;
+  constructor
+  . intro h φ hφ
+    exact truthlemma₁.mp $  def_rel_box_mem₁.mp h (truthlemma₁.mpr hφ)
+  . intro h
+    apply def_rel_box_mem₁.mpr
+    intro φ hφ
     exact truthlemma₁.mpr $ h $ truthlemma₁.mp hφ
 
 lemma def_multirel_multibox_satisfies : x ≺^[n] y ↔ (∀ {φ}, x ⊧ □^[n]φ → y ⊧ φ) := by
-  constructor;
-  . intro h φ hφ;
-    exact Satisfies.multibox_def.mp hφ h;
+  constructor
+  . intro h φ hφ
+    exact Satisfies.multibox_def.mp hφ h
   . induction n generalizing x y with
     | zero =>
-      suffices (∀ {φ : Formula ℕ}, x ⊧ φ → y ⊧ φ) → x = y by simpa;
-      intro h;
-      apply intro_equality;
-      . intro φ hφ; exact truthlemma₁.mpr $ h $ truthlemma₁.mp hφ;
-      . intro φ hφ; exact truthlemma₂.mpr $ h $ Satisfies.not_def.mpr $ truthlemma₂.mp hφ;
+      suffices (∀ {φ : Formula ℕ}, x ⊧ φ → y ⊧ φ) → x = y by simpa
+      intro h
+      apply intro_equality
+      . intro φ hφ; exact truthlemma₁.mpr $ h $ truthlemma₁.mp hφ
+      . intro φ hφ; exact truthlemma₂.mpr $ h $ Satisfies.not_def.mpr $ truthlemma₂.mp hφ
     | succ n ih =>
-      intro h;
+      intro h
       obtain ⟨t, ht⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨{ φ | x ⊧ □φ }, Set.multibox n { φ | ¬y ⊧ φ }⟩) $ by
-        intro Γ Δ hΓ hΔ;
-        by_contra! hC;
-        have : 𝓢 ⊢! □Γ.conj ➝ □Δ.disj := imply_box_distribute'! hC;
+        intro Γ Δ hΓ hΔ
+        by_contra! hC
+        have : 𝓢 ⊢! □Γ.conj ➝ □Δ.disj := imply_box_distribute'! hC
         have : □Δ.disj ∈ x.1.1 := mdp_mem₁_provable this $ by
-          apply truthlemma₁.mpr;
-          intro y Rxy;
-          apply Satisfies.fconj_def.mpr;
-          intro φ hφ;
-          apply hΓ hφ y Rxy;
-        have : x ⊧ □Δ.disj := truthlemma₁.mp this;
+          apply truthlemma₁.mpr
+          intro y Rxy
+          apply Satisfies.fconj_def.mpr
+          intro φ hφ
+          apply hΓ hφ y Rxy
+        have : x ⊧ □Δ.disj := truthlemma₁.mp this
         have : x ⊧ □^[(n + 1)](Δ.premultibox n |>.disj) := by
-          suffices x ⊧ □□^[n](Finset.premultibox n Δ).disj by simpa;
-          intro y Rxy;
-          apply multibox_def.mpr;
-          intro z Ryz;
-          obtain ⟨ψ, hψ₁, hψ₂⟩ := Satisfies.fdisj_def.mp $ this y Rxy;
-          obtain ⟨ξ, _, rfl⟩ := by simpa using hΔ hψ₁;
-          apply Satisfies.fdisj_def.mpr;
-          use ξ;
-          constructor;
-          . simpa;
-          . exact Satisfies.multibox_def.mp hψ₂ Ryz;
-        have : y ⊧ (Δ.premultibox n |>.disj) := h this;
-        obtain ⟨ψ, hψ₁, hψ₂⟩ := fdisj_def.mp this;
-        have : ¬y ⊧ ψ := by simpa using @hΔ (□^[n]ψ) (by simpa using hψ₁);
-        contradiction;
-      use t;
-      constructor;
-      . intro φ hφ;
-        apply ht.1;
-        exact truthlemma₁.mp hφ;
-      . apply ih;
-        intro φ hφ;
+          suffices x ⊧ □□^[n](Finset.premultibox n Δ).disj by simpa
+          intro y Rxy
+          apply multibox_def.mpr
+          intro z Ryz
+          obtain ⟨ψ, hψ₁, hψ₂⟩ := Satisfies.fdisj_def.mp $ this y Rxy
+          obtain ⟨ξ, _, rfl⟩ := by simpa using hΔ hψ₁
+          apply Satisfies.fdisj_def.mpr
+          use ξ
+          constructor
+          . simpa
+          . exact Satisfies.multibox_def.mp hψ₂ Ryz
+        have : y ⊧ (Δ.premultibox n |>.disj) := h this
+        obtain ⟨ψ, hψ₁, hψ₂⟩ := fdisj_def.mp this
+        have : ¬y ⊧ ψ := by simpa using @hΔ (□^[n]ψ) (by simpa using hψ₁)
+        contradiction
+      use t
+      constructor
+      . intro φ hφ
+        apply ht.1
+        exact truthlemma₁.mp hφ
+      . apply ih
+        intro φ hφ
         simpa using (Set.compl_subset_compl.mpr ht.2) $ iff_not_mem₂_mem₁.mpr $ truthlemma₁.mpr hφ
 
 lemma def_multirel_multibox_mem₁ : x ≺^[n] y ↔ (x.1.1.premultibox n ⊆ y.1.1) := ⟨
@@ -211,43 +211,43 @@ lemma def_multirel_multibox_mem₁ : x ≺^[n] y ↔ (x.1.1.premultibox n ⊆ y.
 ⟩
 
 lemma def_multirel_multibox_mem₂ : x ≺^[n] y ↔ (y.1.2 ⊆ x.1.2.premultibox n) := by
-  apply Iff.trans def_multirel_multibox_mem₁;
-  constructor;
-  . intro h φ;
-    contrapose!;
-    intro hφ;
-    apply iff_not_mem₂_mem₁.mpr;
-    apply h;
-    apply iff_not_mem₂_mem₁.mp;
-    assumption;
-  . intro h φ;
-    contrapose!;
-    intro hφ;
-    apply iff_not_mem₁_mem₂.mpr;
-    apply h;
-    apply iff_not_mem₁_mem₂.mp;
-    assumption;
+  apply Iff.trans def_multirel_multibox_mem₁
+  constructor
+  . intro h φ
+    contrapose!
+    intro hφ
+    apply iff_not_mem₂_mem₁.mpr
+    apply h
+    apply iff_not_mem₂_mem₁.mp
+    assumption
+  . intro h φ
+    contrapose!
+    intro hφ
+    apply iff_not_mem₁_mem₂.mpr
+    apply h
+    apply iff_not_mem₁_mem₂.mp
+    assumption
 
 lemma def_rel_box_mem₂ : x ≺ y ↔ (y.1.2 ⊆ x.1.2.prebox) := by
-  simpa using def_multirel_multibox_mem₂ (n := 1);
+  simpa using def_multirel_multibox_mem₂ (n := 1)
 
 lemma def_multirel_multidia_satisfies : x ≺^[n] y ↔ (∀ {φ}, y ⊧ φ → x ⊧ ◇^[n]φ) := by
-  constructor;
-  . intro h φ hφ;
-    apply Formula.Kripke.Satisfies.multidia_def.mpr;
-    use y;
-  . intro h;
-    apply def_multirel_multibox_satisfies.mpr;
-    intro φ;
-    contrapose;
-    intro hφ;
-    apply Satisfies.not_def.mp;
-    have : x ⊧ ∼□^[n](∼∼φ) := multidia_dual.mp $ h (φ := ∼φ) (Satisfies.not_def.mp hφ);
-    revert this;
-    apply intro_neg_semiequiv;
-    apply intro_multibox_semiequiv;
-    intro _ _;
-    apply negneg_def.mpr;
+  constructor
+  . intro h φ hφ
+    apply Formula.Kripke.Satisfies.multidia_def.mpr
+    use y
+  . intro h
+    apply def_multirel_multibox_satisfies.mpr
+    intro φ
+    contrapose
+    intro hφ
+    apply Satisfies.not_def.mp
+    have : x ⊧ ∼□^[n](∼∼φ) := multidia_dual.mp $ h (φ := ∼φ) (Satisfies.not_def.mp hφ)
+    revert this
+    apply intro_neg_semiequiv
+    apply intro_multibox_semiequiv
+    intro _ _
+    apply negneg_def.mpr
 
 lemma def_multirel_multidia_mem₁ : x ≺^[n] y ↔ (y.1.1 ⊆ x.1.1.premultidia n) := ⟨
   fun h _ hφ => truthlemma₁.mpr $ def_multirel_multidia_satisfies.mp h (truthlemma₁.mp hφ),
@@ -255,25 +255,25 @@ lemma def_multirel_multidia_mem₁ : x ≺^[n] y ↔ (y.1.1 ⊆ x.1.1.premultidi
 ⟩
 
 lemma def_rel_dia_mem₁ : x ≺ y ↔ (y.1.1 ⊆ x.1.1.predia) := by
-  simpa using def_multirel_multidia_mem₁ (n := 1);
+  simpa using def_multirel_multidia_mem₁ (n := 1)
 
 lemma def_multirel_multidia_mem₂ : x ≺^[n] y ↔ (x.1.2.premultidia n ⊆ y.1.2) := by
-  constructor;
-  . intro Rxy φ;
-    contrapose;
-    intro hφ;
-    apply iff_not_mem₂_mem₁.mpr;
-    apply def_multirel_multidia_mem₁.mp Rxy;
-    exact iff_not_mem₂_mem₁.mp hφ;
-  . intro H;
-    apply def_multirel_multidia_mem₁.mpr;
-    intro φ;
-    contrapose;
-    intro hφ;
-    exact iff_not_mem₁_mem₂.mpr $ @H φ (iff_not_mem₁_mem₂.mp hφ);
+  constructor
+  . intro Rxy φ
+    contrapose
+    intro hφ
+    apply iff_not_mem₂_mem₁.mpr
+    apply def_multirel_multidia_mem₁.mp Rxy
+    exact iff_not_mem₂_mem₁.mp hφ
+  . intro H
+    apply def_multirel_multidia_mem₁.mpr
+    intro φ
+    contrapose
+    intro hφ
+    exact iff_not_mem₁_mem₂.mpr $ @H φ (iff_not_mem₁_mem₂.mp hφ)
 
 lemma def_rel_dia_mem₂ : x ≺ y ↔ (x.1.2.predia ⊆ y.1.2) := by
-  simpa using def_multirel_multidia_mem₂ (n := 1);
+  simpa using def_multirel_multidia_mem₂ (n := 1)
 
 end canonicalModel
 

--- a/Foundation/Modal/Kripke/ComplexityLimited.lean
+++ b/Foundation/Modal/Kripke/ComplexityLimited.lean
@@ -22,67 +22,67 @@ lemma iff_satisfy_complexityLimitedModel_aux
   (hq : ψ ∈ φ.subformulas)
   (hx : ∃ n ≤ φ.complexity - ψ.complexity, r ≺^[n] x)
   :
-  haveI : x ∈ {y | ∃ n ≤ φ.complexity, r ≺^[n] y} := by obtain ⟨n, _, _⟩ := hx; use n; exact ⟨by omega, by assumption⟩;
+  haveI : x ∈ {y | ∃ n ≤ φ.complexity, r ≺^[n] y} := by obtain ⟨n, _, _⟩ := hx; use n; exact ⟨by omega, by assumption⟩
   x ⊧ ψ ↔ Satisfies (complexityLimitedModel M r φ) ⟨x, this⟩ ψ := by
   induction ψ generalizing x φ with
   | hbox ψ ihq =>
-    obtain ⟨n, hn, hx⟩ := hx;
-    simp [Formula.complexity] at hn;
+    obtain ⟨n, hn, hx⟩ := hx
+    simp [Formula.complexity] at hn
     have : n + 1 ≤ φ.complexity - ψ.complexity := by
-      have : ψ.complexity + 1 ≤ φ.complexity := by simpa using subformulas.complexity_lower hq;
-      omega;
-    constructor;
-    . rintro h ⟨y, hy⟩ Rxy;
-      apply ihq (subformulas.mem_box hq) ?_ |>.mp;
-      . exact h _ Rxy;
-      . use (n + 1);
-        constructor;
-        . assumption;
-        . apply HRel.Iterate.forward.mpr;
-          use x; constructor; assumption; exact Rxy;
-    . rintro h y Rxy;
-      apply ihq (subformulas.mem_box hq) ?_ |>.mpr;
-      . exact h _ Rxy;
-      . use (n + 1);
-        constructor;
-        . assumption;
-        . apply HRel.Iterate.forward.mpr;
-          use x;
+      have : ψ.complexity + 1 ≤ φ.complexity := by simpa using subformulas.complexity_lower hq
+      omega
+    constructor
+    . rintro h ⟨y, hy⟩ Rxy
+      apply ihq (subformulas.mem_box hq) ?_ |>.mp
+      . exact h _ Rxy
+      . use (n + 1)
+        constructor
+        . assumption
+        . apply HRel.Iterate.forward.mpr
+          use x; constructor; assumption; exact Rxy
+    . rintro h y Rxy
+      apply ihq (subformulas.mem_box hq) ?_ |>.mpr
+      . exact h _ Rxy
+      . use (n + 1)
+        constructor
+        . assumption
+        . apply HRel.Iterate.forward.mpr
+          use x
   | himp ψ₁ ψ₂ ihq₁ ihq₂ =>
-    obtain ⟨n, hn, hx⟩ := hx;
-    simp [Formula.complexity] at hn;
-    constructor;
-    . rintro hq₁ hq₂;
-      apply ihq₂ (by grind) ?_ |>.mp;
-      apply hq₁;
-      apply ihq₁ (by grind) ?_ |>.mpr hq₂;
-      use n; constructor; omega; assumption;
-      use n; constructor; omega; assumption;
-    . rintro hq₁ hq₂;
-      apply ihq₂ (subformulas.mem_imp (by assumption) |>.2) ?_ |>.mpr;
-      apply hq₁;
-      apply ihq₁ (subformulas.mem_imp (by assumption) |>.1) ?_ |>.mp hq₂;
-      use n; constructor; omega; assumption;
-      use n; constructor; omega; assumption;
-  | _ => simp [Satisfies, complexityLimitedModel];
+    obtain ⟨n, hn, hx⟩ := hx
+    simp [Formula.complexity] at hn
+    constructor
+    . rintro hq₁ hq₂
+      apply ihq₂ (by grind) ?_ |>.mp
+      apply hq₁
+      apply ihq₁ (by grind) ?_ |>.mpr hq₂
+      use n; constructor; omega; assumption
+      use n; constructor; omega; assumption
+    . rintro hq₁ hq₂
+      apply ihq₂ (subformulas.mem_imp (by assumption) |>.2) ?_ |>.mpr
+      apply hq₁
+      apply ihq₁ (subformulas.mem_imp (by assumption) |>.1) ?_ |>.mp hq₂
+      use n; constructor; omega; assumption
+      use n; constructor; omega; assumption
+  | _ => simp [Satisfies, complexityLimitedModel]
 
 lemma iff_satisfy_complexityLimitedModel : r ⊧ φ ↔ Satisfies (complexityLimitedModel M r φ) ⟨r, (by use 0; simp)⟩ φ := by
-  apply iff_satisfy_complexityLimitedModel_aux (show φ ∈ φ.subformulas by simp);
-  use 0; simp;
+  apply iff_satisfy_complexityLimitedModel_aux (show φ ∈ φ.subformulas by simp)
+  use 0; simp
 
 lemma complexityLimitedModel_subformula_closedAux {ψ₁ ψ₂ : Formula ℕ} (hq₁ : φ ∈ ψ₁.subformulas) (hq₂ : φ ∈ ψ₂.subformulas)
   : Satisfies (complexityLimitedModel M r ψ₁) ⟨r, (by use 0; simp)⟩ φ → Satisfies (complexityLimitedModel M r ψ₂) ⟨r, (by use 0; simp)⟩ φ := by
-  intro h;
-  apply @iff_satisfy_complexityLimitedModel_aux M r r ψ₂ φ hq₂ ?_ |>.mp;
-  apply @iff_satisfy_complexityLimitedModel_aux M r r ψ₁ φ hq₁ ?_ |>.mpr h;
-  . use 0; simp;
-  . use 0; simp;
+  intro h
+  apply @iff_satisfy_complexityLimitedModel_aux M r r ψ₂ φ hq₂ ?_ |>.mp
+  apply @iff_satisfy_complexityLimitedModel_aux M r r ψ₁ φ hq₁ ?_ |>.mpr h
+  . use 0; simp
+  . use 0; simp
 
 lemma complexityLimitedModel_subformula_closed (hq : φ ∈ ψ.subformulas)
   : Satisfies (complexityLimitedModel M r φ) ⟨r, (by use 0; simp)⟩ φ ↔ Satisfies (complexityLimitedModel M r ψ) ⟨r, (by use 0; simp)⟩ φ := by
-  constructor;
-  . apply complexityLimitedModel_subformula_closedAux <;> simp_all;
-  . apply complexityLimitedModel_subformula_closedAux <;> simp_all;
+  constructor
+  . apply complexityLimitedModel_subformula_closedAux <;> simp_all
+  . apply complexityLimitedModel_subformula_closedAux <;> simp_all
 
 end
 

--- a/Foundation/Modal/Kripke/ExtendRoot.lean
+++ b/Foundation/Modal/Kripke/ExtendRoot.lean
@@ -31,8 +31,8 @@ abbrev extend (i : Fin n) : F.extendRoot n := .inl i
 instance : Coe (F.World) ((F.extendRoot n).World) := ⟨embed⟩
 
 instance isFinite [F.IsFinite] : (F.extendRoot n).IsFinite := by
-  unfold Frame.extendRoot;
-  infer_instance;
+  unfold Frame.extendRoot
+  infer_instance
 
 instance fintype [Fintype F] : Fintype (F.extendRoot n) := instFintypeSum (Fin n) F
 
@@ -40,16 +40,16 @@ protected abbrev root : (F.extendRoot n).World := .inl 0
 
 instance instIsRooted : (F.extendRoot n).IsRootedBy extendRoot.root where
   root_generates := by
-    intro x h;
+    intro x h
     match x with
     | .inl j =>
-      obtain ⟨j, hj⟩ := j;
-      apply Relation.TransGen.single;
-      apply Nat.zero_lt_of_not_zero;
+      obtain ⟨j, hj⟩ := j
+      apply Relation.TransGen.single
+      apply Nat.zero_lt_of_not_zero
       simp_all [Frame.Rel', Frame.extendRoot]
     | .inr x =>
-      apply Relation.TransGen.single;
-      tauto;
+      apply Relation.TransGen.single
+      tauto
 
 
 protected abbrev chain : List (F.extendRoot n) := List.finRange n |>.map (extend ·)
@@ -59,38 +59,38 @@ lemma chain_length : extendRoot.chain (F := F) (r := r) (n := n).length = n := b
 
 @[simp]
 lemma chain_Chain' : List.Chain' (· ≺ ·) (extendRoot.chain (F := F) (r := r) (n := n)) := by
-  apply List.chain'_map_of_chain' (R := λ a b => a < b);
-  . tauto;
-  . simp;
+  apply List.chain'_map_of_chain' (R := λ a b => a < b)
+  . tauto
+  . simp
 
 
 instance isAsymmetric [F.IsAsymmetric] : (F.extendRoot n).IsAsymmetric := ⟨by
-  intro x y hxy;
+  intro x y hxy
   match x, y with
   | .inr x, .inr y =>
-    suffices ¬y ≺ x by tauto;
-    exact IsAsymm.asymm _ _ hxy;
-  | .inl i, .inl j => simp_all [Frame.extendRoot]; omega;
-  | .inl _, .inr _ => simp_all [Frame.extendRoot];
-  | .inr _, .inl _ => simp_all [Frame.extendRoot];
+    suffices ¬y ≺ x by tauto
+    exact IsAsymm.asymm _ _ hxy
+  | .inl i, .inl j => simp_all [Frame.extendRoot]; omega
+  | .inl _, .inr _ => simp_all [Frame.extendRoot]
+  | .inr _, .inl _ => simp_all [Frame.extendRoot]
 ⟩
 
 instance isTransitive [F.IsTransitive] : (F.extendRoot n).IsTransitive := ⟨by
-  intro x y z hxy hyz;
+  intro x y z hxy hyz
   match x, y, z with
   | .inr x, .inr y, .inr z =>
-    have : x ≺ z := IsTrans.trans _ _ _ hxy hyz;
-    assumption;
-  | .inr _, .inl _, .inl _ => simp_all [Frame.extendRoot];
-  | .inl _, .inr _, .inr _ => simp_all [Frame.extendRoot];
-  | .inl _, .inl _, .inr _ => simp_all [Frame.extendRoot];
-  | .inl _, .inl _, .inl _ => simp_all [Frame.extendRoot]; omega;
+    have : x ≺ z := IsTrans.trans _ _ _ hxy hyz
+    assumption
+  | .inr _, .inl _, .inl _ => simp_all [Frame.extendRoot]
+  | .inl _, .inr _, .inr _ => simp_all [Frame.extendRoot]
+  | .inl _, .inl _, .inr _ => simp_all [Frame.extendRoot]
+  | .inl _, .inl _, .inl _ => simp_all [Frame.extendRoot]; omega
 ⟩
 
 @[simp] lemma rooted_original [F.IsTransitive] {x : F.World} :
     (extendRoot.root (F := F) (r := r) (n := n)) ≺ x := by
-  apply Frame.root_genaretes'!;
-  tauto;
+  apply Frame.root_genaretes'!
+  tauto
 
 instance isTree [F.IsTree r] : (F.extendRoot n).IsTree extendRoot.root where
 
@@ -98,28 +98,28 @@ instance isFiniteTree [F.IsFiniteTree r] : (F.extendRoot n).IsFiniteTree extendR
 
 def pMorphism : F →ₚ F.extendRoot n where
   toFun := embed
-  forth := by simp [Frame.extendRoot];
+  forth := by simp [Frame.extendRoot]
   back {x y} h := by
     match y with
-    | .inl r => simp [Frame.Rel', Frame.extendRoot] at h;
-    | .inr y => use y; simpa using h;
+    | .inl r => simp [Frame.Rel', Frame.extendRoot] at h
+    | .inr y => use y; simpa using h
 
 lemma not_root_of_from_root [F.IsTree r] {x : F.extendRoot n} (h : extendRoot.root ≺ x) :
     (∃ i > 0, x = extend i) ∨ x = r ∨ embed r ≺ x := by
   match x with
   | .inl i =>
-    left;
-    use i;
-    constructor;
-    . simp_all [Frame.Rel', extendRoot];
-    . tauto;
+    left
+    use i
+    constructor
+    . simp_all [Frame.Rel', extendRoot]
+    . tauto
   | .inr x =>
-    by_cases e : x = r;
-    . tauto;
-    . right;
-      right;
-      apply pMorphism.forth;
-      apply Frame.root_genaretes'! (x := x) (by tauto);
+    by_cases e : x = r
+    . tauto
+    . right
+      right
+      apply pMorphism.forth
+      apply Frame.root_genaretes'! (x := x) (by tauto)
 
 lemma not_root_of_from_root' [F.IsTree r] {x : F.extendRoot n} (h : extendRoot.root ≺ x) :
     (∃ i > 0, x = extend i) ∨ x = r ∨ ∃ x₀ : F, x = x₀ ∧ r ≺ x₀ := by
@@ -189,8 +189,8 @@ instance isTree [M.IsTree r] : (M.extendRoot n).IsTree extendRoot.root := Frame.
 instance isFiniteTree [M.IsFiniteTree r] : (M.extendRoot n).IsFiniteTree extendRoot.root := Frame.extendRoot.isFiniteTree
 
 def pMorphism : M →ₚ M.extendRoot n := PseudoEpimorphism.ofAtomic Frame.extendRoot.pMorphism $ by
-  intros;
-  rfl;
+  intros
+  rfl
 
 lemma modal_equivalence_original_world : x ↭ (embed x : M.extendRoot n) :=
   Model.PseudoEpimorphism.modal_equivalence pMorphism _
@@ -201,37 +201,37 @@ lemma inr_satisfies_iff : (embed x : M.extendRoot n) ⊧ φ ↔ x ⊧ φ := moda
 open Formula.Kripke in
 lemma inl_satisfies_boxdot_iff [IsTrans _ M.Rel] : r ⊧ φᵇ ↔ (extend i : M.extendRoot n) ⊧ φᵇ := by
   induction φ generalizing i with
-  | hatom φ => rfl;
-  | hfalsum => rfl;
+  | hatom φ => rfl
+  | hfalsum => rfl
   | himp φ ψ ihA ihB =>
-    replace ihA := @ihA i;
-    replace ihB := @ihB i;
-    simp_all [Formula.boxdotTranslate];
+    replace ihA := @ihA i
+    replace ihB := @ihB i
+    simp_all [Formula.boxdotTranslate]
   | hbox φ ih =>
-    dsimp [Formula.boxdotTranslate];
-    constructor;
-    . intro h;
-      obtain ⟨h₁, h₂⟩ := Satisfies.and_def.mp h;
-      apply Satisfies.and_def.mpr;
-      constructor;
-      . exact ih.mp h₁;
-      . intro x Rix;
+    dsimp [Formula.boxdotTranslate]
+    constructor
+    . intro h
+      obtain ⟨h₁, h₂⟩ := Satisfies.and_def.mp h
+      apply Satisfies.and_def.mpr
+      constructor
+      . exact ih.mp h₁
+      . intro x Rix
         match x with
-        | .inl j => apply ih.mp h₁;
+        | .inl j => apply ih.mp h₁
         | .inr x =>
-          apply inr_satisfies_iff.mpr;
-          by_cases erx : r = x;
-          . subst erx;
-            exact h₁;
-          . apply h₂;
-            apply Frame.root_genaretes'!;
-            tauto;
-    . intro h;
-      replace ⟨h₁, h₂⟩ := Satisfies.and_def.mp h;
-      apply Satisfies.and_def.mpr;
-      constructor;
-      . apply ih.mpr h₁;
-      . intro x Rix;
+          apply inr_satisfies_iff.mpr
+          by_cases erx : r = x
+          . subst erx
+            exact h₁
+          . apply h₂
+            apply Frame.root_genaretes'!
+            tauto
+    . intro h
+      replace ⟨h₁, h₂⟩ := Satisfies.and_def.mp h
+      apply Satisfies.and_def.mpr
+      constructor
+      . apply ih.mpr h₁
+      . intro x Rix
         exact inr_satisfies_iff.mp $ @h₂ (Sum.inr x) $ by
           simp [Frame.Rel', Model.extendRoot, Frame.extendRoot]
 
@@ -248,94 +248,94 @@ variable {l : List M.World} {n : ℕ+}
 
 lemma atmost_one_validates_axiomT_in_irrefl_trans_chain' (l_chain : List.Chain' (· ≺ ·) l) :
     (∀ x ∈ l, x ⊧ □A ➝ A) ∨ (∃! x ∈ l, ¬x ⊧ □A ➝ A) := by
-  apply or_iff_not_imp_left.mpr;
-  push_neg;
-  rintro ⟨x, x_l, hx⟩;
-  use x;
-  constructor;
-  . simp_all;
-  . rintro y ⟨y_l, hy⟩;
-    wlog neyx : y ≠ x;
-    . tauto;
-    obtain ⟨hx₁, hx₂⟩ : x ⊧ □A ∧ ¬(x ⊧ A) := by simpa using hx;
-    obtain ⟨hy₁, hy₂⟩ : y ⊧ □A ∧ ¬(y ⊧ A) := by simpa using hy;
-    rcases (List.Chain'.connected_of_trans l_chain y_l x_l (by tauto)) with Ryx | Rxy;
-    . have : x ⊧ A := hy₁ x Ryx; contradiction;
-    . have : y ⊧ A := hx₁ y Rxy; contradiction;
+  apply or_iff_not_imp_left.mpr
+  push_neg
+  rintro ⟨x, x_l, hx⟩
+  use x
+  constructor
+  . simp_all
+  . rintro y ⟨y_l, hy⟩
+    wlog neyx : y ≠ x
+    . tauto
+    obtain ⟨hx₁, hx₂⟩ : x ⊧ □A ∧ ¬(x ⊧ A) := by simpa using hx
+    obtain ⟨hy₁, hy₂⟩ : y ⊧ □A ∧ ¬(y ⊧ A) := by simpa using hy
+    rcases (List.Chain'.connected_of_trans l_chain y_l x_l (by tauto)) with Ryx | Rxy
+    . have : x ⊧ A := hy₁ x Ryx; contradiction
+    . have : y ⊧ A := hx₁ y Rxy; contradiction
 
 lemma atmost_one_validates_axiomT_in_irrefl_trans_chain
     (l_chain : List.Chain' (· ≺ ·) l) :
-    haveI : Fintype M.World := Fintype.ofFinite _;
+    haveI : Fintype M.World := Fintype.ofFinite _
     Finset.card { x | x ∈ l ∧ ¬x ⊧ (□A ➝ A) } ≤ 1 := by
-  apply Nat.le_one_iff_eq_zero_or_eq_one.mpr;
-  rcases atmost_one_validates_axiomT_in_irrefl_trans_chain' (l_chain := l_chain) (A := A) with h | h;
-  . left;
-    apply Finset.card_filter_eq_zero_iff.mpr;
-    simp_all;
-  . right;
-    apply Finset.card_eq_one.mpr;
-    apply Finset.singleton_iff_unique_mem _ |>.mpr;
-    simp_all;
+  apply Nat.le_one_iff_eq_zero_or_eq_one.mpr
+  rcases atmost_one_validates_axiomT_in_irrefl_trans_chain' (l_chain := l_chain) (A := A) with h | h
+  . left
+    apply Finset.card_filter_eq_zero_iff.mpr
+    simp_all
+  . right
+    apply Finset.card_eq_one.mpr
+    apply Finset.singleton_iff_unique_mem _ |>.mpr
+    simp_all
 
 lemma validates_axiomT_set_in_irrefl_trans_chain
     (Γ : Finset (Modal.Formula ℕ))
     (l_length : l.length = Γ.card + 1)
     (l_chain : List.Chain' (· ≺ ·) l) :
     ∃ x ∈ l, x ⊧ (Γ.image (λ γ => □γ ➝ γ)).conj := by
-  haveI : Fintype M.World := Fintype.ofFinite _;
-  let t₁ : Finset M.World := { x | x ∈ l ∧ ∃ A ∈ Γ, ¬x ⊧ (□A ➝ A) };
-  let t₂ : Finset M.World := l.toFinset;
+  haveI : Fintype M.World := Fintype.ofFinite _
+  let t₁ : Finset M.World := { x | x ∈ l ∧ ∃ A ∈ Γ, ¬x ⊧ (□A ➝ A) }
+  let t₂ : Finset M.World := l.toFinset
   have : t₁.card ≤ Γ.card :=
     calc
       _ = (Finset.biUnion Γ (λ A => { x | x ∈ l ∧ ¬x ⊧ (□A ➝ A) })).card := by
-        apply Finset.eq_card_of_eq;
-        ext x;
-        constructor;
-        . intro hx;
-          obtain ⟨_, hx₁, ⟨A, hA₁, hA₂⟩⟩ := Finset.mem_filter.mp hx;
-          apply Finset.mem_biUnion.mpr;
-          use A;
-          constructor;
-          . assumption;
-          . apply Finset.mem_filter.mpr;
-            tauto;
-        . intro hx;
-          obtain ⟨A, _, hA⟩ := Finset.mem_biUnion.mp hx;
-          obtain ⟨_, _, _⟩ := Finset.mem_filter.mp hA;
-          apply Finset.mem_filter.mpr;
-          tauto;
+        apply Finset.eq_card_of_eq
+        ext x
+        constructor
+        . intro hx
+          obtain ⟨_, hx₁, ⟨A, hA₁, hA₂⟩⟩ := Finset.mem_filter.mp hx
+          apply Finset.mem_biUnion.mpr
+          use A
+          constructor
+          . assumption
+          . apply Finset.mem_filter.mpr
+            tauto
+        . intro hx
+          obtain ⟨A, _, hA⟩ := Finset.mem_biUnion.mp hx
+          obtain ⟨_, _, _⟩ := Finset.mem_filter.mp hA
+          apply Finset.mem_filter.mpr
+          tauto
       _ ≤ ∑ a ∈ Γ, Finset.card { x | x ∈ l ∧ ¬x ⊧ □a ➝ a } := Finset.card_biUnion_le
       _ ≤ Γ.card * 1 := by
-        apply Finset.sum_le_card;
-        intro A hA;
-        convert atmost_one_validates_axiomT_in_irrefl_trans_chain l_chain;
-      _ = Γ.card := by omega;
+        apply Finset.sum_le_card
+        intro A hA
+        convert atmost_one_validates_axiomT_in_irrefl_trans_chain l_chain
+      _ = Γ.card := by omega
   have : t₂.card = l.length :=
     calc
       _ = l.dedup.length := List.card_toFinset l
       _ = l.length       := by
-        suffices l.dedup = l by rw [this];
-        apply List.dedup_eq_self.mpr;
-        apply List.Chain'.noDup_of_irrefl_trans l_chain;
+        suffices l.dedup = l by rw [this]
+        apply List.dedup_eq_self.mpr
+        apply List.Chain'.noDup_of_irrefl_trans l_chain
   have : t₁ ⊂ t₂ := Finset.ssubset_of_subset_lt_card (by
-    intro x hx;
-    apply List.mem_toFinset.mpr;
-    exact Finset.mem_filter.mp hx |>.2.1;
-  ) (by omega);
-  obtain ⟨x, hx₂, nhx₁⟩ := Finset.exists_of_ssubset this;
-  replace hx₂ := List.mem_toFinset.mp hx₂;
-  replace hx₁ := Finset.mem_filter.not.mp nhx₁;
-  push_neg at hx₁;
-  use x;
-  constructor;
-  . assumption;
-  . apply Formula.Kripke.Satisfies.fconj_def.mpr;
-    simp only [Finset.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂];
-    intro A hA;
-    apply hx₁;
-    . simp;
-    . assumption;
-    . assumption;
+    intro x hx
+    apply List.mem_toFinset.mpr
+    exact Finset.mem_filter.mp hx |>.2.1
+  ) (by omega)
+  obtain ⟨x, hx₂, nhx₁⟩ := Finset.exists_of_ssubset this
+  replace hx₂ := List.mem_toFinset.mp hx₂
+  replace hx₁ := Finset.mem_filter.not.mp nhx₁
+  push_neg at hx₁
+  use x
+  constructor
+  . assumption
+  . apply Formula.Kripke.Satisfies.fconj_def.mpr
+    simp only [Finset.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    intro A hA
+    apply hx₁
+    . simp
+    . assumption
+    . assumption
 
 end
 
@@ -348,13 +348,13 @@ variable {M : Model} {r : M.World} [M.IsFinite] [IsTrans _ M.Rel] [IsIrrefl _ M.
 
 lemma inr_satisfies_axiomT_set
     {Γ : Finset (Modal.Formula ℕ)} :
-    letI n : ℕ+ := ⟨Γ.card + 1, by omega⟩;
+    letI n : ℕ+ := ⟨Γ.card + 1, by omega⟩
     ∃ i : Fin n, (extend i : M.extendRoot n) ⊧ (Γ.image (λ γ => □γ ➝ γ)).conj := by
-  let n : ℕ+ := ⟨Γ.card + 1, by omega⟩;
-  let M' := M.extendRoot n;
+  let n : ℕ+ := ⟨Γ.card + 1, by omega⟩
+  let M' := M.extendRoot n
   have : Finite M'.World := by
-    unfold M' Model.extendRoot Frame.extendRoot;
-    infer_instance;
+    unfold M' Model.extendRoot Frame.extendRoot
+    infer_instance
   obtain ⟨x, hx₁, hx₂⟩ := @validates_axiomT_set_in_irrefl_trans_chain (M := M')
     (by infer_instance)
     (by apply isTransitive)
@@ -363,9 +363,9 @@ lemma inr_satisfies_axiomT_set
     (Γ := Γ)
     (Frame.extendRoot.chain_length)
     (Frame.extendRoot.chain_Chain')
-  simp only [List.mem_map, M', n] at hx₁;
-  obtain ⟨i, _, rfl⟩ := hx₁;
-  use i;
+  simp only [List.mem_map, M', n] at hx₁
+  obtain ⟨i, _, rfl⟩ := hx₁
+  use i
 
 end Model.extendRoot
 

--- a/Foundation/Modal/Kripke/Filtration.lean
+++ b/Foundation/Modal/Kripke/Filtration.lean
@@ -19,11 +19,11 @@ def filterEquiv (M : Kripke.Model) (T : FormulaSet ℕ) [T.IsSubformulaClosed] (
 variable (M : Kripke.Model) (T : FormulaSet ℕ) [T.IsSubformulaClosed]
 
 lemma filterEquiv.equivalence : Equivalence (filterEquiv M T) where
-  refl := by intro x φ _; rfl;
-  symm := by intro x y h φ hp; exact h _ hp |>.symm;
+  refl := by intro x φ _; rfl
+  symm := by intro x y h φ hp; exact h _ hp |>.symm
   trans := by
-    intro x y z exy eyz;
-    intro φ hp;
+    intro x y z exy eyz
+    intro φ hp
     exact Iff.trans (exy φ hp) (eyz φ hp)
 
 def FilterEqvSetoid : Setoid (M.World) := ⟨filterEquiv M T, filterEquiv.equivalence M T⟩
@@ -36,34 +36,34 @@ namespace FilterEqvQuotient
 variable {M T} {x y : M.World}
 
 lemma iff_of_eq (h : (⟦x⟧ : FilterEqvQuotient M T) = ⟦y⟧) (hφ : φ ∈ T) : x ⊧ φ ↔ y ⊧ φ := by
-  apply @Quotient.eq_iff_equiv.mp h;
-  assumption;
+  apply @Quotient.eq_iff_equiv.mp h
+  assumption
 
 lemma finite (T_finite : T.Finite) : Finite (FilterEqvQuotient M T) := by
   have : Finite (𝒫 T) := Set.Finite.powerset T_finite
   let f : FilterEqvQuotient M T → 𝒫 T :=
     λ (X : FilterEqvQuotient M T) => Quotient.lift (λ x => ⟨{ φ ∈ T | x ⊧ φ }, (by simp_all)⟩) (by
-      intro x y hxy;
-      suffices {φ | φ ∈ T ∧ Satisfies M x φ} = {φ | φ ∈ T ∧ Satisfies M y φ} by simpa;
-      apply Set.eq_of_subset_of_subset;
-      . rintro φ ⟨hp, hx⟩; exact ⟨hp, (hxy φ hp).mp hx⟩;
-      . rintro φ ⟨hp, hy⟩; exact ⟨hp, (hxy φ hp).mpr hy⟩;
+      intro x y hxy
+      suffices {φ | φ ∈ T ∧ Satisfies M x φ} = {φ | φ ∈ T ∧ Satisfies M y φ} by simpa
+      apply Set.eq_of_subset_of_subset
+      . rintro φ ⟨hp, hx⟩; exact ⟨hp, (hxy φ hp).mp hx⟩
+      . rintro φ ⟨hp, hy⟩; exact ⟨hp, (hxy φ hp).mpr hy⟩
       ) X
   have hf : Function.Injective f := by
-    intro X Y h;
-    obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-    obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-    simp [f] at h;
-    apply Quotient.eq''.mpr;
-    intro φ hp;
-    constructor;
-    . intro hpx;
-      have : ∀ a ∈ T, x ⊧ a → a ∈ T ∧ y ⊧ a := by simpa using h.subset;
-      exact this φ hp hpx |>.2;
-    . intro hpy;
-      have := h.symm.subset;
-      simp only [Set.setOf_subset_setOf, and_imp] at this;
-      exact this φ hp hpy |>.2;
+    intro X Y h
+    obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+    obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+    simp [f] at h
+    apply Quotient.eq''.mpr
+    intro φ hp
+    constructor
+    . intro hpx
+      have : ∀ a ∈ T, x ⊧ a → a ∈ T ∧ y ⊧ a := by simpa using h.subset
+      exact this φ hp hpx |>.2
+    . intro hpy
+      have := h.symm.subset
+      simp only [Set.setOf_subset_setOf, and_imp] at this
+      exact this φ hp hpy |>.2
   exact Finite.of_injective f hf
 
 instance : Nonempty (FilterEqvQuotient M T) := ⟨⟦M.toFrame.world_nonempty.some⟧⟩
@@ -77,11 +77,11 @@ class FilterOf (FM : Model) (M : outParam Kripke.Model) (T : outParam (FormulaSe
   def_rel_back : ∀ {x y : M}, (cast def_world.symm ⟦x⟧) ≺ (cast def_world.symm ⟦y⟧) → ∀ φ, □φ ∈ T → (x ⊧ □φ → y ⊧ φ)
   def_valuation X a : (ha : (atom a) ∈ T) →
     FM X a ↔ Quotient.lift (λ x => M x a) (by
-      intro x y h;
-      apply eq_iff_iff.mpr;
-      constructor;
-      . intro hx; exact h a ha |>.mp hx;
-      . intro hy; exact h a ha |>.mpr hy;
+      intro x y h
+      apply eq_iff_iff.mpr
+      constructor
+      . intro hx; exact h a ha |>.mp hx
+      . intro hy; exact h a ha |>.mpr hy
     ) (cast def_world X) := by tauto
 
 attribute [simp] FilterOf.def_world
@@ -96,26 +96,26 @@ theorem filtration
   : x ⊧ φ ↔ (cast (filterOf.def_world.symm) ⟦x⟧) ⊧ φ := by
   induction φ generalizing x with
   | hatom a =>
-    have := filterOf.def_valuation (cast filterOf.def_world.symm ⟦x⟧) a;
-    simp_all [Satisfies];
+    have := filterOf.def_valuation (cast filterOf.def_world.symm ⟦x⟧) a
+    simp_all [Satisfies]
   | hbox φ ihφ =>
-    constructor;
-    . rintro h Y RXY;
-      obtain ⟨y, ey⟩ := Quotient.exists_rep (cast (filterOf.def_world) Y);
-      suffices Satisfies FM (cast filterOf.def_world.symm ⟦y⟧) φ by simp_all;
-      apply ihφ (of_mem_box hs) |>.mp;
+    constructor
+    . rintro h Y RXY
+      obtain ⟨y, ey⟩ := Quotient.exists_rep (cast (filterOf.def_world) Y)
+      suffices Satisfies FM (cast filterOf.def_world.symm ⟦y⟧) φ by simp_all
+      apply ihφ (of_mem_box hs) |>.mp
       apply @filterOf.def_rel_back x y (by simp_all) <;>
-      . assumption;
-    . intro h y rxy;
-      apply ihφ (of_mem_box hs) |>.mpr;
-      apply h;
-      apply filterOf.def_rel_forth rxy;
+      . assumption
+    . intro h y rxy
+      apply ihφ (of_mem_box hs) |>.mpr
+      apply h
+      apply filterOf.def_rel_forth rxy
   | himp φ ψ ihp ihq =>
-    constructor;
-    . rintro hxy hp;
-      exact ihq (of_mem_imp₂ hs) |>.mp $ hxy (ihp (of_mem_imp₁ hs) |>.mpr hp);
-    . rintro hxy hp;
-      exact ihq (of_mem_imp₂ hs) |>.mpr $ hxy (ihp (of_mem_imp₁ hs) |>.mp hp);
+    constructor
+    . rintro hxy hp
+      exact ihq (of_mem_imp₂ hs) |>.mp $ hxy (ihp (of_mem_imp₁ hs) |>.mpr hp)
+    . rintro hxy hp
+      exact ihq (of_mem_imp₂ hs) |>.mpr $ hxy (ihp (of_mem_imp₁ hs) |>.mp hp)
   | _ => trivial
 
 
@@ -126,28 +126,28 @@ variable {FM : Model} {M : outParam _} {T : outParam (FormulaSet ℕ)} [T.IsSubf
 
 lemma isReflexive (filterOf : FilterOf FM M T) [M.IsReflexive] : FM.IsReflexive where
   refl := by
-    intro X;
-    obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (filterOf.def_world) X);
-    convert filterOf.def_rel_forth $ IsRefl.refl x <;> simp_all;
+    intro X
+    obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (filterOf.def_world) X)
+    convert filterOf.def_rel_forth $ IsRefl.refl x <;> simp_all
 
 lemma isSerial (filterOf : FilterOf FM M T) [M.IsSerial] : FM.IsSerial where
   serial := by
-    intro X;
-    obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (filterOf.def_world) X);
-    obtain ⟨y, Rxy⟩ : ∃ y, x ≺ y := IsSerial.serial x;
-    use (cast (filterOf.def_world.symm) ⟦y⟧);
-    simpa [hx] using filterOf.def_rel_forth Rxy;
+    intro X
+    obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (filterOf.def_world) X)
+    obtain ⟨y, Rxy⟩ : ∃ y, x ≺ y := IsSerial.serial x
+    use (cast (filterOf.def_world.symm) ⟦y⟧)
+    simpa [hx] using filterOf.def_rel_forth Rxy
 
 
 end FilterOf
 
 
 abbrev standardFiltrationValuation (X : FilterEqvQuotient M T) (a : ℕ) := (ha : (atom a) ∈ T) → Quotient.lift (λ x => M x a) (by
-  intro x y h;
-  apply eq_iff_iff.mpr;
-  constructor;
-  . intro hx; exact h a ha |>.mp hx;
-  . intro hy; exact h a ha |>.mpr hy;
+  intro x y h
+  apply eq_iff_iff.mpr
+  constructor
+  . intro hx; exact h a ha |>.mp hx
+  . intro hy; exact h a ha |>.mpr hy
 ) X
 
 
@@ -159,11 +159,11 @@ variable
 abbrev coarsestFiltrationFrame (M : Model) (T : FormulaSet ℕ) [T.IsSubformulaClosed] : Kripke.Frame where
   World := FilterEqvQuotient M T
   Rel := Quotient.lift₂ (λ x y => ∀ φ, □φ ∈ T → (x ⊧ □φ → y ⊧ φ)) (by
-    intro x₁ y₁ x₂ y₂ hx hy;
-    apply eq_iff_iff.mpr;
-    constructor;
-    . intro h φ hp sp₂; exact hy φ (of_mem_box hp) |>.mp $ h φ hp $ hx (□φ) hp |>.mpr sp₂;
-    . intro h φ hp sp₁; exact hy φ (of_mem_box hp) |>.mpr $ h φ hp $ hx (□φ) hp |>.mp sp₁;
+    intro x₁ y₁ x₂ y₂ hx hy
+    apply eq_iff_iff.mpr
+    constructor
+    . intro h φ hp sp₂; exact hy φ (of_mem_box hp) |>.mp $ h φ hp $ hx (□φ) hp |>.mpr sp₂
+    . intro h φ hp sp₁; exact hy φ (of_mem_box hp) |>.mpr $ h φ hp $ hx (□φ) hp |>.mp sp₁
   )
 
 abbrev coarsestFiltrationModel (M : Model) (T : FormulaSet ℕ) [T.IsSubformulaClosed] : Kripke.Model where
@@ -197,13 +197,13 @@ abbrev finestFiltrationModel (M : Model) (T : outParam (FormulaSet ℕ)) [T.IsSu
 namespace finestFiltrationModel
 
 instance filterOf : FilterOf (finestFiltrationModel M T) M T where
-  def_rel_forth := by tauto;
+  def_rel_forth := by tauto
   def_rel_back := by
-    simp only [cast_eq];
-    rintro x y ⟨x', y', hx, hy, Rx'y'⟩ φ hφ hφx;
-    have : x' ⊧ □φ := FilterEqvQuotient.iff_of_eq hx hφ |>.mp hφx;
-    have : y' ⊧ φ := this _ Rx'y';
-    exact FilterEqvQuotient.iff_of_eq hy (of_mem_box hφ) |>.mpr this;
+    simp only [cast_eq]
+    rintro x y ⟨x', y', hx, hy, Rx'y'⟩ φ hφ hφx
+    have : x' ⊧ □φ := FilterEqvQuotient.iff_of_eq hx hφ |>.mp hφx
+    have : y' ⊧ φ := this _ Rx'y'
+    exact FilterEqvQuotient.iff_of_eq hy (of_mem_box hφ) |>.mpr this
 
 lemma isFinite (T_finite : T.Finite) : (finestFiltrationModel M T).IsFinite where
   world_finite := FilterEqvQuotient.finite T_finite
@@ -211,9 +211,9 @@ instance isReflexive [M.IsReflexive] : (finestFiltrationFrame M T).IsReflexive :
 instance isSerial [M.IsSerial] : (finestFiltrationFrame M T).IsSerial := finestFiltrationModel.filterOf.isSerial
 instance isSymmetric [M.IsSymmetric] : (finestFiltrationModel M T).IsSymmetric where
   symm := by
-    rintro _ _ ⟨x, y, rfl, rfl, Rxy⟩;
-    use y, x;
-    refine ⟨by trivial, by trivial, IsSymm.symm _ _ Rxy⟩;
+    rintro _ _ ⟨x, y, rfl, rfl, Rxy⟩
+    use y, x
+    refine ⟨by trivial, by trivial, IsSymm.symm _ _ Rxy⟩
 
 end finestFiltrationModel
 
@@ -227,30 +227,30 @@ namespace finestFiltrationTransitiveClosureModel
 open Relation in
 instance filterOf [trans : M.IsTransitive] : FilterOf (finestFiltrationTransitiveClosureModel M T) M T where
   def_rel_forth := by
-    intro x y hxy;
-    apply Relation.TransGen.single;
-    dsimp [finestFiltrationTransitiveClosureModel, finestFiltrationFrame];
-    tauto;
+    intro x y hxy
+    apply Relation.TransGen.single
+    dsimp [finestFiltrationTransitiveClosureModel, finestFiltrationFrame]
+    tauto
   def_rel_back := by
-    rintro x y RXY φ hφ hx;
-    simp only [cast_eq] at RXY;
-    replace ⟨n, RXY⟩ := HRel.TransGen.exists_iterate.mp RXY;
+    rintro x y RXY φ hφ hx
+    simp only [cast_eq] at RXY
+    replace ⟨n, RXY⟩ := HRel.TransGen.exists_iterate.mp RXY
     induction n using PNat.recOn generalizing x with
     | one =>
-      simp only [PNat.val_ofNat, HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right] at RXY;
-      obtain ⟨u, v, exu, eyv, Ruv⟩ := RXY;
-      have : u ⊧ □φ := FilterEqvQuotient.iff_of_eq exu hφ |>.mp hx;
-      have : v ⊧ φ := this _ Ruv;
-      exact FilterEqvQuotient.iff_of_eq eyv (of_mem_box hφ) |>.mpr this;
+      simp only [PNat.val_ofNat, HRel.Iterate.iff_succ, HRel.Iterate.iff_zero, exists_eq_right] at RXY
+      obtain ⟨u, v, exu, eyv, Ruv⟩ := RXY
+      have : u ⊧ □φ := FilterEqvQuotient.iff_of_eq exu hφ |>.mp hx
+      have : v ⊧ φ := this _ Ruv
+      exact FilterEqvQuotient.iff_of_eq eyv (of_mem_box hφ) |>.mpr this
     | succ n ih =>
-      obtain ⟨U, RXU, RUY⟩ := RXY;
-      obtain ⟨u, rfl⟩ := Quotient.exists_rep U;
-      apply @ih u ?_ RUY;
-      obtain ⟨w, v, exw, euv, Rwv⟩ := RXU;
-      apply FilterEqvQuotient.iff_of_eq euv (by assumption) |>.mpr;
-      intro z Rvz;
-      apply FilterEqvQuotient.iff_of_eq exw (by assumption) |>.mp hx;
-      exact M.trans Rwv Rvz;
+      obtain ⟨U, RXU, RUY⟩ := RXY
+      obtain ⟨u, rfl⟩ := Quotient.exists_rep U
+      apply @ih u ?_ RUY
+      obtain ⟨w, v, exw, euv, Rwv⟩ := RXU
+      apply FilterEqvQuotient.iff_of_eq euv (by assumption) |>.mpr
+      intro z Rvz
+      apply FilterEqvQuotient.iff_of_eq exw (by assumption) |>.mp hx
+      exact M.trans Rwv Rvz
 
 lemma isFinite (T_finite : T.Finite) : (finestFiltrationTransitiveClosureModel M T).IsFinite where
   world_finite := FilterEqvQuotient.finite T_finite
@@ -264,64 +264,64 @@ instance isEquiv [equiv : M.IsEquivalence] : (finestFiltrationTransitiveClosureM
 
 instance rooted_isPiecewiseStronglyConvergent [preorder : M.IsPreorder] [ps_convergent : M.IsPiecewiseStronglyConvergent] : (finestFiltrationTransitiveClosureModel (M↾r) T).IsPiecewiseStronglyConvergent where
   ps_convergent := by
-    rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ;
-    . simp only [and_self];
-      use ⟦⟨z, by tauto⟩⟧;
-      apply Relation.TransGen.single;
-      suffices z ≺ z by tauto;
-      apply M.refl;
-    . use ⟦⟨z, by tauto⟩⟧;
-      constructor;
-      . apply Relation.TransGen.single;
-        suffices y ≺ z by tauto;
-        exact HRel.TransGen.unwrap Rrz;
-      . apply Relation.TransGen.single;
-        suffices z ≺ z by tauto;
-        apply IsRefl.refl ;
-    . use ⟦⟨y, by tauto⟩⟧;
-      constructor;
-      . apply Relation.TransGen.single;
-        suffices y ≺ y by tauto;
-        apply IsRefl.refl;
-      . apply Relation.TransGen.single;
-        suffices z ≺ y by tauto;
-        exact HRel.TransGen.unwrap Rry;
-    . replace Rry := HRel.TransGen.unwrap Rry;
-      replace Rrz := HRel.TransGen.unwrap Rrz;
-      obtain ⟨u, Ruy, Ruz⟩ := M.ps_convergent Rry Rrz;
+    rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ
+    . simp only [and_self]
+      use ⟦⟨z, by tauto⟩⟧
+      apply Relation.TransGen.single
+      suffices z ≺ z by tauto
+      apply M.refl
+    . use ⟦⟨z, by tauto⟩⟧
+      constructor
+      . apply Relation.TransGen.single
+        suffices y ≺ z by tauto
+        exact HRel.TransGen.unwrap Rrz
+      . apply Relation.TransGen.single
+        suffices z ≺ z by tauto
+        apply IsRefl.refl 
+    . use ⟦⟨y, by tauto⟩⟧
+      constructor
+      . apply Relation.TransGen.single
+        suffices y ≺ y by tauto
+        apply IsRefl.refl
+      . apply Relation.TransGen.single
+        suffices z ≺ y by tauto
+        exact HRel.TransGen.unwrap Rry
+    . replace Rry := HRel.TransGen.unwrap Rry
+      replace Rrz := HRel.TransGen.unwrap Rrz
+      obtain ⟨u, Ruy, Ruz⟩ := M.ps_convergent Rry Rrz
       use ⟦⟨u, by
-        right;
-        apply Relation.TransGen.single;
-        exact IsTrans.trans _ _ _ Rry Ruy;
-      ⟩⟧;
-      constructor;
-      . exact Relation.TransGen.single $ by tauto;
-      . exact Relation.TransGen.single $ by tauto;
+        right
+        apply Relation.TransGen.single
+        exact IsTrans.trans _ _ _ Rry Ruy
+      ⟩⟧
+      constructor
+      . exact Relation.TransGen.single $ by tauto
+      . exact Relation.TransGen.single $ by tauto
 
 instance rooted_isPiecewiseStronglyConnected [preorder : M.IsPreorder] [ps_connected : M.IsPiecewiseStronglyConnected] : (finestFiltrationTransitiveClosureModel (M↾r) T).IsPiecewiseStronglyConnected where
   ps_connected := by
-    rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ;
-    . simp only [or_self];
-      apply Relation.TransGen.single;
-      suffices z ≺ z by tauto;
-      apply IsRefl.refl;
-    . left;
-      apply Relation.TransGen.single;
-      suffices y ≺ z by tauto;
-      exact Rrz.unwrap;
-    . right;
-      apply Relation.TransGen.single;
-      suffices z ≺ y by tauto;
-      exact Rry.unwrap;
-    . replace Rry := Rry.unwrap;
-      replace Rrz := Rrz.unwrap;
-      rcases M.ps_connected Rry Rrz with (Ryz | Rrw);
-      . left;
-        apply Relation.TransGen.single;
-        tauto;
-      . right;
-        apply Relation.TransGen.single;
-        tauto;
+    rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ
+    . simp only [or_self]
+      apply Relation.TransGen.single
+      suffices z ≺ z by tauto
+      apply IsRefl.refl
+    . left
+      apply Relation.TransGen.single
+      suffices y ≺ z by tauto
+      exact Rrz.unwrap
+    . right
+      apply Relation.TransGen.single
+      suffices z ≺ y by tauto
+      exact Rry.unwrap
+    . replace Rry := Rry.unwrap
+      replace Rrz := Rrz.unwrap
+      rcases M.ps_connected Rry Rrz with (Ryz | Rrw)
+      . left
+        apply Relation.TransGen.single
+        tauto
+      . right
+        apply Relation.TransGen.single
+        tauto
 
 
 

--- a/Foundation/Modal/Kripke/Hilbert.lean
+++ b/Foundation/Modal/Kripke/Hilbert.lean
@@ -12,31 +12,31 @@ variable {F : Kripke.Frame} {C : Kripke.FrameClass}
 
 
 lemma eq_hilbert_logic_frameClass_logic {H : Hilbert.Normal ℕ} {C : FrameClass} [sound : Sound H C] [complete : Complete H C] : H.logic = C.logic := by
-  ext φ;
-  constructor;
-  . intro h;
-    apply sound.sound;
-    simpa;
-  . intro h;
-    simpa using complete.complete h;
+  ext φ
+  constructor
+  . intro h
+    apply sound.sound
+    simpa
+  . intro h
+    simpa using complete.complete h
 
 
 namespace Hilbert.Kripke
 
 
 lemma soundness_of_validates_axioms (hV : C ⊧* H.axioms) : H ⊢! φ → C ⊧ φ := by
-  intro hφ F hF;
+  intro hφ F hF
   induction hφ using Hilbert.Normal.rec! with
   | @axm φ s h =>
-    apply ValidOnFrame.subst;
-    apply hV.realize;
-    . assumption;
-    . assumption;
-  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp;
-  | nec ih => exact ValidOnFrame.nec ih;
-  | imply₁ => exact ValidOnFrame.imply₁;
-  | imply₂ => exact ValidOnFrame.imply₂;
-  | ec => exact ValidOnFrame.elimContra;
+    apply ValidOnFrame.subst
+    apply hV.realize
+    . assumption
+    . assumption
+  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp
+  | nec ih => exact ValidOnFrame.nec ih
+  | imply₁ => exact ValidOnFrame.imply₁
+  | imply₂ => exact ValidOnFrame.imply₂
+  | ec => exact ValidOnFrame.elimContra
 
 instance instSound_of_validates_axioms (hV : C ⊧* H.axioms) : Sound H C := ⟨fun {_} =>
   soundness_of_validates_axioms hV
@@ -44,66 +44,66 @@ instance instSound_of_validates_axioms (hV : C ⊧* H.axioms) : Sound H C := ⟨
 
 lemma consistent_of_sound_frameclass (C : Kripke.FrameClass) (C_nonempty: C.Nonempty := by simp)
   [sound : Sound H C] : Entailment.Consistent H := by
-  apply Entailment.Consistent.of_unprovable (f := ⊥);
-  apply not_imp_not.mpr sound.sound;
-  apply Semantics.set_models_iff.not.mpr;
-  push_neg;
-  obtain ⟨F, hF⟩ := C_nonempty;
-  use F;
-  constructor;
-  . assumption;
-  . simp;
+  apply Entailment.Consistent.of_unprovable (f := ⊥)
+  apply not_imp_not.mpr sound.sound
+  apply Semantics.set_models_iff.not.mpr
+  push_neg
+  obtain ⟨F, hF⟩ := C_nonempty
+  use F
+  constructor
+  . assumption
+  . simp
 
 instance [Sound H C] : Sound H.logic C := by
-  constructor;
-  intro φ hφ;
-  apply Sound.sound $ by simpa using hφ;
+  constructor
+  intro φ hφ
+  apply Sound.sound $ by simpa using hφ
 
 instance [Complete H C] : Complete H.logic C := by
-  constructor;
-  intro φ hφ;
-  simpa using Complete.complete hφ;
+  constructor
+  intro φ hφ
+  simpa using Complete.complete hφ
 
 
 lemma soundness_of_frame_validates_axioms (hV : F ⊧* H.axioms) : H ⊢! φ → F ⊧ φ := by
-  intro hφ;
+  intro hφ
   induction hφ using Hilbert.Normal.rec! with
   | axm s h =>
-    apply ValidOnFrame.subst;
-    apply hV.realize;
-    assumption;
-  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp;
-  | nec ih => exact ValidOnFrame.nec ih;
-  | imply₁ => exact ValidOnFrame.imply₁;
-  | imply₂ => exact ValidOnFrame.imply₂;
-  | ec => exact ValidOnFrame.elimContra;
+    apply ValidOnFrame.subst
+    apply hV.realize
+    assumption
+  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp
+  | nec ih => exact ValidOnFrame.nec ih
+  | imply₁ => exact ValidOnFrame.imply₁
+  | imply₂ => exact ValidOnFrame.imply₂
+  | ec => exact ValidOnFrame.elimContra
 
 instance instSound_of_frame_validates_axioms (hV : F ⊧* H.axioms) : Sound H F := ⟨fun {_} =>
   soundness_of_frame_validates_axioms hV
 ⟩
 
 lemma consistent_of_sound_frames (F : Kripke.Frame) [sound : Sound H F] : Entailment.Consistent H := by
-  apply Entailment.Consistent.of_unprovable (f := ⊥);
-  apply not_imp_not.mpr sound.sound;
-  exact Kripke.ValidOnFrame.bot_def;
+  apply Entailment.Consistent.of_unprovable (f := ⊥)
+  apply not_imp_not.mpr sound.sound
+  exact Kripke.ValidOnFrame.bot_def
 
 lemma weakerThan_of_subset_frameClass (C₁ C₂ : FrameClass) (hC : C₂ ⊆ C₁) [Sound H₁ C₁] [Complete H₂ C₂] : H₁ ⪯ H₂ := by
-  apply Entailment.weakerThan_iff.mpr;
-  intro φ hφ;
-  apply Complete.complete (𝓜 := C₂);
-  intro F hF;
-  apply Sound.sound (𝓢 := H₁) (𝓜 := C₁) hφ;
-  apply hC hF;
+  apply Entailment.weakerThan_iff.mpr
+  intro φ hφ
+  apply Complete.complete (𝓜 := C₂)
+  intro F hF
+  apply Sound.sound (𝓢 := H₁) (𝓜 := C₁) hφ
+  apply hC hF
 
 instance [Sound H F] : Sound H.logic F := by
-  constructor;
-  intro φ hφ;
-  apply Sound.sound $ by simpa using hφ;
+  constructor
+  intro φ hφ
+  apply Sound.sound $ by simpa using hφ
 
 instance [Complete H F] : Complete H.logic F := by
-  constructor;
-  intro φ hφ;
-  simpa using Complete.complete hφ;
+  constructor
+  intro φ hφ
+  simpa using Complete.complete hφ
 
 end Hilbert.Kripke
 

--- a/Foundation/Modal/Kripke/Irreflexive.lean
+++ b/Foundation/Modal/Kripke/Irreflexive.lean
@@ -8,7 +8,7 @@ variable {F : Frame} {x y z : F.World}
 
 protected abbrev IsIrreflexive (F : Frame) := IsIrrefl _ F
 
-@[simp] lemma irrefl [F.IsIrreflexive] (x : F) : ¬x ≺ x := by apply IsIrrefl.irrefl;
+@[simp] lemma irrefl [F.IsIrreflexive] (x : F) : ¬x ≺ x := by apply IsIrrefl.irrefl
 
 
 class IsStrictPreorder (F : Frame) extends F.IsIrreflexive, F.IsTransitive

--- a/Foundation/Modal/Kripke/Irreflexivize.lean
+++ b/Foundation/Modal/Kripke/Irreflexivize.lean
@@ -26,15 +26,15 @@ instance : (F^≠).IsIrreflexive := ⟨IsIrrefl.irrefl⟩
 instance [F.IsAntisymmetric] [F.IsTransitive] : (F^≠).IsTransitive := inferInstance
 
 instance [F.IsAntisymmetric] : F^≠.IsAntisymmetric := ⟨by
-  rintro x y ⟨Rxy, _⟩ ⟨Ryx, _⟩;
-  exact F.antisymm Rxy Ryx;
+  rintro x y ⟨Rxy, _⟩ ⟨Ryx, _⟩
+  exact F.antisymm Rxy Ryx
 ⟩
 
 instance [F.IsPiecewiseStronglyConnected] : (F^≠).IsPiecewiseConnected := ⟨by
-  rintro x y z ⟨Rxy, _⟩ ⟨Ryz, _⟩;
-  suffices y ≠ z → F^≠.Rel y z ∨ F^≠.Rel z y by tauto;
-  intro nyz;
-  rcases F.ps_connected Rxy Ryz with (Ryz | Rzy) <;> tauto;
+  rintro x y z ⟨Rxy, _⟩ ⟨Ryz, _⟩
+  suffices y ≠ z → F^≠.Rel y z ∨ F^≠.Rel z y by tauto
+  intro nyz
+  rcases F.ps_connected Rxy Ryz with (Ryz | Rzy) <;> tauto
 ⟩
 
 end IrreflGen

--- a/Foundation/Modal/Kripke/LinearFrame.lean
+++ b/Foundation/Modal/Kripke/LinearFrame.lean
@@ -13,28 +13,28 @@ abbrev natLT : Kripke.Frame where
 namespace natLT
 
 instance : IsTrans _ natLT := by
-  dsimp only [natLT];
-  infer_instance;
+  dsimp only [natLT]
+  infer_instance
 
 instance : natLT.IsSerial := ⟨by
-  intro x;
-  use x + 1;
-  omega;
+  intro x
+  use x + 1
+  omega
 ⟩
 
 instance : natLT.IsPiecewiseConnected := ⟨by
-  rintro x y z Rxy Ryx;
-  rcases lt_trichotomy y z with Rxy | rfl | rxy <;> tauto;
+  rintro x y z Rxy Ryx
+  rcases lt_trichotomy y z with Rxy | rfl | rxy <;> tauto
 ⟩
 
 abbrev min : natLT.World := 0
 
 instance : Frame.IsRootedBy natLT natLT.min where
   root_generates := by
-    intro x hx;
-    apply Relation.TransGen.single;
-    simp_all [natLT, natLT.min];
-    omega;
+    intro x hx
+    apply Relation.TransGen.single
+    simp_all [natLT, natLT.min]
+    omega
 
 end natLT
 
@@ -46,20 +46,20 @@ abbrev natLE : Kripke.Frame where
 namespace natLE
 
 instance : IsTrans _ natLE := by
-  dsimp only [natLE];
-  infer_instance;
+  dsimp only [natLE]
+  infer_instance
 
 instance : IsRefl _ natLE := by
-  dsimp only [natLE];
-  infer_instance;
+  dsimp only [natLE]
+  infer_instance
 
 abbrev min : natLE.World := 0
 
 instance : Frame.IsRootedBy natLE natLE.min where
   root_generates := by
-    intro x _;
-    apply Relation.TransGen.single;
-    simp_all [natLE, natLE.min];
+    intro x _
+    apply Relation.TransGen.single
+    simp_all [natLE, natLE.min]
 
 end natLE
 
@@ -73,8 +73,8 @@ namespace finLT
 variable {n : ℕ} [NeZero n]
 
 instance : Finite (finLT n) := by
-  dsimp only [finLT];
-  infer_instance;
+  dsimp only [finLT]
+  infer_instance
 
 end finLT
 
@@ -88,20 +88,20 @@ namespace finLE
 variable {n : ℕ} [NeZero n]
 
 instance : Finite (finLT n) := by
-  dsimp only [finLT];
-  infer_instance;
+  dsimp only [finLT]
+  infer_instance
 
 instance : IsTrans _ (finLE n) := by
-  dsimp only [finLE];
-  infer_instance;
+  dsimp only [finLE]
+  infer_instance
 
 instance : IsRefl _ (finLE n) := by
-  dsimp only [finLE];
-  infer_instance;
+  dsimp only [finLE]
+  infer_instance
 
 instance : IsAntisymm _ (finLE n) := by
-  dsimp only [finLE];
-  infer_instance;
+  dsimp only [finLE]
+  infer_instance
 
 end finLE
 
@@ -113,125 +113,125 @@ open Formula Formula.Kripke
 
 /-- Goldblatt, Exercise 8.1 (1) -/
 lemma natLT_validates_AxiomZ : natLT ⊧ (Axioms.Z (.atom 0)) := by
-  intro V x hx₁ hx₂ y lt_xy;
-  obtain ⟨z, lt_xz, hz⟩ := Satisfies.dia_def.mp hx₂;
-  rcases lt_trichotomy y z with (lt_yz | rfl | lt_zy);
-  . rcases or_not_of_imp (hx₁ y lt_xy) with _ | hy;
-    . assumption;
-    . exfalso;
+  intro V x hx₁ hx₂ y lt_xy
+  obtain ⟨z, lt_xz, hz⟩ := Satisfies.dia_def.mp hx₂
+  rcases lt_trichotomy y z with (lt_yz | rfl | lt_zy)
+  . rcases or_not_of_imp (hx₁ y lt_xy) with _ | hy
+    . assumption
+    . exfalso
       obtain ⟨⟨u, u_ioc⟩, hu₁, hu⟩ := @WellFounded.has_min (α := Finset.Ioc y z) (· > ·)
         (Finite.wellFounded_of_trans_of_irrefl _)
         ({ u | ¬Satisfies ⟨natLT, V⟩ u (.atom 0) })
         (by
-          replace hy := Satisfies.box_def.not.mp hy;
-          push_neg at hy;
-          obtain ⟨u, lt_yu, hu⟩ := hy;
-          refine ⟨⟨u, ?_⟩, ?_⟩;
-          . apply Finset.mem_Ioc.mpr;
-            constructor;
-            . tauto;
-            . by_contra hC;
-              exact hu $ hz _ $ not_le.mp hC;
-          . tauto;
+          replace hy := Satisfies.box_def.not.mp hy
+          push_neg at hy
+          obtain ⟨u, lt_yu, hu⟩ := hy
+          refine ⟨⟨u, ?_⟩, ?_⟩
+          . apply Finset.mem_Ioc.mpr
+            constructor
+            . tauto
+            . by_contra hC
+              exact hu $ hz _ $ not_le.mp hC
+          . tauto
         )
-      have ⟨lt_yu, le_uz⟩ := Finset.mem_Ioc.mp u_ioc;
-      have := not_imp_not.mpr (hx₁ u (lt_trans lt_xy lt_yu)) hu₁;
-      replace this := Satisfies.box_def.not.mp this;
-      push_neg at this;
-      obtain ⟨v, lt_uv, hv⟩ := this;
-      have := hu ⟨v, ?_⟩ hv;
-      . contradiction;
-      . by_contra hC;
-        apply hv;
-        apply hz;
-        replace hC := Finset.mem_Ioc.not.mp hC;
-        push_neg at hC;
-        apply hC;
-        exact lt_trans lt_yu lt_uv;
-  . apply hx₁ <;> assumption;
-  . apply hz;
-    assumption;
+      have ⟨lt_yu, le_uz⟩ := Finset.mem_Ioc.mp u_ioc
+      have := not_imp_not.mpr (hx₁ u (lt_trans lt_xy lt_yu)) hu₁
+      replace this := Satisfies.box_def.not.mp this
+      push_neg at this
+      obtain ⟨v, lt_uv, hv⟩ := this
+      have := hu ⟨v, ?_⟩ hv
+      . contradiction
+      . by_contra hC
+        apply hv
+        apply hz
+        replace hC := Finset.mem_Ioc.not.mp hC
+        push_neg at hC
+        apply hC
+        exact lt_trans lt_yu lt_uv
+  . apply hx₁ <;> assumption
+  . apply hz
+    assumption
 
 /-- Goldblatt, Exercise 8.9 -/
 lemma natLE_validates_AxiomDum : natLE ⊧ (Axioms.Dum (.atom 0)) := by
-  intro V x hx₁ hx₂;
-  obtain ⟨y, le_xy, hy⟩ := Satisfies.dia_def.mp hx₂;
-  rcases lt_or_eq_of_le le_xy with (le_xy | rfl);
-  . rcases or_not_of_imp (hx₁ x (by omega)) with _ | hx₃;
-    . assumption;
-    . by_contra hx;
+  intro V x hx₁ hx₂
+  obtain ⟨y, le_xy, hy⟩ := Satisfies.dia_def.mp hx₂
+  rcases lt_or_eq_of_le le_xy with (le_xy | rfl)
+  . rcases or_not_of_imp (hx₁ x (by omega)) with _ | hx₃
+    . assumption
+    . by_contra hx
       obtain ⟨⟨u, u_ioc⟩, hu₁, hu⟩ := @WellFounded.has_min (α := Finset.Ioo x y) (· > ·)
         (Finite.wellFounded_of_trans_of_irrefl _)
         ({ u | ¬Satisfies ⟨natLT, V⟩ u (.atom 0) })
         (by
-          replace hx₃ := Satisfies.box_def.not.mp hx₃;
-          push_neg at hx₃;
-          obtain ⟨u, lt_xu, hu⟩ := hx₃;
+          replace hx₃ := Satisfies.box_def.not.mp hx₃
+          push_neg at hx₃
+          obtain ⟨u, lt_xu, hu⟩ := hx₃
           replace lt_xu : x < u := by
-            rcases (lt_or_eq_of_le lt_xu) with h | rfl;
-            . assumption;
-            . exfalso;
-              replace hu := Satisfies.imp_def₂.not.mp hu;
-              push_neg at hu;
-              exact hx $ hu.1;
-          replace hu := Satisfies.imp_def₂.not.mp hu;
-          push_neg at hu;
-          obtain ⟨hu₁, hu₂⟩ := hu;
-          replace hu₂ := Satisfies.box_def.not.mp hu₂;
-          push_neg at hu₂;
-          obtain ⟨v, lt_uv, hv⟩ := hu₂;
+            rcases (lt_or_eq_of_le lt_xu) with h | rfl
+            . assumption
+            . exfalso
+              replace hu := Satisfies.imp_def₂.not.mp hu
+              push_neg at hu
+              exact hx $ hu.1
+          replace hu := Satisfies.imp_def₂.not.mp hu
+          push_neg at hu
+          obtain ⟨hu₁, hu₂⟩ := hu
+          replace hu₂ := Satisfies.box_def.not.mp hu₂
+          push_neg at hu₂
+          obtain ⟨v, lt_uv, hv⟩ := hu₂
           replace lt_uv : u < v := by
-            rcases (lt_or_eq_of_le lt_uv) with h | rfl;
-            . assumption;
-            . contradiction;;
-          refine ⟨⟨v, ?_⟩, ?_⟩;
-          . apply Finset.mem_Ioo.mpr;
-            constructor;
-            . exact lt_trans lt_xu lt_uv;
-            . by_contra hC;
-              replace le_yv := not_lt.mp hC;
-              apply hv;
-              apply hy;
-              exact le_yv;
-          . tauto;
+            rcases (lt_or_eq_of_le lt_uv) with h | rfl
+            . assumption
+            . contradiction;
+          refine ⟨⟨v, ?_⟩, ?_⟩
+          . apply Finset.mem_Ioo.mpr
+            constructor
+            . exact lt_trans lt_xu lt_uv
+            . by_contra hC
+              replace le_yv := not_lt.mp hC
+              apply hv
+              apply hy
+              exact le_yv
+          . tauto
         )
-      have ⟨lt_xu, lt_uy⟩ := Finset.mem_Ioo.mp u_ioc;
-      have hu₂ := hx₁ u (le_of_lt lt_xu);
-      have := not_imp_not.mpr hu₂ hu₁;
-      replace this := Satisfies.box_def.not.mp this;
-      push_neg at this;
-      obtain ⟨v, lt_uv, hv⟩ := this;
+      have ⟨lt_xu, lt_uy⟩ := Finset.mem_Ioo.mp u_ioc
+      have hu₂ := hx₁ u (le_of_lt lt_xu)
+      have := not_imp_not.mpr hu₂ hu₁
+      replace this := Satisfies.box_def.not.mp this
+      push_neg at this
+      obtain ⟨v, lt_uv, hv⟩ := this
       replace lt_uv : u < v := by
-        rcases (lt_or_eq_of_le lt_uv) with h | rfl;
-        . assumption;
-        . exfalso;
-          replace hv := Satisfies.imp_def₂.not.mp hv;
-          push_neg at hv;
-          exact hu₁ hv.1;
-      replace hv := Satisfies.imp_def₂.not.mp hv;
-      push_neg at hv;
-      obtain ⟨hv₁, hv₂⟩ := hv;
-      replace hv₂ := Satisfies.box_def.not.mp hv₂;
-      push_neg at hv₂;
-      obtain ⟨w, lt_vw, hw⟩ := hv₂;
+        rcases (lt_or_eq_of_le lt_uv) with h | rfl
+        . assumption
+        . exfalso
+          replace hv := Satisfies.imp_def₂.not.mp hv
+          push_neg at hv
+          exact hu₁ hv.1
+      replace hv := Satisfies.imp_def₂.not.mp hv
+      push_neg at hv
+      obtain ⟨hv₁, hv₂⟩ := hv
+      replace hv₂ := Satisfies.box_def.not.mp hv₂
+      push_neg at hv₂
+      obtain ⟨w, lt_vw, hw⟩ := hv₂
       replace lt_vw : v < w := by
-        rcases (lt_or_eq_of_le lt_vw) with h | rfl;
-        . assumption;
-        . contradiction;
-      have : u < w := lt_trans lt_uv lt_vw;
-      have := hu ⟨w, ?_⟩ hw;
-      . contradiction;
-      . apply Finset.mem_Ioo.mpr;
-        constructor;
-        . exact lt_trans (lt_trans lt_xu lt_uv) lt_vw;
-        . by_contra hC;
-          apply hw;
-          apply hy;
-          exact not_lt.mp hC;
-  . apply hx₁ x (by tauto);
-    intro y lt_xy hy₂ z lt_yz;
-    apply hy;
-    omega;
+        rcases (lt_or_eq_of_le lt_vw) with h | rfl
+        . assumption
+        . contradiction
+      have : u < w := lt_trans lt_uv lt_vw
+      have := hu ⟨w, ?_⟩ hw
+      . contradiction
+      . apply Finset.mem_Ioo.mpr
+        constructor
+        . exact lt_trans (lt_trans lt_xu lt_uv) lt_vw
+        . by_contra hC
+          apply hw
+          apply hy
+          exact not_lt.mp hC
+  . apply hx₁ x (by tauto)
+    intro y lt_xy hy₂ z lt_yz
+    apply hy
+    omega
 
 end
 

--- a/Foundation/Modal/Kripke/Logic/GL/Completeness.lean
+++ b/Foundation/Modal/Kripke/Logic/GL/Completeness.lean
@@ -30,13 +30,13 @@ instance : (miniCanonicalFrame φ).IsFinite := inferInstance
 instance : (miniCanonicalFrame φ).IsIrreflexive := ⟨by simp⟩
 
 instance : (miniCanonicalFrame φ).IsTransitive := ⟨by
-  rintro X Y Z ⟨RXY, ⟨χ, _, _, _⟩⟩ ⟨RYZ, _⟩;
-  constructor;
-  . rintro ψ hq₁ hq₂;
-    exact RYZ ψ hq₁ $ RXY ψ hq₁ hq₂ |>.2;
-  . use χ;
-    refine ⟨by assumption, by assumption, ?_⟩;
-    exact RYZ χ (by assumption) (by assumption) |>.2;
+  rintro X Y Z ⟨RXY, ⟨χ, _, _, _⟩⟩ ⟨RYZ, _⟩
+  constructor
+  . rintro ψ hq₁ hq₂
+    exact RYZ ψ hq₁ $ RXY ψ hq₁ hq₂ |>.2
+  . use χ
+    refine ⟨by assumption, by assumption, ?_⟩
+    exact RYZ χ (by assumption) (by assumption) |>.2
 ⟩
 
 instance : (miniCanonicalFrame φ).IsFiniteGL where
@@ -52,154 +52,154 @@ abbrev miniCanonicalModel (φ : Formula ℕ) : Kripke.Model where
 lemma truthlemma_lemma1
   {X : ComplementClosedConsistentFinset Hilbert.GL φ.subformulas} (hq : □ψ ∈ φ.subformulas)
   : ((X.1.prebox ∪ X.1.prebox.box) ∪ {□ψ, -ψ}) ⊆ φ.subformulas⁻ := by
-  intro χ hr;
-  replace hr : χ = □ψ ∨ □χ ∈ X ∨ (∃ a, □a ∈ X ∧ □a = χ) ∨ χ = -ψ := by simpa using hr;
-  rcases hr with (rfl | hp | ⟨χ, hr, rfl⟩ | rfl);
-  . apply Finset.mem_union.mpr;
-    tauto;
-  . have := X.closed.subset hp;
-    have := FormulaFinset.complementary_mem_box (by grind) this;
-    apply Finset.mem_union.mpr;
-    grind;
-  . exact X.closed.subset hr;
-  . apply Finset.mem_union.mpr;
-    right;
-    apply Finset.mem_image.mpr;
-    use ψ;
-    grind;
+  intro χ hr
+  replace hr : χ = □ψ ∨ □χ ∈ X ∨ (∃ a, □a ∈ X ∧ □a = χ) ∨ χ = -ψ := by simpa using hr
+  rcases hr with (rfl | hp | ⟨χ, hr, rfl⟩ | rfl)
+  . apply Finset.mem_union.mpr
+    tauto
+  . have := X.closed.subset hp
+    have := FormulaFinset.complementary_mem_box (by grind) this
+    apply Finset.mem_union.mpr
+    grind
+  . exact X.closed.subset hr
+  . apply Finset.mem_union.mpr
+    right
+    apply Finset.mem_image.mpr
+    use ψ
+    grind
 
 lemma truthlemma_lemma2
   {X : ComplementClosedConsistentFinset Hilbert.GL φ.subformulas}
   (hψ₁ : □ψ ∈ φ.subformulas)
   (hψ₂ : □ψ ∉ X)
   : FormulaFinset.Consistent Hilbert.GL ((X.1.prebox ∪ X.1.prebox.box) ∪ {□ψ, -ψ}) := by
-  apply FormulaFinset.intro_union_consistent;
-  rintro Γ₁ Γ₂ hΓ₁ hΓ₂;
-  by_contra hC;
-  apply hψ₂;
-  have := Context.deduct! $ Context.weakening! (Γ := Γ₁ ∪ Γ₂) (Δ := insert (-ψ) (insert (□ψ) Γ₁)) ?_ hC;
-  . replace : (insert (□ψ) Γ₁) *⊢[Hilbert.GL]! ψ := of_imply_complement_bot this;
-    replace := Context.deduct! this;
-    replace : ↑Γ₁.box *⊢[Hilbert.GL]! □(□ψ ➝ ψ) := by simpa using Context.nec! this;
-    replace := axiomL! ⨀ this;
-    replace : (X.1.prebox.box ∪ X.1.prebox.multibox 2) *⊢[Hilbert.GL]! □ψ := Context.weakening! ?_ this;
-    . replace : X.1.prebox.box *⊢[Hilbert.GL]! (X.1.prebox.multibox 2).conj ➝ □ψ := FConj_DT'.mpr $ by simpa using this;
-      replace : X.1.prebox.box *⊢[Hilbert.GL]! (X.1.prebox.box).conj ➝ □ψ := C!_trans ?_ this;
-      . replace := FConj_DT'.mp this;
-        have : X *⊢[Hilbert.GL]! □ψ := Context.weakening! (by simp) this;
-        exact membership_iff hψ₁ |>.mpr this;
-      . apply CFconjFconj!_of_provable;
-        intro ξ hξ;
-        obtain ⟨ξ, h, rfl⟩ := Finset.exists_multibox_of_mem_multibox hξ;
-        apply axiomFour'!;
+  apply FormulaFinset.intro_union_consistent
+  rintro Γ₁ Γ₂ hΓ₁ hΓ₂
+  by_contra hC
+  apply hψ₂
+  have := Context.deduct! $ Context.weakening! (Γ := Γ₁ ∪ Γ₂) (Δ := insert (-ψ) (insert (□ψ) Γ₁)) ?_ hC
+  . replace : (insert (□ψ) Γ₁) *⊢[Hilbert.GL]! ψ := of_imply_complement_bot this
+    replace := Context.deduct! this
+    replace : ↑Γ₁.box *⊢[Hilbert.GL]! □(□ψ ➝ ψ) := by simpa using Context.nec! this
+    replace := axiomL! ⨀ this
+    replace : (X.1.prebox.box ∪ X.1.prebox.multibox 2) *⊢[Hilbert.GL]! □ψ := Context.weakening! ?_ this
+    . replace : X.1.prebox.box *⊢[Hilbert.GL]! (X.1.prebox.multibox 2).conj ➝ □ψ := FConj_DT'.mpr $ by simpa using this
+      replace : X.1.prebox.box *⊢[Hilbert.GL]! (X.1.prebox.box).conj ➝ □ψ := C!_trans ?_ this
+      . replace := FConj_DT'.mp this
+        have : X *⊢[Hilbert.GL]! □ψ := Context.weakening! (by simp) this
+        exact membership_iff hψ₁ |>.mpr this
+      . apply CFconjFconj!_of_provable
+        intro ξ hξ
+        obtain ⟨ξ, h, rfl⟩ := Finset.exists_multibox_of_mem_multibox hξ
+        apply axiomFour'!
         apply Context.by_axm!
-        simpa using h;
-    . simp only [Finset.coe_image, Function.iterate_one, Finset.coe_preimage, Box.multibox_succ, Set.image_subset_iff, Set.preimage_union];
-      intro ξ hξ;
-      simpa using hΓ₁ hξ;
-  . intro ξ;
-    simp only [Set.mem_union, Finset.mem_coe, Set.mem_insert_iff];
-    rintro (hξ₁ | hξ₂);
-    . have := hΓ₁ hξ₁;
-      tauto;
-    . have := hΓ₂ hξ₂;
-      simp at this;
-      tauto;
+        simpa using h
+    . simp only [Finset.coe_image, Function.iterate_one, Finset.coe_preimage, Box.multibox_succ, Set.image_subset_iff, Set.preimage_union]
+      intro ξ hξ
+      simpa using hΓ₁ hξ
+  . intro ξ
+    simp only [Set.mem_union, Finset.mem_coe, Set.mem_insert_iff]
+    rintro (hξ₁ | hξ₂)
+    . have := hΓ₁ hξ₁
+      tauto
+    . have := hΓ₂ hξ₂
+      simp at this
+      tauto
 
 set_option linter.style.multiGoal false in
 lemma truthlemma {X : (miniCanonicalModel φ).World} (q_sub : ψ ∈ φ.subformulas) :
   Satisfies (miniCanonicalModel φ) X ψ ↔ ψ ∈ X := by
   induction ψ generalizing X with
-  | hatom => simp [Satisfies];
-  | hfalsum => simp [Satisfies];
+  | hatom => simp [Satisfies]
+  | hfalsum => simp [Satisfies]
   | himp ψ χ ihq ihr =>
-    constructor;
-    . contrapose;
-      intro h;
-      apply Satisfies.imp_def.not.mpr;
-      push_neg;
-      constructor;
-      . apply ihq ?_ |>.mpr;
-        apply iff_not_mem_imp ?_ ?_ ?_ |>.mp h |>.1;
-        all_goals grind;
-      . apply ihr ?_ |>.not.mpr;
-        apply iff_not_mem_compl ?_ |>.not.mpr;
-        push_neg;
-        apply iff_not_mem_imp ?_ ?_ ?_ |>.mp h |>.2;
-        all_goals grind;
-    . contrapose!;
-      intro h;
-      replace h := Satisfies.imp_def.not.mp h; push_neg at h;
-      obtain ⟨hq, hr⟩ := h;
-      replace hq : ψ ∈ X := ihq ?_ |>.mp hq;
-      replace hr : χ ∉ X := ihr ?_ |>.not.mp hr;
-      apply iff_not_mem_imp ?_ ?_ ?_ |>.mpr;
-      . constructor;
-        . assumption;
-        . apply iff_mem_compl ?_ |>.mp hr;
-          grind;
-      all_goals grind;
+    constructor
+    . contrapose
+      intro h
+      apply Satisfies.imp_def.not.mpr
+      push_neg
+      constructor
+      . apply ihq ?_ |>.mpr
+        apply iff_not_mem_imp ?_ ?_ ?_ |>.mp h |>.1
+        all_goals grind
+      . apply ihr ?_ |>.not.mpr
+        apply iff_not_mem_compl ?_ |>.not.mpr
+        push_neg
+        apply iff_not_mem_imp ?_ ?_ ?_ |>.mp h |>.2
+        all_goals grind
+    . contrapose!
+      intro h
+      replace h := Satisfies.imp_def.not.mp h; push_neg at h
+      obtain ⟨hq, hr⟩ := h
+      replace hq : ψ ∈ X := ihq ?_ |>.mp hq
+      replace hr : χ ∉ X := ihr ?_ |>.not.mp hr
+      apply iff_not_mem_imp ?_ ?_ ?_ |>.mpr
+      . constructor
+        . assumption
+        . apply iff_mem_compl ?_ |>.mp hr
+          grind
+      all_goals grind
   | hbox ψ ih =>
-    constructor;
-    . contrapose;
-      intro h;
-      obtain ⟨Y, hY₁⟩ := lindenbaum (Ψ := φ.subformulas) (truthlemma_lemma1 q_sub) (truthlemma_lemma2 q_sub h);
-      simp only [Finset.union_subset_iff] at hY₁;
-      apply Satisfies.not_box_def.mpr;
-      use Y;
-      constructor;
-      . constructor;
-        . intros;
-          constructor;
-          . apply hY₁.1.1;
-            simpa;
-          · apply hY₁.1.2;
-            simpa;
-        . use ψ;
-          refine ⟨?_, ?_, ?_⟩;
-          . simpa;
-          . simpa;
-          . apply hY₁.2;
-            simp;
-      . apply ih ?_ |>.not.mpr;
-        . apply iff_not_mem_compl (by grind) |>.not.mpr;
-          push_neg;
-          apply hY₁.2;
-          simp;
-        . grind;
-    . intro h Y RXY;
-      apply ih (by grind) |>.mpr;
-      refine RXY.1 ψ ?_ h |>.1;
-      simpa;
+    constructor
+    . contrapose
+      intro h
+      obtain ⟨Y, hY₁⟩ := lindenbaum (Ψ := φ.subformulas) (truthlemma_lemma1 q_sub) (truthlemma_lemma2 q_sub h)
+      simp only [Finset.union_subset_iff] at hY₁
+      apply Satisfies.not_box_def.mpr
+      use Y
+      constructor
+      . constructor
+        . intros
+          constructor
+          . apply hY₁.1.1
+            simpa
+          · apply hY₁.1.2
+            simpa
+        . use ψ
+          refine ⟨?_, ?_, ?_⟩
+          . simpa
+          . simpa
+          . apply hY₁.2
+            simp
+      . apply ih ?_ |>.not.mpr
+        . apply iff_not_mem_compl (by grind) |>.not.mpr
+          push_neg
+          apply hY₁.2
+          simp
+        . grind
+    . intro h Y RXY
+      apply ih (by grind) |>.mpr
+      refine RXY.1 ψ ?_ h |>.1
+      simpa
 
 instance : Complete Hilbert.GL Kripke.FrameClass.finite_GL := ⟨by
-  intro φ;
-  contrapose;
-  intro h;
-  apply Semantics.set_models_iff.not.mpr;
-  push_neg;
-  use (miniCanonicalFrame φ);
-  constructor;
-  . apply Set.mem_setOf_eq.mpr;
-    infer_instance;
-  . apply ValidOnFrame.not_of_exists_model_world;
+  intro φ
+  contrapose
+  intro h
+  apply Semantics.set_models_iff.not.mpr
+  push_neg
+  use (miniCanonicalFrame φ)
+  constructor
+  . apply Set.mem_setOf_eq.mpr
+    infer_instance
+  . apply ValidOnFrame.not_of_exists_model_world
     obtain ⟨X, hX₁⟩ := lindenbaum (Φ := {-φ}) (Ψ := φ.subformulas)
       (by
-        simp only [FormulaFinset.complementary, Finset.singleton_subset_iff, Finset.mem_union, Finset.mem_image];
-        right;
-        use φ;
-        grind;
+        simp only [FormulaFinset.complementary, Finset.singleton_subset_iff, Finset.mem_union, Finset.mem_image]
+        right
+        use φ
+        grind
       )
-      (FormulaFinset.unprovable_iff_singleton_compl_consistent.mpr h);
-    use (miniCanonicalModel φ), X;
-    constructor;
-    . tauto;
-    . apply truthlemma ?_ |>.not.mpr;
+      (FormulaFinset.unprovable_iff_singleton_compl_consistent.mpr h)
+    use (miniCanonicalModel φ), X
+    constructor
+    . tauto
+    . apply truthlemma ?_ |>.not.mpr
       apply iff_not_mem_compl ?_ |>.not.mpr
-      . push_neg;
-        apply hX₁;
-        tauto;
-      all_goals grind;
+      . push_neg
+        apply hX₁
+        tauto
+      all_goals grind
 ⟩
 
 end Hilbert.GL.Kripke

--- a/Foundation/Modal/Kripke/Logic/GL/MDP.lean
+++ b/Foundation/Modal/Kripke/Logic/GL/MDP.lean
@@ -31,26 +31,26 @@ instance {F₁ F₂ : Frame} {r₁ : outParam F₁.World} {r₂ : outParam F₂.
   [tree₁ : F₁.IsFiniteTree r₁] [tree₂ : F₂.IsFiniteTree r₂]
   : (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).IsFiniteTree (.inl ()) where
   root_generates := by
-    intro x hx;
+    intro x hx
     match x with
-    | .inl x => contradiction;
+    | .inl x => contradiction
     | .inr _ =>
-      apply Relation.TransGen.single;
-      tauto;
+      apply Relation.TransGen.single
+      tauto
   asymm := by
-    intro x y hxy;
+    intro x y hxy
     match x, y with
-    | .inr (.inl x), .inr (.inl y) => exact tree₁.asymm _ _ hxy;
-    | .inr (.inr x), .inr (.inr y) => apply tree₂.asymm _ _ hxy;
-    | .inl x, .inl y => contradiction;
-    | .inl x, .inr y => simp;
+    | .inr (.inl x), .inr (.inl y) => exact tree₁.asymm _ _ hxy
+    | .inr (.inr x), .inr (.inr y) => apply tree₂.asymm _ _ hxy
+    | .inl x, .inl y => contradiction
+    | .inl x, .inr y => simp
   trans := by
-    intro x y z hxy hyz;
+    intro x y z hxy hyz
     match x, y, z with
-    | .inr (.inl x), .inr (.inl y), .inr (.inl z) => apply tree₁.trans _ _ _ hxy hyz;
-    | .inr (.inr x), .inr (.inr y), .inr (.inr z) => apply tree₂.trans _ _ _ hxy hyz;
-    | .inl _, .inr (.inr _), .inr (.inr _) => simp;
-    | .inl _, .inr (.inl _), .inr (.inl _) => simp;
+    | .inr (.inl x), .inr (.inl y), .inr (.inl z) => apply tree₁.trans _ _ _ hxy hyz
+    | .inr (.inr x), .inr (.inr y), .inr (.inr z) => apply tree₂.trans _ _ _ hxy hyz
+    | .inl _, .inr (.inr _), .inr (.inr _) => simp
+    | .inl _, .inr (.inl _), .inr (.inl _) => simp
 
 -- TODO: remove?
 instance : (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).IsIrreflexive := ⟨by simp⟩
@@ -60,37 +60,37 @@ protected abbrev root : (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).World := .in
 
 def pMorphism₁ : F₁ →ₚ (mdpCounterexmpleFrame F₁ F₂ r₁ r₂) where
   toFun x := .inr (.inl x)
-  forth := by intro x y hxy; exact hxy;
-  back {x y} h := by match y with | .inr (.inl y) => use y;
+  forth := by intro x y hxy; exact hxy
+  back {x y} h := by match y with | .inr (.inl y) => use y
 
 def pMorphism₂ : F₂ →ₚ (mdpCounterexmpleFrame F₁ F₂ r₁ r₂) where
   toFun x := .inr (.inr x)
-  forth := by intro x y hxy; exact hxy;
-  back {x y} h := by match y with | .inr (.inr y) => use y;
+  forth := by intro x y hxy; exact hxy
+  back {x y} h := by match y with | .inr (.inr y) => use y
 
 lemma through_original_root {x : (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).World} (h : mdpCounterexmpleFrame.root ≺ x)
   : (x = r₁ ∨ (Sum.inr (Sum.inl r₁) ≺ x)) ∨ (x = r₂ ∨ (Sum.inr (Sum.inr r₂) ≺ x)) := by
   match x with
   | .inl x =>
-    simp only [Function.comp_apply, reduceCtorEq, or_self];
-    apply (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).irrefl mdpCounterexmpleFrame.root;
-    contradiction;
+    simp only [Function.comp_apply, reduceCtorEq, or_self]
+    apply (mdpCounterexmpleFrame F₁ F₂ r₁ r₂).irrefl mdpCounterexmpleFrame.root
+    contradiction
   | .inr (.inl x) =>
-    by_cases e : x = r₁;
-    . subst e; left; tauto;
-    . left; right;
+    by_cases e : x = r₁
+    . subst e; left; tauto
+    . left; right
       exact pMorphism₁.forth $ Frame.root_genaretes'! x e
   | .inr (.inr x) =>
-    by_cases h : x = r₂;
-    . subst h; right; tauto;
-    . right; right;
+    by_cases h : x = r₂
+    . subst h; right; tauto
+    . right; right
       exact pMorphism₂.forth $ Frame.root_genaretes'! x h
 
 end mdpCounterexmpleFrame
 
 
 abbrev mdpCounterexmpleModel (M₁ M₂ : Model) (r₁ r₂) [M₁.IsFiniteTree r₁] [M₂.IsFiniteTree r₂] : Model where
-  toFrame := mdpCounterexmpleFrame (M₁.toFrame) (M₂.toFrame) r₁ r₂;
+  toFrame := mdpCounterexmpleFrame (M₁.toFrame) (M₂.toFrame) r₁ r₂
   Val := λ x a =>
     match x with
     | .inr (.inl x) => M₁.Val x a
@@ -108,17 +108,17 @@ abbrev root : (mdpCounterexmpleModel M₁ M₂ r₁ r₂).World := mdpCounterexm
 
 def pMorphism₁ : M₁ →ₚ (mdpCounterexmpleModel M₁ M₂ r₁ r₂) :=
   Model.PseudoEpimorphism.ofAtomic (mdpCounterexmpleFrame.pMorphism₁ (F₁ := M₁.toFrame) (F₂ := M₂.toFrame) (r₁ := r₁) (r₂ := r₂)) $ by
-  simp [mdpCounterexmpleFrame.pMorphism₁];
+  simp [mdpCounterexmpleFrame.pMorphism₁]
 
 def pMorphism₂ : M₂ →ₚ (mdpCounterexmpleModel M₁ M₂ r₁ r₂) :=
   Model.PseudoEpimorphism.ofAtomic (mdpCounterexmpleFrame.pMorphism₂ (F₁ := M₁.toFrame) (F₂ := M₂.toFrame) (r₁ := r₁) (r₂ := r₂)) $ by
-  simp [mdpCounterexmpleFrame.pMorphism₂];
+  simp [mdpCounterexmpleFrame.pMorphism₂]
 
 lemma modal_equivalence_original_world₁ {x : M₁.World} : ModalEquivalent (M₁ := M₁) (M₂ := (mdpCounterexmpleModel M₁ M₂ r₁ r₂)) x (↑x) := by
-  apply Kripke.Model.PseudoEpimorphism.modal_equivalence pMorphism₁;
+  apply Kripke.Model.PseudoEpimorphism.modal_equivalence pMorphism₁
 
 lemma modal_equivalence_original_world₂ {x : M₂.World} : ModalEquivalent (M₁ := M₂) (M₂ := (mdpCounterexmpleModel M₁ M₂ r₁ r₂)) x (↑x) := by
-  apply Kripke.Model.PseudoEpimorphism.modal_equivalence pMorphism₂;
+  apply Kripke.Model.PseudoEpimorphism.modal_equivalence pMorphism₂
 
 end mdpCounterexmpleModel
 
@@ -126,79 +126,79 @@ end Kripke
 
 
 lemma MDP_Aux {X : Set _} (h : (X.box) *⊢[Hilbert.GL]! □φ₁ ⋎ □φ₂) : (X.box) *⊢[Hilbert.GL]! □φ₁ ∨ (X.box) *⊢[Hilbert.GL]! □φ₂ := by
-  obtain ⟨Δ, sΓ, hΓ⟩ := Context.provable_iff_boxed.mp h;
+  obtain ⟨Δ, sΓ, hΓ⟩ := Context.provable_iff_boxed.mp h
 
-  have : Hilbert.GL ⊢! ⋀Δ.box ➝ (□φ₁ ⋎ □φ₂) := FiniteContext.provable_iff.mp hΓ;
-  have : Hilbert.GL ⊢! □⋀Δ ➝ (□φ₁ ⋎ □φ₂) := C!_trans (by simp) this;
-  generalize e : ⋀Δ = c at this;
+  have : Hilbert.GL ⊢! ⋀Δ.box ➝ (□φ₁ ⋎ □φ₂) := FiniteContext.provable_iff.mp hΓ
+  have : Hilbert.GL ⊢! □⋀Δ ➝ (□φ₁ ⋎ □φ₂) := C!_trans (by simp) this
+  generalize e : ⋀Δ = c at this
 
   have : (Hilbert.GL ⊢! ⊡c ➝ φ₁) ∨ (Hilbert.GL ⊢! ⊡c ➝ φ₂) := by
-    by_contra! hC;
-    have ⟨h₁, h₂⟩ : (Hilbert.GL ⊬ ⊡c ➝ φ₁) ∧ (Hilbert.GL ⊬ ⊡c ➝ φ₂) := hC;
+    by_contra! hC
+    have ⟨h₁, h₂⟩ : (Hilbert.GL ⊬ ⊡c ➝ φ₁) ∧ (Hilbert.GL ⊬ ⊡c ➝ φ₂) := hC
 
-    obtain ⟨M₁, r₁, _, hM₁⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h₁;
-    obtain ⟨M₂, r₂, _, hM₂⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h₂;
+    obtain ⟨M₁, r₁, _, hM₁⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h₁
+    obtain ⟨M₂, r₂, _, hM₂⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h₂
 
-    let M₀ := Kripke.mdpCounterexmpleModel M₁ M₂ r₁ r₂;
+    let M₀ := Kripke.mdpCounterexmpleModel M₁ M₂ r₁ r₂
     let r₀ := Kripke.mdpCounterexmpleModel.root (M₁ := M₁) (M₂ := M₂) (r₁ := r₁) (r₂ := r₂)
 
-    replace hM₁ : Satisfies M₀ ↑r₁ (⊡c ⋏ ∼φ₁) := Kripke.mdpCounterexmpleModel.modal_equivalence_original_world₁.mp (Formula.Kripke.Satisfies.not_imp.mp hM₁);
-    replace hM₂ : Satisfies M₀ ↑r₂ (⊡c ⋏ ∼φ₂) := Kripke.mdpCounterexmpleModel.modal_equivalence_original_world₂.mp (Formula.Kripke.Satisfies.not_imp.mp hM₂);
+    replace hM₁ : Satisfies M₀ ↑r₁ (⊡c ⋏ ∼φ₁) := Kripke.mdpCounterexmpleModel.modal_equivalence_original_world₁.mp (Formula.Kripke.Satisfies.not_imp.mp hM₁)
+    replace hM₂ : Satisfies M₀ ↑r₂ (⊡c ⋏ ∼φ₂) := Kripke.mdpCounterexmpleModel.modal_equivalence_original_world₂.mp (Formula.Kripke.Satisfies.not_imp.mp hM₂)
 
     have hc : Satisfies M₀ r₀ (□c) := by
-      intro x Rrx;
+      intro x Rrx
       rcases Kripke.mdpCounterexmpleFrame.through_original_root Rrx with ((rfl | Rrx) | (rfl | Rrx))
-      . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₁).1).1;
+      . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₁).1).1
       . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₁).1).2 _ Rrx
-      . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₂).1).1;
+      . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₂).1).1
       . exact (Satisfies.and_def.mp $ (Satisfies.and_def.mp hM₂).1).2 _ Rrx
     have hp₁ : ¬(Satisfies M₀ r₀ (□φ₁)) := by
-      dsimp [Satisfies];
-      push_neg;
-      use (↑r₁);
-      constructor;
-      . tauto;
-      . exact (Satisfies.and_def.mp hM₁).2;
+      dsimp [Satisfies]
+      push_neg
+      use (↑r₁)
+      constructor
+      . tauto
+      . exact (Satisfies.and_def.mp hM₁).2
     have hp₂ : ¬(Satisfies M₀ r₀ (□φ₂)) := by
-      dsimp [Satisfies];
-      push_neg;
-      use (↑r₂);
-      constructor;
-      . tauto;
-      . exact (Satisfies.and_def.mp hM₂).2;
+      dsimp [Satisfies]
+      push_neg
+      use (↑r₂)
+      constructor
+      . tauto
+      . exact (Satisfies.and_def.mp hM₂).2
     have : ¬(Satisfies M₀ r₀ (□φ₁ ⋎ □φ₂)) := by
-      apply Satisfies.not_def.mpr;
-      apply Satisfies.or_def.not.mpr;
-      push_neg;
-      exact ⟨hp₁, hp₂⟩;
-    have : ¬(Satisfies M₀ r₀ (□c ➝ (□φ₁ ⋎ □φ₂))) := _root_.not_imp.mpr ⟨hc, this⟩;
+      apply Satisfies.not_def.mpr
+      apply Satisfies.or_def.not.mpr
+      push_neg
+      exact ⟨hp₁, hp₂⟩
+    have : ¬(Satisfies M₀ r₀ (□c ➝ (□φ₁ ⋎ □φ₂))) := _root_.not_imp.mpr ⟨hc, this⟩
     have : Hilbert.GL ⊬ □c ➝ □φ₁ ⋎ □φ₂ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mpr $ by
-      use M₀, r₀;
-      constructor;
-      . infer_instance;
-      . exact this;
-    contradiction;
+      use M₀, r₀
+      constructor
+      . infer_instance
+      . exact this
+    contradiction
 
   rcases this with (h | h) <;> {
-    subst e;
-    have := imply_box_box_of_imply_boxdot_plain! h;
-    have := C!_trans collect_box_conj! this;
-    have := FiniteContext.provable_iff.mpr this;
-    have := Context.provable_iff.mpr $ by use Δ.box;
-    tauto;
-  };
+    subst e
+    have := imply_box_box_of_imply_boxdot_plain! h
+    have := C!_trans collect_box_conj! this
+    have := FiniteContext.provable_iff.mpr this
+    have := Context.provable_iff.mpr $ by use Δ.box
+    tauto
+  }
 
 theorem modal_disjunctive (h : Hilbert.GL ⊢! □φ₁ ⋎ □φ₂) : Hilbert.GL ⊢! φ₁ ∨ Hilbert.GL ⊢! φ₂ := by
-  have : ∅ *⊢[Hilbert.GL]! □φ₁ ∨ ∅ *⊢[Hilbert.GL]! □φ₂ := by simpa using MDP_Aux (X := ∅) (φ₁ := φ₁) (φ₂ := φ₂) $ Context.of! h;
+  have : ∅ *⊢[Hilbert.GL]! □φ₁ ∨ ∅ *⊢[Hilbert.GL]! □φ₂ := by simpa using MDP_Aux (X := ∅) (φ₁ := φ₁) (φ₂ := φ₂) $ Context.of! h
   rcases this with (h | h) <;> {
-    have := unnec! $ Context.emptyPrf! h;
-    tauto;
+    have := unnec! $ Context.emptyPrf! h
+    tauto
   }
 instance : ModalDisjunctive Hilbert.GL := ⟨modal_disjunctive⟩
 instance : ModalDisjunctive Modal.GL where
   modal_disjunctive := by
-    simp only [Normal.iff_logic_provable_provable];
-    apply modal_disjunctive;
+    simp only [Normal.iff_logic_provable_provable]
+    apply modal_disjunctive
 
 end Hilbert.GL
 

--- a/Foundation/Modal/Kripke/Logic/GL/Soundness.lean
+++ b/Foundation/Modal/Kripke/Logic/GL/Soundness.lean
@@ -30,16 +30,16 @@ end Kripke
 namespace Logic.GL.Kripke
 
 instance : Sound Hilbert.GL FrameClass.finite_GL := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F ⟨_, _, _⟩;
-  exact validate_AxiomL_of_trans_cwf;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F ⟨_, _, _⟩
+  exact validate_AxiomL_of_trans_cwf
 
 instance : Entailment.Consistent Hilbert.GL :=
   consistent_of_sound_frameclass FrameClass.finite_GL $ by
-    use blackpoint;
-    constructor;
+    use blackpoint
+    constructor
 
 end Logic.GL.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/GL/Tree.lean
+++ b/Foundation/Modal/Kripke/Logic/GL/Tree.lean
@@ -18,10 +18,10 @@ variable (F : Kripke.Frame) {φ : Formula _}
 
 lemma valid_on_FiniteTransitiveTreeClass_of_valid_on_TransitiveIrreflexiveFrameClass (h : FrameClass.finite_GL ⊧ φ)
   : ∀ F : Kripke.Frame, ∀ r, [F.IsFiniteTree r] → F ⊧ φ := by
-  intro F r h_tree;
-  apply h;
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  intro F r h_tree
+  apply h
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 lemma satisfies_at_root_on_FiniteTransitiveTree (h : ∀ F : Kripke.Frame, ∀ r, [Finite F.World] → [F.IsTree r] → F ⊧ φ)
   : ∀ M : Model, ∀ r, [M.IsFiniteTree r] → Satisfies M r φ := fun M r _ => h M.toFrame r M.Val r
@@ -29,18 +29,18 @@ lemma satisfies_at_root_on_FiniteTransitiveTree (h : ∀ F : Kripke.Frame, ∀ r
 open Model Classical in
 lemma valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTransitiveTree
   : (∀ M : Model, ∀ r : M.World, [M.IsFiniteTree r] → Satisfies M r φ) → FrameClass.finite_GL ⊧ φ := by
-  rintro H F ⟨_, F_trans, F_irrefl⟩ V r;
-  let M : Kripke.Model := ⟨F, V⟩;
-  have : (M↾r).IsTransitive := Frame.pointGenerate.isTransitive;
+  rintro H F ⟨_, F_trans, F_irrefl⟩ V r
+  let M : Kripke.Model := ⟨F, V⟩
+  have : (M↾r).IsTransitive := Frame.pointGenerate.isTransitive
   have : Satisfies ((M↾r).mkTransTreeUnravelling pointGenerate.root) mkTransTreeUnravelling.root φ := @H _ _ $
     @Frame.mkTransTreeUnravelling.instIsFiniteTree (F := (M↾r).toFrame) (r := pointGenerate.root) _
       (Subtype.finite)
       (Frame.pointGenerate.isTransitive)
-      (Frame.pointGenerate.isIrreflexive);
+      (Frame.pointGenerate.isIrreflexive)
   have : Satisfies (M↾r) pointGenerate.root φ := mkTransTreeUnravelling.pMorphism (M↾r) _
     |>.modal_equivalence _
-    |>.mp this;
-  exact pointGenerate.pMorphism.modal_equivalence _ |>.mp this;
+    |>.mp this
+  exact pointGenerate.pMorphism.modal_equivalence _ |>.mp this
 
 
 end Kripke
@@ -49,20 +49,20 @@ end Kripke
 namespace Logic.GL.Kripke
 
 theorem iff_provable_satisfies_FiniteTransitiveTree : Hilbert.GL ⊢! φ ↔ (∀ M : Kripke.Model, ∀ r, [M.IsFiniteTree r] → Satisfies M r φ) := by
-  constructor;
-  . intro h M r M_tree;
-    have : FrameClass.finite_GL ⊧ φ := Sound.sound (𝓜 := FrameClass.finite_GL) h;
-    apply valid_on_FiniteTransitiveTreeClass_of_valid_on_TransitiveIrreflexiveFrameClass this M.toFrame r;
-  . intro h;
-    apply Complete.complete (𝓜 := FrameClass.finite_GL);
-    intro F hF V;
-    apply valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTransitiveTree h hF;
+  constructor
+  . intro h M r M_tree
+    have : FrameClass.finite_GL ⊧ φ := Sound.sound (𝓜 := FrameClass.finite_GL) h
+    apply valid_on_FiniteTransitiveTreeClass_of_valid_on_TransitiveIrreflexiveFrameClass this M.toFrame r
+  . intro h
+    apply Complete.complete (𝓜 := FrameClass.finite_GL)
+    intro F hF V
+    apply valid_on_TransitiveIrreflexiveFrameClass_of_satisfies_at_root_on_FiniteTransitiveTree h hF
 
 lemma iff_unprovable_exists_unsatisfies_FiniteTransitiveTree
   : Hilbert.GL ⊬ φ ↔ ∃ M : Model, ∃ r, M.IsFiniteTree r ∧ ¬Satisfies M r φ := by
-  apply Iff.not_left;
-  push_neg;
-  exact iff_provable_satisfies_FiniteTransitiveTree;
+  apply Iff.not_left
+  push_neg
+  exact iff_provable_satisfies_FiniteTransitiveTree
 
 end Logic.GL.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/GL/Unnecessitation.lean
+++ b/Foundation/Modal/Kripke/Logic/GL/Unnecessitation.lean
@@ -12,43 +12,43 @@ namespace Logic.GL
 
 open Model in
 lemma imply_boxdot_plain_of_imply_box_box : Hilbert.GL ⊢! □φ ➝ □ψ → Hilbert.GL ⊢! ⊡φ ➝ ψ := by
-  contrapose;
-  intro h;
-  have := Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h;
-  obtain ⟨M, r, M_tree, hs⟩ := this;
+  contrapose
+  intro h
+  have := Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp h
+  obtain ⟨M, r, M_tree, hs⟩ := this
 
-  let M₀ := M.extendRoot 1;
-  let r₀ : M₀.World := extendRoot.root;
+  let M₀ := M.extendRoot 1
+  let r₀ : M₀.World := extendRoot.root
 
-  have hs : Satisfies M r (⊡φ ⋏ ∼ψ) := by simp_all [Satisfies];
-  replace hs := @Model.extendRoot.modal_equivalence_original_world (M := M) (r := r) (n := 1) inferInstance r (⊡φ ⋏ ∼ψ) |>.mp hs;
-  have ⟨hs₁₂, hs₃⟩ := Satisfies.and_def.mp hs;
-  have ⟨hs₁, hs₂⟩ := Satisfies.and_def.mp hs₁₂;
+  have hs : Satisfies M r (⊡φ ⋏ ∼ψ) := by simp_all [Satisfies]
+  replace hs := @Model.extendRoot.modal_equivalence_original_world (M := M) (r := r) (n := 1) inferInstance r (⊡φ ⋏ ∼ψ) |>.mp hs
+  have ⟨hs₁₂, hs₃⟩ := Satisfies.and_def.mp hs
+  have ⟨hs₁, hs₂⟩ := Satisfies.and_def.mp hs₁₂
 
   have hbp : Satisfies M₀ r₀ (□φ) := by
-    intro x hx;
-    rcases Frame.extendRoot.not_root_of_from_root₁ (F := M.toFrame) (x := x) hx with (rfl | hr);
-    . tauto;
-    . apply hs₂; exact hr;
+    intro x hx
+    rcases Frame.extendRoot.not_root_of_from_root₁ (F := M.toFrame) (x := x) hx with (rfl | hr)
+    . tauto
+    . apply hs₂; exact hr
   have hbq : ¬(Satisfies M₀ r₀ (□ψ)) := by
-    apply Satisfies.box_def.not.mpr;
-    push_neg;
-    use (Sum.inr r);
-    constructor;
-    . exact @Frame.IsRootedBy.root_generates (F := M₀.toFrame) (r := r₀) (Frame.extendRoot.instIsRooted) (Sum.inr r) (by tauto) |>.unwrap;
-    . assumption;
+    apply Satisfies.box_def.not.mpr
+    push_neg
+    use (Sum.inr r)
+    constructor
+    . exact @Frame.IsRootedBy.root_generates (F := M₀.toFrame) (r := r₀) (Frame.extendRoot.instIsRooted) (Sum.inr r) (by tauto) |>.unwrap
+    . assumption
 
-  apply Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mpr;
-  use M₀, r₀;
-  refine ⟨?_, ?_⟩;
-  . exact {};
-  . tauto;
+  apply Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mpr
+  use M₀, r₀
+  refine ⟨?_, ?_⟩
+  . exact {}
+  . tauto
 
 theorem unnecessitation! : Hilbert.GL ⊢! □φ → Hilbert.GL ⊢! φ := by
-  intro h;
-  have : Hilbert.GL ⊢! □⊤ ➝ □φ := C!_of_conseq! (ψ := □⊤) h;
-  have : Hilbert.GL ⊢! ⊡⊤ ➝ φ := imply_boxdot_plain_of_imply_box_box this;
-  exact this ⨀ boxdotverum!;
+  intro h
+  have : Hilbert.GL ⊢! □⊤ ➝ □φ := C!_of_conseq! (ψ := □⊤) h
+  have : Hilbert.GL ⊢! ⊡⊤ ➝ φ := imply_boxdot_plain_of_imply_box_box this
+  exact this ⨀ boxdotverum!
 
 noncomputable instance : Entailment.Unnecessitation Hilbert.GL := ⟨λ h => unnecessitation! ⟨h⟩ |>.some⟩
 

--- a/Foundation/Modal/Kripke/Logic/GLPoint3.lean
+++ b/Foundation/Modal/Kripke/Logic/GLPoint3.lean
@@ -17,7 +17,7 @@ protected class Frame.IsFiniteGLPoint3 (F : Frame) extends F.IsFiniteGL, F.IsPie
 abbrev FrameClass.finite_GLPoint3 : FrameClass := { F | F.IsFiniteGLPoint3 }
 
 instance : blackpoint.IsFiniteGLPoint3 where
-  p_connected := by tauto;
+  p_connected := by tauto
 
 end Kripke
 
@@ -25,63 +25,63 @@ end Kripke
 namespace Hilbert.GLPoint3.Kripke
 
 instance : Sound Hilbert.GLPoint3 FrameClass.finite_GLPoint3 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomL_of_finite_trans_irrefl;
-  . exact validate_WeakPoint3_of_weakConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomL_of_finite_trans_irrefl
+  . exact validate_WeakPoint3_of_weakConnected
 
 instance : Entailment.Consistent Hilbert.GLPoint3 :=
   consistent_of_sound_frameclass FrameClass.finite_GLPoint3 $ by
-    use blackpoint;
-    constructor;
+    use blackpoint
+    constructor
 
-instance : Complete Hilbert.GLPoint3 FrameClass.finite_GLPoint3 := by sorry;
+instance : Complete Hilbert.GLPoint3 FrameClass.finite_GLPoint3 := by sorry
 
 
 instance : Hilbert.GL ⪱ Hilbert.GLPoint3 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.WeakPoint3 (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GL);
-      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x = 0 ∧ y = 2)⟩, (λ w a => match a with | 0 => w = 1 | 1 => w = 2 | _ => False)⟩;
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use M, 0;
-      constructor;
-      . apply Set.mem_setOf_eq.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.WeakPoint3 (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GL)
+      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x = 0 ∧ y = 2)⟩, (λ w a => match a with | 0 => w = 1 | 1 => w = 2 | _ => False)⟩
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use M, 0
+      constructor
+      . apply Set.mem_setOf_eq.mpr
         exact {
           trans := by omega,
           irrefl := by omega
-        };
+        }
       . suffices (0 : M.World) ≺ 1 ∧ (∀ x, (1 : M.World) ≺ x → x = 1) ∧ (0 : M.World) ≺ 2 ∧ ∀ x, (2 : M.World) ≺ x → x = 2 by
-          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M];
-        refine ⟨?_, ?_, ?_, ?_⟩;
-        all_goals omega;
+          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M]
+        refine ⟨?_, ?_, ?_, ?_⟩
+        all_goals omega
 
 instance : Hilbert.K4Point3 ⪱ Hilbert.GLPoint3 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.L (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.K4Point3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w a => False)⟩, 0;
-      constructor;
-      . apply Set.mem_setOf_eq.mpr;
-        constructor;
-      . simp [Semantics.Realize, Satisfies];
-        constructor;
-        . intro y Rxy;
-          use y;
-        . use 1;
-          omega;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.L (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.K4Point3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w a => False)⟩, 0
+      constructor
+      . apply Set.mem_setOf_eq.mpr
+        constructor
+      . simp [Semantics.Realize, Satisfies]
+        constructor
+        . intro y Rxy
+          use y
+        . use 1
+          omega
 
 end Hilbert.GLPoint3.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/Grz/Completeness.lean
+++ b/Foundation/Modal/Kripke/Logic/Grz/Completeness.lean
@@ -14,19 +14,19 @@ namespace subformulasGrz
 
 @[simp, grind] lemma mem_self : φ ∈ φ.subformulasGrz := by simp [subformulasGrz, subformulas.mem_self]
 
-@[grind] protected lemma mem_of_mem_subformula (h : ψ ∈ φ.subformulas) : ψ ∈ φ.subformulasGrz := by simp_all [subformulasGrz];
+@[grind] protected lemma mem_of_mem_subformula (h : ψ ∈ φ.subformulas) : ψ ∈ φ.subformulasGrz := by simp_all [subformulasGrz]
 
-@[grind ⇒] lemma mem_boximpbox (h : ψ ∈ φ.subformulas.prebox) : □(ψ ➝ □ψ) ∈ φ.subformulasGrz := by simp_all [subformulasGrz];
+@[grind ⇒] lemma mem_boximpbox (h : ψ ∈ φ.subformulas.prebox) : □(ψ ➝ □ψ) ∈ φ.subformulasGrz := by simp_all [subformulasGrz]
 
 @[grind ⇒]
 protected lemma mem_imp (h : (ψ ➝ χ) ∈ φ.subformulasGrz) : ψ ∈ φ.subformulasGrz ∧ χ ∈ φ.subformulasGrz := by
   simp_all only [
     Finset.mem_union, Finset.mem_image, Finset.mem_preimage, Function.iterate_one,
     reduceCtorEq, and_false, exists_const, or_false
-  ];
-  grind;
+  ]
+  grind
 
-example {_ : φ ∈ φ.subformulasGrz} : φ ∈ φ.subformulasGrz := by grind;
+example {_ : φ ∈ φ.subformulasGrz} : φ ∈ φ.subformulasGrz := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulasGrz} : ψ ∈ φ.subformulasGrz := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulasGrz} : χ ∈ φ.subformulasGrz := by grind
 
@@ -54,28 +54,28 @@ abbrev miniCanonicalFrame (𝓢 : S) [Entailment.Grz 𝓢] [Entailment.Consisten
     ((∀ ψ ∈ (φ.subformulasGrz).prebox, □ψ ∈ Y → □ψ ∈ X) → X = Y)
 
 instance : (miniCanonicalFrame 𝓢 φ).IsReflexive where
-  refl := by tauto_set;
+  refl := by tauto_set
 
 instance : (miniCanonicalFrame 𝓢 φ).IsAntisymmetric where
   antisymm := by
-    rintro X Y ⟨_, h₁⟩ ⟨h₂, _⟩;
-    exact h₁ h₂;
+    rintro X Y ⟨_, h₁⟩ ⟨h₂, _⟩
+    exact h₁ h₂
 
 instance : (miniCanonicalFrame 𝓢 φ).IsTransitive where
   trans := by
-    rintro X Y Z ⟨RXY₁, RXY₂⟩ ⟨RYZ₁, RYZ₂⟩;
-    constructor;
-    . rintro ψ hq₁ hq₂;
-      exact RYZ₁ ψ hq₁ $ RXY₁ ψ hq₁ hq₂;
-    . intro h;
+    rintro X Y Z ⟨RXY₁, RXY₂⟩ ⟨RYZ₁, RYZ₂⟩
+    constructor
+    . rintro ψ hq₁ hq₂
+      exact RYZ₁ ψ hq₁ $ RXY₁ ψ hq₁ hq₂
+    . intro h
       have eXY : X = Y := RXY₂ $ by
-        intro ψ hs hq;
-        exact h ψ hs $ RYZ₁ ψ hs hq;
+        intro ψ hs hq
+        exact h ψ hs $ RYZ₁ ψ hs hq
       have eYZ : Y = Z := RYZ₂ $ by
-        intro ψ hs hq;
-        exact RXY₁ ψ hs $ h ψ hs hq;
-      subst_vars;
-      tauto;
+        intro ψ hs hq
+        exact RXY₁ ψ hs $ h ψ hs hq
+      subst_vars
+      tauto
 
 instance : (miniCanonicalFrame 𝓢 φ).IsFiniteGrz where
 
@@ -88,22 +88,22 @@ omit [Consistent 𝓢] [Entailment.Grz 𝓢] in
 lemma truthlemma_lemma1
   {X : ComplementClosedConsistentFinset 𝓢 (φ.subformulasGrz)} (hq : □ψ ∈ φ.subformulas)
   : ((X.1.prebox.box) ∪ {□(ψ ➝ □ψ), -ψ}) ⊆ (φ.subformulasGrz)⁻ := by
-  simp only [FormulaFinset.complementary];
-  intro χ hr;
+  simp only [FormulaFinset.complementary]
+  intro χ hr
   replace hr : χ = □(ψ ➝ □ψ) ∨ (∃ a, □a ∈ X ∧ □a = χ) ∨ χ = -ψ := by
-    simpa [Finset.mem_union] using hr;
-  apply Finset.mem_union.mpr;
-  rcases hr with (rfl | ⟨χ, hr, rfl⟩ | rfl);
-  . left;
-    simp;
-    tauto;
-  . have := X.closed.subset hr;
-    left;
-    exact FormulaFinset.complementary_mem_box (by grind) this;
-  . right;
-    simp only [Finset.mem_image, Finset.mem_union, Finset.mem_preimage, Function.iterate_one];
-    use ψ;
-    grind;
+    simpa [Finset.mem_union] using hr
+  apply Finset.mem_union.mpr
+  rcases hr with (rfl | ⟨χ, hr, rfl⟩ | rfl)
+  . left
+    simp
+    tauto
+  . have := X.closed.subset hr
+    left
+    exact FormulaFinset.complementary_mem_box (by grind) this
+  . right
+    simp only [Finset.mem_image, Finset.mem_union, Finset.mem_preimage, Function.iterate_one]
+    use ψ
+    grind
 
 omit [Consistent 𝓢] in
 lemma truthlemma_lemma2
@@ -111,178 +111,178 @@ lemma truthlemma_lemma2
   (hψ₁ : □ψ ∈ φ.subformulas)
   (hψ₂ : □ψ ∉ X)
   : FormulaFinset.Consistent 𝓢 ((X.1.prebox.box) ∪ {□(ψ ➝ □ψ), -ψ}) := by
-    apply FormulaFinset.intro_union_consistent;
-    rintro Γ₁ Γ₂ hΓ₁ hΓ₂;
-    by_contra! hC;
-    apply hψ₂;
-    have := Context.weakening! (Γ := Γ₁ ∪ Γ₂) (Δ := insert (-ψ) (insert (□(ψ ➝ □ψ)) Γ₁)) ?_ hC;
-    . replace := Context.deduct! this;
-      replace := of_imply_complement_bot this;
-      replace := Context.deduct! this;
-      replace := Context.nec! this;
-      replace := axiomGrz! ⨀ this;
-      replace := Context.nec! this;
-      replace := Context.boxbox_in_context_to_box this;
-      replace : X.1.toSet.prebox.box.box *⊢[𝓢]! □ψ := Context.weakening! ?_ this;
-      . replace := Context.boxbox_in_context_to_box this;
-        replace : X *⊢[𝓢]! □ψ := Context.weakening! ?_ this;
-        . exact membership_iff (subformulasGrz.mem_of_mem_subformula hψ₁) |>.mpr this;
-        . intro ξ hξ;
-          obtain ⟨ξ, hξ, rfl⟩ := hξ;
-          tauto;
-      . intro ξ hξ;
-        obtain ⟨ξ, hξ, rfl⟩ := hξ;
-        have := hΓ₁ hξ;
-        simp at this ⊢;
-        obtain ⟨χ, hχ, rfl⟩ := this;
-        use χ;
-    . intro ξ;
-      simp only [Set.mem_union, Finset.mem_coe, Set.mem_insert_iff];
-      rintro (hξ₁ | hξ₂);
-      . have := hΓ₁ hξ₁; tauto;
-      . have := hΓ₂ hξ₂;
-        simp at this;
-        tauto;
+    apply FormulaFinset.intro_union_consistent
+    rintro Γ₁ Γ₂ hΓ₁ hΓ₂
+    by_contra! hC
+    apply hψ₂
+    have := Context.weakening! (Γ := Γ₁ ∪ Γ₂) (Δ := insert (-ψ) (insert (□(ψ ➝ □ψ)) Γ₁)) ?_ hC
+    . replace := Context.deduct! this
+      replace := of_imply_complement_bot this
+      replace := Context.deduct! this
+      replace := Context.nec! this
+      replace := axiomGrz! ⨀ this
+      replace := Context.nec! this
+      replace := Context.boxbox_in_context_to_box this
+      replace : X.1.toSet.prebox.box.box *⊢[𝓢]! □ψ := Context.weakening! ?_ this
+      . replace := Context.boxbox_in_context_to_box this
+        replace : X *⊢[𝓢]! □ψ := Context.weakening! ?_ this
+        . exact membership_iff (subformulasGrz.mem_of_mem_subformula hψ₁) |>.mpr this
+        . intro ξ hξ
+          obtain ⟨ξ, hξ, rfl⟩ := hξ
+          tauto
+      . intro ξ hξ
+        obtain ⟨ξ, hξ, rfl⟩ := hξ
+        have := hΓ₁ hξ
+        simp at this ⊢
+        obtain ⟨χ, hχ, rfl⟩ := this
+        use χ
+    . intro ξ
+      simp only [Set.mem_union, Finset.mem_coe, Set.mem_insert_iff]
+      rintro (hξ₁ | hξ₂)
+      . have := hΓ₁ hξ₁; tauto
+      . have := hΓ₂ hξ₂
+        simp at this
+        tauto
 
 omit [Consistent 𝓢] in
 lemma truthlemma_lemma3 : 𝓢 ⊢! (φ ⋏ □(φ ➝ □φ)) ➝ □φ := by
-  refine C!_trans ?_ $ inner_mdp! (𝓢 := 𝓢) (φ := φ) (ψ := □φ);
-  apply CKK!_of_C!';
-  exact axiomT!;
+  refine C!_trans ?_ $ inner_mdp! (𝓢 := 𝓢) (φ := φ) (ψ := □φ)
+  apply CKK!_of_C!'
+  exact axiomT!
 
 lemma truthlemma {X : (miniCanonicalModel 𝓢 φ).World} (q_sub : ψ ∈ φ.subformulas) :
   Satisfies (miniCanonicalModel 𝓢 φ) X ψ ↔ ψ ∈ X := by
   induction ψ generalizing X with
-  | hatom => simp [Satisfies];
-  | hfalsum => simp [Satisfies];
+  | hatom => simp [Satisfies]
+  | hfalsum => simp [Satisfies]
   | himp ψ χ ihq ihr =>
-    constructor;
-    . contrapose;
-      intro h;
-      apply Satisfies.not_imp.mpr;
-      apply Satisfies.and_def.mpr;
-      constructor;
-      . apply ihq (by grind) |>.mpr;
-        exact iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mp h |>.1;
-      . apply ihr (by grind) |>.not.mpr;
+    constructor
+    . contrapose
+      intro h
+      apply Satisfies.not_imp.mpr
+      apply Satisfies.and_def.mpr
+      constructor
+      . apply ihq (by grind) |>.mpr
+        exact iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mp h |>.1
+      . apply ihr (by grind) |>.not.mpr
         exact iff_not_mem_compl (by grind) |>.not.mpr $ by
-          push_neg;
-          exact iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mp h |>.2;
-    . contrapose;
-      intro h;
-      replace h := Satisfies.and_def.mp $ Satisfies.not_imp.mp h;
-      obtain ⟨hq, hr⟩ := h;
-      replace hq := ihq (by grind) |>.mp hq;
-      replace hr := ihr (by grind) |>.not.mp hr;
-      apply iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mpr;
-      constructor;
-      . assumption;
-      . simpa using iff_not_mem_compl (by grind) |>.not.mp hr;
+          push_neg
+          exact iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mp h |>.2
+    . contrapose
+      intro h
+      replace h := Satisfies.and_def.mp $ Satisfies.not_imp.mp h
+      obtain ⟨hq, hr⟩ := h
+      replace hq := ihq (by grind) |>.mp hq
+      replace hr := ihr (by grind) |>.not.mp hr
+      apply iff_not_mem_imp (ψ := ψ) (χ := χ) |>.mpr
+      constructor
+      . assumption
+      . simpa using iff_not_mem_compl (by grind) |>.not.mp hr
   | hbox ψ ih =>
-    constructor;
-    . contrapose;
-      by_cases w : ψ ∈ X;
-      . intro h;
-        obtain ⟨Y, hY⟩ := lindenbaum (𝓢 := 𝓢) (truthlemma_lemma1 q_sub) (truthlemma_lemma2 q_sub h);
-        simp only [Finset.union_subset_iff] at hY;
-        simp only [Satisfies]; push_neg;
-        use Y;
-        constructor;
-        . constructor;
-          . intro χ _ hr₂;
-            apply hY.1;
-            simpa;
-          . apply imp_iff_not_or (b := X = Y) |>.mpr;
-            left; push_neg;
-            use (ψ ➝ □ψ);
-            refine ⟨?_, ?_, ?_⟩;
-            . simp_all;
-            . apply hY.2;
-              simp;
-            . by_contra hC;
-              have : ↑X *⊢[𝓢]! ψ := membership_iff (by grind) |>.mp w;
-              have : ↑X *⊢[𝓢]! □(ψ ➝ □ψ) := membership_iff (by simp; right; assumption) |>.mp hC;
-              have : ↑X *⊢[𝓢]! (ψ ⋏ □(ψ ➝ □ψ)) ➝ □ψ := Context.of! $ truthlemma_lemma3;
-              have : ↑X *⊢[𝓢]! □ψ := this ⨀ K!_intro (by assumption) (by assumption);
-              have : □ψ ∈ X := membership_iff (by grind) |>.mpr this;
-              contradiction;
-        . apply ih (by grind) |>.not.mpr;
-          apply iff_not_mem_compl (by grind) |>.not.mpr;
-          push_neg;
-          apply hY.2;
-          simp;
-      . intro _;
-        simp only [Satisfies]; push_neg;
-        use X;
-        constructor;
-        . apply Frame.refl;
-        . exact ih (by grind) |>.not.mpr w;
-    . intro h Y RXY;
-      apply ih (by grind) |>.mpr;
-      have : ↑Y *⊢[𝓢]! □ψ ➝ ψ := Context.of! $ axiomT!;
-      have : ↑Y *⊢[𝓢]! ψ := this ⨀ (membership_iff (by grind) |>.mp (RXY.1 ψ (by simp; grind) h));
-      exact membership_iff (by grind) |>.mpr this;
+    constructor
+    . contrapose
+      by_cases w : ψ ∈ X
+      . intro h
+        obtain ⟨Y, hY⟩ := lindenbaum (𝓢 := 𝓢) (truthlemma_lemma1 q_sub) (truthlemma_lemma2 q_sub h)
+        simp only [Finset.union_subset_iff] at hY
+        simp only [Satisfies]; push_neg
+        use Y
+        constructor
+        . constructor
+          . intro χ _ hr₂
+            apply hY.1
+            simpa
+          . apply imp_iff_not_or (b := X = Y) |>.mpr
+            left; push_neg
+            use (ψ ➝ □ψ)
+            refine ⟨?_, ?_, ?_⟩
+            . simp_all
+            . apply hY.2
+              simp
+            . by_contra hC
+              have : ↑X *⊢[𝓢]! ψ := membership_iff (by grind) |>.mp w
+              have : ↑X *⊢[𝓢]! □(ψ ➝ □ψ) := membership_iff (by simp; right; assumption) |>.mp hC
+              have : ↑X *⊢[𝓢]! (ψ ⋏ □(ψ ➝ □ψ)) ➝ □ψ := Context.of! $ truthlemma_lemma3
+              have : ↑X *⊢[𝓢]! □ψ := this ⨀ K!_intro (by assumption) (by assumption)
+              have : □ψ ∈ X := membership_iff (by grind) |>.mpr this
+              contradiction
+        . apply ih (by grind) |>.not.mpr
+          apply iff_not_mem_compl (by grind) |>.not.mpr
+          push_neg
+          apply hY.2
+          simp
+      . intro _
+        simp only [Satisfies]; push_neg
+        use X
+        constructor
+        . apply Frame.refl
+        . exact ih (by grind) |>.not.mpr w
+    . intro h Y RXY
+      apply ih (by grind) |>.mpr
+      have : ↑Y *⊢[𝓢]! □ψ ➝ ψ := Context.of! $ axiomT!
+      have : ↑Y *⊢[𝓢]! ψ := this ⨀ (membership_iff (by grind) |>.mp (RXY.1 ψ (by simp; grind) h))
+      exact membership_iff (by grind) |>.mpr this
 
 lemma complete_of_mem_miniCanonicalFrame
   (C : Kripke.FrameClass)
   (hC : ∀ {φ}, miniCanonicalFrame 𝓢 φ ∈ C)
   : Complete 𝓢 C := ⟨by
-  intro φ;
-  contrapose;
-  intro h;
-  apply Semantics.set_models_iff.not.mpr;
-  push_neg;
-  use (miniCanonicalFrame 𝓢 φ);
-  constructor;
-  . apply hC;
-  . apply ValidOnFrame.not_of_exists_valuation_world;
+  intro φ
+  contrapose
+  intro h
+  apply Semantics.set_models_iff.not.mpr
+  push_neg
+  use (miniCanonicalFrame 𝓢 φ)
+  constructor
+  . apply hC
+  . apply ValidOnFrame.not_of_exists_valuation_world
     obtain ⟨X, hX₁⟩ := lindenbaum (𝓢 := 𝓢) (Φ := {-φ}) (Ψ := φ.subformulasGrz)
       (by
-        simp only [Finset.singleton_subset_iff];
-        apply FormulaFinset.complementary_comp;
-        grind;
+        simp only [Finset.singleton_subset_iff]
+        apply FormulaFinset.complementary_comp
+        grind
       )
-      (FormulaFinset.unprovable_iff_singleton_compl_consistent.mpr h);
-    use (miniCanonicalModel _ φ).Val, X;
-    apply truthlemma (by grind) |>.not.mpr;
+      (FormulaFinset.unprovable_iff_singleton_compl_consistent.mpr h)
+    use (miniCanonicalModel _ φ).Val, X
+    apply truthlemma (by grind) |>.not.mpr
     exact iff_not_mem_compl (by grind) |>.not.mpr $ by
-      push_neg;
-      apply hX₁;
-      tauto;
+      push_neg
+      apply hX₁
+      tauto
 ⟩
 
 instance : Complete Hilbert.Grz FrameClass.finite_Grz := complete_of_mem_miniCanonicalFrame FrameClass.finite_Grz $ by
-  simp only [Set.mem_setOf_eq];
-  intro φ;
-  infer_instance;
+  simp only [Set.mem_setOf_eq]
+  intro φ
+  infer_instance
 
 
 instance : Hilbert.S4McK ⪱ Hilbert.Grz := by
-  constructor;
+  constructor
   . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4McK FrameClass.finite_Grz
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
     use Axioms.Grz (.atom 0)
-    constructor;
-    . simp;
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4McK)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 3, λ x y => y = 2 ∨ x = 0 ∨ x = 1⟩, λ w _ => w = 1 ∨ w = 2⟩, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 3, λ x y => y = 2 ∨ x = 0 ∨ x = 1⟩, λ w _ => w = 1 ∨ w = 2⟩, 0
+      constructor
       . exact {
           refl := by omega,
           trans := by omega,
-          mckinsey := by simp;
+          mckinsey := by simp
         }
       . suffices ∀ (x : Fin 3), (∀ (y : Fin 3), x = 0 ∨ x = 1 → y = 1 ∨ y = 2 → ∀ (z : Fin 3), y = 0 ∨ y = 1 → z = 1 ∨ z = 2) → x ≠ 1 → x = 2 by
-          simpa [Semantics.Realize, Satisfies];
-        intro x hx hxn1;
-        by_contra hxn2;
-        rcases @hx 1 (by omega) (by tauto) x (by omega);
-        . contradiction;
-        . contradiction;
+          simpa [Semantics.Realize, Satisfies]
+        intro x hx hxn1
+        by_contra hxn2
+        rcases @hx 1 (by omega) (by tauto) x (by omega)
+        . contradiction
+        . contradiction
 
 instance : Hilbert.S4 ⪱ Hilbert.Grz := calc
   Hilbert.S4 ⪱ Hilbert.S4McK := by infer_instance

--- a/Foundation/Modal/Kripke/Logic/Grz/Soundness.lean
+++ b/Foundation/Modal/Kripke/Logic/Grz/Soundness.lean
@@ -27,19 +27,19 @@ instance : whitepoint.IsFiniteGrz where
 
 instance [F.IsFinite] [F.IsPartialOrder] : F.SatisfiesMcKinseyCondition where
   mckinsey := by
-    intro x;
+    intro x
     obtain ⟨y, _, Rxy, hy₃⟩ :=  @Finite.exists_le_maximal _ {
       le := F,
       le_refl := fun a ↦ Frame.refl,
       le_trans := fun x y z ↦ Frame.trans
-    } _ (λ y => x ≺ y) x Frame.refl;
-    use y;
-    constructor;
-    . tauto;
-    . intro z Ryz;
-      apply F.antisymm;
-      . assumption;
-      . exact @hy₃ z (F.trans Rxy Ryz) Ryz;
+    } _ (λ y => x ≺ y) x Frame.refl
+    use y
+    constructor
+    . tauto
+    . intro z Ryz
+      apply F.antisymm
+      . assumption
+      . exact @hy₃ z (F.trans Rxy Ryz) Ryz
 instance [F.IsFiniteGrz] : F.IsS4McK where
 
 end Kripke
@@ -48,15 +48,15 @@ end Kripke
 namespace Logic.Grz.Kripke
 
 instance : Sound Hilbert.Grz FrameClass.finite_Grz := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  exact validate_AxiomGrz_of_refl_trans_wcwf;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  exact validate_AxiomGrz_of_refl_trans_wcwf
 
 instance : Entailment.Consistent Hilbert.Grz :=
   consistent_of_sound_frameclass FrameClass.finite_Grz $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 end Logic.Grz.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/GrzPoint2.lean
+++ b/Foundation/Modal/Kripke/Logic/GrzPoint2.lean
@@ -26,19 +26,19 @@ def Frame.terminals (F : Frame) : Set F.World := { t | ∀ {y}, t ≺ y → t = 
 def Frame.terminals_of (F : Frame) (x : F.World) : Set F.World := { t | x ≺^+ t ∧ ∀ {y}, t ≺ y → t = y }
 
 lemma Frame.exists_card [IsFinite F] : ∃ n : ℕ+, Nonempty (F.World ≃ Fin n) := by
-  obtain ⟨n, ⟨hn⟩⟩ := Finite.exists_equiv_fin F.World;
+  obtain ⟨n, ⟨hn⟩⟩ := Finite.exists_equiv_fin F.World
   refine ⟨⟨n, ?_⟩, ⟨hn⟩⟩
-  . by_contra hn0;
-    replace hn0 : n = 0 := by simpa [gt_iff_lt, not_lt, nonpos_iff_eq_zero] using hn0;
-    subst hn0;
-    apply Fin.elim0 $ hn.toFun (F.world_nonempty.some);
+  . by_contra hn0
+    replace hn0 : n = 0 := by simpa [gt_iff_lt, not_lt, nonpos_iff_eq_zero] using hn0
+    subst hn0
+    apply Fin.elim0 $ hn.toFun (F.world_nonempty.some)
 
 lemma Frame.exists_terminal [F.SatisfiesMcKinseyCondition] : ∃ t ∈ F.terminals, s ≺ t := by
-  obtain ⟨t, ht₁, ht₂⟩ := F.mckinsey s;
-  use t;
-  constructor;
-  . apply ht₂;
-  . assumption;
+  obtain ⟨t, ht₁, ht₂⟩ := F.mckinsey s
+  use t
+  constructor
+  . apply ht₂
+  . assumption
 
 end Kripke
 
@@ -48,18 +48,18 @@ namespace Formula.Kripke.Satisfies
 variable {F V} {φ : Formula ℕ}
 
 lemma box_at_terminal {x : F.World} (hx : x ∈ F.terminals) (h : Satisfies ⟨F, V⟩ x φ) : Satisfies ⟨F, V⟩ x (□φ) := by
-  intro y Rxy;
-  have := hx Rxy;
-  subst this;
-  exact h;
+  intro y Rxy
+  have := hx Rxy
+  subst this
+  exact h
 
 lemma dia_at_terminal {x : F.World} (hx : x ∈ F.terminals) (h : ¬Satisfies ⟨F, V⟩ x φ) : ¬Satisfies ⟨F, V⟩ x (◇φ) := by
-  apply Satisfies.dia_def.not.mpr;
-  push_neg;
-  intro y Rxy;
-  have := hx Rxy;
-  subst this;
-  exact h;
+  apply Satisfies.dia_def.not.mpr
+  push_neg
+  intro y Rxy
+  have := hx Rxy
+  subst this
+  exact h
 
 end Formula.Kripke.Satisfies
 
@@ -72,22 +72,22 @@ namespace Logic
 
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 
-instance : Hilbert.Grz ⪯ Hilbert.GrzPoint2 := Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
+instance : Hilbert.Grz ⪯ Hilbert.GrzPoint2 := Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
 
 lemma GrzPoint2_of_Grz (h : (φ.atoms.image (λ a => Axioms.Point2 (.atom a))).toSet *⊢[Hilbert.Grz]! φ) : Hilbert.GrzPoint2 ⊢! φ := by
-  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-  simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe] at hΓ₁;
-  replace hΓ₂ : Hilbert.GrzPoint2 ⊢! ⋀Γ ➝ φ := WeakerThan.pbl $ FiniteContext.provable_iff.mp hΓ₂;
+  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+  simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe] at hΓ₁
+  replace hΓ₂ : Hilbert.GrzPoint2 ⊢! ⋀Γ ➝ φ := WeakerThan.pbl $ FiniteContext.provable_iff.mp hΓ₂
   exact hΓ₂ ⨀ by
-    apply Conj₂!_intro;
-    intro γ hγ;
-    obtain ⟨a, ha, rfl⟩ := hΓ₁ _ hγ;
-    exact axiomPoint2!;
+    apply Conj₂!_intro
+    intro γ hγ
+    obtain ⟨a, ha, rfl⟩ := hΓ₁ _ hγ
+    exact axiomPoint2!
 
 lemma not_Grz_of_not_GrzPoint2 (h : Hilbert.GrzPoint2 ⊬ φ) : (φ.atoms.image (λ a => Axioms.Point2 (.atom a))).toList ⊬[Hilbert.Grz] φ := by
-  have := Context.provable_iff.not.mp $ not_imp_not.mpr GrzPoint2_of_Grz h;
-  push_neg at this;
-  convert this ((φ.atoms.image (λ a => Axioms.Point2 (.atom a))).toList) $ by simp;
+  have := Context.provable_iff.not.mp $ not_imp_not.mpr GrzPoint2_of_Grz h
+  push_neg at this
+  convert this ((φ.atoms.image (λ a => Axioms.Point2 (.atom a))).toList) $ by simp
 
 end Logic
 
@@ -110,16 +110,16 @@ end Kripke
 namespace Logic.GrzPoint2.Kripke
 
 instance : Sound Hilbert.GrzPoint2 FrameClass.finite_GrzPoint2 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomGrz_of_finite_strict_preorder;
-  . exact validate_AxiomPoint2_of_confluent;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomGrz_of_finite_strict_preorder
+  . exact validate_AxiomPoint2_of_confluent
 
 instance : Entailment.Consistent Hilbert.GrzPoint2 :=
   consistent_of_sound_frameclass FrameClass.finite_GrzPoint2 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 
 section
@@ -127,27 +127,27 @@ section
 open Relation
 
 instance : Complete Hilbert.GrzPoint2 FrameClass.finite_GrzPoint2 := ⟨by
-  intro φ;
-  contrapose;
-  intro hφ;
+  intro φ
+  contrapose
+  intro hφ
 
-  replace hφ : Hilbert.Grz ⊬ ⋀((φ.atoms.image (λ a => Axioms.Point2 (atom a))).toList) ➝ φ := not_Grz_of_not_GrzPoint2 hφ;
-  generalize eΓ : (φ.atoms.image (λ a => Axioms.Point2 (atom a))).toList = Γ at hφ;
-  obtain ⟨M, r, hM, hΓφ⟩ := exists_model_world_of_not_validOnFrameClass $ not_imp_not.mpr (Complete.complete (𝓢 := Hilbert.Grz) (𝓜 := FrameClass.finite_Grz)) hφ;
-  replace hM := Set.mem_setOf_eq.mp hM;
+  replace hφ : Hilbert.Grz ⊬ ⋀((φ.atoms.image (λ a => Axioms.Point2 (atom a))).toList) ➝ φ := not_Grz_of_not_GrzPoint2 hφ
+  generalize eΓ : (φ.atoms.image (λ a => Axioms.Point2 (atom a))).toList = Γ at hφ
+  obtain ⟨M, r, hM, hΓφ⟩ := exists_model_world_of_not_validOnFrameClass $ not_imp_not.mpr (Complete.complete (𝓢 := Hilbert.Grz) (𝓜 := FrameClass.finite_Grz)) hφ
+  replace hM := Set.mem_setOf_eq.mp hM
   -- have : IsPartialOrder _ M.toFrame := IsPartialOrder.mk
 
-  let RM := M↾r;
-  let r' : RM.World := ⟨r, by tauto⟩;
+  let RM := M↾r
+  let r' : RM.World := ⟨r, by tauto⟩
   have RM_rooted : ∀ (w : RM.World), r' ≺ w := by
-    intro w;
-    by_cases e : r' = w;
-    . subst e; apply RM.refl;
-    . exact Frame.IsRootedBy.root_generates w (by tauto) |>.unwrap;
+    intro w
+    by_cases e : r' = w
+    . subst e; apply RM.refl
+    . exact Frame.IsRootedBy.root_generates w (by tauto) |>.unwrap
 
-  replace hΓφ : ¬(r' ⊧ ⋀Γ → r' ⊧ φ) := Satisfies.imp_def.not.mp $ Model.pointGenerate.modal_equivalent_at_root (r := r) |>.not.mpr hΓφ;
-  push_neg at hΓφ;
-  obtain ⟨hΓ, hφ⟩ := hΓφ;
+  replace hΓφ : ¬(r' ⊧ ⋀Γ → r' ⊧ φ) := Satisfies.imp_def.not.mp $ Model.pointGenerate.modal_equivalent_at_root (r := r) |>.not.mpr hΓφ
+  push_neg at hΓφ
+  obtain ⟨hΓ, hφ⟩ := hΓφ
 
   let M' : Kripke.Model := {
     World := RM.World ⊕ Unit
@@ -160,192 +160,192 @@ instance : Complete Hilbert.GrzPoint2 FrameClass.finite_GrzPoint2 := ⟨by
       match x with
       | Sum.inl x => RM.Val x a
       | _ => ∀ y ∈ RM.toFrame.terminals, RM.Val y a
-  };
-  apply not_validOnFrameClass_of_exists_model_world;
-  use M', (Sum.inl r');
-  constructor;
-  . apply Set.mem_setOf_eq.mpr;
+  }
+  apply not_validOnFrameClass_of_exists_model_world
+  use M', (Sum.inl r')
+  constructor
+  . apply Set.mem_setOf_eq.mpr
     exact {
       refl := by
-        intro x;
+        intro x
         match x with
-        | Sum.inl x => simp [M'];
+        | Sum.inl x => simp [M']
         | Sum.inr x => simp_all [M'];,
       trans := by
-        intro x y z Rxy Ryz;
+        intro x y z Rxy Ryz
         match x, y, z with
-        | Sum.inl x, Sum.inl y, Sum.inl z => exact Frame.pointGenerate.isTransitive.trans _ _ _ Rxy Ryz;
-        | _, _, Sum.inr z => simp_all [M'];
-        | _, Sum.inr y, Sum.inl z => simp_all [M'];
+        | Sum.inl x, Sum.inl y, Sum.inl z => exact Frame.pointGenerate.isTransitive.trans _ _ _ Rxy Ryz
+        | _, _, Sum.inr z => simp_all [M']
+        | _, Sum.inr y, Sum.inl z => simp_all [M']
       antisymm := by
-        intro x y Rxy Ryz;
+        intro x y Rxy Ryz
         match x, y with
         | Sum.inl x, Sum.inl y =>
-          simp only [Sum.inl.injEq, M'];
-          exact Frame.pointGenerate.isAntisymmetric.antisymm _ _ Rxy Ryz;
-        | Sum.inl x, Sum.inr y => simp_all [M'];
-        | Sum.inr x, Sum.inr y => simp_all [M'];
-        | Sum.inr x, Sum.inl y => simp_all [M'];
+          simp only [Sum.inl.injEq, M']
+          exact Frame.pointGenerate.isAntisymmetric.antisymm _ _ Rxy Ryz
+        | Sum.inl x, Sum.inr y => simp_all [M']
+        | Sum.inr x, Sum.inr y => simp_all [M']
+        | Sum.inr x, Sum.inl y => simp_all [M']
       ps_convergent := by
-        rintro x y z Rxy Ryz;
-        use (Sum.inr ());
-        simp [M'];
+        rintro x y z Rxy Ryz
+        use (Sum.inr ())
+        simp [M']
     }
   . have H₁ : ∀ a ∈ φ.atoms, ∀ t ∈ RM.toFrame.terminals, ∀ t' ∈ RM.toFrame.terminals, RM t a → RM t' a := by
-      intro a ha t t_terminal t' t'_terminal hy;
-      by_contra hy';
-      have : ¬t' ⊧ (◇atom a) := Kripke.Satisfies.dia_at_terminal t'_terminal hy';
+      intro a ha t t_terminal t' t'_terminal hy
+      by_contra hy'
+      have : ¬t' ⊧ (◇atom a) := Kripke.Satisfies.dia_at_terminal t'_terminal hy'
       have : ¬r' ⊧ □(◇atom a) := by
-        apply Satisfies.box_def.not.mpr;
-        push_neg;
-        use t';
-        constructor;
-        . apply RM_rooted;
-        . assumption;
+        apply Satisfies.box_def.not.mpr
+        push_neg
+        use t'
+        constructor
+        . apply RM_rooted
+        . assumption
       have : ¬r' ⊧ ◇(□atom a) := by
-        revert this;
+        revert this
         apply not_imp_not.mpr
-        exact Satisfies.conj_def.mp hΓ (Axioms.Point2 (atom a)) (by simpa [←eΓ]);
-      have := Satisfies.dia_def.not.mp this;
-      push_neg at this;
-      have : ¬t ⊧ □atom a := this t (RM_rooted t);
-      have : t ⊧ □atom a := Kripke.Satisfies.box_at_terminal t_terminal hy;
-      contradiction;
+        exact Satisfies.conj_def.mp hΓ (Axioms.Point2 (atom a)) (by simpa [←eΓ])
+      have := Satisfies.dia_def.not.mp this
+      push_neg at this
+      have : ¬t ⊧ □atom a := this t (RM_rooted t)
+      have : t ⊧ □atom a := Kripke.Satisfies.box_at_terminal t_terminal hy
+      contradiction
     have H₂ : ∀ t ∈ RM.terminals, ∀ ψ ∈ φ.subformulas, t ⊧ ψ ↔ (Satisfies M' (Sum.inr ()) ψ) := by
-      intro t t_terminal ψ ψ_sub;
+      intro t t_terminal ψ ψ_sub
       induction ψ with
       | hatom a =>
         simp only [Satisfies.iff_models, Satisfies, RM, M']
-        constructor;
-        . intro ha t' t'_terminal;
-          exact H₁ a (iff_mem_atoms_mem_subformula.mpr ψ_sub) t t_terminal t' t'_terminal ha;
-        . intro h;
-          apply h;
-          exact t_terminal;
-      | hfalsum => tauto;
+        constructor
+        . intro ha t' t'_terminal
+          exact H₁ a (iff_mem_atoms_mem_subformula.mpr ψ_sub) t t_terminal t' t'_terminal ha
+        . intro h
+          apply h
+          exact t_terminal
+      | hfalsum => tauto
       | himp χ ξ ihχ ihξ =>
-        constructor;
-        . intro h hχ;
-          apply ihξ (by grind) |>.mp;
-          apply h;
-          apply ihχ (by grind) |>.mpr;
-          assumption;
-        . intro h hχ;
-          apply ihξ (by grind) |>.mpr;
-          apply h;
-          apply ihχ (by grind) |>.mp;
-          assumption;
+        constructor
+        . intro h hχ
+          apply ihξ (by grind) |>.mp
+          apply h
+          apply ihχ (by grind) |>.mpr
+          assumption
+        . intro h hχ
+          apply ihξ (by grind) |>.mpr
+          apply h
+          apply ihχ (by grind) |>.mp
+          assumption
       | hbox ψ ihψ =>
-        constructor;
-        . intro ht u Ru;
+        constructor
+        . intro ht u Ru
           match u with
-          | Sum.inl x => simp [M', Frame.Rel'] at Ru;
+          | Sum.inl x => simp [M', Frame.Rel'] at Ru
           | Sum.inr _ =>
-            apply ihψ (by grind) |>.mp;
-            apply ht;
-            apply Frame.refl;
-        . intro ht u Rtu;
-          have := t_terminal Rtu; subst this;
-          apply ihψ (by grind) |>.mpr;
-          apply ht;
-          tauto;
+            apply ihψ (by grind) |>.mp
+            apply ht
+            apply Frame.refl
+        . intro ht u Rtu
+          have := t_terminal Rtu; subst this
+          apply ihψ (by grind) |>.mpr
+          apply ht
+          tauto
     have : ∀ y : RM.World, ∀ ψ ∈ φ.subformulas, y ⊧ ψ ↔ (Satisfies M' (Sum.inl y) ψ) := by
-      intro y ψ ψ_sub;
+      intro y ψ ψ_sub
       induction ψ generalizing y with
       | hbox ψ ihψ =>
-        constructor;
-        . intro hψ v Ruv;
+        constructor
+        . intro hψ v Ruv
           match v with
           | Sum.inl x =>
-            simp only [Frame.Rel', M', RM] at Ruv;
-            exact ihψ x (by grind) |>.mp $ hψ _ Ruv;
+            simp only [Frame.Rel', M', RM] at Ruv
+            exact ihψ x (by grind) |>.mp $ hψ _ Ruv
           | Sum.inr x =>
-            obtain ⟨t, t_terminal, Rut⟩ : ∃ t ∈ RM.terminals, y ≺ t := Frame.exists_terminal;
-            apply H₂ t t_terminal ψ (by grind) |>.mp;
-            apply hψ;
-            exact Rut;
-        . intro h v Ruv;
-          exact ihψ v (by grind) |>.mpr $ @h (Sum.inl v) Ruv;
+            obtain ⟨t, t_terminal, Rut⟩ : ∃ t ∈ RM.terminals, y ≺ t := Frame.exists_terminal
+            apply H₂ t t_terminal ψ (by grind) |>.mp
+            apply hψ
+            exact Rut
+        . intro h v Ruv
+          exact ihψ v (by grind) |>.mpr $ @h (Sum.inl v) Ruv
       | himp _ _ ihχ ihξ =>
-        have := ihχ y (by grind);
-        have := ihξ y (by grind);
-        tauto;
-      | _ => tauto;
-    exact this r' φ (by simp) |>.not.mp hφ;
+        have := ihχ y (by grind)
+        have := ihξ y (by grind)
+        tauto
+      | _ => tauto
+    exact this r' φ (by simp) |>.not.mp hφ
 ⟩
 
 end
 
 
 instance : Hilbert.Grz ⪱ Hilbert.GrzPoint2 := by
-  constructor;
-  . infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Point2 (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_Grz);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Point2 (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_Grz)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 3, λ x y => x = 0 ∨ x = y⟩,
         λ x a => x = 1
-      ⟩;
-      use M, 0;
-      constructor;
+      ⟩
+      use M, 0
+      constructor
       . refine {
           refl := by omega
           trans := by omega
-          antisymm := by simp [M]; omega;
-        };
-      . apply Satisfies.imp_def₂.not.mpr;
-        push_neg;
-        constructor;
-        . apply Satisfies.dia_def.mpr;
-          use 1;
-          constructor;
-          . omega;
-          . intro y Rxy;
-            simp_all [M, Satisfies, Frame.Rel'];
-        . apply Satisfies.box_def.not.mpr;
-          push_neg;
-          use 2;
-          constructor;
-          . omega;
-          . apply Satisfies.dia_def.not.mpr;
-            push_neg;
-            simp [M, Semantics.Realize, Satisfies, Frame.Rel'];
+          antisymm := by simp [M]; omega
+        }
+      . apply Satisfies.imp_def₂.not.mpr
+        push_neg
+        constructor
+        . apply Satisfies.dia_def.mpr
+          use 1
+          constructor
+          . omega
+          . intro y Rxy
+            simp_all [M, Satisfies, Frame.Rel']
+        . apply Satisfies.box_def.not.mpr
+          push_neg
+          use 2
+          constructor
+          . omega
+          . apply Satisfies.dia_def.not.mpr
+            push_neg
+            simp [M, Semantics.Realize, Satisfies, Frame.Rel']
 
 instance : Hilbert.S4Point2McK ⪱ Hilbert.GrzPoint2 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point2McK FrameClass.finite_GrzPoint2;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Grz (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2McK);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 3, λ x y => y = 2 ∨ x = 0 ∨ x = 1⟩, λ w _ => w = 1 ∨ w = 2⟩, 0;
-      constructor;
-      . apply Set.mem_setOf_eq.mpr;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point2McK FrameClass.finite_GrzPoint2
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Grz (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2McK)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 3, λ x y => y = 2 ∨ x = 0 ∨ x = 1⟩, λ w _ => w = 1 ∨ w = 2⟩, 0
+      constructor
+      . apply Set.mem_setOf_eq.mpr
         exact {
           trans := by omega,
           refl := by omega,
-          mckinsey := by simp;
+          mckinsey := by simp
           ps_convergent := by
-            intro x y z Rxy Rxz;
-            use 2;
-            omega;
-        };
+            intro x y z Rxy Rxz
+            use 2
+            omega
+        }
       . suffices ∀ (x : Fin 3), (∀ (y : Fin 3), x = 0 ∨ x = 1 → y = 1 ∨ y = 2 → ∀ (z : Fin 3), y = 0 ∨ y = 1 → z = 1 ∨ z = 2) → x ≠ 1 → x = 2 by
-          simpa [Semantics.Realize, Satisfies];
-        intro x hx hxn1;
-        by_contra hxn2;
-        rcases @hx 1 (by omega) (by tauto) x (by omega);
-        . contradiction;
-        . contradiction;
+          simpa [Semantics.Realize, Satisfies]
+        intro x hx hxn1
+        by_contra hxn2
+        rcases @hx 1 (by omega) (by tauto) x (by omega)
+        . contradiction
+        . contradiction
 
 instance : Hilbert.S4Point2 ⪱ Hilbert.GrzPoint2 := calc
   Hilbert.S4Point2 ⪱ Hilbert.S4Point2McK := by infer_instance

--- a/Foundation/Modal/Kripke/Logic/GrzPoint3.lean
+++ b/Foundation/Modal/Kripke/Logic/GrzPoint3.lean
@@ -33,48 +33,48 @@ end Kripke
 namespace Logic.GrzPoint3.Kripke
 
 instance : Sound Hilbert.GrzPoint3 FrameClass.finite_GrzPoint3 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomGrz_of_finite_strict_preorder;
-  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomGrz_of_finite_strict_preorder
+  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected
 
 instance : Entailment.Consistent Hilbert.GrzPoint3 :=
   consistent_of_sound_frameclass FrameClass.finite_GrzPoint3 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Complete Hilbert.GrzPoint3 FrameClass.finite_GrzPoint3 :=
   Hilbert.Grz.Kripke.complete_of_mem_miniCanonicalFrame FrameClass.finite_GrzPoint3 $ by
-    sorry;
+    sorry
     /-
-    intro φ;
-    refine ⟨miniCanonicalFrame.reflexive, miniCanonicalFrame.transitive, miniCanonicalFrame.antisymm, ?_⟩;
-    intro x y z ⟨⟨Rxy₁, Rxy₂⟩, ⟨Rxz₁, Rxz₂⟩⟩;
-    apply or_iff_not_imp_left.mpr;
-    intro nRyz;
-    rcases (not_and_or.mp nRyz) with (nRyz | nRyz);
-    . push_neg at nRyz;
-      obtain ⟨ψ, hψ, ⟨hψy, hψz⟩⟩ := nRyz;
-      constructor;
-      . intro ξ hξ₁ hξ₂;
-        apply Rxy₁;
-        . exact hξ₁;
-        . sorry;
-      . intro hyz;
-        have exy := Rxy₂ ?_;
-        have exz := Rxz₂ ?_;
-        tauto;
-        . subst exy;
-          intro ξ hξ hξz;
-          sorry;
-        . intro ξ hξ hξy;
-          sorry;
-    . push_neg at nRyz;
-      replace ⟨nRyz₁, nRyz₂⟩ := nRyz;
-      constructor;
-      . sorry;
-      . sorry;
+    intro φ
+    refine ⟨miniCanonicalFrame.reflexive, miniCanonicalFrame.transitive, miniCanonicalFrame.antisymm, ?_⟩
+    intro x y z ⟨⟨Rxy₁, Rxy₂⟩, ⟨Rxz₁, Rxz₂⟩⟩
+    apply or_iff_not_imp_left.mpr
+    intro nRyz
+    rcases (not_and_or.mp nRyz) with (nRyz | nRyz)
+    . push_neg at nRyz
+      obtain ⟨ψ, hψ, ⟨hψy, hψz⟩⟩ := nRyz
+      constructor
+      . intro ξ hξ₁ hξ₂
+        apply Rxy₁
+        . exact hξ₁
+        . sorry
+      . intro hyz
+        have exy := Rxy₂ ?_
+        have exz := Rxz₂ ?_
+        tauto
+        . subst exy
+          intro ξ hξ hξz
+          sorry
+        . intro ξ hξ hξy
+          sorry
+    . push_neg at nRyz
+      replace ⟨nRyz₁, nRyz₂⟩ := nRyz
+      constructor
+      . sorry
+      . sorry
     -/
 
 end Logic.GrzPoint3.Kripke
@@ -87,77 +87,77 @@ open Kripke
 
 
 instance : Hilbert.GrzPoint2 ⪱ Hilbert.GrzPoint3 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GrzPoint2 FrameClass.finite_GrzPoint3;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Point3 (.atom 0) (.atom 1);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GrzPoint2);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let F : Frame := ⟨Fin 4, λ x y => x = 0 ∨ x = y ∨ y = 3⟩;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GrzPoint2 FrameClass.finite_GrzPoint3
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Point3 (.atom 0) (.atom 1)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GrzPoint2)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let F : Frame := ⟨Fin 4, λ x y => x = 0 ∨ x = y ∨ y = 3⟩
       let M : Model := ⟨
         F,
         λ x a => match a with | 0 => (1 : F.World) ≺ x | 1 => (2 : F.World) ≺ x | _ => False
-      ⟩;
-      use M, 0;
-      constructor;
+      ⟩
+      use M, 0
+      constructor
       . exact {
           refl := by omega,
           trans := by omega,
           antisymm := by simp [M, F]; omega,
           ps_convergent := by
-            rintro x y z Rxy Rxz;
-            use 3;
-            tauto;
+            rintro x y z Rxy Rxz
+            use 3
+            tauto
         }
       . apply Satisfies.or_def.not.mpr
-        push_neg;
-        constructor;
-        . apply Satisfies.box_def.not.mpr;
-          push_neg;
-          use 1;
-          constructor;
-          . tauto;
-          . apply Satisfies.imp_def₂.not.mpr;
-            push_neg;
-            constructor;
-            . tauto;
-            . simp [M, Semantics.Realize, Satisfies, Frame.Rel', F];
-        . apply Satisfies.box_def.not.mpr;
-          push_neg;
-          use 2;
-          constructor;
-          . tauto;
-          . apply Satisfies.imp_def₂.not.mpr;
-            push_neg;
-            constructor;
-            . tauto;
-            . simp [M, Semantics.Realize, Satisfies, Frame.Rel', F];
+        push_neg
+        constructor
+        . apply Satisfies.box_def.not.mpr
+          push_neg
+          use 1
+          constructor
+          . tauto
+          . apply Satisfies.imp_def₂.not.mpr
+            push_neg
+            constructor
+            . tauto
+            . simp [M, Semantics.Realize, Satisfies, Frame.Rel', F]
+        . apply Satisfies.box_def.not.mpr
+          push_neg
+          use 2
+          constructor
+          . tauto
+          . apply Satisfies.imp_def₂.not.mpr
+            push_neg
+            constructor
+            . tauto
+            . simp [M, Semantics.Realize, Satisfies, Frame.Rel', F]
 
 instance : Hilbert.S4Point3 ⪱ Hilbert.GrzPoint3 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro _ (rfl | rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Grz (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 1⟩, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro _ (rfl | rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Grz (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 1⟩, 0
+      constructor
       . exact {
           refl := by simp,
           trans := by simp,
           ps_connected := by
-            rintro x y z Rxy Rxz;
-            simp;
-        };
-      . simp [Semantics.Realize, Satisfies];
+            rintro x y z Rxy Rxz
+            simp
+        }
+      . simp [Semantics.Realize, Satisfies]
 
 end Logic
 

--- a/Foundation/Modal/Kripke/Logic/K.lean
+++ b/Foundation/Modal/Kripke/Logic/K.lean
@@ -19,36 +19,36 @@ end Kripke
 namespace Hilbert.K.Kripke
 
 instance : Sound (Hilbert.K) FrameClass.K := instSound_of_validates_axioms $ by
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  intro F _;
-  exact Formula.Kripke.ValidOnFrame.axiomK;
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  intro F _
+  exact Formula.Kripke.ValidOnFrame.axiomK
 
 instance : Sound (Hilbert.K) FrameClass.finite_K := instSound_of_validates_axioms $ by
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  intro F hF;
-  exact Formula.Kripke.ValidOnFrame.axiomK;
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  intro F hF
+  exact Formula.Kripke.ValidOnFrame.axiomK
 
 instance : Entailment.Consistent (Hilbert.K) := consistent_of_sound_frameclass FrameClass.K $ by
   use whitepoint
-  simp;
+  simp
 
 instance : Kripke.Canonical (Hilbert.K) FrameClass.K := ⟨by trivial⟩
 
 instance : Complete (Hilbert.K) FrameClass.K := inferInstance
 
 instance : Complete (Hilbert.K) (FrameClass.finite_K) := ⟨by
-  intro φ hp;
-  apply Complete.complete (𝓜 := FrameClass.K);
-  intro F _ V x;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := coarsestFiltrationModel M ↑φ.subformulas;
-  apply filtration FM (coarsestFiltrationModel.filterOf) (by simp) |>.mpr;
-  apply hp;
+  intro φ hp
+  apply Complete.complete (𝓜 := FrameClass.K)
+  intro F _ V x
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := coarsestFiltrationModel M ↑φ.subformulas
+  apply filtration FM (coarsestFiltrationModel.filterOf) (by simp) |>.mpr
+  apply hp
   apply Frame.isFinite_iff _ |>.mpr
-  apply FilterEqvQuotient.finite;
-  simp;
+  apply FilterEqvQuotient.finite
+  simp
 ⟩
 
 end Hilbert.K.Kripke

--- a/Foundation/Modal/Kripke/Logic/K4.lean
+++ b/Foundation/Modal/Kripke/Logic/K4.lean
@@ -28,62 +28,62 @@ namespace Hilbert
 namespace K4.Kripke
 
 instance : Sound Hilbert.K4 FrameClass.K4 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_trans φ;
-  apply validate_AxiomFour_of_transitive (trans := F_trans);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_trans φ
+  apply validate_AxiomFour_of_transitive (trans := F_trans)
 
 instance : Entailment.Consistent Hilbert.K4 :=
   consistent_of_sound_frameclass FrameClass.K4 $ by
-    use whitepoint;
-    apply Set.mem_setOf_eq.mpr;
-    infer_instance;
+    use whitepoint
+    apply Set.mem_setOf_eq.mpr
+    infer_instance
 
 instance : Canonical Hilbert.K4 FrameClass.K4 := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.K4 FrameClass.K4 := inferInstance
 
 open finestFiltrationTransitiveClosureModel in
 instance : Complete Hilbert.K4 FrameClass.finite_K4 := ⟨by
-  intro φ hp;
-  apply Complete.complete (𝓜 := FrameClass.K4);
-  intro F F_trans V x;
-  replace F_trans := Set.mem_setOf_eq.mp F_trans;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas;
-  apply filtration FM (finestFiltrationTransitiveClosureModel.filterOf) (by simp) |>.mpr;
-  apply hp;
-  apply Set.mem_setOf_eq.mpr;
+  intro φ hp
+  apply Complete.complete (𝓜 := FrameClass.K4)
+  intro F F_trans V x
+  replace F_trans := Set.mem_setOf_eq.mp F_trans
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas
+  apply filtration FM (finestFiltrationTransitiveClosureModel.filterOf) (by simp) |>.mpr
+  apply hp
+  apply Set.mem_setOf_eq.mpr
   exact { world_finite := by apply FilterEqvQuotient.finite $ by simp }
 ⟩
 
 end K4.Kripke
 
 instance : Hilbert.K ⪱ Hilbert.K4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≠ y⟩, λ w _ => w = 1⟩;
-      use M, 0;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≠ y⟩, λ w _ => w = 1⟩
+      use M, 0
       constructor
-      . trivial;
+      . trivial
       . suffices (∀ (y : M.World), (0 : M.World) ≺ y → y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ∃ y, x ≺ y ∧ y ≠ 1 by
-          simpa [Semantics.Realize, Satisfies];
-        constructor;
-        . intro x;
+          simpa [Semantics.Realize, Satisfies]
+        constructor
+        . intro x
           match x with
-          | 0 => tauto;
-          | 1 => tauto;
-        . exact ⟨1, by omega, 0, by omega, by trivial⟩;
+          | 0 => tauto
+          | 1 => tauto
+        . exact ⟨1, by omega, 0, by omega, by trivial⟩
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/K45.lean
+++ b/Foundation/Modal/Kripke/Logic/K45.lean
@@ -22,15 +22,15 @@ end Kripke
 namespace Logic.K45.Kripke
 
 instance : Sound Hilbert.K45 FrameClass.K45 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_AxiomFive_of_euclidean;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_AxiomFive_of_euclidean
 
 instance : Entailment.Consistent Hilbert.K45 := consistent_of_sound_frameclass FrameClass.K45 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 
 instance : Canonical Hilbert.K45 FrameClass.K45 := ⟨by constructor⟩
@@ -39,54 +39,54 @@ instance : Complete Hilbert.K45 FrameClass.K45 := inferInstance
 
 
 instance : Hilbert.K5 ⪱ Hilbert.K45 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K5);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x ≠ 0 ∧ y ≠ 0)⟩, λ w _ => w = 1⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K5)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x ≠ 0 ∧ y ≠ 0)⟩, λ w _ => w = 1⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
         exact { reucl := by simp [RightEuclidean]; omega }
       . suffices (∀ (y : M.World), (0 : M.World) ≺ y → y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ∃ z, x ≺ z ∧ ¬z = 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . intro y; tauto;
-        . exact ⟨1, by omega, 2, by omega, by trivial⟩;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . intro y; tauto
+        . exact ⟨1, by omega, 2, by omega, by trivial⟩
 
 instance : Hilbert.K4Point3 ⪱ Hilbert.K45 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.K4Point3 FrameClass.K45;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Five (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4Point3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.K4Point3 FrameClass.K45
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Five (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4Point3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 3, λ x y => x < y⟩,
         λ w a => w = 2
-      ⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
+      ⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
         refine {
           trans := by omega,
-          p_connected := by simp [PiecewiseConnected, M]; omega;
-        };
+          p_connected := by simp [PiecewiseConnected, M]; omega
+        }
       . suffices (0 : M.World) ≺ 2 ∧ ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 2 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . omega;
-        . use 2;
-          omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . omega
+        . use 2
+          omega
 
 end Logic.K45.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/K4McK.lean
+++ b/Foundation/Modal/Kripke/Logic/K4McK.lean
@@ -20,15 +20,15 @@ end Kripke
 namespace Hilbert.K4McK.Kripke
 
 instance : Sound Hilbert.K4McK FrameClass.K4McK := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition
 
 instance : Entailment.Consistent Hilbert.K4McK := consistent_of_sound_frameclass FrameClass.K4McK $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.K4McK FrameClass.K4McK := ⟨by constructor⟩
 
@@ -36,18 +36,18 @@ instance : Complete Hilbert.K4McK FrameClass.K4McK := inferInstance
 
 
 instance : Hilbert.K4 ⪱ Hilbert.K4McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.McK (.atom 0));
-    constructor;
-    . exact axiomMcK!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.McK (.atom 0))
+    constructor
+    . exact axiomMcK!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => False⟩, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => False⟩, 0
+      constructor
       . simp only [Set.mem_setOf_eq]; refine { trans := by simp; }
-      . simp [Semantics.Realize, Satisfies];
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert.K4McK.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/K4Point2.lean
+++ b/Foundation/Modal/Kripke/Logic/K4Point2.lean
@@ -23,16 +23,16 @@ end Kripke
 namespace Hilbert.K4Point2.Kripke
 
 instance : Sound (Hilbert.K4Point2) Kripke.FrameClass.K4Point2 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_WeakPoint2_of_weakConfluent;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_WeakPoint2_of_weakConfluent
 
 instance : Entailment.Consistent Hilbert.K4Point2 :=
   consistent_of_sound_frameclass Kripke.FrameClass.K4Point2 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical (Hilbert.K4Point2) Kripke.FrameClass.K4Point2 :=  ⟨by constructor⟩
 
@@ -40,28 +40,28 @@ instance : Complete (Hilbert.K4Point2) Kripke.FrameClass.K4Point2 := inferInstan
 
 
 instance : Hilbert.K4 ⪱ Hilbert.K4Point2 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.WeakPoint2 (.atom 0) (.atom 1));
-    constructor;
-    . exact axiomWeakPoint2!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.WeakPoint2 (.atom 0) (.atom 1))
+    constructor
+    . exact axiomWeakPoint2!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 2, λ x y => x = 0⟩,
         λ w a => if a = 0 then True else w = 0
-      ⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
-        exact { trans := by omega };
+      ⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
+        exact { trans := by omega }
       . suffices ∃ (x : M.World), (∀ y, ¬x ≺ y) ∧ x ≠ 0 by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        constructor;
-        . omega;
-        . trivial;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        constructor
+        . omega
+        . trivial
 
 end Hilbert.K4Point2.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/K4Point3.lean
+++ b/Foundation/Modal/Kripke/Logic/K4Point3.lean
@@ -23,16 +23,16 @@ end Kripke
 namespace Logic.K4Point3.Kripke
 
 instance : Sound Hilbert.K4Point3 FrameClass.K4Point3 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_WeakPoint3_of_weakConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_WeakPoint3_of_weakConnected
 
 instance : Entailment.Consistent Hilbert.K4Point3 :=
   consistent_of_sound_frameclass FrameClass.K4Point3 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical Hilbert.K4Point3 FrameClass.K4Point3 :=  ⟨by constructor⟩
 
@@ -40,33 +40,33 @@ instance : Complete Hilbert.K4Point3 FrameClass.K4Point3 := inferInstance
 
 
 instance : Hilbert.K4 ⪱ Hilbert.K4Point3 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.WeakPoint3 (.atom 0) (.atom 1));
-    constructor;
-    . exact axiomWeakPoint3!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.WeakPoint3 (.atom 0) (.atom 1))
+    constructor
+    . exact axiomWeakPoint3!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 3, λ x y => x = 0 ∧ y ≠ 0⟩,
         λ w a => if a = 0 then w = 1 else w = 2
-      ⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
+      ⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
         exact { trans := by omega }
       . suffices
           ∃ x : M.World, (0 : M.World) ≺ x ∧ x = 1 ∧ (∀ y, x ≺ y → y = 1) ∧ ¬x = 2 ∧
           ∃ x : M.World, (0 : M.World) ≺ x ∧ x = 2 ∧ (∀ z : M.World, x ≺ z → z = 2) ∧ x ≠ 1
-          by simpa [M, Semantics.Realize, Satisfies];
-        refine ⟨1, ?_, rfl, ?_, ?_, 2, ?_, rfl, ?_, ?_⟩;
-        . trivial;
-        . omega;
-        . trivial;
-        . omega;
-        . trivial;
-        . trivial;
+          by simpa [M, Semantics.Realize, Satisfies]
+        refine ⟨1, ?_, rfl, ?_, ?_, 2, ?_, rfl, ?_, ?_⟩
+        . trivial
+        . omega
+        . trivial
+        . omega
+        . trivial
+        . trivial
 
 end Logic.K4Point3.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/K5.lean
+++ b/Foundation/Modal/Kripke/Logic/K5.lean
@@ -24,21 +24,21 @@ namespace Hilbert
 namespace K5.Kripke
 
 instance : Sound Hilbert.K5 FrameClass.K5 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_eucl;
-  exact validate_AxiomFive_of_euclidean (eucl := F_eucl);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_eucl
+  exact validate_AxiomFive_of_euclidean (eucl := F_eucl)
 
 instance : Entailment.Consistent Hilbert.K5 :=
   consistent_of_sound_frameclass FrameClass.K5 $ by
-    use whitepoint;
-    apply Set.mem_setOf_eq.mpr;
-    infer_instance;
+    use whitepoint
+    apply Set.mem_setOf_eq.mpr
+    infer_instance
 
 instance : Canonical Hilbert.K5 FrameClass.K5 := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.K5 FrameClass.K5 := inferInstance
@@ -46,21 +46,21 @@ instance : Complete Hilbert.K5 FrameClass.K5 := inferInstance
 end K5.Kripke
 
 instance : Hilbert.K ⪱ Hilbert.K5 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Five (.atom 0));
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Five (.atom 0))
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x _ => x = 0⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
-      . trivial;
-      . suffices ∃ (x : M.World), ¬x = 0 by simpa [Semantics.Realize, Satisfies, M];
-        use 1;
-        trivial;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x _ => x = 0⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
+      . trivial
+      . suffices ∃ (x : M.World), ¬x = 0 by simpa [Semantics.Realize, Satisfies, M]
+        use 1
+        trivial
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/KB.lean
+++ b/Foundation/Modal/Kripke/Logic/KB.lean
@@ -24,20 +24,20 @@ namespace Hilbert
 namespace KB.Kripke
 
 instance : Sound Hilbert.KB FrameClass.KB := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_symm;
-  exact validate_AxiomB_of_symmetric (sym := F_symm);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_symm
+  exact validate_AxiomB_of_symmetric (sym := F_symm)
 
 instance : Entailment.Consistent Hilbert.KB := consistent_of_sound_frameclass FrameClass.KB $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 instance : Canonical Hilbert.KB FrameClass.KB := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.KB FrameClass.KB := inferInstance
@@ -45,21 +45,21 @@ instance : Complete Hilbert.KB FrameClass.KB := inferInstance
 end KB.Kripke
 
 instance : Hilbert.K ⪱ Hilbert.KB := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.B (.atom 0));
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.B (.atom 0))
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x = 0 ∧ y = 1⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
-      . trivial;
-      . suffices ∃ (x : M.World), (0 : M.World) ≺ x ∧ ¬x ≺ 0 by simpa [Semantics.Realize, Satisfies, M];
-        use 1;
-        trivial;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x = 0 ∧ y = 1⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
+      . trivial
+      . suffices ∃ (x : M.World), (0 : M.World) ≺ x ∧ ¬x ≺ 0 by simpa [Semantics.Realize, Satisfies, M]
+        use 1
+        trivial
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/KB4.lean
+++ b/Foundation/Modal/Kripke/Logic/KB4.lean
@@ -26,18 +26,18 @@ end Kripke
 namespace Logic.KB4.Kripke
 
 instance : Sound Hilbert.KB4 FrameClass.KB4 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomB_of_symmetric;
-  . exact validate_AxiomFour_of_transitive;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomB_of_symmetric
+  . exact validate_AxiomFour_of_transitive
 
 instance : Entailment.Consistent Hilbert.KB4 := consistent_of_sound_frameclass FrameClass.KB4 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.KB4 FrameClass.KB4 := ⟨by
-  apply Set.mem_setOf_eq.mpr;
+  apply Set.mem_setOf_eq.mpr
   constructor
 ⟩
 
@@ -53,38 +53,38 @@ open Kripke
 
 
 instance : Hilbert.K45 ⪱ Hilbert.KB4 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.K45 FrameClass.KB4;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.B (.atom 0);
-    constructor;
-    . exact axiomB!;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K45);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 0⟩, 0;
-      constructor;
-      . simp only [Fin.isValue, Set.mem_setOf_eq];
-        refine { trans := by omega, reucl := by tauto };
-      . simp [Semantics.Realize, Satisfies];
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.K45 FrameClass.KB4
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.B (.atom 0)
+    constructor
+    . exact axiomB!
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K45)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 0⟩, 0
+      constructor
+      . simp only [Fin.isValue, Set.mem_setOf_eq]
+        refine { trans := by omega, reucl := by tauto }
+      . simp [Semantics.Realize, Satisfies]
 
 instance : Hilbert.KB ⪱ Hilbert.KB4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Four (.atom 0);
-    constructor;
-    . exact axiomFour!;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KB);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Bool, λ x y => x != y⟩, λ w _ => w = true⟩, false;
-      constructor;
-      . simp only [bne_iff_ne, ne_eq, Set.mem_setOf_eq];
-        refine { symm := by tauto };
-      . simp [Semantics.Realize, Satisfies];
-        tauto;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Four (.atom 0)
+    constructor
+    . exact axiomFour!
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KB)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Bool, λ x y => x != y⟩, λ w _ => w = true⟩, false
+      constructor
+      . simp only [bne_iff_ne, ne_eq, Set.mem_setOf_eq]
+        refine { symm := by tauto }
+      . simp [Semantics.Realize, Satisfies]
+        tauto
 
 end Logic
 

--- a/Foundation/Modal/Kripke/Logic/KB5.lean
+++ b/Foundation/Modal/Kripke/Logic/KB5.lean
@@ -20,16 +20,16 @@ end Kripke
 namespace Logic.KB5.Kripke
 
 instance : Sound (Hilbert.KB5) Kripke.FrameClass.KB5 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F ⟨_, _⟩ _ (rfl | rfl);
-  . exact validate_AxiomB_of_symmetric;
-  . exact validate_AxiomFive_of_euclidean;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F ⟨_, _⟩ _ (rfl | rfl)
+  . exact validate_AxiomB_of_symmetric
+  . exact validate_AxiomFive_of_euclidean
 
 instance : Entailment.Consistent (Hilbert.KB5) := consistent_of_sound_frameclass Kripke.FrameClass.KB5 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 
 instance : Canonical (Hilbert.KB5) Kripke.FrameClass.KB5 := ⟨by constructor⟩

--- a/Foundation/Modal/Kripke/Logic/KD.lean
+++ b/Foundation/Modal/Kripke/Logic/KD.lean
@@ -24,21 +24,21 @@ namespace Hilbert
 namespace KD.Kripke
 
 instance : Sound Hilbert.KD FrameClass.KD := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_serial φ;
-  apply validate_AxiomD_of_serial (ser := F_serial);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_serial φ
+  apply validate_AxiomD_of_serial (ser := F_serial)
 
 instance : Entailment.Consistent Hilbert.KD :=
   consistent_of_sound_frameclass FrameClass.KD $ by
-    use whitepoint;
-    apply Set.mem_setOf_eq.mpr;
-    infer_instance;
+    use whitepoint
+    apply Set.mem_setOf_eq.mpr
+    infer_instance
 
 instance : Canonical Hilbert.KD FrameClass.KD := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.KD FrameClass.KD := inferInstance
@@ -46,18 +46,18 @@ instance : Complete Hilbert.KD FrameClass.KD := inferInstance
 end KD.Kripke
 
 instance : Hilbert.K ⪱ Hilbert.KD := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.D (.atom 0));
-    constructor;
-    . exact axiomD!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.D (.atom 0))
+    constructor
+    . exact axiomD!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => False⟩, 0;
-      constructor;
-      . trivial;
-      . simp [Semantics.Realize, Satisfies];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => False⟩, 0
+      constructor
+      . trivial
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/KD4.lean
+++ b/Foundation/Modal/Kripke/Logic/KD4.lean
@@ -23,19 +23,19 @@ end Kripke
 namespace Hilbert.KD4.Kripke
 
 instance : Sound Hilbert.KD4 FrameClass.KD4 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomD_of_serial;
-  . exact validate_AxiomFour_of_transitive;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomD_of_serial
+  . exact validate_AxiomFour_of_transitive
 
 instance : Entailment.Consistent Hilbert.KD4 := consistent_of_sound_frameclass
   FrameClass.KD4 $ by
-    use whitepoint;
+    use whitepoint
     constructor
 
 instance : Canonical Hilbert.KD4 FrameClass.KD4 := ⟨by
-  apply Set.mem_setOf_eq.mpr;
+  apply Set.mem_setOf_eq.mpr
   constructor
 ⟩
 
@@ -43,33 +43,33 @@ instance : Complete Hilbert.KD4 FrameClass.KD4 := inferInstance
 
 
 instance : Hilbert.KD ⪱ Hilbert.KD4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Four (.atom 0);
-    constructor;
-    . exact axiomFour!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Four (.atom 0)
+    constructor
+    . exact axiomFour!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Bool, λ x y => x != y⟩, λ w _ => w = true⟩, false;
-      constructor;
-      . exact { serial := by simp [Serial]; };
-      . simp [Semantics.Realize, Satisfies];
-        tauto;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Bool, λ x y => x != y⟩, λ w _ => w = true⟩, false
+      constructor
+      . exact { serial := by simp [Serial]; }
+      . simp [Semantics.Realize, Satisfies]
+        tauto
 
 instance : Hilbert.K4 ⪱ Hilbert.KD4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.D (.atom 0));
-    constructor;
-    . exact axiomD!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.D (.atom 0))
+    constructor
+    . exact axiomD!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0
+      constructor
       . exact { trans := by simp; }
-      . simp [Semantics.Realize, Satisfies];
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert.KD4.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/KD45.lean
+++ b/Foundation/Modal/Kripke/Logic/KD45.lean
@@ -25,16 +25,16 @@ end Kripke
 namespace Hilbert.KD45.Kripke
 
 instance : Sound Hilbert.KD45 FrameClass.KD45 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomD_of_serial;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_AxiomFive_of_euclidean;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomD_of_serial
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_AxiomFive_of_euclidean
 
 instance : Entailment.Consistent Hilbert.KD45 := consistent_of_sound_frameclass FrameClass.KD45 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.KD45 FrameClass.KD45 := ⟨by constructor⟩
 
@@ -42,80 +42,80 @@ instance : Complete Hilbert.KD45 FrameClass.KD45 := inferInstance
 
 
 instance : Hilbert.KD4 ⪱ Hilbert.KD45 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Five (.atom 0);
-    constructor;
-    . exact axiomFive!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Five (.atom 0)
+    constructor
+    . exact axiomFive!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
           ⟨Fin 3, λ x y => x = y ∨ x < y⟩,
           λ w _ => w = 0
-        ⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
-        refine { serial := by tauto, trans := by omega };
+        ⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
+        refine { serial := by tauto, trans := by omega }
       . suffices (0 : M.World) ≺ 0 ∧ ∃ x : M.World, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . tauto;
-        . use 1;
-          constructor <;> omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . tauto
+        . use 1
+          constructor <;> omega
 
 instance : Hilbert.KD5 ⪱ Hilbert.KD45 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . exact axiomFour!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . exact axiomFour!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD5)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x ≠ 0 ∧ y ≠ 0)⟩, λ w _ => w = 1⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0 ∧ y = 1) ∨ (x ≠ 0 ∧ y ≠ 0)⟩, λ w _ => w = 1⟩
+      use M, 0
+      constructor
       . refine {
           serial := by
-            intro x;
+            intro x
             match x with
-            | 0 => use 1; tauto;
-            | 1 => use 1; omega;
-            | 2 => use 2; omega;
-          reucl := by simp [RightEuclidean]; omega;
-        };
+            | 0 => use 1; tauto
+            | 1 => use 1; omega
+            | 2 => use 2; omega
+          reucl := by simp [RightEuclidean]; omega
+        }
       . suffices (∀ (y : M.World), (0 : M.World) ≺ y → y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ∃ y, x ≺ y ∧ y ≠ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . intro y;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . intro y
           match y with
-          | 0 => tauto;
-          | 1 => tauto;
-          | 2 => tauto;
-        . use 1;
-          constructor;
-          . tauto;
-          . use 2;
-            constructor;
-            . omega;
-            . trivial;
+          | 0 => tauto
+          | 1 => tauto
+          | 2 => tauto
+        . use 1
+          constructor
+          . tauto
+          . use 2
+            constructor
+            . omega
+            . trivial
 
 instance : Hilbert.K45 ⪱ Hilbert.KD45 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.D (.atom 0);
-    constructor;
-    . exact axiomD!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.D (.atom 0)
+    constructor
+    . exact axiomD!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K45)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => True⟩, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => True⟩, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
         refine { trans := by simp, reucl := by simp [RightEuclidean] }
-      . simp [Semantics.Realize, Satisfies];
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert.KD45.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/KD4Point3Z.lean
+++ b/Foundation/Modal/Kripke/Logic/KD4Point3Z.lean
@@ -17,13 +17,13 @@ open Hilbert.Kripke
 namespace Logic.KD4Point3Z.Kripke
 
 instance : Sound Hilbert.KD4Point3Z natLT := instSound_of_frame_validates_axioms $ by
-  simp only [Semantics.RealizeSet.insert_iff, ValidOnFrame.models_iff, Semantics.RealizeSet.singleton_iff];
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩;
-  . apply FrameClass.K.validates_axiomK <;> tauto;
-  . apply validate_AxiomD_of_serial;
-  . apply validate_AxiomFour_of_transitive;
-  . apply validate_WeakPoint3_of_weakConnected;
-  . apply Kripke.natLT_validates_AxiomZ;
+  simp only [Semantics.RealizeSet.insert_iff, ValidOnFrame.models_iff, Semantics.RealizeSet.singleton_iff]
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  . apply FrameClass.K.validates_axiomK <;> tauto
+  . apply validate_AxiomD_of_serial
+  . apply validate_AxiomFour_of_transitive
+  . apply validate_WeakPoint3_of_weakConnected
+  . apply Kripke.natLT_validates_AxiomZ
 
 instance : Entailment.Consistent Logic.KD4Point3Z := consistent_of_sound_frames natLT
 

--- a/Foundation/Modal/Kripke/Logic/KD5.lean
+++ b/Foundation/Modal/Kripke/Logic/KD5.lean
@@ -22,15 +22,15 @@ end Kripke
 namespace Hilbert.KD5.Kripke
 
 instance : Sound (Hilbert.KD5) Kripke.FrameClass.KD5 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomD_of_serial;
-  . exact validate_AxiomFive_of_euclidean;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomD_of_serial
+  . exact validate_AxiomFive_of_euclidean
 
 instance : Entailment.Consistent (Hilbert.KD5) := consistent_of_sound_frameclass Kripke.FrameClass.KD5 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical (Hilbert.KD5) Kripke.FrameClass.KD5 := ⟨by constructor⟩
 
@@ -39,38 +39,38 @@ instance : Complete (Hilbert.KD5) Kripke.FrameClass.KD5 := inferInstance
 end KD5.Kripke
 
 instance : Hilbert.KD ⪱ Hilbert.KD5 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Five (.atom 0));
-    constructor;
-    . exact axiomFive!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Five (.atom 0))
+    constructor
+    . exact axiomFive!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
-      . tauto;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
+      . tauto
       . suffices (0 : M.World) ≺ 0 ∧ ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . tauto;
-        . use 1;
-          constructor <;> tauto;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . tauto
+        . use 1
+          constructor <;> tauto
 
 instance : Hilbert.K5 ⪱ Hilbert.KD5 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.D (.atom 0));
-    constructor;
-    . exact axiomD!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.D (.atom 0))
+    constructor
+    . exact axiomD!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K5)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0;
-      constructor;
-      . refine { reucl := by simp [RightEuclidean]; };
-      . simp [Semantics.Realize, Satisfies];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0
+      constructor
+      . refine { reucl := by simp [RightEuclidean]; }
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/KDB.lean
+++ b/Foundation/Modal/Kripke/Logic/KDB.lean
@@ -23,15 +23,15 @@ end Kripke
 namespace Hilbert.KDB.Kripke
 
 instance : Sound (Hilbert.KDB) Kripke.FrameClass.KDB := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomD_of_serial;
-  . exact validate_AxiomB_of_symmetric;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomD_of_serial
+  . exact validate_AxiomB_of_symmetric
 
 instance : Entailment.Consistent (Hilbert.KDB) := consistent_of_sound_frameclass Kripke.FrameClass.KDB $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 
 instance : Canonical (Hilbert.KDB) Kripke.FrameClass.KDB := ⟨by constructor⟩
@@ -40,35 +40,35 @@ instance : Complete (Hilbert.KDB) Kripke.FrameClass.KDB := inferInstance
 
 
 instance : Hilbert.KD ⪱ Hilbert.KDB := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.B (.atom 0);
-    constructor;
-    . exact axiomB!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.B (.atom 0)
+    constructor
+    . exact axiomB!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . refine { serial := by intro x; use 1; omega;}
-      . suffices ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        constructor <;> omega;
+      . suffices ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        constructor <;> omega
 
 instance : Hilbert.KB ⪱ Hilbert.KDB := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.D (.atom 0);
-    constructor;
-    . exact axiomD!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.D (.atom 0)
+    constructor
+    . exact axiomD!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KB)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0;
-      constructor;
-      . refine { symm := by simp; };
-      . simp [Semantics.Realize, Satisfies];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ w _ => w = 0⟩, 0
+      constructor
+      . refine { symm := by simp; }
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert.KDB.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/KHen.lean
+++ b/Foundation/Modal/Kripke/Logic/KHen.lean
@@ -16,58 +16,58 @@ namespace Kripke
 variable {F : Kripke.Frame} {a : ℕ} {φ : Formula ℕ}
 
 lemma valid_atomic_axiomHen_of_valid_atomic_axiomL : F ⊧ (Axioms.L (atom a)) → F ⊧ (Axioms.Hen (atom a)) := by
-  intro h V x hx;
+  intro h V x hx
   have : Satisfies ⟨F, V⟩ x (□(□a ➝ a)) := by
-    intro y Rxy;
-    exact (Satisfies.and_def.mp $ @hx y Rxy) |>.1;
-  exact @h V x this;
+    intro y Rxy
+    exact (Satisfies.and_def.mp $ @hx y Rxy) |>.1
+  exact @h V x this
 
 lemma valid_atomic_axiomL_of_valid_atomic_axiomHen : F ⊧ Axioms.Hen (atom a) → F ⊧ Axioms.L (atom a) := by
-  intro hH V x hx;
+  intro hH V x hx
 
-  let V' : Valuation F := λ w a => ∀ n : ℕ, Satisfies ⟨F, V⟩ w (□^[n] a);
+  let V' : Valuation F := λ w a => ∀ n : ℕ, Satisfies ⟨F, V⟩ w (□^[n] a)
 
   have h₁ : Satisfies ⟨F, V'⟩ x (□(□a ⭤ a)) := by
-    intro y Rxy;
+    intro y Rxy
     have : Satisfies ⟨F, V'⟩ y a ↔ Satisfies ⟨F, V'⟩ y (□a) := calc
-      _ ↔ ∀ n, Satisfies ⟨F, V⟩ y (□^[n] a) := by simp [Satisfies, V'];
+      _ ↔ ∀ n, Satisfies ⟨F, V⟩ y (□^[n] a) := by simp [Satisfies, V']
       _ ↔ ∀ n, Satisfies ⟨F, V⟩ y (□^[(n + 1)]a) := by
-        constructor;
-        . intro h n; apply h;
-        . intro h n;
+        constructor
+        . intro h n; apply h
+        . intro h n
           have h₁ : Satisfies ⟨F, V⟩ y (□□^[n](atom a) ➝ □^[n](atom a)) := by
             induction n with
-            | zero => apply @hx y Rxy;
-            | succ n => intro _; apply h;
-          apply h₁;
-          simpa using h n;
-      _ ↔ ∀ n, ∀ z, y ≺ z → Satisfies ⟨F, V⟩ z (□^[n] a) := by simp [Satisfies];
-      _ ↔ ∀ z, y ≺ z → ∀ n : ℕ, Satisfies ⟨F, V⟩ z (□^[n]a) := by aesop;
-      _ ↔ ∀ z, y ≺ z → Satisfies ⟨F, V'⟩ z (atom a) := by simp [Satisfies, V'];
-      _ ↔ Satisfies ⟨F, V'⟩ y (□(atom a)) := by simp [Satisfies];
-    simp [Satisfies, V'];
-    tauto;
+            | zero => apply @hx y Rxy
+            | succ n => intro _; apply h
+          apply h₁
+          simpa using h n
+      _ ↔ ∀ n, ∀ z, y ≺ z → Satisfies ⟨F, V⟩ z (□^[n] a) := by simp [Satisfies]
+      _ ↔ ∀ z, y ≺ z → ∀ n : ℕ, Satisfies ⟨F, V⟩ z (□^[n]a) := by aesop
+      _ ↔ ∀ z, y ≺ z → Satisfies ⟨F, V'⟩ z (atom a) := by simp [Satisfies, V']
+      _ ↔ Satisfies ⟨F, V'⟩ y (□(atom a)) := by simp [Satisfies]
+    simp [Satisfies, V']
+    tauto
 
-  have h₂ : Satisfies ⟨F, V'⟩ x (□atom a) := @hH V' x h₁;
+  have h₂ : Satisfies ⟨F, V'⟩ x (□atom a) := @hH V' x h₁
 
-  intro w Rxw;
-  exact @h₂ w Rxw 0;
+  intro w Rxw
+  exact @h₂ w Rxw 0
 
 lemma valid_atomic_axiomL_iff_valid_atomic_axiomH : F ⊧ Axioms.L (atom 0) ↔ F ⊧ Axioms.Hen (atom 0) := by
-  constructor;
-  . exact valid_atomic_axiomHen_of_valid_atomic_axiomL;
-  . exact valid_atomic_axiomL_of_valid_atomic_axiomHen;
+  constructor
+  . exact valid_atomic_axiomHen_of_valid_atomic_axiomL
+  . exact valid_atomic_axiomL_of_valid_atomic_axiomHen
 
 lemma valid_atomic_axiomFour_of_valid_atomic_axiomL (h : F ⊧ Axioms.L (atom 0)) : F ⊧ Axioms.Four (atom 0) := by
-  intro V x h₂ y Rxy z Ryz;
-  refine h₂ z ?_;
-  have := isTransitive_of_validate_axiomL h;
-  apply F.trans Rxy Ryz;
+  intro V x h₂ y Rxy z Ryz
+  refine h₂ z ?_
+  have := isTransitive_of_validate_axiomL h
+  apply F.trans Rxy Ryz
 
 lemma valid_atomic_axiomFour_of_valid_atomic_axiomH : F ⊧ Axioms.Hen (atom 0) → F ⊧ Axioms.Four (atom 0) := by
-  trans;
-  . exact valid_atomic_axiomL_iff_valid_atomic_axiomH.mpr;
-  . exact valid_atomic_axiomFour_of_valid_atomic_axiomL;
+  trans
+  . exact valid_atomic_axiomL_iff_valid_atomic_axiomH.mpr
+  . exact valid_atomic_axiomFour_of_valid_atomic_axiomL
 
 
 abbrev cresswellFrame : Kripke.Frame where
@@ -91,23 +91,23 @@ variable {n m : ℕ} {x y : cresswellFrame.World}
 
 lemma trichonomy : x ≺ y ∨ x = y ∨ y ≺ x := by
   match x, y with
-  | x♯, y♯ => simp [cresswellFrame, Frame.Rel']; omega;
-  | x♭, y♯ => simp [cresswellFrame, Frame.Rel'];
-  | x♯, y♭ => simp [cresswellFrame, Frame.Rel'];
-  | x♭, y♭ => simp [cresswellFrame, Frame.Rel']; omega;
+  | x♯, y♯ => simp [cresswellFrame, Frame.Rel']; omega
+  | x♭, y♯ => simp [cresswellFrame, Frame.Rel']
+  | x♯, y♭ => simp [cresswellFrame, Frame.Rel']
+  | x♭, y♭ => simp [cresswellFrame, Frame.Rel']; omega
 
 @[simp] lemma sharp_to_flat : n♯ ≺ m♭ := by simp [Frame.Rel']
 
-@[simp] lemma not_flat_to_sharp : ¬(n♭ ≺ m♯):= by simp [Frame.Rel'];
+@[simp] lemma not_flat_to_sharp : ¬(n♭ ≺ m♯):= by simp [Frame.Rel']
 
 lemma sharp_to_sharp : n♯ ≺ m♯ ↔ n ≤ m + 1 := by simp [Frame.Rel']
 
-lemma flat_to_flat : n♭ ≺ m♭ ↔ n > m := by simp [Frame.Rel'];
+lemma flat_to_flat : n♭ ≺ m♭ ↔ n > m := by simp [Frame.Rel']
 
 lemma exists_flat_of_from_flat (h : n♭ ≺ x) : ∃ m, x = ⟨m, 1⟩ ∧ n > m := by
   match x with
-  | ⟨m, 0⟩ => aesop;
-  | ⟨m, 1⟩ => use m;
+  | ⟨m, 0⟩ => aesop
+  | ⟨m, 1⟩ => use m
 
 end cresswellFrame
 
@@ -123,27 +123,27 @@ end cresswellModel
 open cresswellFrame cresswellModel
 
 lemma cresswellModel.not_valid_axiomFour : ¬(Satisfies cresswellModel 2♯ (Axioms.Four (atom 0))) := by
-  apply Satisfies.imp_def.not.mpr;
-  push_neg;
-  constructor;
-  . intro x;
+  apply Satisfies.imp_def.not.mpr
+  push_neg
+  constructor
+  . intro x
     match x with
     | n♯ =>
-      intro h2n;
-      suffices n ≠ 0 by simpa [Satisfies];
-      omega;
-    | n♭ => simp [Satisfies];
+      intro h2n
+      suffices n ≠ 0 by simpa [Satisfies]
+      omega
+    | n♭ => simp [Satisfies]
   . apply Satisfies.box_def.not.mpr
-    push_neg;
-    use 1♯;
-    constructor;
-    . omega;
-    . apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use 0♯;
-      constructor;
-      . omega;
-      . tauto;
+    push_neg
+    use 1♯
+    constructor
+    . omega
+    . apply Satisfies.box_def.not.mpr
+      push_neg
+      use 0♯
+      constructor
+      . omega
+      . tauto
 
 
 abbrev cresswellModel.truthset (φ : Formula _) := { x : cresswellModel.World | Satisfies cresswellModel x φ }
@@ -152,195 +152,195 @@ local notation "‖" φ "‖" => cresswellModel.truthset φ
 namespace cresswellModel.truthset
 
 lemma infinite_of_all_flat (h : ∀ n, n♭ ∈ ‖φ‖) : (‖φ‖.Infinite) := by
-  apply Set.infinite_coe_iff.mp;
+  apply Set.infinite_coe_iff.mp
   exact Infinite.of_injective (λ n => ⟨n♭, h n⟩) $ by simp [Function.Injective]
 
 -- TODO: need golf
 lemma exists_max_sharp (h₁ : ∀ n, n♭ ∈ ‖φ‖) (h₂ : ‖φ‖ᶜ.Finite) (h₃ : ‖φ‖ᶜ.Nonempty) :
   ∃ n, n♯ ∉ ‖φ‖ ∧ (∀ m > n, m♯ ∈ ‖φ‖) := by
-  obtain ⟨s, hs⟩ := Set.Finite.exists_finset (s := (λ x => x.1) '' ‖φ‖ᶜ) $ Set.Finite.image _ h₂;
+  obtain ⟨s, hs⟩ := Set.Finite.exists_finset (s := (λ x => x.1) '' ‖φ‖ᶜ) $ Set.Finite.image _ h₂
   have se : s.Nonempty := by
-    let ⟨x, hx⟩ := h₃;
-    use x.1;
-    apply hs _ |>.mpr;
-    use x;
-  use (s.max' se);
-  constructor;
-  . obtain ⟨f, hx₁⟩ := by simpa using @hs _ |>.mp $ Finset.max'_mem _ se;
+    let ⟨x, hx⟩ := h₃
+    use x.1
+    apply hs _ |>.mpr
+    use x
+  use (s.max' se)
+  constructor
+  . obtain ⟨f, hx₁⟩ := by simpa using @hs _ |>.mp $ Finset.max'_mem _ se
     match f with
-    | 0 => exact hx₁;
+    | 0 => exact hx₁
     | 1 =>
-      have := hx₁ $ h₁ _;
-      contradiction;
-  . intro m hm;
-    by_contra hC;
+      have := hx₁ $ h₁ _
+      contradiction
+  . intro m hm
+    by_contra hC
     have : m < m := Finset.max'_lt_iff (H := se) |>.mp hm m (by
-      apply hs m |>.mpr;
-      use m♯;
-      simpa;
-    );
-    simp at this;
+      apply hs m |>.mpr
+      use m♯
+      simpa
+    )
+    simp at this
 
 -- TODO: need golf
 open Classical in
 lemma exists_min_flat (h₁ : ∃ n, n♭ ∉ ‖φ‖) :
   ∃ n, n♭ ∉ ‖φ‖ ∧ (∀ m < n, m♭ ∈ ‖φ‖) := by
-  obtain ⟨n, hn⟩ := h₁;
-  let s := Finset.Icc 0 n |>.filter (λ k => k♭ ∉ ‖φ‖);
-  have hse : s.Nonempty := by use n; simpa [s];
-  use (s.min' hse);
-  have ⟨h₁, h₂⟩ := Finset.mem_filter |>.mp $ @Finset.min'_mem (s := s) _ _ hse;
-  constructor;
-  . exact h₂;
-  . intro m hm;
-    by_contra hC;
+  obtain ⟨n, hn⟩ := h₁
+  let s := Finset.Icc 0 n |>.filter (λ k => k♭ ∉ ‖φ‖)
+  have hse : s.Nonempty := by use n; simpa [s]
+  use (s.min' hse)
+  have ⟨h₁, h₂⟩ := Finset.mem_filter |>.mp $ @Finset.min'_mem (s := s) _ _ hse
+  constructor
+  . exact h₂
+  . intro m hm
+    by_contra hC
     have := Finset.lt_min'_iff _ _ |>.mp hm m $ by
-      simp only [Set.mem_setOf_eq, Finset.mem_filter, Finset.mem_Icc, zero_le, true_and, s];
-      constructor;
-      . simp only [Finset.lt_min'_iff, s] at hm;
-        have := hm n $ by simpa [s];
-        omega;
-      . exact hC;
-    simp at this;
+      simp only [Set.mem_setOf_eq, Finset.mem_filter, Finset.mem_Icc, zero_le, true_and, s]
+      constructor
+      . simp only [Finset.lt_min'_iff, s] at hm
+        have := hm n $ by simpa [s]
+        omega
+      . exact hC
+    simp at this
 
 lemma either_finite_cofinite : (‖φ‖.Finite) ∨ (‖φ‖ᶜ.Finite) := by
   induction φ with
-  | hatom a => simp [truthset, Satisfies];
-  | hfalsum => simp [truthset, Satisfies];
+  | hatom a => simp [truthset, Satisfies]
+  | hfalsum => simp [truthset, Satisfies]
   | himp φ ψ ihφ ihψ =>
-    rw [(show ‖φ ➝ ψ‖ = ‖φ‖ᶜ ∪ ‖ψ‖ by tauto_set), Set.compl_union, compl_compl];
-    rcases ihφ with (_ | _) <;> rcases ihψ with (_ | _);
-    . right; apply Set.Finite.inter_of_left; assumption;
-    . right; apply Set.Finite.inter_of_left; assumption;
-    . left;
-      rw [Set.finite_union];
-      constructor <;> assumption;
-    . right; apply Set.Finite.inter_of_right; assumption;
+    rw [(show ‖φ ➝ ψ‖ = ‖φ‖ᶜ ∪ ‖ψ‖ by tauto_set), Set.compl_union, compl_compl]
+    rcases ihφ with (_ | _) <;> rcases ihψ with (_ | _)
+    . right; apply Set.Finite.inter_of_left; assumption
+    . right; apply Set.Finite.inter_of_left; assumption
+    . left
+      rw [Set.finite_union]
+      constructor <;> assumption
+    . right; apply Set.Finite.inter_of_right; assumption
   | hbox φ ihφ =>
-    by_cases h : ∀ n, n♭ ∈ ‖φ‖;
-    . have tsφc_finite : ‖φ‖ᶜ.Finite := or_iff_not_imp_left.mp ihφ $ truthset.infinite_of_all_flat h;
-      wlog tsφc_ne : ‖φ‖ᶜ.Nonempty;
+    by_cases h : ∀ n, n♭ ∈ ‖φ‖
+    . have tsφc_finite : ‖φ‖ᶜ.Finite := or_iff_not_imp_left.mp ihφ $ truthset.infinite_of_all_flat h
+      wlog tsφc_ne : ‖φ‖ᶜ.Nonempty
       . have : ‖□φ‖ᶜ = ∅ := by
-          simp only [Set.compl_empty_iff, Set.eq_univ_iff_forall, Set.mem_setOf_eq];
-          intro x y Rxy;
+          simp only [Set.compl_empty_iff, Set.eq_univ_iff_forall, Set.mem_setOf_eq]
+          intro x y Rxy
           match x, y with
           | m♯, k♯ =>
-            have : ∀ x, Satisfies cresswellModel x φ := by simpa [Set.compl_empty, Set.Nonempty] using tsφc_ne;
-            apply this;
-          | m♭, k♯ => simp at Rxy;
-          | m♯, k♭ => apply h;
-          | m♭, k♭ => apply h;
-        rw [this];
-        simp;
-      obtain ⟨n, hn, hn_max⟩ := exists_max_sharp h tsφc_finite tsφc_ne;
-      right;
-      apply @Set.Finite.subset (s := (·♯) '' Set.Icc 0 (n + 1));
+            have : ∀ x, Satisfies cresswellModel x φ := by simpa [Set.compl_empty, Set.Nonempty] using tsφc_ne
+            apply this
+          | m♭, k♯ => simp at Rxy
+          | m♯, k♭ => apply h
+          | m♭, k♭ => apply h
+        rw [this]
+        simp
+      obtain ⟨n, hn, hn_max⟩ := exists_max_sharp h tsφc_finite tsφc_ne
+      right
+      apply @Set.Finite.subset (s := (·♯) '' Set.Icc 0 (n + 1))
       . apply Set.toFinite
-      . intro x hx;
-        replace := Satisfies.box_def.not.mp hx;
-        push_neg at this;
-        obtain ⟨y, Rxy, _⟩ := this;
+      . intro x hx
+        replace := Satisfies.box_def.not.mp hx
+        push_neg at this
+        obtain ⟨y, Rxy, _⟩ := this
         match x, y with
         | m♯, k♯ =>
-          by_contra hC; simp at hC;
-          replace Rxy := sharp_to_sharp.mp Rxy;
-          have : k♯ ∈ ‖φ‖ := @hn_max k (by omega);
-          contradiction;
-        | m♭, k♯ => simp at Rxy;
-        | _♯, k♭ => have := h k; contradiction;
-        | _♭, k♭ => have := h k; contradiction;
-    . left;
-      push_neg at h;
-      obtain ⟨n, hn⟩ := h;
-      apply @Set.Finite.subset (s := (·♭) '' Set.Icc 0 n);
+          by_contra hC; simp at hC
+          replace Rxy := sharp_to_sharp.mp Rxy
+          have : k♯ ∈ ‖φ‖ := @hn_max k (by omega)
+          contradiction
+        | m♭, k♯ => simp at Rxy
+        | _♯, k♭ => have := h k; contradiction
+        | _♭, k♭ => have := h k; contradiction
+    . left
+      push_neg at h
+      obtain ⟨n, hn⟩ := h
+      apply @Set.Finite.subset (s := (·♭) '' Set.Icc 0 n)
       . apply Set.toFinite
-      . intro x hx;
+      . intro x hx
         match x with
         | m♯ =>
-          have := hx n♭ sharp_to_flat;
-          contradiction;
+          have := hx n♭ sharp_to_flat
+          contradiction
         | m♭ =>
-          by_contra hC;
-          have := hx n♭ $ (cresswellFrame.flat_to_flat.mpr $ by simpa using hC);
-          contradiction;
+          by_contra hC
+          have := hx n♭ $ (cresswellFrame.flat_to_flat.mpr $ by simpa using hC)
+          contradiction
 
 end cresswellModel.truthset
 
 open Classical in
 lemma cresswellModel.valid_axiomHen : cresswellModel ⊧ □(□φ ⭤ φ) ➝ □φ := by
-  rintro x;
-  by_cases h : ∀ n, n♭ ∈ ‖φ‖;
-  . have tsφc_fin : ‖φ‖ᶜ.Finite := or_iff_not_imp_left.mp truthset.either_finite_cofinite $ truthset.infinite_of_all_flat h;
-    wlog tsφc_ne : ‖φ‖ᶜ.Nonempty;
-    . apply Satisfies.imp_def₂.mpr;
-      right;
-      intro y Rxy;
-      have : ∀ x, Satisfies cresswellModel x φ := by simpa [Set.compl_empty, Set.Nonempty] using tsφc_ne;
-      apply this;
-    obtain ⟨n, hn, hn_max⟩ := truthset.exists_max_sharp h tsφc_fin tsφc_ne;
+  rintro x
+  by_cases h : ∀ n, n♭ ∈ ‖φ‖
+  . have tsφc_fin : ‖φ‖ᶜ.Finite := or_iff_not_imp_left.mp truthset.either_finite_cofinite $ truthset.infinite_of_all_flat h
+    wlog tsφc_ne : ‖φ‖ᶜ.Nonempty
+    . apply Satisfies.imp_def₂.mpr
+      right
+      intro y Rxy
+      have : ∀ x, Satisfies cresswellModel x φ := by simpa [Set.compl_empty, Set.Nonempty] using tsφc_ne
+      apply this
+    obtain ⟨n, hn, hn_max⟩ := truthset.exists_max_sharp h tsφc_fin tsφc_ne
     match x with
     | m♭ =>
-      apply Satisfies.imp_def₂.mpr;
-      right;
-      rintro y Rny;
-      obtain ⟨k, ⟨rfl, _⟩⟩ := exists_flat_of_from_flat Rny;
-      apply h;
+      apply Satisfies.imp_def₂.mpr
+      right
+      rintro y Rny
+      obtain ⟨k, ⟨rfl, _⟩⟩ := exists_flat_of_from_flat Rny
+      apply h
     | m♯ =>
-      by_cases hnm : n + 2 ≤ m;
-      . apply Satisfies.imp_def₂.mpr;
-        right;
-        rintro y Rny;
+      by_cases hnm : n + 2 ≤ m
+      . apply Satisfies.imp_def₂.mpr
+        right
+        rintro y Rny
         match y with
-        | _♭ => apply h;
-        | _♯ => apply hn_max; omega;
-      . apply Satisfies.imp_def₂.mpr;
-        left;
-        apply Satisfies.box_def.not.mpr;
-        push_neg;
-        use (n + 1)♯;
-        constructor;
-        . omega;
-        . have : Satisfies cresswellModel (n + 1)♯ φ := hn_max (n + 1) (by omega);
+        | _♭ => apply h
+        | _♯ => apply hn_max; omega
+      . apply Satisfies.imp_def₂.mpr
+        left
+        apply Satisfies.box_def.not.mpr
+        push_neg
+        use (n + 1)♯
+        constructor
+        . omega
+        . have : Satisfies cresswellModel (n + 1)♯ φ := hn_max (n + 1) (by omega)
           have : ¬Satisfies cresswellModel (n + 1)♯ (□φ) := by
-            apply Satisfies.box_def.not.mpr;
-            push_neg;
-            use n♯;
-            constructor;
-            . omega;
-            . apply hn;
-          apply Satisfies.iff_def.not.mpr;
-          tauto;
-  . push_neg at h;
-    obtain ⟨n, hn, hn_max⟩ := truthset.exists_min_flat h;
+            apply Satisfies.box_def.not.mpr
+            push_neg
+            use n♯
+            constructor
+            . omega
+            . apply hn
+          apply Satisfies.iff_def.not.mpr
+          tauto
+  . push_neg at h
+    obtain ⟨n, hn, hn_max⟩ := truthset.exists_min_flat h
     have hn₁ : Satisfies cresswellModel n♭ (□φ) := by
-      intro x Rnx;
-      obtain ⟨m, ⟨rfl, hnm⟩⟩ := exists_flat_of_from_flat Rnx;
-      exact hn_max m hnm;
+      intro x Rnx
+      obtain ⟨m, ⟨rfl, hnm⟩⟩ := exists_flat_of_from_flat Rnx
+      exact hn_max m hnm
     have hn₂ : ¬Satisfies cresswellModel n♭ (□φ ⭤ φ) := by
-      apply Satisfies.iff_def.not.mpr;
-      push_neg;
-      tauto;
+      apply Satisfies.iff_def.not.mpr
+      push_neg
+      tauto
     match x with
     | m♯ =>
-      apply Satisfies.imp_def₂.mpr;
-      left;
-      apply Satisfies.box_def.not.mpr;
-      push_neg;
-      use n♭;
-      constructor;
-      . exact sharp_to_flat;
-      . assumption;
+      apply Satisfies.imp_def₂.mpr
+      left
+      apply Satisfies.box_def.not.mpr
+      push_neg
+      use n♭
+      constructor
+      . exact sharp_to_flat
+      . assumption
     | m♭ =>
-      by_cases hmn : m > n;
-      . intro h;
-        have := @h n♭ $ (flat_to_flat.mpr hmn);
-        contradiction;
-      . apply Satisfies.imp_def₂.mpr;
-        right;
-        rintro y Rmy;
-        obtain ⟨k, ⟨rfl, hk₂⟩⟩ := exists_flat_of_from_flat Rmy;
-        apply hn_max;
-        omega;
+      by_cases hmn : m > n
+      . intro h
+        have := @h n♭ $ (flat_to_flat.mpr hmn)
+        contradiction
+      . apply Satisfies.imp_def₂.mpr
+        right
+        rintro y Rmy
+        obtain ⟨k, ⟨rfl, hk₂⟩⟩ := exists_flat_of_from_flat Rmy
+        apply hn_max
+        omega
 
 end Kripke
 
@@ -348,28 +348,28 @@ end Kripke
 namespace Logic.KHen
 
 lemma Kripke.valid_cresswellModel_of_provable : Hilbert.KHen ⊢! φ → cresswellModel ⊧ φ := by
-  intro h;
+  intro h
   induction h using Hilbert.Normal.rec! with
   | axm s h =>
-    rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩);
-    . exact Kripke.ValidOnModel.axiomK;
-    . exact cresswellModel.valid_axiomHen;
-  | mdp ihφψ ihφ => exact Kripke.ValidOnModel.mdp ihφψ ihφ;
-  | nec ihφ => exact Kripke.ValidOnModel.nec ihφ;
-  | imply₁ => exact Kripke.ValidOnModel.imply₁;
-  | imply₂ => exact Kripke.ValidOnModel.imply₂;
-  | ec => exact Kripke.ValidOnModel.elimContra;
+    rcases h with (⟨_, rfl⟩ | ⟨_, rfl⟩)
+    . exact Kripke.ValidOnModel.axiomK
+    . exact cresswellModel.valid_axiomHen
+  | mdp ihφψ ihφ => exact Kripke.ValidOnModel.mdp ihφψ ihφ
+  | nec ihφ => exact Kripke.ValidOnModel.nec ihφ
+  | imply₁ => exact Kripke.ValidOnModel.imply₁
+  | imply₂ => exact Kripke.ValidOnModel.imply₂
+  | ec => exact Kripke.ValidOnModel.elimContra
 
 lemma unprovable_atomic_axiomFour : Hilbert.KHen ⊬ Axioms.Four (atom a) := by
-  by_contra hC;
-  exact cresswellModel.not_valid_axiomFour $ Kripke.valid_cresswellModel_of_provable hC 2♯;
+  by_contra hC
+  exact cresswellModel.not_valid_axiomFour $ Kripke.valid_cresswellModel_of_provable hC 2♯
 
 theorem Kripke.incomplete : ¬∃ C : Kripke.FrameClass, ∀ φ, Hilbert.KHen ⊢! φ ↔ C ⊧ φ := by
-  rintro ⟨C, h⟩;
-  have : C ⊧ Axioms.Hen (atom 0) := @h (Axioms.Hen (atom 0)) |>.mp $ by simp;
-  have : C ⊧ Axioms.Four (atom 0) := fun {F} hF => valid_atomic_axiomFour_of_valid_atomic_axiomH (this hF);
-  have : Hilbert.KHen ⊢! Axioms.Four (atom 0) := @h (Axioms.Four (atom 0)) |>.mpr this;
-  exact @unprovable_atomic_axiomFour _ this;
+  rintro ⟨C, h⟩
+  have : C ⊧ Axioms.Hen (atom 0) := @h (Axioms.Hen (atom 0)) |>.mp $ by simp
+  have : C ⊧ Axioms.Four (atom 0) := fun {F} hF => valid_atomic_axiomFour_of_valid_atomic_axiomH (this hF)
+  have : Hilbert.KHen ⊢! Axioms.Four (atom 0) := @h (Axioms.Four (atom 0)) |>.mpr this
+  exact @unprovable_atomic_axiomFour _ this
 
 end Logic.KHen
 
@@ -381,27 +381,27 @@ open Entailment
 open Kripke
 
 instance : Hilbert.K ⪱ Hilbert.KHen := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Hen (.atom 0));
-    constructor;
-    . exact axiomHen!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Hen (.atom 0))
+    constructor
+    . exact axiomHen!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => True⟩, λ w _ => False⟩, 0;
-      simp [Satisfies, Semantics.Realize];
-      constructor <;> tauto;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => True⟩, λ w _ => False⟩, 0
+      simp [Satisfies, Semantics.Realize]
+      constructor <;> tauto
 
 instance : Hilbert.KHen ⪱ Hilbert.GL := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . exact axiomFour!;
-    . apply Logic.KHen.unprovable_atomic_axiomFour;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . exact axiomFour!
+    . apply Logic.KHen.unprovable_atomic_axiomFour
 
 end Logic
 

--- a/Foundation/Modal/Kripke/Logic/KT.lean
+++ b/Foundation/Modal/Kripke/Logic/KT.lean
@@ -27,21 +27,21 @@ namespace Hilbert
 namespace KT.Kripke
 
 instance : Sound Hilbert.KT FrameClass.KT := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_refl;
-  exact Kripke.validate_AxiomT_of_reflexive (refl := F_refl);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_refl
+  exact Kripke.validate_AxiomT_of_reflexive (refl := F_refl)
 
 instance : Entailment.Consistent Hilbert.KT := consistent_of_sound_frameclass FrameClass.KT $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
-  simp;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
+  simp
 
 instance : Canonical Hilbert.KT FrameClass.KT := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  dsimp [Frame.IsKT];
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  dsimp [Frame.IsKT]
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.KT FrameClass.KT := inferInstance
@@ -49,18 +49,18 @@ instance : Complete Hilbert.KT FrameClass.KT := inferInstance
 end KT.Kripke
 
 instance : Hilbert.KD ⪱ Hilbert.KT := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . exact axiomT!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms $ by rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . exact axiomT!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 1⟩, 0;
-      constructor;
-      . exact { serial := by tauto };
-      . simp [Semantics.Realize, Satisfies];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 1⟩, 0
+      constructor
+      . exact { serial := by tauto }
+      . simp [Semantics.Realize, Satisfies]
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/KT4B.lean
+++ b/Foundation/Modal/Kripke/Logic/KT4B.lean
@@ -25,16 +25,16 @@ end Kripke
 namespace Hilbert.KT4B.Kripke
 
 instance : Sound Hilbert.KT4B FrameClass.KT4B := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_AxiomB_of_symmetric;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_AxiomB_of_symmetric
 
 instance : Entailment.Consistent Hilbert.KT4B := consistent_of_sound_frameclass FrameClass.KT4B $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.KT4B FrameClass.KT4B := ⟨by constructor⟩
 
@@ -42,33 +42,33 @@ instance : Complete Hilbert.KT4B FrameClass.KT4B := inferInstance
 
 open finestFiltrationTransitiveClosureModel in
 instance : Complete Hilbert.KT4B FrameClass.finite_KT4B := ⟨by
-  intro φ hp;
-  apply Complete.complete (𝓜 := FrameClass.KT4B);
-  intro F F_equiv V x;
-  replace F_equiv := Set.mem_setOf_eq.mp F_equiv;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas;
-  apply filtration FM (finestFiltrationTransitiveClosureModel.filterOf) (by simp) |>.mpr;
-  apply hp;
-  apply Set.mem_setOf_eq.mpr;
+  intro φ hp
+  apply Complete.complete (𝓜 := FrameClass.KT4B)
+  intro F F_equiv V x
+  replace F_equiv := Set.mem_setOf_eq.mp F_equiv
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas
+  apply filtration FM (finestFiltrationTransitiveClosureModel.filterOf) (by simp) |>.mpr
+  apply hp
+  apply Set.mem_setOf_eq.mpr
   exact {
-    world_finite := by apply FilterEqvQuotient.finite $ by simp;
+    world_finite := by apply FilterEqvQuotient.finite $ by simp
     symm := finestFiltrationTransitiveClosureModel.isSymmetric.symm
     refl := finestFiltrationTransitiveClosureModel.isReflexive.refl
   }
 ⟩
 
 instance : Hilbert.S5 ≊ Hilbert.KT4B := by
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S5) (FrameClass.KT4B);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KT4B) (FrameClass.S5);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S5) (FrameClass.KT4B)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KT4B) (FrameClass.S5)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
 
 end Hilbert.KT4B.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/KTB.lean
+++ b/Foundation/Modal/Kripke/Logic/KTB.lean
@@ -27,15 +27,15 @@ end Kripke
 namespace Hilbert.KTB.Kripke
 
 instance : Sound Hilbert.KTB FrameClass.KTB := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomB_of_symmetric;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomB_of_symmetric
 
 instance : Entailment.Consistent Hilbert.KTB := consistent_of_sound_frameclass FrameClass.KTB $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 
 instance : Canonical Hilbert.KTB FrameClass.KTB := ⟨by constructor⟩
@@ -43,17 +43,17 @@ instance : Canonical Hilbert.KTB FrameClass.KTB := ⟨by constructor⟩
 instance : Complete Hilbert.KTB FrameClass.KTB := inferInstance
 
 instance : Complete Hilbert.KTB FrameClass.finite_KTB := ⟨by
-  intro φ hp;
-  apply Complete.complete (𝓜 := FrameClass.KTB);
-  intro F hF V x;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := finestFiltrationModel M φ.subformulas;
-  apply filtration FM (finestFiltrationModel.filterOf) (by simp) |>.mpr;
-  apply hp;
-  apply Set.mem_setOf_eq.mpr;
+  intro φ hp
+  apply Complete.complete (𝓜 := FrameClass.KTB)
+  intro F hF V x
+  replace hF := Set.mem_setOf_eq.mp hF
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := finestFiltrationModel M φ.subformulas
+  apply filtration FM (finestFiltrationModel.filterOf) (by simp) |>.mpr
+  apply hp
+  apply Set.mem_setOf_eq.mpr
   refine {
-    world_finite := by apply FilterEqvQuotient.finite $ by simp;
+    world_finite := by apply FilterEqvQuotient.finite $ by simp
     refl := finestFiltrationModel.isReflexive.refl
     symm := finestFiltrationModel.isSymmetric.symm
   }
@@ -61,47 +61,47 @@ instance : Complete Hilbert.KTB FrameClass.finite_KTB := ⟨by
 
 
 instance : Hilbert.KT ⪱ Hilbert.KTB := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.B (.atom 0));
-    constructor;
-    . exact axiomB!;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KT);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
-      . tauto;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.B (.atom 0))
+    constructor
+    . exact axiomB!
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KT)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
+      . tauto
       . suffices ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        omega
 
 instance : Hilbert.KDB ⪱ Hilbert.KTB := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KDB FrameClass.KTB;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . exact axiomT!;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KDB);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => x ≠ y⟩, λ x _ => x = 1⟩, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KDB FrameClass.KTB
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . exact axiomT!
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KDB)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => x ≠ y⟩, λ x _ => x = 1⟩, 0
+      constructor
       . refine {
           serial := by
-            intro x;
+            intro x
             match x with
-            | 0 => use 1; omega;
-            | 1 => use 0; omega;
+            | 0 => use 1; omega
+            | 1 => use 0; omega
           symm := by simp; omega
-        };
-      . simp [Semantics.Realize, Satisfies];
-        omega;
+        }
+      . simp [Semantics.Realize, Satisfies]
+        omega
 
 end Hilbert.KTB.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/KTMk.lean
+++ b/Foundation/Modal/Kripke/Logic/KTMk.lean
@@ -27,15 +27,15 @@ open Hilbert.Kripke
 namespace Logic.KTMk.Kripke
 
 instance : Sound (Hilbert.KTMk) Kripke.FrameClass.KTMk := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_axiomMk_of_satisfiesMakinsonCondition;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_axiomMk_of_satisfiesMakinsonCondition
 
 instance : Entailment.Consistent (Hilbert.KTMk) := consistent_of_sound_frameclass Kripke.FrameClass.KTMk $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical (Hilbert.KTMk) Kripke.FrameClass.KTMk := ⟨by constructor⟩
 
@@ -49,90 +49,90 @@ open Entailment
 
 lemma validate_axiomFour_of_model_finitely {M : Kripke.Model} (hM : M ⊧* Modal.KTMk)
   : Finite M → ∀ φ : Formula ℕ, M ⊧ Axioms.Four φ := by
-  contrapose!;
-  rintro ⟨φ, hφ⟩;
-  apply not_finite_iff_infinite.mpr;
-  apply List.Nodup.infinite_of_infinite;
+  contrapose!
+  rintro ⟨φ, hφ⟩
+  apply not_finite_iff_infinite.mpr
+  apply List.Nodup.infinite_of_infinite
   have H : ∀ n : ℕ+, ∃ l : List M.World, l.Nodup ∧ l.length = n ∧ List.Chain' (· ≺ ·) l ∧ (∀ i : Fin l.length, l[i] ⊧ □^[(i + 1)]φ ⋏ ∼□^[(i + 2)]φ) := by
-    intro n;
+    intro n
     induction n with
     | one =>
-      replace ⟨x₀, hφ⟩ := ValidOnModel.exists_world_of_not hφ;
-      use [x₀];
-      simpa using hφ;
+      replace ⟨x₀, hφ⟩ := ValidOnModel.exists_world_of_not hφ
+      use [x₀]
+      simpa using hφ
     | succ n ih =>
-      obtain ⟨l, hl_nodup, hl_len, hl_chain, hl⟩ := ih;
-      let m : Fin l.length := ⟨n - 1, by simp [hl_len]⟩;
-      have : l[m] ⊧ ◇(□^[(m + 2)]φ ⋏ ∼□^[(m + 3)]φ) := Satisfies.mdp ?_ $ hl m;
-      obtain ⟨y, Rmy, hy₂⟩ := Satisfies.dia_def.mp this;
-      let l' := l.concat y;
-      use l';
+      obtain ⟨l, hl_nodup, hl_len, hl_chain, hl⟩ := ih
+      let m : Fin l.length := ⟨n - 1, by simp [hl_len]⟩
+      have : l[m] ⊧ ◇(□^[(m + 2)]φ ⋏ ∼□^[(m + 3)]φ) := Satisfies.mdp ?_ $ hl m
+      obtain ⟨y, Rmy, hy₂⟩ := Satisfies.dia_def.mp this
+      let l' := l.concat y
+      use l'
       have hl' : ∀ (i : Fin l'.length), l'[i] ⊧ □^[(i + 1)]φ ⋏ ∼□^[(i + 2)]φ := by
-        rintro ⟨i, hi'⟩;
+        rintro ⟨i, hi'⟩
         replace hi : i < l.length ∨ i = l.length := by
-          simp [l'] at hi';
-          omega;
-        rcases hi with (hi | rfl);
-        . let i : Fin (l.length) := ⟨i, by omega⟩;
-          generalize ei' : (⟨i, hi'⟩ : Fin l'.length) = i';
+          simp [l'] at hi'
+          omega
+        rcases hi with (hi | rfl)
+        . let i : Fin (l.length) := ⟨i, by omega⟩
+          generalize ei' : (⟨i, hi'⟩ : Fin l'.length) = i'
           simpa [
             show l[i] = l'[i'] by simp [←ei', l'],
             show □^[(i + 1)]φ = □^[(i' + 1)]φ by simp [←ei'],
             show ∼□^[(i + 2)]φ = ∼□^[(i' + 2)]φ by simp [←ei']
-          ] using @hl i;
-        . simpa [l', hl_len, m] using hy₂;
-      refine ⟨?_, by simpa [l'], ?_, hl'⟩;
-      . apply List.nodup_iff_get_ne_get.mpr;
-        rintro ⟨i, hi⟩ ⟨j, hj⟩ hij eij;
-        replace hij : i < j := hij;
-        apply Satisfies.not_def.mp $ Satisfies.and_def.mp (hl' ⟨i, hi⟩) |>.2;
-        apply Satisfies.mdp ?_ $ eij ▸ Satisfies.and_def.mp (hl' ⟨j, hj⟩) |>.1;
-        apply hM.realize;
-        simp only [Entailment.theory, Set.mem_setOf_eq];
-        obtain ⟨c, hc, rfl⟩ := lt_iff_exists_add.mp hij;
+          ] using @hl i
+        . simpa [l', hl_len, m] using hy₂
+      refine ⟨?_, by simpa [l'], ?_, hl'⟩
+      . apply List.nodup_iff_get_ne_get.mpr
+        rintro ⟨i, hi⟩ ⟨j, hj⟩ hij eij
+        replace hij : i < j := hij
+        apply Satisfies.not_def.mp $ Satisfies.and_def.mp (hl' ⟨i, hi⟩) |>.2
+        apply Satisfies.mdp ?_ $ eij ▸ Satisfies.and_def.mp (hl' ⟨j, hj⟩) |>.1
+        apply hM.realize
+        simp only [Entailment.theory, Set.mem_setOf_eq]
+        obtain ⟨c, hc, rfl⟩ := lt_iff_exists_add.mp hij
         match c with
-        | 0 => contradiction;
+        | 0 => contradiction
         | n + 1 =>
           suffices Hilbert.KTMk ⊢! □^[((i + 2) + n)]φ ➝ □^[(i + 2)]φ by
-            rwa [show (i + (n + 1) + 1) = (i + 2 + n) by omega];
-          apply reduce_box_in_CAnt!;
-      . apply List.chain'_concat_of_not_nil (List.length_pos_iff_ne_nil.mp (by simp [hl_len])) |>.mpr;
-        constructor;
-        . assumption;
-        . convert Rmy;
-          trans l[l.length - 1]'(by simp [hl_len]);
-          . apply List.getLast_eq_getElem;
-          . simp [m, hl_len];
-      . intro h;
+            rwa [show (i + (n + 1) + 1) = (i + 2 + n) by omega]
+          apply reduce_box_in_CAnt!
+      . apply List.chain'_concat_of_not_nil (List.length_pos_iff_ne_nil.mp (by simp [hl_len])) |>.mpr
+        constructor
+        . assumption
+        . convert Rmy
+          trans l[l.length - 1]'(by simp [hl_len])
+          . apply List.getLast_eq_getElem
+          . simp [m, hl_len]
+      . intro h
         have : l[m] ⊧ □^[(m + 1)]φ ⋏ ∼□^[(m + 2)]φ ➝ ◇(□^[(m + 2)]φ ⋏ ◇(∼□^[(m + 2)]φ)) := by
-          apply hM.realize;
-          simp only [Entailment.theory, Set.mem_setOf_eq];
-          simp;
-        replace : l[m] ⊧ ◇(□^[(m + 2)]φ ⋏ ◇(∼□^[(m + 2)]φ)) := this h;
-        obtain ⟨y, hy₁, hy₂⟩ := Satisfies.dia_def.mp this;
-        apply Satisfies.dia_def.mpr;
-        use y;
-        constructor;
-        . assumption;
-        . apply Satisfies.and_def.mpr;
-          constructor;
-          . exact Satisfies.and_def.mp hy₂ |>.1;
-          . apply Satisfies.not_def.mpr;
-            simpa using Satisfies.box_dn.not.mp $ Satisfies.not_def.mp $ Satisfies.dia_dual.mp $ Satisfies.and_def.mp hy₂ |>.2;
-  apply Infinite.of_injective (β := ℕ+) (λ n => ⟨H n |>.choose, H n |>.choose_spec.1⟩);
-  intro i j;
-  simp only [Subtype.mk.injEq];
-  contrapose!;
-  suffices i ≠ j → (H i).choose.length ≠ (H j).choose.length by tauto;
-  rw [H i |>.choose_spec.2.1, H j |>.choose_spec.2.1];
-  simp;
+          apply hM.realize
+          simp only [Entailment.theory, Set.mem_setOf_eq]
+          simp
+        replace : l[m] ⊧ ◇(□^[(m + 2)]φ ⋏ ◇(∼□^[(m + 2)]φ)) := this h
+        obtain ⟨y, hy₁, hy₂⟩ := Satisfies.dia_def.mp this
+        apply Satisfies.dia_def.mpr
+        use y
+        constructor
+        . assumption
+        . apply Satisfies.and_def.mpr
+          constructor
+          . exact Satisfies.and_def.mp hy₂ |>.1
+          . apply Satisfies.not_def.mpr
+            simpa using Satisfies.box_dn.not.mp $ Satisfies.not_def.mp $ Satisfies.dia_dual.mp $ Satisfies.and_def.mp hy₂ |>.2
+  apply Infinite.of_injective (β := ℕ+) (λ n => ⟨H n |>.choose, H n |>.choose_spec.1⟩)
+  intro i j
+  simp only [Subtype.mk.injEq]
+  contrapose!
+  suffices i ≠ j → (H i).choose.length ≠ (H j).choose.length by tauto
+  rw [H i |>.choose_spec.2.1, H j |>.choose_spec.2.1]
+  simp
 
 lemma model_infinitity_of_not_validate_axiomFour {M : Kripke.Model} (hM : M ⊧* Hilbert.KTMk.logic)
   : (∃ φ : Formula ℕ, ¬M ⊧ Axioms.Four φ) → Infinite M := by
-  contrapose!;
-  intro h;
-  apply validate_axiomFour_of_model_finitely hM;
-  simpa using h;
+  contrapose!
+  intro h
+  apply validate_axiomFour_of_model_finitely hM
+  simpa using h
 
 abbrev recessionFrame : Kripke.Frame where
   World := ℕ
@@ -142,44 +142,44 @@ abbrev recessionFrame : Kripke.Frame where
 namespace recessionFrame
 
 instance : recessionFrame.IsKTMk where
-  refl := by tauto;
+  refl := by tauto
   makinson := by
-    intro i;
-    use i + 1;
-    refine ⟨by omega, by omega, by simp_all; omega⟩;
+    intro i
+    use i + 1
+    refine ⟨by omega, by omega, by simp_all; omega⟩
 
 lemma not_transitive : ¬recessionFrame.IsTransitive := by
-  by_contra h_trans;
-  have := @Frame.trans recessionFrame _ 2 1 0;
-  omega;
+  by_contra h_trans
+  have := @Frame.trans recessionFrame _ 2 1 0
+  omega
 
 lemma exists_not_validate_axiomFour : ∃ φ : Formula ℕ, ¬recessionFrame ⊧ Axioms.Four φ := by
-  use (.atom 0);
-  exact not_imp_not.mpr transitive_of_validate_AxiomFour not_transitive;
+  use (.atom 0)
+  exact not_imp_not.mpr transitive_of_validate_AxiomFour not_transitive
 
 end recessionFrame
 
 lemma exists_not_provable_axiomFour : ∃ φ : Formula ℕ, Hilbert.KTMk ⊬ Axioms.Four φ := by
-  obtain ⟨φ, hφ⟩ := recessionFrame.exists_not_validate_axiomFour;
-  use! φ;
-  apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTMk);
-  apply iff_not_validOnFrameClass_exists_frame.mpr;
-  use recessionFrame;
-  constructor;
-  . apply Set.mem_setOf_eq.mpr;
-    infer_instance;
-  . assumption;
+  obtain ⟨φ, hφ⟩ := recessionFrame.exists_not_validate_axiomFour
+  use! φ
+  apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTMk)
+  apply iff_not_validOnFrameClass_exists_frame.mpr
+  use recessionFrame
+  constructor
+  . apply Set.mem_setOf_eq.mpr
+    infer_instance
+  . assumption
 
 lemma no_finite_model_property : ¬(∀ φ, Hilbert.KTMk ⊬ φ → ∃ M : Kripke.Model, Finite M ∧ M ⊧* Hilbert.KTMk.logic ∧ ¬M ⊧ φ)  := by
-  by_contra! hC;
-  obtain ⟨φ, hφ⟩ := exists_not_provable_axiomFour;
-  obtain ⟨M, hM₁, hM₂, hM₃⟩ := @hC (Axioms.Four φ) hφ;
-  apply not_finite_iff_infinite.mpr $ @model_infinitity_of_not_validate_axiomFour M ?_ ⟨φ, hM₃⟩;
-  . assumption;
-  . assumption;
+  by_contra! hC
+  obtain ⟨φ, hφ⟩ := exists_not_provable_axiomFour
+  obtain ⟨M, hM₁, hM₂, hM₃⟩ := @hC (Axioms.Four φ) hφ
+  apply not_finite_iff_infinite.mpr $ @model_infinitity_of_not_validate_axiomFour M ?_ ⟨φ, hM₃⟩
+  . assumption
+  . assumption
 
 example : ∃ φ, Hilbert.KTMk ⊬ φ ∧ (∀ M : Kripke.Model, Finite M → M ⊧* Hilbert.KTMk.logic → M ⊧ φ) := by
-  simpa using no_finite_model_property;
+  simpa using no_finite_model_property
 
 end
 
@@ -194,57 +194,57 @@ open Entailment
 open Kripke
 
 instance : Hilbert.KT ⪱ Hilbert.KTMk := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Mk (.atom 0) (.atom 1));
-    constructor;
-    . exact axiomMk!;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KT);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 3, λ x y => x = y ∨ x + 1 = y⟩, λ w a => match a with | 0 => w ≠ 2 | 1 => w = 0 | _ => True⟩, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Mk (.atom 0) (.atom 1))
+    constructor
+    . exact axiomMk!
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KT)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 3, λ x y => x = y ∨ x + 1 = y⟩, λ w a => match a with | 0 => w ≠ 2 | 1 => w = 0 | _ => True⟩, 0
+      constructor
       . exact { refl := by omega; }
       . suffices ∀ (x : Fin 3), 0 = x ∨ 1 = x → (∀ y, x = y ∨ x + 1 = y → ∀ z, y = z ∨ y + 1 = z → z ≠ 2) → x ≠ 0 ∧ x + 1 ≠ 0 by
-          simpa [Frame.Rel', Satisfies, Semantics.Realize];
-        rintro x (rfl | rfl);
-        . intro h;
-          exfalso;
-          have : (1 : Fin 3) ≠ 2 := h 0 (by omega) 1 (by omega);
-          tauto;
-        . omega;
+          simpa [Frame.Rel', Satisfies, Semantics.Realize]
+        rintro x (rfl | rfl)
+        . intro h
+          exfalso
+          have : (1 : Fin 3) ≠ 2 := h 0 (by omega) 1 (by omega)
+          tauto
+        . omega
 
 instance : Hilbert.KTMk ⪱ Hilbert.S4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    intro φ hφ;
-    rcases hφ with (rfl | rfl | rfl);
-    . simp;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    intro φ hφ
+    rcases hφ with (rfl | rfl | rfl)
+    . simp
+    . simp
     . apply Complete.complete (𝓢 := Hilbert.S4) (𝓜 := FrameClass.S4)
-      intro F hF V x hx;
-      replace hF := Set.mem_setOf_eq.mp hF;
-      replace ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx;
-      apply Satisfies.dia_def.mpr;
-      use x;
-      constructor;
-      . apply F.refl;
-      . apply Satisfies.and_def.mpr;
-        constructor;
-        . intro y Rxy z Ryz;
-          apply hx₁;
-          exact F.trans Rxy Ryz;
-        . apply Satisfies.dia_def.mpr;
-          use x;
-          constructor;
-          . apply F.refl;
-          . assumption;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    obtain ⟨φ, hφ⟩ := Logic.KTMk.Kripke.exists_not_provable_axiomFour;
-    use Axioms.Four φ;
-    constructor;
-    . simp;
-    . assumption;
+      intro F hF V x hx
+      replace hF := Set.mem_setOf_eq.mp hF
+      replace ⟨hx₁, hx₂⟩ := Satisfies.and_def.mp hx
+      apply Satisfies.dia_def.mpr
+      use x
+      constructor
+      . apply F.refl
+      . apply Satisfies.and_def.mpr
+        constructor
+        . intro y Rxy z Ryz
+          apply hx₁
+          exact F.trans Rxy Ryz
+        . apply Satisfies.dia_def.mpr
+          use x
+          constructor
+          . apply F.refl
+          . assumption
+  . apply Entailment.not_weakerThan_iff.mpr
+    obtain ⟨φ, hφ⟩ := Logic.KTMk.Kripke.exists_not_provable_axiomFour
+    use Axioms.Four φ
+    constructor
+    . simp
+    . assumption
 
 end Logic
 

--- a/Foundation/Modal/Kripke/Logic/KTc.lean
+++ b/Foundation/Modal/Kripke/Logic/KTc.lean
@@ -26,49 +26,49 @@ end Kripke
 namespace Hilbert.KTc.Kripke
 
 instance : Sound (Hilbert.KTc) Kripke.FrameClass.KTc := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F F_corefl;
-  exact Kripke.validate_AxiomTc_of_coreflexive (corefl := F_corefl);
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F F_corefl
+  exact Kripke.validate_AxiomTc_of_coreflexive (corefl := F_corefl)
 
 instance : Entailment.Consistent (Hilbert.KTc) := consistent_of_sound_frameclass Kripke.FrameClass.KTc $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 instance : Canonical (Hilbert.KTc) Kripke.FrameClass.KTc := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete (Hilbert.KTc) Kripke.FrameClass.KTc := inferInstance
 
 
 instance : Hilbert.KB4 ⪱ Hilbert.KTc := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KB4 FrameClass.KTc;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Tc (.atom 0));
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KB4 FrameClass.KTc
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Tc (.atom 0))
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KB4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . exact {
           symm := by simp [M],
           trans := by simp [M],
         }
       . suffices ∃ x, (x : M.World) ≠ 0 by
-          simp [M, Semantics.Realize, Satisfies];
-          tauto;
-        use 1;
-        aesop;
+          simp [M, Semantics.Realize, Satisfies]
+          tauto
+        use 1
+        aesop
 
 end Hilbert.KTc.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4.lean
+++ b/Foundation/Modal/Kripke/Logic/S4.lean
@@ -24,15 +24,15 @@ end Kripke
 namespace Hilbert.S4.Kripke
 
 instance : Sound Hilbert.S4 FrameClass.S4 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
 
 instance : Entailment.Consistent Hilbert.S4 := consistent_of_sound_frameclass FrameClass.S4 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.S4 FrameClass.S4 := ⟨by constructor⟩
 
@@ -40,68 +40,68 @@ instance : Complete Hilbert.S4 FrameClass.S4 := inferInstance
 
 open finestFiltrationTransitiveClosureModel in
 instance : Complete Hilbert.S4 FrameClass.finite_S4 := ⟨by
-  intro φ hp;
-  apply Complete.complete (𝓜 := FrameClass.S4);
-  rintro F hF V x;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas;
-  apply filtration FM filterOf (by simp) |>.mpr;
-  apply hp;
+  intro φ hp
+  apply Complete.complete (𝓜 := FrameClass.S4)
+  rintro F hF V x
+  replace hF := Set.mem_setOf_eq.mp hF
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := finestFiltrationTransitiveClosureModel M φ.subformulas
+  apply filtration FM filterOf (by simp) |>.mpr
+  apply hp
   refine {
-    world_finite := by apply FilterEqvQuotient.finite $ by simp;
+    world_finite := by apply FilterEqvQuotient.finite $ by simp
     refl := finestFiltrationTransitiveClosureModel.isReflexive.refl
   }
 ⟩
 
 
 instance : Hilbert.KT ⪱ Hilbert.S4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Four (.atom 0);
-    constructor;
-    . exact axiomFour!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Four (.atom 0)
+    constructor
+    . exact axiomFour!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KT)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
           ⟨Fin 3, λ x y => (x = 0 ∧ y ≠ 2) ∨ (x = 1 ∧ y ≠ 0) ∨ (x = 2 ∧ y = 2)⟩,
           λ w _ => w = 0 ∨ w = 1
-        ⟩;
-      use M, 0;
-      constructor;
-      . exact { refl := by omega };
+        ⟩
+      use M, 0
+      constructor
+      . exact { refl := by omega }
       . suffices (∀ (y : M.World), (0 : M.World) ≺ y → y = 0 ∨ y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ∃ y, x ≺ y ∧ y ≠ 0 ∧ y ≠ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . intro y hy;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . intro y hy
           match y with
-          | 0 => tauto;
-          | 1 => tauto;
-          | 2 => omega;
-        . use 1;
-          constructor;
-          . omega;
-          . use 2;
-            refine ⟨by omega;, by trivial, by trivial⟩;
+          | 0 => tauto
+          | 1 => tauto
+          | 2 => omega
+        . use 1
+          constructor
+          . omega
+          . use 2
+            refine ⟨by omega;, by trivial, by trivial⟩
 
 instance : Hilbert.KD4 ⪱ Hilbert.S4 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
     rintro _ (rfl | rfl | rfl) <;> simp
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.T (.atom 0);
-    constructor;
-    . exact axiomT!;
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.T (.atom 0)
+    constructor
+    . exact axiomT!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 3, λ _ y => y = 1⟩, (λ w _ => w = 1)⟩, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 3, λ _ y => y = 1⟩, (λ w _ => w = 1)⟩, 0
+      constructor
       . refine {
           serial := by simp [Serial],
           trans := by simp
-        };
-      . simp [Semantics.Realize, Satisfies];
+        }
+      . simp [Semantics.Realize, Satisfies]
 
 instance : Hilbert.KD ⪱ Hilbert.S4 := calc
   Hilbert.KD ⪱ Hilbert.KD4 := by infer_instance

--- a/Foundation/Modal/Kripke/Logic/S4H.lean
+++ b/Foundation/Modal/Kripke/Logic/S4H.lean
@@ -32,16 +32,16 @@ namespace Hilbert
 namespace S4H.Kripke
 
 instance : Sound (Hilbert.S4H) FrameClass.S4H := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomH_of_isDetourFree;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomH_of_isDetourFree
 
 instance : Entailment.Consistent (Hilbert.S4H) := consistent_of_sound_frameclass FrameClass.S4H $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical (Hilbert.S4H) FrameClass.S4H := ⟨by constructor⟩
 
@@ -52,30 +52,30 @@ instance : Complete Hilbert.S4H FrameClass.finite_S4H := by sorry
 end S4H.Kripke
 
 instance : Hilbert.Grz ⪱ Hilbert.S4H := by
-  constructor;
+  constructor
   . apply weakerThan_of_subset_frameClass (FrameClass.finite_Grz) (FrameClass.finite_S4H)
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.H (.atom 0);
-    constructor;
-    . simp;
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.H (.atom 0)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.finite_Grz)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => x ≤ y⟩, λ w a => w ≠ 1⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => x ≤ y⟩, λ w a => w ≠ 1⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
         exact {}
       . suffices ∃ x : M, (0 : M) ≺ x ∧ ∃ y, x ≺ y ∧ y ≠ 1 ∧ x = 1 by
-          simpa [Semantics.Realize, Satisfies, M];
-        use 1;
-        constructor;
-        . tauto;
-        . use 2;
-          simp [M];
-          omega;
+          simpa [Semantics.Realize, Satisfies, M]
+        use 1
+        constructor
+        . tauto
+        . use 2
+          simp [M]
+          omega
 
 end Hilbert
 

--- a/Foundation/Modal/Kripke/Logic/S4McK.lean
+++ b/Foundation/Modal/Kripke/Logic/S4McK.lean
@@ -25,16 +25,16 @@ end Kripke
 namespace Hilbert.S4McK.Kripke
 
 instance : Sound Hilbert.S4McK FrameClass.S4McK := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition
 
 instance : Entailment.Consistent Hilbert.S4McK := consistent_of_sound_frameclass FrameClass.S4McK $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
   constructor
 
 instance : Canonical Hilbert.S4McK FrameClass.S4McK := ⟨by constructor⟩
@@ -43,45 +43,45 @@ instance : Complete Hilbert.S4McK FrameClass.S4McK := inferInstance
 
 
 instance : Hilbert.S4 ⪱ Hilbert.S4McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.McK (.atom 0));
-    constructor;
-    . exact axiomMcK!;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.McK (.atom 0))
+    constructor
+    . exact axiomMcK!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . refine {
-          refl := by tauto;
-          trans := by tauto;
+          refl := by tauto
+          trans := by tauto
         }
-      . suffices ∃ x, x ≠ (0 : M.World) by simpa [M, Transitive, Reflexive, Semantics.Realize, Satisfies];
-        use 1;
-        trivial;
+      . suffices ∃ x, x ≠ (0 : M.World) by simpa [M, Transitive, Reflexive, Semantics.Realize, Satisfies]
+        use 1
+        trivial
 
 instance : Hilbert.K4McK ⪱ Hilbert.S4McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4McK)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 1⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => y = 1⟩, λ w _ => w = 1⟩
+      use M, 0
+      constructor
       . exact {
-          trans := by omega;
+          trans := by omega
           mckinsey := by
-            simp only [Fin.isValue, forall_eq, and_self, M];
-            intro;
-            use 1;
+            simp only [Fin.isValue, forall_eq, and_self, M]
+            intro
+            use 1
         }
-      . simp [Semantics.Realize, Satisfies, M];
+      . simp [Semantics.Realize, Satisfies, M]
 
 end Hilbert.S4McK.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point2.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point2.lean
@@ -33,17 +33,17 @@ end Kripke
 namespace Logic.S4Point2.Kripke
 
 instance : Sound Hilbert.S4Point2 FrameClass.S4Point2 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_AxiomPoint2_of_confluent;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_AxiomPoint2_of_confluent
 
 instance : Entailment.Consistent Hilbert.S4Point2 :=
   consistent_of_sound_frameclass FrameClass.S4Point2 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical Hilbert.S4Point2 FrameClass.S4Point2 := ⟨by constructor⟩
 
@@ -57,36 +57,36 @@ open
   Relation
 
 instance : Sound Hilbert.S4Point2 FrameClass.finite_S4Point2 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_AxiomPoint2_of_confluent;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_AxiomPoint2_of_confluent
 
 instance : Complete Hilbert.S4Point2 FrameClass.finite_S4Point2 := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.S4Point2);
-  rintro F hF V r;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let RM := M↾r;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.S4Point2)
+  rintro F hF V r
+  replace hF := Set.mem_setOf_eq.mp hF
+  let M : Kripke.Model := ⟨F, V⟩
+  let RM := M↾r
 
-  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp;
+  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp
 
-  let FRM := finestFiltrationTransitiveClosureModel (M↾r) (φ.subformulas);
-  apply filtration FRM (finestFiltrationTransitiveClosureModel.filterOf (trans := Frame.pointGenerate.isTransitive)) (by simp) |>.mpr;
-  apply hφ;
-  apply Set.mem_setOf_eq.mpr;
+  let FRM := finestFiltrationTransitiveClosureModel (M↾r) (φ.subformulas)
+  apply filtration FRM (finestFiltrationTransitiveClosureModel.filterOf (trans := Frame.pointGenerate.isTransitive)) (by simp) |>.mpr
+  apply hφ
+  apply Set.mem_setOf_eq.mpr
   exact {
-    world_finite := by apply FilterEqvQuotient.finite $ by simp;
+    world_finite := by apply FilterEqvQuotient.finite $ by simp
   }
   /-
 
-  refine ⟨?_, ?_, ?_⟩;
-  . apply isFinite $ by simp;
-  . exact finestFiltrationTransitiveClosureModel.isPreorder (preorder := Frame.pointGenerate.isPreorder);
-  . exact finestFiltrationTransitiveClosureModel.rooted_isPiecewiseStronglyConvergent;
+  refine ⟨?_, ?_, ?_⟩
+  . apply isFinite $ by simp
+  . exact finestFiltrationTransitiveClosureModel.isPreorder (preorder := Frame.pointGenerate.isPreorder)
+  . exact finestFiltrationTransitiveClosureModel.rooted_isPiecewiseStronglyConvergent
   -/
 ⟩
 
@@ -94,59 +94,59 @@ end FFP
 
 
 instance : Hilbert.S4 ⪱ Hilbert.S4Point2 := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
     use Axioms.Point2 (.atom 0)
-    constructor;
-    . exact axiomPoint2!;
+    constructor
+    . exact axiomPoint2!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0) ∨ (x = y) ⟩, λ w _ => w = 1⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq]; refine { refl := by omega, trans := by omega; };
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0) ∨ (x = y) ⟩, λ w _ => w = 1⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]; refine { refl := by omega, trans := by omega; }
       . suffices ∃ x, (0 : M.World) ≺ x ∧ (∀ y, x ≺ y → y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        refine ⟨by omega, ?_, ?_⟩;
-        . intro y;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        refine ⟨by omega, ?_, ?_⟩
+        . intro y
           match y with
-          | 0 => omega;
-          | 1 => tauto;
-          | 2 => omega;
-        . use 2;
-          constructor;
-          . omega;
-          . omega;
+          | 0 => omega
+          | 1 => tauto
+          | 2 => omega
+        . use 2
+          constructor
+          . omega
+          . omega
 
 instance : Hilbert.K4Point2 ⪱ Hilbert.S4Point2 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.K4Point2) (FrameClass.S4Point2);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Point2 (.atom 0));
-    constructor;
-    . exact axiomPoint2!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.K4Point2) (FrameClass.S4Point2)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Point2 (.atom 0))
+    constructor
+    . exact axiomPoint2!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4Point2)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 2, λ x y => x < y⟩,
         λ w a => False
-      ⟩;
-      use M, 0;
-      constructor;
-      . simp only [Set.mem_setOf_eq];
-        refine { p_convergent := by simp [M, PiecewiseConvergent ]; omega; };
+      ⟩
+      use M, 0
+      constructor
+      . simp only [Set.mem_setOf_eq]
+        refine { p_convergent := by simp [M, PiecewiseConvergent ]; omega; }
       . suffices ∃ x, (0 : M.World) ≺ x ∧ (∀ y, ¬x ≺ y) ∧ ∃ x, (0 : M.World) ≺ x by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        refine ⟨?_, ?_, ?_⟩;
-        . omega;
-        . omega;
-        . use 1; omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        refine ⟨?_, ?_, ?_⟩
+        . omega
+        . omega
+        . use 1; omega
 
 end Logic.S4Point2.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point2McK.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point2McK.lean
@@ -22,18 +22,18 @@ end Kripke
 namespace Hilbert.S4Point2McK.Kripke
 
 instance : Sound (Hilbert.S4Point2McK) FrameClass.S4Point2McK := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition;
-  . exact validate_AxiomPoint2_of_confluent;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition
+  . exact validate_AxiomPoint2_of_confluent
 
 instance : Entailment.Consistent Hilbert.S4Point2McK :=
   consistent_of_sound_frameclass FrameClass.S4Point2McK $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical (Hilbert.S4Point2McK) FrameClass.S4Point2McK := ⟨by constructor⟩
 
@@ -41,58 +41,58 @@ instance : Complete (Hilbert.S4Point2McK) FrameClass.S4Point2McK := inferInstanc
 
 
 instance : Hilbert.S4McK ⪱ Hilbert.S4Point2McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Point2 (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4McK);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => x = 0 ∨ x = y⟩, λ w a => w = 1⟩;
-      use M, 0;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Point2 (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4McK)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => x = 0 ∨ x = y⟩, λ w a => w = 1⟩
+      use M, 0
       constructor
       . exact {
-          refl := by omega;
-          trans := by omega;
+          refl := by omega
+          trans := by omega
           mckinsey := by
-            intro x;
-            simp only [M];
+            intro x
+            simp only [M]
             match x with
-            | 0 => use 1; tauto;
-            | 1 => use 1; tauto;
-            | 2 => use 2; tauto;
+            | 0 => use 1; tauto
+            | 1 => use 1; tauto
+            | 2 => use 2; tauto
         }
       . suffices ∃ x, (0 : M.World) ≺ x ∧ (∀ y, x ≺ y → y = 1) ∧ ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        refine ⟨?_, ?_, ?_⟩;
-        . omega;
-        . simp [M];
-          omega;
-        . use 2;
-          omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        refine ⟨?_, ?_, ?_⟩
+        . omega
+        . simp [M]
+          omega
+        . use 2
+          omega
 
 instance : Hilbert.S4Point2 ⪱ Hilbert.S4Point2McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop
+  . apply Entailment.not_weakerThan_iff.mpr
     use (Axioms.McK (.atom 0))
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . refine {
-          refl := by tauto;
-          trans := by tauto;
-          ps_convergent := by tauto;
+          refl := by tauto
+          trans := by tauto
+          ps_convergent := by tauto
         }
-      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        trivial;
+      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        trivial
 
 end Hilbert.S4Point2McK.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point3.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point3.lean
@@ -37,29 +37,29 @@ end Kripke
 namespace Logic.S4Point3.Kripke
 
 instance : Sound Hilbert.S4Point3 FrameClass.S4Point3 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected
 
 instance : Entailment.Consistent Hilbert.S4Point3 :=
   consistent_of_sound_frameclass FrameClass.S4Point3 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical Hilbert.S4Point3 FrameClass.S4Point3 := ⟨by constructor⟩
 
 instance : Complete Hilbert.S4Point3 FrameClass.S4Point3 := inferInstance
 
 instance : Complete Hilbert.S4Point3 { F : Frame | F.IsLinearPreorder } := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.S4Point3);
-  intro F hF V r;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply Model.pointGenerate.modal_equivalent_at_root (M := ⟨F, V⟩) (r := r) |>.mp;
-  apply hφ;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.S4Point3)
+  intro F hF V r
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply Model.pointGenerate.modal_equivalent_at_root (M := ⟨F, V⟩) (r := r) |>.mp
+  apply hφ
   exact {}
 ⟩
 
@@ -70,26 +70,26 @@ open
   Relation
 
 instance : Sound Hilbert.S4Point3 FrameClass.finite_S4Point3 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected
 
 instance : Complete Hilbert.S4Point3 FrameClass.finite_S4Point3 := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.S4Point3);
-  rintro F hF V r;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let RM := M↾r;
-  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.S4Point3)
+  rintro F hF V r
+  replace hF := Set.mem_setOf_eq.mp hF
+  let M : Kripke.Model := ⟨F, V⟩
+  let RM := M↾r
+  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp
 
-  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas);
-  apply filtration FRM (finestFiltrationTransitiveClosureModel.filterOf (trans := Frame.pointGenerate.isTransitive)) (by simp) |>.mpr;
-  apply hφ;
-  apply Set.mem_setOf_eq.mpr;
+  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas)
+  apply filtration FRM (finestFiltrationTransitiveClosureModel.filterOf (trans := Frame.pointGenerate.isTransitive)) (by simp) |>.mpr
+  apply hφ
+  apply Set.mem_setOf_eq.mpr
   refine { world_finite := FilterEqvQuotient.finite $ by simp; }
 ⟩
 
@@ -97,73 +97,73 @@ end FFP
 
 
 instance : Hilbert.S4Point2 ⪱ Hilbert.S4Point3 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point2) (FrameClass.S4Point3);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Point3 (.atom 0) (.atom 1);
-    constructor;
-    . exact axiomPoint3!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point2) (FrameClass.S4Point3)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Point3 (.atom 0) (.atom 1)
+    constructor
+    . exact axiomPoint3!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4Point2)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 4, λ x y => ¬(x = 1 ∧ y = 2) ∧ ¬(x = 2 ∧ y = 1) ∧ (x ≤ y)⟩,
         λ w a => (a = 0 ∧ (w = 1 ∨ w = 3)) ∨ (a = 1 ∧ (w = 2 ∨ w = 3))
-      ⟩;
-      use M, 0;
-      constructor;
+      ⟩
+      use M, 0
+      constructor
       . refine {
           refl := by omega,
           trans := by omega,
           ps_convergent := by intro x y z Rxy Rxz; use 3; omega
-        };
-      . apply Kripke.Satisfies.or_def.not.mpr;
-        push_neg;
-        constructor;
-        . apply Kripke.Satisfies.box_def.not.mpr;
-          push_neg;
-          use 1;
-          simp [Satisfies, Semantics.Realize, M];
-          constructor <;> omega;
-        . apply Kripke.Satisfies.box_def.not.mpr;
-          push_neg;
-          use 2;
-          simp [Satisfies, Semantics.Realize, M];
-          constructor <;> omega;
+        }
+      . apply Kripke.Satisfies.or_def.not.mpr
+        push_neg
+        constructor
+        . apply Kripke.Satisfies.box_def.not.mpr
+          push_neg
+          use 1
+          simp [Satisfies, Semantics.Realize, M]
+          constructor <;> omega
+        . apply Kripke.Satisfies.box_def.not.mpr
+          push_neg
+          use 2
+          simp [Satisfies, Semantics.Realize, M]
+          constructor <;> omega
 
 instance : Hilbert.S4 ⪱ Hilbert.S4Point3 := calc
   Hilbert.S4 ⪱ Hilbert.S4Point2 := by infer_instance
   _          ⪱ Hilbert.S4Point3 := by infer_instance
 
 instance : Hilbert.K4Point3 ⪱ Hilbert.S4Point3 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.K4Point3) (FrameClass.S4Point3);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Point3 (.atom 0) (.atom 1));
-    constructor;
-    . exact axiomPoint3!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.K4Point3) (FrameClass.S4Point3)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Point3 (.atom 0) (.atom 1))
+    constructor
+    . exact axiomPoint3!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.K4Point3)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 2, λ x y => x < y⟩,
         λ w a => False
-      ⟩;
-      use M, 0;
-      constructor;
+      ⟩
+      use M, 0
+      constructor
       . refine {
           trans := by omega,
           p_connected := by simp [M, PiecewiseConnected]; omega
-        };
+        }
       . suffices ∃ x, (0 : M.World) ≺ x ∧ (∀ y, ¬x ≺ y) ∧ ∃ x, (0 : M.World) ≺ x ∧ ∀ y, ¬x ≺ y by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        refine ⟨?_, ?_, ⟨1, ?_, ?_⟩⟩;
-        repeat omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        refine ⟨?_, ?_, ⟨1, ?_, ?_⟩⟩
+        repeat omega
 
 end Logic.S4Point3.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point3McK.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point3McK.lean
@@ -24,18 +24,18 @@ end Kripke
 namespace Hilbert.S4Point3McK.Kripke
 
 instance : Sound (Hilbert.S4Point3McK) FrameClass.S4Point3McK := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition;
-  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition
+  . exact validate_axiomPoint3_of_isPiecewiseStronglyConnected
 
 instance : Entailment.Consistent Hilbert.S4Point3McK :=
   consistent_of_sound_frameclass FrameClass.S4Point3McK $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical (Hilbert.S4Point3McK) FrameClass.S4Point3McK := ⟨by constructor⟩
 
@@ -43,64 +43,64 @@ instance : Complete (Hilbert.S4Point3McK) FrameClass.S4Point3McK := inferInstanc
 
 
 instance : Hilbert.S4Point2McK ⪱ Hilbert.S4Point3McK := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point2McK FrameClass.S4Point3McK;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Point3 (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2McK);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point2McK FrameClass.S4Point3McK
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Point3 (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point2McK)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 4, λ x y => x = 0 ∨ y = 3 ∨ x = y⟩,
         λ w a => match a with | 0 => w = 1 ∨ w = 3 | 1 => w = 2 ∨ w = 3 | _ => False
-      ⟩;
-      use M, 0;
+      ⟩
+      use M, 0
       constructor
       . refine {
           refl := by omega,
           trans := by omega,
           mckinsey := by
-            intro x;
-            use 3;
-            simp [Frame.Rel', M];
+            intro x
+            use 3
+            simp [Frame.Rel', M]
           ps_convergent := by
-            intro x y z Rxy Ryz;
-            use 3;
-            tauto;
+            intro x y z Rxy Ryz
+            use 3
+            tauto
         }
       . suffices
           (∃ x, (0 : M) ≺ x ∧ (∀ (w : M), x ≺ w → w = 1 ∨ w = 3) ∧ x ≠ 2 ∧ x ≠ 3) ∧
           (∃ x, (0 : M) ≺ x ∧ (∀ (w : M), x ≺ w → w = 2 ∨ w = 3) ∧ x ≠ 1 ∧ x ≠ 3) by
-          simp [M, Semantics.Realize, Satisfies];
-          tauto;
-        constructor;
-        . use 1; simp only [M]; refine ⟨?_, ?_, ?_, ?_⟩ <;> omega;
-        . use 2; simp only [M]; refine ⟨?_, ?_, ?_, ?_⟩ <;> omega;
+          simp [M, Semantics.Realize, Satisfies]
+          tauto
+        constructor
+        . use 1; simp only [M]; refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
+        . use 2; simp only [M]; refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
 
 instance : Hilbert.S4Point3 ⪱ Hilbert.S4Point3McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop
+  . apply Entailment.not_weakerThan_iff.mpr
     use (Axioms.McK (.atom 0))
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . exact {
           refl := by tauto,
           trans := by tauto,
-          ps_connected := by tauto;
+          ps_connected := by tauto
         }
-      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        trivial;
+      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        trivial
 
 end Hilbert.S4Point3McK.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point4.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point4.lean
@@ -24,17 +24,17 @@ end Kripke
 namespace Hilbert.S4Point4.Kripke
 
 instance : Sound Hilbert.S4Point4 FrameClass.S4Point4 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomPoint4_of_satisfiesSobocinskiCondition;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomPoint4_of_satisfiesSobocinskiCondition
 
 instance : Entailment.Consistent Hilbert.S4Point4 :=
   consistent_of_sound_frameclass FrameClass.S4Point4 $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical Hilbert.S4Point4 FrameClass.S4Point4 := ⟨by constructor⟩
 
@@ -42,28 +42,28 @@ instance : Complete Hilbert.S4Point4 FrameClass.S4Point4 := inferInstance
 
 
 instance : Hilbert.S4Point3 ⪱ Hilbert.S4Point4 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point3) (FrameClass.S4Point4);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Point4 (.atom 0);
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point3) (FrameClass.S4Point4)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Point4 (.atom 0)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4Point3)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
       let M : Model := ⟨
         ⟨Fin 3, λ x y => x ≤ y⟩,
         λ w a => w ≠ 1
-      ⟩;
-      use M, 0;
-      constructor;
-      . exact {};
+      ⟩
+      use M, 0
+      constructor
+      . exact {}
       . suffices ∃ x : M.World, (0 : M.World) ≺ x ∧ ¬x ≺ 1 ∧ (0 : M.World) ≺ 1 by
-          simpa [Semantics.Realize, Satisfies, M];
-        use 2;
-        omega;
+          simpa [Semantics.Realize, Satisfies, M]
+        use 2
+        omega
 
 end Hilbert.S4Point4.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S4Point4McK.lean
+++ b/Foundation/Modal/Kripke/Logic/S4Point4McK.lean
@@ -25,18 +25,18 @@ end Kripke
 namespace Hilbert.S4Point4McK.Kripke
 
 instance : Sound Hilbert.S4Point4McK FrameClass.S4Point4McK := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFour_of_transitive;
-  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition;
-  . exact validate_axiomPoint4_of_satisfiesSobocinskiCondition;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl | rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFour_of_transitive
+  . exact validate_axiomMcK_of_satisfiesMcKinseyCondition
+  . exact validate_axiomPoint4_of_satisfiesSobocinskiCondition
 
 instance : Entailment.Consistent Hilbert.S4Point4McK :=
   consistent_of_sound_frameclass FrameClass.S4Point4McK $ by
-    use whitepoint;
-    constructor;
+    use whitepoint
+    constructor
 
 instance : Canonical Hilbert.S4Point4McK FrameClass.S4Point4McK := ⟨by constructor⟩
 
@@ -44,54 +44,54 @@ instance : Complete Hilbert.S4Point4McK FrameClass.S4Point4McK := inferInstance
 
 
 instance : Hilbert.S4Point3McK ⪱ Hilbert.S4Point4McK := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point3McK FrameClass.S4Point4McK;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Point4 (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3McK);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => x ≤ y⟩, λ w a => w ≠ 1⟩;
-      use M, 0;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point3McK FrameClass.S4Point4McK
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Point4 (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point3McK)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => x ≤ y⟩, λ w a => w ≠ 1⟩
+      use M, 0
       constructor
       . exact {
           refl := by omega,
           trans := by omega,
           mckinsey := by
-            simp only [ne_eq, M];
-            intro x;
-            use 2;
-            constructor <;> omega;
+            simp only [ne_eq, M]
+            intro x
+            use 2
+            constructor <;> omega
         }
       . suffices ∃ x, (0 : M) ≺ x ∧ ¬x ≺ 1 ∧ (0 : M) ≺ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        use 2;
-        omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        use 2
+        omega
 
 instance : Hilbert.S4Point4 ⪱ Hilbert.S4Point4McK := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; intro φ; aesop
+  . apply Entailment.not_weakerThan_iff.mpr
     use (Axioms.McK (.atom 0))
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point4);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩;
-      use M, 0;
-      constructor;
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point4)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 0⟩
+      use M, 0
+      constructor
       . exact {
           refl := by tauto,
           trans := by tauto,
           sobocinski := by tauto
         }
-      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies];
-        use 1;
-        trivial;
+      . suffices ∃ x : M, x ≠ 0 by simpa [M, Semantics.Realize, Satisfies]
+        use 1
+        trivial
 
 end Hilbert.S4Point4McK.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/S5.lean
+++ b/Foundation/Modal/Kripke/Logic/S5.lean
@@ -17,7 +17,7 @@ namespace Kripke
 variable {F : Frame}
 
 class Frame.IsUniversal (F : Frame) extends _root_.IsUniversal F.Rel
-@[simp] lemma universal [F.IsUniversal] : ∀ {x y : F.World}, x ≺ y := by apply IsUniversal.universal;
+@[simp] lemma universal [F.IsUniversal] : ∀ {x y : F.World}, x ≺ y := by apply IsUniversal.universal
 
 instance [F.IsUniversal] : F.IsEuclidean := by simp
 instance [F.IsUniversal] : F.IsPreorder where
@@ -36,24 +36,24 @@ protected abbrev FrameClass.universal : FrameClass := { F | F.IsUniversal }
 
 instance Frame.pointGenerate.isUniversal (F : Frame) (r : F.World) (_ : F.IsS5) : (F↾r).IsUniversal where
   universal := by
-    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩;
-    . simp;
-    . exact hy.unwrap;
-    . suffices x ≺ y by simpa;
-      exact IsSymm.symm _ _ hx.unwrap;
-    . suffices x ≺ y by simpa;
-      apply F.eucl hx.unwrap hy.unwrap ;
+    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩
+    . simp
+    . exact hy.unwrap
+    . suffices x ≺ y by simpa
+      exact IsSymm.symm _ _ hx.unwrap
+    . suffices x ≺ y by simpa
+      apply F.eucl hx.unwrap hy.unwrap 
 
 lemma iff_validOnUniversalFrameClass_validOnReflexiveEuclideanFrameClass : FrameClass.universal ⊧ φ ↔ FrameClass.S5 ⊧ φ := by
-  constructor;
-  . rintro h F hF V r;
-    apply @Model.pointGenerate.modal_equivalent_at_root _ _ |>.mp;
-    apply h;
-    apply Frame.pointGenerate.isUniversal F r hF;
-  . rintro h F F_univ;
-    apply h;
-    simp_all;
-    constructor;
+  constructor
+  . rintro h F hF V r
+    apply @Model.pointGenerate.modal_equivalent_at_root _ _ |>.mp
+    apply h
+    apply Frame.pointGenerate.isUniversal F r hF
+  . rintro h F F_univ
+    apply h
+    simp_all
+    constructor
 
 end Kripke
 
@@ -61,31 +61,31 @@ end Kripke
 namespace Hilbert.S5.Kripke
 
 instance : Sound Hilbert.S5 FrameClass.S5 := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomFive_of_euclidean;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomFive_of_euclidean
 
 instance : Sound Hilbert.S5 FrameClass.universal := ⟨by
-  intro φ hF;
-  apply iff_validOnUniversalFrameClass_validOnReflexiveEuclideanFrameClass.mpr;
-  exact Sound.sound (𝓜 := FrameClass.S5) hF;
+  intro φ hF
+  apply iff_validOnUniversalFrameClass_validOnReflexiveEuclideanFrameClass.mpr
+  exact Sound.sound (𝓜 := FrameClass.S5) hF
 ⟩
 
 instance : Entailment.Consistent Hilbert.S5 := consistent_of_sound_frameclass FrameClass.S5 $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.S5 FrameClass.S5 := ⟨by constructor⟩
 
 instance : Complete Hilbert.S5 FrameClass.S5 := inferInstance
 
 instance : Complete Hilbert.S5 FrameClass.universal := ⟨by
-  intro φ hF;
-  apply Complete.complete (𝓜 := FrameClass.S5);
-  apply iff_validOnUniversalFrameClass_validOnReflexiveEuclideanFrameClass.mp;
-  exact hF;
+  intro φ hF
+  apply Complete.complete (𝓜 := FrameClass.S5)
+  apply iff_validOnUniversalFrameClass_validOnReflexiveEuclideanFrameClass.mp
+  exact hF
 ⟩
 
 end Hilbert.S5.Kripke
@@ -99,98 +99,98 @@ open Kripke
 
 
 instance : Hilbert.KTB ⪱ Hilbert.S5 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KTB) (FrameClass.S5);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Five (.atom 0);
-    constructor;
-    . exact axiomFive!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KTB) (FrameClass.S5)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Five (.atom 0)
+    constructor
+    . exact axiomFive!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KTB)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0) ∨ (x = 1 ∧ y ≠ 2) ∨ (x = 2 ∧ y ≠ 1)⟩, λ x _ => x = 1⟩;
-      use M, 0;
-      constructor;
-      . refine { refl := by omega, symm := by omega };
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 3, λ x y => (x = 0) ∨ (x = 1 ∧ y ≠ 2) ∨ (x = 2 ∧ y ≠ 1)⟩, λ x _ => x = 1⟩
+      use M, 0
+      constructor
+      . refine { refl := by omega, symm := by omega }
       . suffices (0 : M.World) ≺ 1 ∧ ∃ x : M.World, (0 : M.World) ≺ x ∧ ¬x ≺ 1 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . omega;
-        . use 2;
-          constructor <;> omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . omega
+        . use 2
+          constructor <;> omega
 
 instance : Hilbert.KD45 ⪱ Hilbert.S5 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KD45) (FrameClass.S5);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . exact axiomT!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KD45) (FrameClass.S5)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . exact axiomT!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KD45)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 1)⟩, λ x _ => x = 1⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 1)⟩, λ x _ => x = 1⟩
+      use M, 0
+      constructor
       . refine {
           serial := by intro x; use 1; omega;,
           trans := by omega,
           reucl := by simp [RightEuclidean]; omega
         }
-      . simp [Semantics.Realize, Satisfies, M];
-        tauto;
+      . simp [Semantics.Realize, Satisfies, M]
+        tauto
 
 instance : Hilbert.KB4 ⪱ Hilbert.S5 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KB4) (FrameClass.S5);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . exact axiomT!;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.KB4) (FrameClass.S5)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . exact axiomT!
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KB4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 1, λ x y => False⟩, λ x _ => False⟩, 0;
-      constructor;
-      . refine { symm := by tauto, trans := by tauto };
-      . simp [Semantics.Realize, Satisfies];
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 1, λ x y => False⟩, λ x _ => False⟩, 0
+      constructor
+      . refine { symm := by tauto, trans := by tauto }
+      . simp [Semantics.Realize, Satisfies]
 
 instance : Hilbert.S4Point4 ⪱ Hilbert.S5 := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point4) (FrameClass.S5);
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Five (.atom 0);
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass (FrameClass.S4Point4) (FrameClass.S5)
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Five (.atom 0)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.S4Point4)
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w a => w = 0⟩;
-      use M, 0;
-      constructor;
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, λ w a => w = 0⟩
+      use M, 0
+      constructor
       . refine {
           sobocinski := by
-            intro x y z _ _;
+            intro x y z _ _
             match x, y with
-            | 0, 0 => contradiction;
-            | 0, 1 => omega;
-            | 1, 0 => contradiction;
-            | 1, 1 => contradiction;
-        };
+            | 0, 0 => contradiction
+            | 0, 1 => omega
+            | 1, 0 => contradiction
+            | 1, 1 => contradiction
+        }
       . suffices (0 : M.World) ≺ 0 ∧ ∃ x : M.World, (0 : M) ≺ x ∧ ¬x ≺ 0 by
-          simpa [M, Semantics.Realize, Satisfies];
-        constructor;
-        . omega;
-        . use 1;
-          constructor <;> omega;
+          simpa [M, Semantics.Realize, Satisfies]
+        constructor
+        . omega
+        . use 1
+          constructor <;> omega
 
 instance : Hilbert.S4 ⪱ Hilbert.S5 := calc
   Hilbert.S4 ⪱ Hilbert.S4Point2 := by infer_instance

--- a/Foundation/Modal/Kripke/Logic/S5Grz.lean
+++ b/Foundation/Modal/Kripke/Logic/S5Grz.lean
@@ -10,44 +10,44 @@ open Kripke
 open Hilbert.Kripke
 
 instance : Hilbert.S5 ⪱ Hilbert.S5Grz := by
-  constructor;
+  constructor
   . exact Hilbert.Normal.weakerThan_of_subset_axioms (by simp)
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Grz (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.universal);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 1⟩, 0;
-      constructor;
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Grz (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.universal)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => True⟩, λ w _ => w = 1⟩, 0
+      constructor
       . exact { universal := by tauto }
-      . simp [Semantics.Realize, Satisfies];
-        tauto;
+      . simp [Semantics.Realize, Satisfies]
+        tauto
 
 instance : Hilbert.Grz ⪱ Hilbert.S5Grz := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro _ (rfl | rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro _ (rfl | rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
     use Axioms.Five (.atom 0)
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_Grz);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩;
-      use M, 0;
-      constructor;
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_Grz)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩
+      use M, 0
+      constructor
       . refine {
           refl := by omega,
-          trans := by omega;
-          antisymm := by simp [M]; omega;
-        };
+          trans := by omega
+          antisymm := by simp [M]; omega
+        }
       . suffices (0 : M.World) ≺ 0 ∧ ∃ x, (0 : M.World) ≺ x ∧ ¬x ≺ 0 by
-          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M];
-        constructor;
-        . omega;
-        . use 1;
-          constructor <;> omega;
+          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M]
+        constructor
+        . omega
+        . use 1
+          constructor <;> omega
 
 instance : Hilbert.S4 ⪱ Hilbert.Triv := calc
   Hilbert.S4 ⪱ Hilbert.S5    := by infer_instance
@@ -56,10 +56,10 @@ instance : Hilbert.S4 ⪱ Hilbert.Triv := calc
 
 instance : Sound Hilbert.S5Grz FrameClass.finite_Triv := by
   suffices Hilbert.S5Grz ≊ Hilbert.Triv by
-    constructor;
-    intro φ h;
-    apply Sound.sound $ Entailment.Equiv.iff.mp this φ |>.mp h;
-  infer_instance;
+    constructor
+    intro φ h
+    apply Sound.sound $ Entailment.Equiv.iff.mp this φ |>.mp h
+  infer_instance
 
 instance : Modal.S5 ⪱ Modal.S5Grz := inferInstance
 

--- a/Foundation/Modal/Kripke/Logic/Triv.lean
+++ b/Foundation/Modal/Kripke/Logic/Triv.lean
@@ -21,7 +21,7 @@ instance [F.IsTriv] : F.IsS4Point4McK where
 protected class Frame.IsFiniteTriv (F : Frame) extends F.IsFinite, F.IsTriv
 instance [F.IsFiniteTriv] : F.IsFiniteGrzPoint3 where
 
-@[simp] lemma Frame.equality [F.IsTriv] {x y : F} : x ≺ y ↔ x = y := by apply _root_.equality;
+@[simp] lemma Frame.equality [F.IsTriv] {x y : F} : x ≺ y ↔ x = y := by apply _root_.equality
 
 protected abbrev FrameClass.Triv : FrameClass := { F | F.IsTriv }
 protected abbrev FrameClass.finite_Triv : FrameClass := { F | F.IsFiniteTriv }
@@ -33,22 +33,22 @@ end Kripke
 namespace Hilbert.Triv.Kripke
 
 instance : Sound Hilbert.Triv Kripke.FrameClass.Triv := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomTc_of_coreflexive;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomTc_of_coreflexive
 
 instance : Sound Hilbert.Triv Kripke.FrameClass.finite_Triv := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  rintro _ (rfl | rfl) F ⟨_, _⟩;
-  . exact validate_AxiomT_of_reflexive;
-  . exact validate_AxiomTc_of_coreflexive;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  rintro _ (rfl | rfl) F ⟨_, _⟩
+  . exact validate_AxiomT_of_reflexive
+  . exact validate_AxiomTc_of_coreflexive
 
 instance : Entailment.Consistent Hilbert.Triv := consistent_of_sound_frameclass Kripke.FrameClass.Triv $ by
-  use whitepoint;
-  constructor;
+  use whitepoint
+  constructor
 
 instance : Canonical Hilbert.Triv Kripke.FrameClass.Triv := ⟨by constructor⟩
 
@@ -58,26 +58,26 @@ section FFP
 
 open Relation in
 instance : Complete Hilbert.Triv Kripke.FrameClass.finite_Triv := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := Kripke.FrameClass.Triv);
-  intro F F_eq V r;
-  replace F_eq := Set.mem_setOf_eq.mp F_eq;
-  apply Model.pointGenerate.modal_equivalent_at_root (r := r) |>.mp;
-  apply hφ;
+  intro φ hφ
+  apply Complete.complete (𝓜 := Kripke.FrameClass.Triv)
+  intro F F_eq V r
+  replace F_eq := Set.mem_setOf_eq.mp F_eq
+  apply Model.pointGenerate.modal_equivalent_at_root (r := r) |>.mp
+  apply hφ
   exact {
     world_finite := by
-      apply finite_iff_exists_equiv_fin.mpr;
-      use 1;
-      constructor;
-      trans Unit;
+      apply finite_iff_exists_equiv_fin.mpr
+      use 1
+      constructor
+      trans Unit
       . refine ⟨λ _ => (), λ _ => ⟨r, by tauto⟩, ?_, ?_⟩
-        . simp only [Function.LeftInverse, Subtype.forall, Subtype.mk.injEq, forall_eq_or_imp, true_and];
-          intro x Rrx;
+        . simp only [Function.LeftInverse, Subtype.forall, Subtype.mk.injEq, forall_eq_or_imp, true_and]
+          intro x Rrx
           exact Frame.equality.mp $ Rrx.unwrap
-        . simp [Function.RightInverse, Function.LeftInverse];
-      . exact finOneEquiv.symm;
-    refl := by simp;
-    corefl := by rintro ⟨x⟩ ⟨y⟩ Rxy; simpa [Subtype.mk.injEq] using Rxy;
+        . simp [Function.RightInverse, Function.LeftInverse]
+      . exact finOneEquiv.symm
+    refl := by simp
+    corefl := by rintro ⟨x⟩ ⟨y⟩ Rxy; simpa [Subtype.mk.injEq] using Rxy
   }
 ⟩
 
@@ -85,82 +85,82 @@ end FFP
 
 
 instance : Hilbert.KTc ⪱ Hilbert.Triv := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTc);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => False⟩, λ w _ => False⟩, 0;
-      constructor;
-      . refine ⟨by tauto⟩;
-      . simp [Satisfies, Semantics.Realize];
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTc)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => False⟩, λ w _ => False⟩, 0
+      constructor
+      . refine ⟨by tauto⟩
+      . simp [Satisfies, Semantics.Realize]
 
 instance : Hilbert.GrzPoint3 ⪱ Hilbert.Triv := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GrzPoint3 FrameClass.finite_Triv;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Tc (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GrzPoint3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩;
-      use M, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GrzPoint3 FrameClass.finite_Triv
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Tc (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GrzPoint3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩
+      use M, 0
+      constructor
       . exact {}
       . suffices (0 : M) = 0 ∧ ∃ x, (0 : M.World) ≺ x ∧ x ≠ 0 by
-          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M];
-        constructor;
-        . tauto;
-        . use 1;
-          constructor;
-          . omega;
-          . trivial;
+          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M]
+        constructor
+        . tauto
+        . use 1
+          constructor
+          . omega
+          . trivial
 
 instance : Hilbert.S4Point4McK ⪱ Hilbert.Triv := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point4McK FrameClass.Triv;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Tc (.atom 0);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point4McK);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩;
-      use M, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.S4Point4McK FrameClass.Triv
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Tc (.atom 0)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.S4Point4McK)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 2, λ x y => x ≤ y⟩, (λ w _ => w = 0)⟩
+      use M, 0
+      constructor
       . exact {
           refl := by tauto
           sobocinski := by
-            intro x y z _ Rxy Ryz;
+            intro x y z _ Rxy Ryz
             match x, y, z with
-            | 0, 0, _ => contradiction;
-            | 1, 1, _ => contradiction;
+            | 0, 0, _ => contradiction
+            | 1, 1, _ => contradiction
             | 0, 1, _ => omega
-            | 1, 0, _ => omega;
+            | 1, 0, _ => omega
           mckinsey := by
-            intro x;
-            use 1;
-            simp [M];
-            constructor <;> omega;
+            intro x
+            use 1
+            simp [M]
+            constructor <;> omega
         }
       . suffices (0 : M) = 0 ∧ ∃ x : M, (0 : M) ≺ x ∧ ¬x = 0 by
-          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M];
-        constructor;
-        . tauto;
-        . use 1;
-          constructor;
-          . omega;
-          . trivial;
+          simpa [Semantics.Realize, Satisfies, ValidOnFrame, M]
+        constructor
+        . tauto
+        . use 1
+          constructor
+          . omega
+          . trivial
 
 end Hilbert.Triv.Kripke
 

--- a/Foundation/Modal/Kripke/Logic/Ver.lean
+++ b/Foundation/Modal/Kripke/Logic/Ver.lean
@@ -20,7 +20,7 @@ protected class Frame.IsFiniteVer (F : Frame) extends F.IsFinite, F.IsVer
 
 instance [F.IsFiniteVer] : F.IsFiniteGLPoint3 where
 
-@[simp] lemma Frame.isolated [F.IsVer] {x y : F} : ¬x ≺ y := by apply _root_.isolated;
+@[simp] lemma Frame.isolated [F.IsVer] {x y : F} : ¬x ≺ y := by apply _root_.isolated
 
 protected abbrev FrameClass.Ver : FrameClass := { F | F.IsVer }
 protected abbrev FrameClass.finite_Ver : FrameClass := { F | F.IsFiniteVer }
@@ -31,94 +31,94 @@ end Kripke
 namespace Hilbert.Ver.Kripke
 
 instance : Sound Hilbert.Ver FrameClass.Ver := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
   rintro F hF
-  simp_all only [Set.mem_setOf_eq];
-  exact validate_AxiomVer_of_isIsolated;
+  simp_all only [Set.mem_setOf_eq]
+  exact validate_AxiomVer_of_isIsolated
 
 instance : Sound (Hilbert.Ver) Kripke.FrameClass.finite_Ver := instSound_of_validates_axioms $ by
-  apply FrameClass.validates_with_AxiomK_of_validates;
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_eq];
-  rintro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  exact validate_AxiomVer_of_isIsolated;
+  apply FrameClass.validates_with_AxiomK_of_validates
+  constructor
+  simp only [Set.mem_singleton_iff, forall_eq]
+  rintro F hF
+  simp_all only [Set.mem_setOf_eq]
+  exact validate_AxiomVer_of_isIsolated
 
 instance : Entailment.Consistent Hilbert.Ver := consistent_of_sound_frameclass FrameClass.Ver $ by
-  use blackpoint;
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  use blackpoint
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 instance : Kripke.Canonical Hilbert.Ver FrameClass.Ver := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.Ver FrameClass.Ver := inferInstance
 
 instance : Complete (Hilbert.Ver) Kripke.FrameClass.finite_Ver := ⟨by
-  intro φ hφ;
-  apply LO.Complete.complete (𝓢 := Hilbert.Ver) (𝓜 := FrameClass.Ver);
-  intro F hF V r;
-  apply Model.pointGenerate.modal_equivalent_at_root (r := r) |>.mp;
-  apply hφ;
+  intro φ hφ
+  apply LO.Complete.complete (𝓢 := Hilbert.Ver) (𝓜 := FrameClass.Ver)
+  intro F hF V r
+  apply Model.pointGenerate.modal_equivalent_at_root (r := r) |>.mp
+  apply hφ
   exact {
     world_finite := by
-      apply finite_iff_exists_equiv_fin.mpr;
-      use 1;
-      constructor;
-      trans Unit;
+      apply finite_iff_exists_equiv_fin.mpr
+      use 1
+      constructor
+      trans Unit
       . refine ⟨λ _ => (), λ _ => ⟨r, by tauto⟩, ?_, ?_⟩
-        . simp only [Function.LeftInverse, Subtype.forall, Subtype.mk.injEq, forall_eq_or_imp, true_and];
-          intro x Rrx;
-          induction Rrx <;> simp_all;
-        . simp [Function.RightInverse, Function.LeftInverse];
-      . exact finOneEquiv.symm;
-    isolated := by rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ <;> simp_all;
+        . simp only [Function.LeftInverse, Subtype.forall, Subtype.mk.injEq, forall_eq_or_imp, true_and]
+          intro x Rrx
+          induction Rrx <;> simp_all
+        . simp [Function.RightInverse, Function.LeftInverse]
+      . exact finOneEquiv.symm
+    isolated := by rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ <;> simp_all
   }
 ⟩
 
 
 instance : Hilbert.KTc ⪱ Hilbert.Ver := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KTc FrameClass.Ver;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Ver ⊥);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTc);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      let M : Model := ⟨⟨Fin 1, λ x y => True⟩, λ w _ => False⟩;
-      use M, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.KTc FrameClass.Ver
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Ver ⊥)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.KTc)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      let M : Model := ⟨⟨Fin 1, λ x y => True⟩, λ w _ => False⟩
+      use M, 0
+      constructor
       . refine ⟨by unfold Coreflexive; trivial⟩
       . suffices ∃ x, (0 : M.World) ≺ x by
-          simpa [Satisfies, Semantics.Realize];
-        use 0;
+          simpa [Satisfies, Semantics.Realize]
+        use 0
 
 instance : Hilbert.GLPoint3 ⪱ Hilbert.Ver := by
-  constructor;
-  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GLPoint3 FrameClass.finite_Ver;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
-    infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Ver ⊥);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GLPoint3);
-      apply Kripke.not_validOnFrameClass_of_exists_model_world;
-      use ⟨⟨Fin 2, λ x y => x < y⟩, (λ w a => False)⟩, 0;
-      constructor;
+  constructor
+  . apply Hilbert.Kripke.weakerThan_of_subset_frameClass FrameClass.finite_GLPoint3 FrameClass.finite_Ver
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
+    infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Ver ⊥)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := Kripke.FrameClass.finite_GLPoint3)
+      apply Kripke.not_validOnFrameClass_of_exists_model_world
+      use ⟨⟨Fin 2, λ x y => x < y⟩, (λ w a => False)⟩, 0
+      constructor
       . exact {}
-      . simp only [Semantics.Realize, Satisfies, imp_false, not_forall, not_not];
-        use 1;
-        tauto;
+      . simp only [Semantics.Realize, Satisfies, imp_false, not_forall, not_not]
+        use 1
+        tauto
 
 end Hilbert.Ver.Kripke
 

--- a/Foundation/Modal/Kripke/NNFormula.lean
+++ b/Foundation/Modal/Kripke/NNFormula.lean
@@ -28,72 +28,72 @@ protected instance semantics : Semantics (NNFormula ℕ) (M.World) := ⟨λ x �
 protected lemma iff_models : x ⊧ φ ↔ Satisfies M x φ := iff_of_eq rfl
 
 @[simp]
-protected lemma atom_def (a : ℕ) : x ⊧ (atom a) ↔ M x a := by simp [Satisfies.iff_models, Satisfies];
+protected lemma atom_def (a : ℕ) : x ⊧ (atom a) ↔ M x a := by simp [Satisfies.iff_models, Satisfies]
 
 @[simp]
-protected lemma natom_def (a : ℕ) : x ⊧ (natom a) ↔ ¬M x a := by simp [Satisfies.iff_models, Satisfies];
+protected lemma natom_def (a : ℕ) : x ⊧ (natom a) ↔ ¬M x a := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma bot_def : ¬x ⊧ ⊥ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma bot_def : ¬x ⊧ ⊥ := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺ y → y ⊧ φ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺ y → y ⊧ φ := by simp [Satisfies.iff_models, Satisfies]
 
-protected lemma dia_def : x ⊧ ◇φ ↔ ∃ y, x ≺ y ∧ y ⊧ φ := by simp [Satisfies.iff_models, Satisfies];
+protected lemma dia_def : x ⊧ ◇φ ↔ ∃ y, x ≺ y ∧ y ⊧ φ := by simp [Satisfies.iff_models, Satisfies]
 
 protected lemma neg_def : x ⊧ ∼φ ↔ ¬x ⊧ φ := by
   induction φ using NNFormula.rec' generalizing x with
   | hOr φ ψ ihφ ihψ =>
-    simp only [DeMorgan.or, Satisfies.or_def, not_or];
-    constructor;
-    . rintro ⟨h₁, h₂⟩;
-      exact ⟨ihφ.mp h₁, ihψ.mp h₂⟩;
-    . rintro ⟨h₁, h₂⟩;
-      exact ⟨ihφ.mpr h₁, ihψ.mpr h₂⟩;
+    simp only [DeMorgan.or, Satisfies.or_def, not_or]
+    constructor
+    . rintro ⟨h₁, h₂⟩
+      exact ⟨ihφ.mp h₁, ihψ.mp h₂⟩
+    . rintro ⟨h₁, h₂⟩
+      exact ⟨ihφ.mpr h₁, ihψ.mpr h₂⟩
   | hAnd φ ψ ihφ ihψ =>
-    simp only [DeMorgan.and, Satisfies.and_def, not_and_or];
-    constructor;
-    . rintro (h₁ | h₂);
-      . left; exact ihφ.mp h₁;
-      . right; exact ihψ.mp h₂;
-    . rintro (h₁ | h₂);
-      . left; exact ihφ.mpr h₁;
-      . right; exact ihψ.mpr h₂;
+    simp only [DeMorgan.and, Satisfies.and_def, not_and_or]
+    constructor
+    . rintro (h₁ | h₂)
+      . left; exact ihφ.mp h₁
+      . right; exact ihψ.mp h₂
+    . rintro (h₁ | h₂)
+      . left; exact ihφ.mpr h₁
+      . right; exact ihψ.mpr h₂
   | hBox φ ihφ =>
-    simp only [ModalDeMorgan.box, Satisfies.box_def];
-    push_neg;
-    constructor;
-    . intro h;
-      obtain ⟨y, Rxy, hy⟩ := h;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply ihφ.mp;
-        exact hy;
-    . rintro ⟨y, Rxy, h⟩;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply ihφ.mpr;
-        exact h;
+    simp only [ModalDeMorgan.box, Satisfies.box_def]
+    push_neg
+    constructor
+    . intro h
+      obtain ⟨y, Rxy, hy⟩ := h
+      use y
+      constructor
+      . exact Rxy
+      . apply ihφ.mp
+        exact hy
+    . rintro ⟨y, Rxy, h⟩
+      use y
+      constructor
+      . exact Rxy
+      . apply ihφ.mpr
+        exact h
   | hDia φ ihφ =>
-    simp only [ModalDeMorgan.dia, Satisfies.dia_def, not_exists, not_and];
-    constructor;
-    . intro h y Rxy;
-      apply ihφ.mp;
-      exact h y Rxy;
-    . intro h y Rxy;
-      apply ihφ.mpr;
-      exact h y Rxy;
-  | _ => simp [Satisfies.iff_models, Satisfies];
+    simp only [ModalDeMorgan.dia, Satisfies.dia_def, not_exists, not_and]
+    constructor
+    . intro h y Rxy
+      apply ihφ.mp
+      exact h y Rxy
+    . intro h y Rxy
+      apply ihφ.mpr
+      exact h y Rxy
+  | _ => simp [Satisfies.iff_models, Satisfies]
 
 protected lemma imp_def : x ⊧ φ ➝ ψ ↔ x ⊧ φ → x ⊧ ψ := by
-  simp [Satisfies.or_def, Satisfies.neg_def];
-  tauto;
+  simp [Satisfies.or_def, Satisfies.neg_def]
+  tauto
 
 protected instance : Semantics.Tarski (M.World) where
   realize_top := λ _ => Satisfies.top_def
@@ -150,59 +150,59 @@ variable {φ : NNFormula ℕ}
 lemma Satisfies.toFormula : NNFormula.Kripke.Satisfies M x φ ↔ Formula.Kripke.Satisfies M x φ.toFormula := by
   induction φ using NNFormula.rec' generalizing x with
   | hOr φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . apply Formula.Kripke.Satisfies.or_def.mpr;
-        left;
-        exact ihφ.mp hφ;
-      . apply Formula.Kripke.Satisfies.or_def.mpr;
-        right;
-        exact ihψ.mp hψ;
-    . rintro h;
-      rcases Formula.Kripke.Satisfies.or_def.mp h with (hφ | hψ);
-      . left; exact ihφ.mpr hφ;
-      . right; exact ihψ.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . apply Formula.Kripke.Satisfies.or_def.mpr
+        left
+        exact ihφ.mp hφ
+      . apply Formula.Kripke.Satisfies.or_def.mpr
+        right
+        exact ihψ.mp hψ
+    . rintro h
+      rcases Formula.Kripke.Satisfies.or_def.mp h with (hφ | hψ)
+      . left; exact ihφ.mpr hφ
+      . right; exact ihψ.mpr hψ
   | hAnd φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      apply Formula.Kripke.Satisfies.and_def.mpr;
-      constructor;
-      . exact ihφ.mp hφ;
-      . exact ihψ.mp hψ;
-    . rintro h;
-      replace ⟨hφ, hψ⟩ := Formula.Kripke.Satisfies.and_def.mp h;
-      constructor;
-      . apply ihφ.mpr hφ;
-      . apply ihψ.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      apply Formula.Kripke.Satisfies.and_def.mpr
+      constructor
+      . exact ihφ.mp hφ
+      . exact ihψ.mp hψ
+    . rintro h
+      replace ⟨hφ, hψ⟩ := Formula.Kripke.Satisfies.and_def.mp h
+      constructor
+      . apply ihφ.mpr hφ
+      . apply ihψ.mpr hψ
   | hBox φ ihφ =>
-    constructor;
-    . intro h y Rxy;
-      apply ihφ.mp;
-      exact h y Rxy;
-    . intro h y Rxy;
-      apply ihφ.mpr;
-      exact h y Rxy;
+    constructor
+    . intro h y Rxy
+      apply ihφ.mp
+      exact h y Rxy
+    . intro h y Rxy
+      apply ihφ.mpr
+      exact h y Rxy
   | hDia φ ihφ =>
-    constructor;
-    . rintro ⟨y, Rxy, hy⟩;
-      apply Formula.Kripke.Satisfies.dia_def.mpr;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply ihφ.mp;
-        exact hy;
-    . rintro h;
-      obtain ⟨y, Rxy, hy⟩ := Formula.Kripke.Satisfies.dia_def.mp h;
-      use y;
-      constructor;
-      . exact Rxy;
-      . apply ihφ.mpr;
-        exact hy;
-  | _ => simp [NNFormula.Kripke.Satisfies, Formula.Kripke.Satisfies];
+    constructor
+    . rintro ⟨y, Rxy, hy⟩
+      apply Formula.Kripke.Satisfies.dia_def.mpr
+      use y
+      constructor
+      . exact Rxy
+      . apply ihφ.mp
+        exact hy
+    . rintro h
+      obtain ⟨y, Rxy, hy⟩ := Formula.Kripke.Satisfies.dia_def.mp h
+      use y
+      constructor
+      . exact Rxy
+      . apply ihφ.mpr
+        exact hy
+  | _ => simp [NNFormula.Kripke.Satisfies, Formula.Kripke.Satisfies]
 
 lemma ValidOnModel.toFormula : NNFormula.Kripke.ValidOnModel M φ ↔ Formula.Kripke.ValidOnModel M φ.toFormula := by
-  simp only [NNFormula.Kripke.ValidOnModel, Formula.Kripke.ValidOnModel, Satisfies.toFormula];
-  exact ⟨λ h x => h x, λ h x => h x⟩;
+  simp only [NNFormula.Kripke.ValidOnModel, Formula.Kripke.ValidOnModel, Satisfies.toFormula]
+  exact ⟨λ h x => h x, λ h x => h x⟩
 
 lemma ValidOnFrame.toFormula : NNFormula.Kripke.ValidOnFrame F φ ↔ Formula.Kripke.ValidOnFrame F φ.toFormula := ⟨
   λ h V => ValidOnModel.toFormula.mp (h V),
@@ -219,28 +219,28 @@ variable {φ : Formula ℕ}
 lemma Satisfies.toNNFormula : Formula.Kripke.Satisfies M x φ ↔ NNFormula.Kripke.Satisfies M x φ.toNNFormula := by
   induction φ generalizing x with
   | hbox φ ihφ =>
-    constructor;
-    . intro h y Rxy;
-      apply ihφ.mp;
-      exact h y Rxy;
-    . intro h y Rxy;
-      apply ihφ.mpr;
-      exact h y Rxy;
+    constructor
+    . intro h y Rxy
+      apply ihφ.mp
+      exact h y Rxy
+    . intro h y Rxy
+      apply ihφ.mpr
+      exact h y Rxy
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . rintro h;
-      apply NNFormula.Kripke.Satisfies.imp_def.mpr;
-      intro hφ;
-      apply ihψ.mp;
-      apply h;
-      apply ihφ.mpr;
-      exact hφ;
-    . intro h hφ;
-      apply ihψ.mpr;
-      apply NNFormula.Kripke.Satisfies.imp_def.mp h;
-      apply ihφ.mp;
-      exact hφ;
-  | _ => simp [Formula.Kripke.Satisfies, NNFormula.Kripke.Satisfies];
+    constructor
+    . rintro h
+      apply NNFormula.Kripke.Satisfies.imp_def.mpr
+      intro hφ
+      apply ihψ.mp
+      apply h
+      apply ihφ.mpr
+      exact hφ
+    . intro h hφ
+      apply ihψ.mpr
+      apply NNFormula.Kripke.Satisfies.imp_def.mp h
+      apply ihφ.mp
+      exact hφ
+  | _ => simp [Formula.Kripke.Satisfies, NNFormula.Kripke.Satisfies]
 
 lemma ValidOnModel.toNNFormula : Formula.Kripke.ValidOnModel M φ ↔ NNFormula.Kripke.ValidOnModel M φ.toNNFormula := ⟨
   fun h x => Satisfies.toNNFormula.mp (h x),

--- a/Foundation/Modal/Kripke/Preservation.lean
+++ b/Foundation/Modal/Kripke/Preservation.lean
@@ -21,16 +21,16 @@ instance : CoeFun (Model.Bisimulation M₁ M₂) (λ _ => M₁.World → M₂.Wo
 def Model.Bisimulation.symm (bi : M₁ ⇄ M₂) : M₂ ⇄ M₁ := {
   toRel := λ a b => bi.toRel b a
   atomic := by
-    intro x₂ x₁ a h;
-    exact (bi.atomic h).symm;
+    intro x₂ x₁ a h
+    exact (bi.atomic h).symm
   forth := by
-    intro x₂ y₂ x₁ hxy h;
-    obtain ⟨y₁, ⟨hy₁, hxy⟩⟩ := bi.back hxy h;
-    use y₁;
+    intro x₂ y₂ x₁ hxy h
+    obtain ⟨y₁, ⟨hy₁, hxy⟩⟩ := bi.back hxy h
+    use y₁
   back := by
-    intro x₁ x₂ y₁ hxy h;
-    obtain ⟨y₂, ⟨hy₂, hxy⟩⟩ := bi.forth hxy h;
-    use y₂;
+    intro x₁ x₂ y₁ hxy h
+    obtain ⟨y₂, ⟨hy₂, hxy⟩⟩ := bi.forth hxy h
+    use y₂
 }
 
 end Bisimulation
@@ -42,24 +42,24 @@ def ModalEquivalent {M₁ M₂ : Model} (w₁ : M₁.World) (w₂ : M₂.World) 
 infix:50 " ↭ " => ModalEquivalent
 
 lemma modal_equivalent_of_bisimilar (Bi : M₁ ⇄ M₂) (bisx : Bi x₁ x₂) : x₁ ↭ x₂ := by
-  intro φ;
+  intro φ
   induction φ generalizing x₁ x₂ with
-  | hatom a => exact Bi.atomic bisx;
+  | hatom a => exact Bi.atomic bisx
   | himp φ ψ ihp ihq =>
-    constructor;
-    . intro hpq hp;
-      exact ihq bisx |>.mp $ hpq $ ihp bisx |>.mpr hp;
-    . intro hpq hp;
-      exact ihq bisx |>.mpr $ hpq $ ihp bisx |>.mp hp;
+    constructor
+    . intro hpq hp
+      exact ihq bisx |>.mp $ hpq $ ihp bisx |>.mpr hp
+    . intro hpq hp
+      exact ihq bisx |>.mpr $ hpq $ ihp bisx |>.mp hp
   | hbox φ ih =>
-    constructor;
-    . intro h y₂ rx₂y₂;
-      obtain ⟨y₁, ⟨bisy, rx₁y₁⟩⟩ := Bi.back bisx rx₂y₂;
-      exact ih bisy |>.mp (h _ rx₁y₁);
-    . intro h y₁ rx₁y₁;
-      obtain ⟨y₂, ⟨bisy, rx₂y₂⟩⟩ := Bi.forth bisx rx₁y₁;
-      exact ih bisy |>.mpr (h _ rx₂y₂);
-  | _ => simp_all;
+    constructor
+    . intro h y₂ rx₂y₂
+      obtain ⟨y₁, ⟨bisy, rx₁y₁⟩⟩ := Bi.back bisx rx₂y₂
+      exact ih bisy |>.mp (h _ rx₁y₁)
+    . intro h y₁ rx₁y₁
+      obtain ⟨y₂, ⟨bisy, rx₂y₂⟩⟩ := Bi.forth bisx rx₁y₁
+      exact ih bisy |>.mpr (h _ rx₂y₂)
+  | _ => simp_all
 
 def ModalEquivalent.symm {M₁ M₂ : Model} {w₁ : M₁.World} {w₂ : M₂.World} (h : w₁ ↭ w₂) : w₂ ↭ w₁ := fun {_} => Iff.symm h
 
@@ -83,39 +83,39 @@ variable {F F₁ F₂ F₃ : Kripke.Frame}
 
 def id : F →ₚ F where
   toFun := _root_.id
-  forth := by simp;
-  back := by simp;
+  forth := by simp
+  back := by simp
 
 def comp (f : F₁ →ₚ F₂) (g : F₂ →ₚ F₃) : F₁ →ₚ F₃ where
   toFun := g ∘ f
   forth := by
-    intro x y hxy;
-    exact g.forth $ f.forth hxy;
+    intro x y hxy
+    exact g.forth $ f.forth hxy
   back := by
-    intro x w hxw;
-    obtain ⟨y, ⟨rfl, hxy⟩⟩ := g.back hxw;
-    obtain ⟨u, ⟨rfl, hfu⟩⟩ := f.back hxy;
-    use u;
-    constructor;
-    . simp_all;
-    . assumption;
+    intro x w hxw
+    obtain ⟨y, ⟨rfl, hxy⟩⟩ := g.back hxw
+    obtain ⟨u, ⟨rfl, hfu⟩⟩ := f.back hxy
+    use u
+    constructor
+    . simp_all
+    . assumption
 
 def TransitiveClosure (f : F₁ →ₚ F₂) [F₂.IsTransitive] : F₁^+ →ₚ F₂ where
   toFun := f.toFun
   forth := by
-    intro x y hxy;
+    intro x y hxy
     induction hxy with
-    | single hxy => exact f.forth hxy;
+    | single hxy => exact f.forth hxy
     | @tail z y _ Rzy Rxz =>
-      replace Rzy := f.forth Rzy;
-      exact IsTrans.trans _ _ _ Rxz Rzy;
+      replace Rzy := f.forth Rzy
+      exact IsTrans.trans _ _ _ Rxz Rzy
   back := by
-    intro x w hxw;
-    obtain ⟨u, ⟨rfl, hxu⟩⟩ := f.back hxw;
-    use u;
-    constructor;
-    . rfl;
-    . exact Relation.TransGen.single hxu;
+    intro x w hxw
+    obtain ⟨u, ⟨rfl, hxu⟩⟩ := f.back hxw
+    use u
+    constructor
+    . rfl
+    . exact Relation.TransGen.single hxu
 
 variable (f : F₁ →ₚ F₂)
 
@@ -179,41 +179,41 @@ def ofAtomic (f : M₁.toFrame →ₚ M₂.toFrame) (atomic : ∀ {w a}, (M₁ w
 
 def id : M →ₚ M where
   toFun := _root_.id
-  forth := by simp;
-  back := by simp;
-  atomic := by simp;
+  forth := by simp
+  back := by simp
+  atomic := by simp
 
 def comp (f : M₁ →ₚ M₂) (g : M₂ →ₚ M₃) : M₁ →ₚ M₃ := ofAtomic (f.toPseudoEpimorphism.comp (g.toPseudoEpimorphism)) $ by
-  intro x φ;
-  constructor;
-  . intro h;
-    apply g.atomic.mp;
-    apply f.atomic.mp;
-    assumption;
-  . intro h;
-    apply f.atomic.mpr;
-    apply g.atomic.mpr;
-    assumption;
+  intro x φ
+  constructor
+  . intro h
+    apply g.atomic.mp
+    apply f.atomic.mp
+    assumption
+  . intro h
+    apply f.atomic.mpr
+    apply g.atomic.mpr
+    assumption
 
 def bisimulation (f : M₁ →ₚ M₂) : M₁ ⇄ M₂ where
   toRel x y := y = f x
   atomic := by
-    rintro x₁ x₂ a rfl;
-    constructor;
-    . apply f.atomic.mp;
-    . apply f.atomic.mpr;
+    rintro x₁ x₂ a rfl
+    constructor
+    . apply f.atomic.mp
+    . apply f.atomic.mpr
   forth := by
-    simp only [exists_eq_left, forall_eq];
-    intro x₁ y₁ rx₁y₁;
-    exact f.forth rx₁y₁;
+    simp only [exists_eq_left, forall_eq]
+    intro x₁ y₁ rx₁y₁
+    exact f.forth rx₁y₁
   back := by
-    rintro x₁ x₂ y₂ rfl rx₂y₂;
-    obtain ⟨y₁, ⟨rfl, _⟩⟩ := f.back rx₂y₂;
-    use y₁;
+    rintro x₁ x₂ y₂ rfl rx₂y₂
+    obtain ⟨y₁, ⟨rfl, _⟩⟩ := f.back rx₂y₂
+    use y₁
 
 lemma modal_equivalence (f : M₁ →ₚ M₂) (w : M₁.World) : w ↭ (f w) := by
-  apply modal_equivalent_of_bisimilar $ Model.PseudoEpimorphism.bisimulation f;
-  simp [Model.PseudoEpimorphism.bisimulation];
+  apply modal_equivalent_of_bisimilar $ Model.PseudoEpimorphism.bisimulation f
+  simp [Model.PseudoEpimorphism.bisimulation]
 
 end Model.PseudoEpimorphism
 
@@ -221,15 +221,15 @@ end Model.PseudoEpimorphism
 variable {F₁ F₂ : Kripke.Frame} {M₁ M₂ : Kripke.Model} {φ : Formula ℕ} {T : FormulaSet ℕ}
 
 lemma validOnFrame_of_surjective_pseudoMorphism (f : F₁ →ₚ F₂) (f_surjective : Function.Surjective f) : F₁ ⊧ φ → F₂ ⊧ φ := by
-  intro h V₂ u;
-  obtain ⟨x, rfl⟩ := f_surjective u;
-  refine (Model.PseudoEpimorphism.ofAtomic (M₁ := ⟨F₁, λ w a => V₂ (f w) a⟩) (M₂ := ⟨F₂, V₂⟩) f ?_).modal_equivalence x |>.mp $ h _ x;
-  simp;
+  intro h V₂ u
+  obtain ⟨x, rfl⟩ := f_surjective u
+  refine (Model.PseudoEpimorphism.ofAtomic (M₁ := ⟨F₁, λ w a => V₂ (f w) a⟩) (M₂ := ⟨F₂, V₂⟩) f ?_).modal_equivalence x |>.mp $ h _ x
+  simp
 
 lemma theory_ValidOnFrame_of_surjective_pseudoMorphism (f : F₁ →ₚ F₂) (f_surjective : Function.Surjective f) : F₁ ⊧* T → F₂ ⊧* T := by
-  simp only [Semantics.realizeSet_iff];
-  intro h φ hp;
-  exact validOnFrame_of_surjective_pseudoMorphism f f_surjective (h hp);
+  simp only [Semantics.realizeSet_iff]
+  intro h φ hp
+  exact validOnFrame_of_surjective_pseudoMorphism f f_surjective (h hp)
 
 end PseudoEpimorphism
 

--- a/Foundation/Modal/Kripke/Rooted.lean
+++ b/Foundation/Modal/Kripke/Rooted.lean
@@ -30,11 +30,11 @@ lemma s_connected [F.IsStronglyConnected] : ∀ {x y : F.World}, x ≺ y ∨ y �
 protected abbrev IsConnected (F : Frame) := _root_.IsTrichotomous _ F.Rel
 lemma connected [F.IsConnected] : ∀ x y : F.World, x ≺ y ∨ x = y ∨ y ≺ x := by apply IsTrichotomous.trichotomous
 lemma connected' [F.IsConnected] : ∀ x y : F.World, x ≠ y → x ≺ y ∨ y ≺ x := by
-  rintro x y nexy;
-  rcases F.connected x y with (Rxy | rfl | Ryx);
-  . tauto;
-  . contradiction;
-  . tauto;
+  rintro x y nexy
+  rcases F.connected x y with (Rxy | rfl | Ryx)
+  . tauto
+  . contradiction
+  . tauto
 
 
 protected class IsGenerated (F : Kripke.Frame) (R : { s : Set F.World // s.Nonempty }) where
@@ -51,18 +51,18 @@ instance {r : outParam F.World} [F.IsRootedBy r] : F.IsRooted := ⟨by use r⟩
 protected noncomputable def root (F : Frame) [F.IsRooted] : F.World := Classical.choose Frame.IsRooted.exists_root
 
 lemma root_generates [F.IsRooted] : ∀ x ≠ F.root, F.root ≺^+ x := by
-  apply @Frame.IsRooted.exists_root F _ |>.choose_spec |>.root_generates;
+  apply @Frame.IsRooted.exists_root F _ |>.choose_spec |>.root_generates
 
 lemma root_generates' [F.IsRooted] [F.IsTransitive] : ∀ x ≠ F.root, F.root ≺ x := by
-  intro x hx;
-  exact HRel.TransGen.unwrap $ F.root_generates _ hx;
+  intro x hx
+  exact HRel.TransGen.unwrap $ F.root_generates _ hx
 
 /-- `Frame.root` is first. -/
 @[simp] lemma root_first [F.IsRooted] [F.IsTransitive] [F.IsReflexive] : ∀ x, F.root ≺ x := by
-  intro x;
-  by_cases hx : x = F.root;
-  . subst hx; apply F.refl;
-  . exact F.root_generates' x hx;
+  intro x
+  by_cases hx : x = F.root
+  . subst hx; apply F.refl
+  . exact F.root_generates' x hx
 
 
 /-- Explicit version of `root_generates` for rooted by `r`. -/
@@ -70,85 +70,85 @@ lemma root_generates! [F.IsRootedBy r] : ∀ x ≠ r, r ≺^+ x := IsRootedBy.ro
 
 /-- Explicit version of `root_generates'` for rooted by `r`. -/
 lemma root_genaretes'! [F.IsTransitive] [F.IsRootedBy r] : ∀ x ≠ r, r ≺ x := by
-  intro x hx;
-  apply HRel.TransGen.unwrap;
-  exact IsRootedBy.root_generates x hx;
+  intro x hx
+  apply HRel.TransGen.unwrap
+  exact IsRootedBy.root_generates x hx
 
 @[simp] lemma root_first! [F.IsRootedBy r] [F.IsTransitive] [F.IsReflexive] : ∀ x, r ≺ x := by
-  intro x;
-  by_cases hx : x = r;
-  . subst hx; apply F.refl;
-  . exact F.root_genaretes'! x hx;
+  intro x
+  by_cases hx : x = r
+  . subst hx; apply F.refl
+  . exact F.root_genaretes'! x hx
 
 
 instance [F.IsRooted] : F.IsRootedBy F.root where
-  root_generates := by apply @Frame.IsRooted.exists_root F _ |>.choose_spec |>.root_generates;
+  root_generates := by apply @Frame.IsRooted.exists_root F _ |>.choose_spec |>.root_generates
 
 
 instance [rooted : F.IsRootedBy r] : F.IsGenerated (⟨{r}, by tauto⟩) where
   roots_generates := by
-    rintro x hx;
-    use r;
-    constructor;
-    . tauto;
-    . exact rooted.root_generates x hx;
+    rintro x hx
+    use r
+    constructor
+    . tauto
+    . exact rooted.root_generates x hx
 
 
 
 namespace isRooted
 
 instance isConvergent [F.IsRooted] [F.IsPiecewiseConvergent] [F.IsTransitive] [F.IsReflexive] : F.IsConvergent := ⟨by
-  rintro x y nexy;
-  apply F.p_convergent (x := F.root) ?_ ?_ nexy;
-  . by_cases ex : x = F.root;
-    . subst ex; apply F.refl;
-    . apply F.root_generates';
-      tauto;
-  . by_cases ey : y = F.root;
-    . subst ey; apply F.refl;
-    . apply F.root_generates';
-      tauto;
+  rintro x y nexy
+  apply F.p_convergent (x := F.root) ?_ ?_ nexy
+  . by_cases ex : x = F.root
+    . subst ex; apply F.refl
+    . apply F.root_generates'
+      tauto
+  . by_cases ey : y = F.root
+    . subst ey; apply F.refl
+    . apply F.root_generates'
+      tauto
 ⟩
 
 instance isStronglyConvergent [F.IsRooted] [F.IsPiecewiseStronglyConvergent] [F.IsReflexive] [F.IsTransitive] : F.IsStronglyConvergent := ⟨by
-  rintro x y;
-  apply F.ps_convergent (x := F.root) ?_ ?_;
-  . by_cases ex : x = F.root;
-    . subst ex; apply F.refl;
-    . apply F.root_generates';
-      tauto;
-  . by_cases ey : y = F.root;
-    . subst ey; apply F.refl;
-    . apply F.root_generates';
-      tauto;
+  rintro x y
+  apply F.ps_convergent (x := F.root) ?_ ?_
+  . by_cases ex : x = F.root
+    . subst ex; apply F.refl
+    . apply F.root_generates'
+      tauto
+  . by_cases ey : y = F.root
+    . subst ey; apply F.refl
+    . apply F.root_generates'
+      tauto
 ⟩
 
 instance isConnected [F.IsRooted] [F.IsPiecewiseConnected] [F.IsReflexive] [F.IsTransitive] : F.IsConnected := ⟨by
-  rintro x y;
-  suffices x ≠ y → x ≺ y ∨ y ≺ x by tauto;
-  intro nexy;
-  apply F.p_connected' (x := F.root) ?_ ?_ nexy;
-  . by_cases ex : x = F.root;
-    . subst ex; apply F.refl;
-    . apply F.root_generates';
-      tauto;
-  . by_cases ey : y = F.root;
-    . subst ey; apply F.refl;
-    . apply F.root_generates';
-      tauto;
+  rintro x y
+  suffices x ≠ y → x ≺ y ∨ y ≺ x by tauto
+  intro nexy
+  apply F.p_connected' (x := F.root) ?_ ?_ nexy
+  . by_cases ex : x = F.root
+    . subst ex; apply F.refl
+    . apply F.root_generates'
+      tauto
+  . by_cases ey : y = F.root
+    . subst ey; apply F.refl
+    . apply F.root_generates'
+      tauto
 ⟩
 
 instance isStronglyConnected [F.IsRooted] [F.IsPiecewiseStronglyConnected] [F.IsReflexive] [F.IsTransitive] : F.IsStronglyConnected := ⟨by
-  rintro x y;
-  apply F.ps_connected (x := F.root) ?_ ?_;
-  . by_cases ex : x = F.root;
-    . subst ex; apply F.refl;
-    . apply F.root_generates';
-      tauto;
-  . by_cases ey : y = F.root;
-    . subst ey; apply F.refl;
-    . apply F.root_generates';
-      tauto;
+  rintro x y
+  apply F.ps_connected (x := F.root) ?_ ?_
+  . by_cases ex : x = F.root
+    . subst ex; apply F.refl
+    . apply F.root_generates'
+      tauto
+  . by_cases ey : y = F.root
+    . subst ey; apply F.refl
+    . apply F.root_generates'
+      tauto
 ⟩
 
 end isRooted
@@ -156,8 +156,8 @@ end isRooted
 
 instance [rooted : F.IsRootedBy r] : (F^+).IsRootedBy r where
   root_generates := by
-    intro x hx;
-    exact Relation.TransGen.single $ rooted.root_generates x hx;
+    intro x hx
+    exact Relation.TransGen.single $ rooted.root_generates x hx
 
 
 end Frame
@@ -178,45 +178,45 @@ namespace setGenerate
 variable {F : Frame} {R}
 
 protected abbrev roots : { s : Set (F↾R) // s.Nonempty } := ⟨{ r | r.1 ∈ R.1 }, by
-  obtain ⟨r, hr⟩ := R.2;
-  use ⟨r, by tauto⟩;
-  tauto;
+  obtain ⟨r, hr⟩ := R.2
+  use ⟨r, by tauto⟩
+  tauto
 ⟩
 
 lemma trans_rel_of_origin_trans_rel {hx hy} (Rxy : F.Rel.TransGen x y)
   : ((F↾R)^+.Rel ⟨x, hx⟩ ⟨y, hy⟩) := by
   induction Rxy using TransGen.head_induction_on with
-  | base h => exact _root_.Relation.TransGen.single h;
+  | base h => exact _root_.Relation.TransGen.single h
   | @ih a c ha hb hc =>
     let b : (F.setGenerate R).World := ⟨c, by
       rcases hx with hx | ⟨r₁, hR₁, Rr₁a⟩ <;>
-      rcases hy with hy | ⟨r₂, hR₂, Rr₂b⟩;
-      . right; use a; constructor; assumption; exact TransGen.single ha;
-      . right; use a; constructor; assumption; exact TransGen.single ha;
-      . right;
-        use r₁;
-        constructor;
-        . assumption;
-        . exact TransGen.tail Rr₁a ha;
-      . right;
-        use r₁;
-        constructor;
-        . assumption;
-        . exact TransGen.tail Rr₁a ha;
-    ⟩;
-    apply Relation.TransGen.head (b := b);
-    . exact ha;
-    . apply hc;
+      rcases hy with hy | ⟨r₂, hR₂, Rr₂b⟩
+      . right; use a; constructor; assumption; exact TransGen.single ha
+      . right; use a; constructor; assumption; exact TransGen.single ha
+      . right
+        use r₁
+        constructor
+        . assumption
+        . exact TransGen.tail Rr₁a ha
+      . right
+        use r₁
+        constructor
+        . assumption
+        . exact TransGen.tail Rr₁a ha
+    ⟩
+    apply Relation.TransGen.head (b := b)
+    . exact ha
+    . apply hc
 
 instance instGenerated : (F↾R).IsGenerated (setGenerate.roots) where
   roots_generates := by
-    rintro ⟨r, (hr | ⟨t, ht, Rtx⟩)⟩ _;
-    . simp_all;
-    . use ⟨t, by simp_all⟩;
-      constructor;
-      . simpa;
-      . apply trans_rel_of_origin_trans_rel;
-        exact Rtx;
+    rintro ⟨r, (hr | ⟨t, ht, Rtx⟩)⟩ _
+    . simp_all
+    . use ⟨t, by simp_all⟩
+      constructor
+      . simpa
+      . apply trans_rel_of_origin_trans_rel
+        exact Rtx
 
 end setGenerate
 
@@ -234,33 +234,33 @@ variable {F : Frame} {r : outParam (F.World)}
 lemma trans_rel_of_origin_trans_rel {hx hy} (Rxy : F.TransGen x y)
   : ((F↾r)^+.Rel ⟨x, hx⟩ ⟨y, hy⟩) := by
   induction Rxy using TransGen.head_induction_on with
-  | base h => exact Relation.TransGen.single h;
+  | base h => exact Relation.TransGen.single h
   | @ih a c ha hb hc =>
     let b : (F↾r).World := ⟨c, by
       rcases hx with rfl | Rra <;>
-      rcases hy with rfl | Rrb;
-      . right; exact TransGen.single ha;
-      . right; exact TransGen.single ha;
-      . right; exact TransGen.tail Rra ha;
-      . right; exact TransGen.tail Rra ha;
-    ⟩;
-    apply Relation.TransGen.head (b := b);
-    . exact ha;
-    . apply hc;
+      rcases hy with rfl | Rrb
+      . right; exact TransGen.single ha
+      . right; exact TransGen.single ha
+      . right; exact TransGen.tail Rra ha
+      . right; exact TransGen.tail Rra ha
+    ⟩
+    apply Relation.TransGen.head (b := b)
+    . exact ha
+    . apply hc
 
 lemma origin_trans_rel_of_trans_rel {u v : (F↾r).World} (Ruv : (F↾r).TransGen u v) : F.TransGen u.1 v.1 := by
   induction Ruv using TransGen.head_induction_on with
-  | base h => exact Relation.TransGen.single h;
-  | ih a b c => exact TransGen.head a c;
+  | base h => exact Relation.TransGen.single h
+  | ih a b c => exact TransGen.head a c
 
 protected abbrev root : (F↾r).World := ⟨r, by tauto⟩
 
 instance : (F↾r).IsRootedBy pointGenerate.root where
   root_generates := by
-    rintro ⟨w, (rfl | Rrw)⟩ hw;
-    . simp at hw;
-    . apply trans_rel_of_origin_trans_rel;
-      exact Rrw;
+    rintro ⟨w, (rfl | Rrw)⟩ hw
+    . simp at hw
+    . apply trans_rel_of_origin_trans_rel
+      exact Rrw
 
 instance : (F↾r).IsRooted := inferInstance
 
@@ -269,26 +269,26 @@ instance [F.IsFinite] : (F↾r).IsFinite := inferInstance
 instance [DecidableEq F.World] : DecidableEq (F↾r).World := Subtype.instDecidableEq
 
 instance isReflexive [F.IsReflexive] : (F↾r).IsReflexive where
-  refl := by rintro ⟨x, (rfl | hx)⟩ <;> exact IsRefl.refl x;
+  refl := by rintro ⟨x, (rfl | hx)⟩ <;> exact IsRefl.refl x
 
 instance isTransitive [F.IsTransitive] : (F↾r).IsTransitive where
   trans := by
-    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ ⟨z, (rfl | hz)⟩ hxy hyz;
-    . assumption;
-    . assumption;
-    . have : z ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this;
-    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this;
-    . assumption;
-    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this;
-    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this;
-    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this;
+    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ ⟨z, (rfl | hz)⟩ hxy hyz
+    . assumption
+    . assumption
+    . have : z ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this
+    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this
+    . assumption
+    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this
+    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this
+    . have : x ≺ z := IsTrans.trans _ _ _ hxy hyz; exact this
 
 instance isAntisymmetric [F.IsAntisymmetric] : (F↾r).IsAntisymmetric := ⟨by
-  rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ Rxy Ryx;
-  . tauto;
-  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx;
-  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx;
-  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx;
+  rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ Rxy Ryx
+  . tauto
+  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx
+  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx
+  . simp only [Subtype.mk.injEq]; apply F.antisymm Rxy Ryx
 ⟩
 
 instance isIrreflexive [F.IsIrreflexive] : (F↾r).IsIrreflexive := ⟨by rintro ⟨x, (rfl | hx)⟩ h <;> simp at h⟩
@@ -299,38 +299,38 @@ instance isAsymmetric [F.IsAsymmetric] : (F↾r).IsAsymmetric := ⟨by
 ⟩
 
 instance isPiecewiseConvergent [F.IsPiecewiseConvergent] : (F↾r).IsPiecewiseConvergent := ⟨by
-  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz nexy;
-  any_goals contradiction;
+  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz nexy
+  any_goals contradiction
   case mk.inl.mk.inr.mk.inr | mk.inr.mk.inr.mk.inr =>
-    have ⟨u, Ryu, Rzu⟩ := F.p_convergent Rxy Rxz $ by simp_all;
-    use ⟨u, by right; apply HRel.TransGen.tail Rry Ryu⟩;
+    have ⟨u, Ryu, Rzu⟩ := F.p_convergent Rxy Rxz $ by simp_all
+    use ⟨u, by right; apply HRel.TransGen.tail Rry Ryu⟩
   all_goals
-  . have ⟨u, _⟩ := F.p_convergent Rxy Rxz $ by simp_all;
-    use ⟨u, by tauto⟩;
+  . have ⟨u, _⟩ := F.p_convergent Rxy Rxz $ by simp_all
+    use ⟨u, by tauto⟩
 ⟩
 
 instance isPiecewiseStronglyConvergent [F.IsPiecewiseStronglyConvergent] : (F↾r).IsPiecewiseStronglyConvergent := ⟨by
-  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz;
-  case mk.inl.mk.inl.mk.inl => tauto;
+  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz
+  case mk.inl.mk.inl.mk.inl => tauto
   case mk.inr.mk.inr.mk.inr | mk.inl.mk.inr.mk.inr =>
-    obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz;
-    use ⟨u, ?_⟩;
-    . right; exact HRel.TransGen.tail Rry Ryu;
+    obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz
+    use ⟨u, ?_⟩
+    . right; exact HRel.TransGen.tail Rry Ryu
   all_goals
-  . obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz;
-    use ⟨u, by tauto⟩;
+  . obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz
+    use ⟨u, by tauto⟩
 ⟩
 
 instance isPiecewiseConnected [F.IsPiecewiseConnected] : (F↾r).IsPiecewiseConnected := by
-  apply IsPiecewiseConnected.mk';
-  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz nexy;
-  any_goals tauto;
-  all_goals exact F.p_connected' Rxy Rxz $ by simp_all;;
+  apply IsPiecewiseConnected.mk'
+  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz nexy
+  any_goals tauto
+  all_goals exact F.p_connected' Rxy Rxz $ by simp_all;
 
 instance isPiecewiseStronglyConnected [F.IsPiecewiseStronglyConnected] : (F↾r).IsPiecewiseStronglyConnected := ⟨by
-  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz;
-  any_goals tauto;
-  all_goals exact F.ps_connected Rxy Rxz;
+  rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ Rxy Rxz
+  any_goals tauto
+  all_goals exact F.ps_connected Rxy Rxz
 ⟩
 
 instance isConvergent [F.IsPiecewiseConvergent] [F.IsTransitive] [F.IsReflexive] : (F↾r).IsConvergent := isRooted.isConvergent
@@ -345,24 +345,24 @@ instance isStronglyConnected [F.IsPiecewiseStronglyConnected] [F.IsReflexive] [F
 def pMorphism (F : Kripke.Frame) (r : F) : (F↾r) →ₚ F where
   toFun := λ ⟨x, _⟩ => x
   forth := by
-    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy;
-    repeat exact hxy;
+    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy
+    repeat exact hxy
   back := by
-    rintro ⟨x, (rfl | hx)⟩ y Rwv;
+    rintro ⟨x, (rfl | hx)⟩ y Rwv
     . simp at Rwv; use ⟨y, by tauto⟩
-    . use ⟨y, by right; exact Relation.TransGen.tail hx Rwv⟩;
+    . use ⟨y, by right; exact Relation.TransGen.tail hx Rwv⟩
 
 /-
 def generatedSub : F↾r ⥹ F where
   toFun := λ ⟨x, _⟩ => x
   forth := by
-    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy;
-    repeat exact hxy;
+    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy
+    repeat exact hxy
   back := by
-    rintro ⟨x, (rfl | hx)⟩ y Rwv;
+    rintro ⟨x, (rfl | hx)⟩ y Rwv
     . simp at Rwv; use ⟨y, by tauto⟩
-    . use ⟨y, by right; exact Relation.TransGen.tail hx Rwv⟩;
-  monic := by simp;
+    . use ⟨y, by right; exact Relation.TransGen.tail hx Rwv⟩
+  monic := by simp
 -/
 
 end pointGenerate
@@ -377,16 +377,16 @@ namespace Model.pointGenerate
 
 variable {M : Kripke.Model} {r : outParam M.World}
 
-instance [M.IsFinite] : (M↾r).IsFinite := by dsimp [Model.pointGenerate]; infer_instance;
+instance [M.IsFinite] : (M↾r).IsFinite := by dsimp [Model.pointGenerate]; infer_instance
 
 protected abbrev root : (M↾r).World := ⟨r, by tauto⟩
 
-instance : (M↾r).IsRootedBy pointGenerate.root := by dsimp [Model.pointGenerate]; infer_instance;
+instance : (M↾r).IsRootedBy pointGenerate.root := by dsimp [Model.pointGenerate]; infer_instance
 
 protected def pMorphism : (M↾r) →ₚ M := by
-  apply Model.PseudoEpimorphism.ofAtomic (Frame.pointGenerate.pMorphism M.toFrame r);
-  simp only [pointGenerate, Frame.pointGenerate, Subtype.forall];
-  rintro p x (rfl | Rrx) <;> tauto;
+  apply Model.PseudoEpimorphism.ofAtomic (Frame.pointGenerate.pMorphism M.toFrame r)
+  simp only [pointGenerate, Frame.pointGenerate, Subtype.forall]
+  rintro p x (rfl | Rrx) <;> tauto
 
 instance isReflexive [M.IsReflexive] : (M↾r).IsReflexive := Frame.pointGenerate.isReflexive
 instance isTransitive [M.IsTransitive] : (M↾r).IsTransitive := Frame.pointGenerate.isTransitive
@@ -401,15 +401,15 @@ instance isStronglyConnected [M.IsPiecewiseStronglyConnected] [M.IsReflexive] [M
 
 /-
 instance : (M↾r) ⥹ M := by
-  letI g := Frame.pointGenerate.generatedSub (F := M.toFrame) (r := r);
+  letI g := Frame.pointGenerate.generatedSub (F := M.toFrame) (r := r)
   exact {
     toFun := g.toFun,
     forth := g.forth,
     back := g.back,
     monic := g.monic
     atomic := by
-      simp [Model.pointGenerate, Frame.pointGenerate, g];
-      rintro p x (rfl | Rrx) <;> tauto;
+      simp [Model.pointGenerate, Frame.pointGenerate, g]
+      rintro p x (rfl | Rrx) <;> tauto
   }
 -/
 

--- a/Foundation/Modal/Kripke/Terminated.lean
+++ b/Foundation/Modal/Kripke/Terminated.lean
@@ -10,8 +10,8 @@ namespace Frame.IsTerminated
 variable {F : Frame} {t : F.World} [F.IsTerminated t]
 
 lemma direct_terminated_of_trans [F.IsTransitive] : ∀ x ≠ t, x ≺ t := by
-  intro x hx;
-  exact HRel.TransGen.unwrap $ IsTerminated.terminal_terminated x hx;
+  intro x hx
+  exact HRel.TransGen.unwrap $ IsTerminated.terminal_terminated x hx
 
 end Frame.IsTerminated
 

--- a/Foundation/Modal/Kripke/Tree.lean
+++ b/Foundation/Modal/Kripke/Tree.lean
@@ -30,102 +30,102 @@ variable {X Y : (F.mkTreeUnravelling r).World}
 
 @[simp]
 lemma not_nil : X.1 ≠ [] := by
-  by_contra;
-  have := X.2.1;
-  simp_all;
+  by_contra
+  have := X.2.1
+  simp_all
 
 lemma rel_length (h : X ≺ Y) : X.1.length < Y.1.length := by
-  obtain ⟨z, hz⟩ := h;
-  simp_all;
+  obtain ⟨z, hz⟩ := h
+  simp_all
 
 lemma transrel_def : X ≺^+ Y ↔ ∃ l ≠ [], Y.1 = X.1 ++ l ∧ (List.Chain' F.Rel (X.1 ++ l)) := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h using Relation.TransGen.head_induction_on with
     | base RZY =>
-      obtain ⟨w, hw⟩ := RZY;
-      use [w];
-      refine ⟨by tauto, by tauto, ?_⟩;
-      rw [←hw];
-      exact Y.2.2;
+      obtain ⟨w, hw⟩ := RZY
+      use [w]
+      refine ⟨by tauto, by tauto, ?_⟩
+      rw [←hw]
+      exact Y.2.2
     | @ih Z U RZU UY ih =>
-      obtain ⟨w, hw⟩ := RZU;
-      obtain ⟨l, ⟨_, _, hl₃⟩⟩ := ih;
-      use w :: l;
-      refine ⟨by tauto, by simp_all, ?_⟩;
-      rwa [hw, (show Z.1 ++ [w] ++ l = Z.1 ++ (w :: l) by simp)] at hl₃;
-  . rintro ⟨l, hl⟩;
+      obtain ⟨w, hw⟩ := RZU
+      obtain ⟨l, ⟨_, _, hl₃⟩⟩ := ih
+      use w :: l
+      refine ⟨by tauto, by simp_all, ?_⟩
+      rwa [hw, (show Z.1 ++ [w] ++ l = Z.1 ++ (w :: l) by simp)] at hl₃
+  . rintro ⟨l, hl⟩
     induction l using List.induction_with_singleton generalizing X with
-    | hnil => tauto;
+    | hnil => tauto
     | hsingle z =>
-      apply Relation.TransGen.single;
-      use z;
-      tauto;
+      apply Relation.TransGen.single
+      use z
+      tauto
     | hcons z zs h ih =>
-      rcases hl with ⟨_, hl₂, hl₃⟩;
+      rcases hl with ⟨_, hl₂, hl₃⟩
       apply Relation.TransGen.head (b := ⟨X.1 ++ [z], by
-        constructor;
-        . obtain ⟨l, hl⟩ := X.2.1;
-          use (l ++ [z]);
-          rw [←hl];
-          simp;
-        . apply List.Chain'.prefix hl₃;
-          use zs;
-          simp_all;
-      ⟩);
-      . use z;
-      . apply ih;
-        refine ⟨by simp_all, by simpa, by simpa⟩;
+        constructor
+        . obtain ⟨l, hl⟩ := X.2.1
+          use (l ++ [z])
+          rw [←hl]
+          simp
+        . apply List.Chain'.prefix hl₃
+          use zs
+          simp_all
+      ⟩)
+      . use z
+      . apply ih
+        refine ⟨by simp_all, by simpa, by simpa⟩
 
 protected instance isIrreflexive : (F.mkTreeUnravelling r).IsIrreflexive := ⟨by
-  intro x; simp [Frame.mkTreeUnravelling];
+  intro x; simp [Frame.mkTreeUnravelling]
 ⟩
 
 protected instance isAsymmetric : (F.mkTreeUnravelling r).IsAsymmetric := ⟨by
-  rintro x y hxy;
-  by_contra hyx;
-  replace hxy := rel_length hxy;
-  replace hyx := rel_length hyx;
-  exact hxy.not_lt hyx;
+  rintro x y hxy
+  by_contra hyx
+  replace hxy := rel_length hxy
+  replace hyx := rel_length hyx
+  exact hxy.not_lt hyx
 ⟩
 
 protected def pMorphism (F : Frame) (r : F) : F.mkTreeUnravelling r →ₚ F where
   toFun c := c.1.getLast (by simp)
   forth {cx cy} h := by
-    obtain ⟨z, hz⟩ := h;
-    have ⟨_, _, h⟩ := @List.chain'_append _ F.Rel cx.1 [z] |>.mp (by rw [←hz]; exact cy.2.2);
-    refine h (cx.1.getLast (by aesop)) ?hx (cy.1.getLast (by aesop)) ?hy;
-    . exact List.getLast?_eq_getLast_of_ne_nil (by simp);
-    . simp;
-      convert @List.getLast_append_singleton (l := cx.1) (a := z) |>.symm;
+    obtain ⟨z, hz⟩ := h
+    have ⟨_, _, h⟩ := @List.chain'_append _ F.Rel cx.1 [z] |>.mp (by rw [←hz]; exact cy.2.2)
+    refine h (cx.1.getLast (by aesop)) ?hx (cy.1.getLast (by aesop)) ?hy
+    . exact List.getLast?_eq_getLast_of_ne_nil (by simp)
+    . simp
+      convert @List.getLast_append_singleton (l := cx.1) (a := z) |>.symm
   back {cx y} h := by
-    use ⟨cx.1 ++ [y], ?_⟩;
-    . constructor;
-      . simp;
-      . use y;
-    . constructor;
-      . obtain ⟨i, hi⟩ := cx.2.1;
-        use (i ++ [y]);
-        simp_rw [←List.append_assoc, hi];
-      . apply List.Chain'.append;
-        . exact cx.2.2;
-        . simp;
-        . intro z hz; simp;
-          convert h;
-          exact List.mem_getLast?_eq_getLast hz |>.2;
+    use ⟨cx.1 ++ [y], ?_⟩
+    . constructor
+      . simp
+      . use y
+    . constructor
+      . obtain ⟨i, hi⟩ := cx.2.1
+        use (i ++ [y])
+        simp_rw [←List.append_assoc, hi]
+      . apply List.Chain'.append
+        . exact cx.2.2
+        . simp
+        . intro z hz; simp
+          convert h
+          exact List.mem_getLast?_eq_getLast hz |>.2
 
 protected abbrev root : (F.mkTreeUnravelling r).World := ⟨[r], by tauto⟩
 
 instance : (F.mkTreeUnravelling r).IsRootedBy treeUnravelling.root where
   root_generates := by
-    rintro ⟨_, ⟨l, rfl⟩, l_chain⟩ hn;
-    apply transrel_def.mpr;
-    simp only [ne_eq, List.cons_append, List.nil_append, List.cons.injEq, true_and, existsAndEq];
-    constructor;
-    . by_contra hC;
-      subst hC;
-      simp at hn;
-    . assumption;
+    rintro ⟨_, ⟨l, rfl⟩, l_chain⟩ hn
+    apply transrel_def.mpr
+    simp only [ne_eq, List.cons_append, List.nil_append, List.cons.injEq, true_and, existsAndEq]
+    constructor
+    . by_contra hC
+      subst hC
+      simp at hn
+    . assumption
 
 end Frame.treeUnravelling
 
@@ -140,23 +140,23 @@ variable {X Y : (F.mkTransTreeUnravelling r).World}
 
 @[simp]
 lemma not_nil : X.1 ≠ [] := by
-  by_contra;
-  have := X.2.1;
-  simp_all;
+  by_contra
+  have := X.2.1
+  simp_all
 
 lemma rel_length (Rxy : X ≺ Y) : X.1.length < Y.1.length := by
   induction Rxy with
-  | single Rxy => exact treeUnravelling.rel_length Rxy;
-  | tail _ h ih => have := treeUnravelling.rel_length h; omega;
+  | single Rxy => exact treeUnravelling.rel_length Rxy
+  | tail _ h ih => have := treeUnravelling.rel_length h; omega
 
 instance : (F.mkTransTreeUnravelling r).IsTransitive := inferInstance
 
 instance : (F.mkTransTreeUnravelling r).IsAsymmetric := ⟨by
-  rintro x y hxy;
-  by_contra hyx;
-  replace hxy := rel_length hxy;
-  replace hyx := rel_length hyx;
-  exact hxy.not_lt hyx;
+  rintro x y hxy
+  by_contra hyx
+  replace hxy := rel_length hxy
+  replace hyx := rel_length hyx
+  exact hxy.not_lt hyx
 ⟩
 
 lemma rel_def : X ≺ Y ↔ (∃ l ≠ [], Y.1 = X.1 ++ l ∧ (List.Chain' F.Rel (X.1 ++ l))) := treeUnravelling.transrel_def
@@ -173,13 +173,13 @@ instance instFinite [DecidableEq F.World] [F.IsFinite] [F.IsTransitive] [F.IsIrr
      Finite.of_injective
      (β := { x // List.Chain' F.Rel x })
      (fun x => ⟨x.1, x.2.2⟩)
-     (by rintro ⟨x, hx⟩ ⟨y, hy⟩; simp_all);
-  apply List.chains_finite;
+     (by rintro ⟨x, hx⟩ ⟨y, hy⟩; simp_all)
+  apply List.chains_finite
 
 instance instIsTree : (F.mkTransTreeUnravelling r).IsTree (mkTransTreeUnravelling.root) where
   root_generates := by
-    intro w;
-    exact Frame.mkTransTreeUnravelling.instIsRooted.root_generates w;
+    intro w
+    exact Frame.mkTransTreeUnravelling.instIsRooted.root_generates w
 
 instance instIsFiniteTree [DecidableEq F.World] [Finite F] [F.IsTransitive] [F.IsIrreflexive]
   : (F.mkTransTreeUnravelling r).IsFiniteTree (mkTransTreeUnravelling.root) where
@@ -197,7 +197,7 @@ instance {F : Frame} [DecidableEq F.World] [Finite F] {r : F.World} (F_trans : T
 def Model.mkTreeUnravelling (M : Kripke.Model) (r : M.World) : Kripke.Model := ⟨M.toFrame.mkTreeUnravelling r, λ c a => M.Val (c.1.getLast (by simp)) a⟩
 
 def Model.mkTreeUnravelling.pMorphism (M : Kripke.Model) (r : M.World) : (M.mkTreeUnravelling r) →ₚ M :=
-  PseudoEpimorphism.ofAtomic (Frame.treeUnravelling.pMorphism M.toFrame r) $ by rfl;
+  PseudoEpimorphism.ofAtomic (Frame.treeUnravelling.pMorphism M.toFrame r) $ by rfl
 
 
 def Model.mkTransTreeUnravelling (M : Kripke.Model) (r : M.World) : Kripke.Model := ⟨M.toFrame.mkTransTreeUnravelling r, λ c a => M.Val (c.1.getLast (by simp)) a⟩
@@ -205,7 +205,7 @@ def Model.mkTransTreeUnravelling (M : Kripke.Model) (r : M.World) : Kripke.Model
 namespace Model.mkTransTreeUnravelling
 
 protected def pMorphism (M : Kripke.Model) (r : M.World) [M.IsTransitive] : M.mkTransTreeUnravelling r →ₚ M :=
-  PseudoEpimorphism.ofAtomic (Frame.mkTransTreeUnravelling.pMorphism M.toFrame r) $ by rfl;
+  PseudoEpimorphism.ofAtomic (Frame.mkTransTreeUnravelling.pMorphism M.toFrame r) $ by rfl
 
 protected abbrev root {M : Kripke.Model} {r : M.World} : (M.mkTransTreeUnravelling r).World := Frame.mkTransTreeUnravelling.root
 

--- a/Foundation/Modal/Kripke/Undefinability.lean
+++ b/Foundation/Modal/Kripke/Undefinability.lean
@@ -7,33 +7,33 @@ namespace Kripke
 abbrev FrameClass.irrefl : FrameClass := { F | F.IsIrreflexive }
 
 theorem undefinable_irreflexive : ¬∃ φ, ∀ F, F ∈ FrameClass.irrefl ↔ (F ⊧ φ) := by
-  by_contra hC;
-  obtain ⟨φ, h⟩ := hC;
+  by_contra hC
+  obtain ⟨φ, h⟩ := hC
 
-  let F₁ : Frame := ⟨Fin 2, (· ≠ ·)⟩;
-  let F₂ : Frame := ⟨Fin 1, (· = ·)⟩;
+  let F₁ : Frame := ⟨Fin 2, (· ≠ ·)⟩
+  let F₂ : Frame := ⟨Fin 1, (· = ·)⟩
 
   let f : F₁ →ₚ F₂ := {
     toFun := λ _ => 0,
-    forth := by omega;
+    forth := by omega
     back := by
-      intro x y h;
-      use 1 - x;
-      constructor;
-      . simpa;
-      . omega;
-  };
+      intro x y h
+      use 1 - x
+      constructor
+      . simpa
+      . omega
+  }
   have f_surjective : Function.Surjective f := by
-    simp [Function.Surjective];
-    aesop;
+    simp [Function.Surjective]
+    aesop
 
   have : F₁.IsIrreflexive := { irrefl := by omega; }
   have : F₂.IsIrreflexive := by
-    apply h F₂ |>.mpr;
-    apply validOnFrame_of_surjective_pseudoMorphism f f_surjective;
-    exact h F₁ |>.mp $ by simpa;
-  apply F₂.irrefl 0;
-  omega;
+    apply h F₂ |>.mpr
+    apply validOnFrame_of_surjective_pseudoMorphism f f_surjective
+    exact h F₁ |>.mp $ by simpa
+  apply F₂.irrefl 0
+  omega
 
 end Kripke
 

--- a/Foundation/Modal/Logic/Basic.lean
+++ b/Foundation/Modal/Logic/Basic.lean
@@ -36,25 +36,25 @@ variable {L : Logic α} {φ ψ : Formula α}
 
 @[simp low]
 lemma iff_provable : L ⊢! φ ↔ φ ∈ L := by
-  constructor;
-  . intro h;
-    exact PLift.down h.some;
-  . intro h;
-    constructor;
-    constructor;
-    exact h;
+  constructor
+  . intro h
+    exact PLift.down h.some
+  . intro h
+    constructor
+    constructor
+    exact h
 
 @[simp low]
 lemma iff_unprovable : L ⊬ φ ↔ φ ∉ L := by
-  apply not_congr;
-  simp [iff_provable];
+  apply not_congr
+  simp [iff_provable]
 
 lemma iff_equal_provable_equiv : L₁ = L₂ ↔ L₁ ≊ L₂ := by
-  constructor;
-  . tauto;
-  . rintro h;
-    ext φ;
-    simpa using Equiv.iff.mp h φ;
+  constructor
+  . tauto
+  . rintro h
+    ext φ
+    simpa using Equiv.iff.mp h φ
 
 lemma subst! [L.Substitution] (s : Substitution _) (hφ : L ⊢! φ) : L ⊢! φ⟦s⟧ := ⟨Substitution.subst s hφ.some⟩
 
@@ -65,17 +65,17 @@ variable [DecidableEq α] [L.IsQuasiNormal] [Consistent L]
 
 @[simp]
 lemma no_bot : L ⊬ ⊥ := by
-  obtain ⟨φ, hφ⟩ := Consistent.exists_unprovable (𝓢 := L) inferInstance;
-  by_contra! hC;
-  apply hφ;
-  apply of_O!;
-  exact hC;
+  obtain ⟨φ, hφ⟩ := Consistent.exists_unprovable (𝓢 := L) inferInstance
+  by_contra! hC
+  apply hφ
+  apply of_O!
+  exact hC
 
 -- TODO: more general place
 lemma not_neg_of! (hφ : L ⊢! φ) : L ⊬ ∼φ := by
-  by_contra! hC;
-  apply L.no_bot;
-  exact hC ⨀ hφ;
+  by_contra! hC
+  apply L.no_bot
+  exact hC ⨀ hφ
 
 end
 
@@ -91,21 +91,21 @@ variable {L : Logic α}
 instance : (∅ : Logic α) ⪯ L := ⟨by simp [Entailment.theory]⟩
 
 instance [HasAxiomVerum L] : (∅ : Logic α) ⪱ L := by
-  apply strictlyWeakerThan_iff.mpr;
-  constructor;
-  . simp;
-  . use ⊤; constructor <;> simp;
+  apply strictlyWeakerThan_iff.mpr
+  constructor
+  . simp
+  . use ⊤; constructor <;> simp
 
 instance : L ⪯ (Set.univ : Logic α) := ⟨by simp [Entailment.theory]⟩
 
 instance [Consistent L] : L ⪱ (Set.univ : Logic α) := by
-  apply strictlyWeakerThan_iff.mpr;
-  constructor;
-  . simp;
-  . obtain ⟨φ, hφ⟩ := consistent_iff_exists_unprovable (𝓢 := L) |>.mp (by assumption);
-    use φ;
-    constructor;
-    . assumption;
+  apply strictlyWeakerThan_iff.mpr
+  constructor
+  . simp
+  . obtain ⟨φ, hφ⟩ := consistent_iff_exists_unprovable (𝓢 := L) |>.mp (by assumption)
+    use φ
+    constructor
+    . assumption
     . simp
 
 end

--- a/Foundation/Modal/Logic/Dz/Basic.lean
+++ b/Foundation/Modal/Logic/Dz/Basic.lean
@@ -11,23 +11,23 @@ instance : Modal.Dz.IsQuasiNormal := inferInstance
 
 instance : Entailment.HasAxiomP Modal.Dz where
   P := by
-    constructor;
-    apply Logic.sumQuasiNormal.mem₂;
-    simp;
+    constructor
+    apply Logic.sumQuasiNormal.mem₂
+    simp
 
 lemma Dz.mem_axiomDz : Modal.Dz ⊢! □(□φ ⋎ □ψ) ➝ □φ ⋎ □ψ := by
-  apply Logic.subst! (φ := □(□(.atom 0) ⋎ □(.atom 1)) ➝ □(.atom 0) ⋎ □(.atom 1)) (s := λ a => if a = 0 then φ else ψ);
-  apply Logic.sumQuasiNormal.mem₂!;
-  simp;
+  apply Logic.subst! (φ := □(□(.atom 0) ⋎ □(.atom 1)) ➝ □(.atom 0) ⋎ □(.atom 1)) (s := λ a => if a = 0 then φ else ψ)
+  apply Logic.sumQuasiNormal.mem₂!
+  simp
 
 instance : Modal.GL ⪱ Modal.Dz := by
-  constructor;
-  . infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use ∼□⊥;
-    constructor;
-    . simp;
-    . simpa using GL.unprovable_notbox;
+  constructor
+  . infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use ∼□⊥
+    constructor
+    . simp
+    . simpa using GL.unprovable_notbox
 
 section
 
@@ -38,33 +38,33 @@ private inductive Dz' : Logic ℕ
   | mdp  {φ ψ} : Modal.Dz' (φ ➝ ψ) → Modal.Dz' φ → Modal.Dz' ψ
 
 private lemma Dz'.eq_Dz : Modal.Dz' = Modal.Dz := by
-  ext φ;
-  constructor;
-  . intro h;
-    apply iff_provable.mp;
+  ext φ
+  constructor
+  . intro h
+    apply iff_provable.mp
     induction h with
-    | mem_GL h => exact sumQuasiNormal.mem₁! h;
-    | mdp _ _ ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | axiomDz φ => apply Modal.Dz.mem_axiomDz;
-    | axiomP => simp;
-  . intro h;
+    | mem_GL h => exact sumQuasiNormal.mem₁! h
+    | mdp _ _ ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | axiomDz φ => apply Modal.Dz.mem_axiomDz
+    | axiomP => simp
+  . intro h
     induction h with
-    | mem₁ h => exact Modal.Dz'.mem_GL h;
+    | mem₁ h => exact Modal.Dz'.mem_GL h
     | mem₂ h =>
-      rcases h with (rfl | rfl);
-      . apply Modal.Dz'.axiomP;
-      . apply Modal.Dz'.axiomDz;
-    | mdp _ _ ihφψ ihφ => exact Modal.Dz'.mdp ihφψ ihφ;
+      rcases h with (rfl | rfl)
+      . apply Modal.Dz'.axiomP
+      . apply Modal.Dz'.axiomDz
+    | mdp _ _ ihφψ ihφ => exact Modal.Dz'.mdp ihφψ ihφ
     | subst hφ ihφ =>
-      clear hφ;
+      clear hφ
       induction ihφ with
       | mem_GL h =>
-        apply Modal.Dz'.mem_GL;
-        apply subst!;
-        exact h;
-      | axiomP => apply Modal.Dz'.axiomP;
-      | axiomDz _ _ => apply Modal.Dz'.axiomDz;
-      | mdp _ _ ihφψ ihφ => apply Modal.Dz'.mdp ihφψ ihφ;
+        apply Modal.Dz'.mem_GL
+        apply subst!
+        exact h
+      | axiomP => apply Modal.Dz'.axiomP
+      | axiomDz _ _ => apply Modal.Dz'.axiomDz
+      | mdp _ _ ihφψ ihφ => apply Modal.Dz'.mdp ihφψ ihφ
 
 -- TODO: Remove `eq_Dz_Dz'`?
 protected def Dz.rec'
@@ -74,20 +74,20 @@ protected def Dz.rec'
   (axiomDz : ∀ {φ ψ}, motive (□(□φ ⋎ □ψ) ➝ □φ ⋎ □ψ) (Modal.Dz.mem_axiomDz))
   (mdp : ∀ {φ ψ}, {hφψ : Modal.Dz ⊢! φ ➝ ψ} → {hφ : Modal.Dz ⊢! φ} → (motive (φ ➝ ψ) hφψ) → (motive φ hφ) → motive ψ (hφψ ⨀ hφ))
   : ∀ {φ}, (h : Modal.Dz ⊢! φ) → motive φ h := by
-  intro φ h;
-  replace h := iff_provable.mp $ Modal.Dz'.eq_Dz ▸ h;
+  intro φ h
+  replace h := iff_provable.mp $ Modal.Dz'.eq_Dz ▸ h
   induction h with
-  | mem_GL h => apply mem_GL; assumption;
-  | axiomP => apply axiomP;
-  | axiomDz φ ψ => apply axiomDz;
+  | mem_GL h => apply mem_GL; assumption
+  | axiomP => apply axiomP
+  | axiomDz φ ψ => apply axiomDz
   | mdp hφψ hφ ihφψ ihφ =>
-    apply mdp;
-    . apply ihφψ;
-    . apply ihφ;
-    . replace hφψ := iff_provable.mpr hφψ;
-      rwa [Dz'.eq_Dz] at hφψ;
-    . replace hφ := iff_provable.mpr hφ;
-      rwa [Dz'.eq_Dz] at hφ;
+    apply mdp
+    . apply ihφψ
+    . apply ihφ
+    . replace hφψ := iff_provable.mpr hφψ
+      rwa [Dz'.eq_Dz] at hφψ
+    . replace hφ := iff_provable.mpr hφ
+      rwa [Dz'.eq_Dz] at hφ
 
 end
 

--- a/Foundation/Modal/Logic/Extension.lean
+++ b/Foundation/Modal/Logic/Extension.lean
@@ -20,25 +20,25 @@ namespace sumQuasiNormal
 variable {φ ψ : Formula α}
 
 lemma mem₁! (hφ : L₁ ⊢! φ) : sumQuasiNormal L₁ L₂ ⊢! φ := by
-  apply iff_provable.mpr;
-  apply sumQuasiNormal.mem₁ hφ;
+  apply iff_provable.mpr
+  apply sumQuasiNormal.mem₁ hφ
 
 lemma mem₂! (hφ : L₂ ⊢! φ) : sumQuasiNormal L₁ L₂ ⊢! φ := by
-  apply iff_provable.mpr;
-  apply sumQuasiNormal.mem₂ hφ;
+  apply iff_provable.mpr
+  apply sumQuasiNormal.mem₂ hφ
 
 instance : Entailment.ModusPonens (sumQuasiNormal L₁ L₂) where
   mdp hφψ hφ := by
-    constructor;
-    apply sumQuasiNormal.mdp;
-    . exact PLift.down hφψ;
-    . exact PLift.down hφ;
+    constructor
+    apply sumQuasiNormal.mdp
+    . exact PLift.down hφψ
+    . exact PLift.down hφ
 
 instance : (sumQuasiNormal L₁ L₂).Substitution where
   subst s hφ := by
-    constructor;
-    apply sumQuasiNormal.subst;
-    exact PLift.down hφ;
+    constructor
+    apply sumQuasiNormal.subst
+    exact PLift.down hφ
 
 lemma rec!
   {motive : (φ : Formula α) → ((sumQuasiNormal L₁ L₂) ⊢! φ) → Sort}
@@ -50,63 +50,63 @@ lemma rec!
   )
   (subst : ∀ {φ s}, {hφ : (sumQuasiNormal L₁ L₂) ⊢! φ} → (motive φ hφ) → motive (φ⟦s⟧) (Logic.subst! _ hφ))
   : ∀ {φ}, (h : sumQuasiNormal L₁ L₂ ⊢! φ) → motive φ h := by
-  intro _ hφ;
+  intro _ hφ
   induction (iff_provable.mp $ hφ) with
-  | mem₁ h => apply mem₁ h;
-  | mem₂ h => apply mem₂ h;
+  | mem₁ h => apply mem₁ h
+  | mem₂ h => apply mem₂ h
   | mdp hφψ hφ ihφψ ihφ =>
-    apply mdp;
-    . apply ihφψ;
-    . apply ihφ;
-    . apply iff_provable.mpr; assumption;
-    . apply iff_provable.mpr; assumption;
+    apply mdp
+    . apply ihφψ
+    . apply ihφ
+    . apply iff_provable.mpr; assumption
+    . apply iff_provable.mpr; assumption
   | subst hφ ihφ =>
-    apply subst;
-    . apply ihφ;
-    . apply iff_provable.mpr; assumption;
+    apply subst
+    . apply ihφ
+    . apply iff_provable.mpr; assumption
 
 lemma symm : sumQuasiNormal L₁ L₂ = sumQuasiNormal L₂ L₁ := by
-  ext φ;
-  constructor;
-  . intro h;
+  ext φ
+  constructor
+  . intro h
     induction h with
-    | mem₁ h => exact sumQuasiNormal.mem₂ h;
-    | mem₂ h => exact sumQuasiNormal.mem₁ h;
-    | mdp _ _ ihφψ ihφ => exact sumQuasiNormal.mdp ihφψ ihφ;
-    | subst _ ihφ => exact sumQuasiNormal.subst ihφ;
-  . intro h;
+    | mem₁ h => exact sumQuasiNormal.mem₂ h
+    | mem₂ h => exact sumQuasiNormal.mem₁ h
+    | mdp _ _ ihφψ ihφ => exact sumQuasiNormal.mdp ihφψ ihφ
+    | subst _ ihφ => exact sumQuasiNormal.subst ihφ
+  . intro h
     induction h with
-    | mem₁ h => exact sumQuasiNormal.mem₂ h;
-    | mem₂ h => exact sumQuasiNormal.mem₁ h;
-    | mdp _ _ ihφψ ihφ => exact sumQuasiNormal.mdp ihφψ ihφ;
-    | subst _ ihφ => exact sumQuasiNormal.subst ihφ;
+    | mem₁ h => exact sumQuasiNormal.mem₂ h
+    | mem₂ h => exact sumQuasiNormal.mem₁ h
+    | mdp _ _ ihφψ ihφ => exact sumQuasiNormal.mdp ihφψ ihφ
+    | subst _ ihφ => exact sumQuasiNormal.subst ihφ
 
 variable [DecidableEq α]
 
 instance [Entailment.Cl L₁] : Entailment.Lukasiewicz (sumQuasiNormal L₁ L₂) where
-  imply₁ _ _ := by constructor; apply sumQuasiNormal.mem₁; simp;
-  imply₂ _ _ _ := by constructor; apply sumQuasiNormal.mem₁; simp;
-  elimContra _ _ := by constructor; apply sumQuasiNormal.mem₁; simp;
+  imply₁ _ _ := by constructor; apply sumQuasiNormal.mem₁; simp
+  imply₂ _ _ _ := by constructor; apply sumQuasiNormal.mem₁; simp
+  elimContra _ _ := by constructor; apply sumQuasiNormal.mem₁; simp
 
 instance [L₁.IsQuasiNormal] : (sumQuasiNormal L₁ L₂).IsQuasiNormal where
-  K _ _ := by constructor; apply sumQuasiNormal.mem₁; simp;
+  K _ _ := by constructor; apply sumQuasiNormal.mem₁; simp
   subst s hφ := by
-    constructor;
-    apply sumQuasiNormal.subst;
-    exact PLift.down hφ;
+    constructor
+    apply sumQuasiNormal.subst
+    exact PLift.down hφ
 
 instance [L₂.IsQuasiNormal] : (sumQuasiNormal L₁ L₂).IsQuasiNormal := by
-  rw [sumQuasiNormal.symm];
-  infer_instance;
+  rw [sumQuasiNormal.symm]
+  infer_instance
 
 instance : L₁ ⪯ sumQuasiNormal L₁ L₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ hφ;
-  exact mem₁! hφ;
+  apply weakerThan_iff.mpr
+  intro φ hφ
+  exact mem₁! hφ
 
 instance : L₂ ⪯ sumQuasiNormal L₁ L₂ := by
-  rw [sumQuasiNormal.symm];
-  infer_instance;
+  rw [sumQuasiNormal.symm]
+  infer_instance
 
 end sumQuasiNormal
 
@@ -123,31 +123,31 @@ namespace sumNormal
 variable {φ ψ : Formula α}
 
 lemma mem₁! (hφ : L₁ ⊢! φ) : sumNormal L₁ L₂ ⊢! φ := by
-  apply iff_provable.mpr;
-  apply sumNormal.mem₁ hφ;
+  apply iff_provable.mpr
+  apply sumNormal.mem₁ hφ
 
 lemma mem₂! (hφ : L₂ ⊢! φ) : sumNormal L₁ L₂ ⊢! φ := by
-  apply iff_provable.mpr;
-  apply sumNormal.mem₂ hφ;
+  apply iff_provable.mpr
+  apply sumNormal.mem₂ hφ
 
 instance : Entailment.ModusPonens (sumNormal L₁ L₂) where
   mdp hφψ hφ := by
-    constructor;
-    apply sumNormal.mdp;
-    . exact PLift.down hφψ;
-    . exact PLift.down hφ;
+    constructor
+    apply sumNormal.mdp
+    . exact PLift.down hφψ
+    . exact PLift.down hφ
 
 instance : Entailment.Necessitation (sumNormal L₁ L₂) where
   nec hφ := by
-    constructor;
-    apply sumNormal.nec;
-    exact PLift.down hφ;
+    constructor
+    apply sumNormal.nec
+    exact PLift.down hφ
 
 instance : (sumNormal L₁ L₂).Substitution where
   subst s hφ := by
-    constructor;
-    apply sumNormal.subst;
-    exact PLift.down hφ;
+    constructor
+    apply sumNormal.subst
+    exact PLift.down hφ
 
 
 lemma rec!
@@ -161,78 +161,78 @@ lemma rec!
   (nec   : ∀ {φ}, {hφ : (sumNormal L₁ L₂) ⊢! φ} → (motive φ hφ) → motive (□φ) (Entailment.nec! hφ))
   (subst : ∀ {φ s}, {hφ : (sumNormal L₁ L₂) ⊢! φ} → (motive φ hφ) → motive (φ⟦s⟧) (Logic.subst! _ hφ))
   : ∀ {φ}, (h : sumNormal L₁ L₂ ⊢! φ) → motive φ h := by
-  intro _ hφ;
+  intro _ hφ
   induction (iff_provable.mp $ hφ) with
-  | mem₁ h => apply mem₁ h;
-  | mem₂ h => apply mem₂ h;
+  | mem₁ h => apply mem₁ h
+  | mem₂ h => apply mem₂ h
   | mdp hφψ hφ ihφψ ihφ =>
-    apply mdp;
-    . apply ihφψ;
-    . apply ihφ;
-    . apply iff_provable.mpr; assumption;
-    . apply iff_provable.mpr; assumption;
+    apply mdp
+    . apply ihφψ
+    . apply ihφ
+    . apply iff_provable.mpr; assumption
+    . apply iff_provable.mpr; assumption
   | nec hφ ihφ =>
-    apply nec;
-    . apply ihφ;
-    . apply iff_provable.mpr; assumption;
+    apply nec
+    . apply ihφ
+    . apply iff_provable.mpr; assumption
   | subst hφ ihφ =>
-    apply subst;
-    . apply ihφ;
-    . apply iff_provable.mpr; assumption;
+    apply subst
+    . apply ihφ
+    . apply iff_provable.mpr; assumption
 
 lemma symm : sumNormal L₁ L₂ = sumNormal L₂ L₁ := by
-  ext φ;
-  constructor;
-  . intro h;
+  ext φ
+  constructor
+  . intro h
     induction h with
-    | mem₁ h => exact sumNormal.mem₂ h;
-    | mem₂ h => exact sumNormal.mem₁ h;
-    | mdp _ _ ihφψ ihφ => exact sumNormal.mdp ihφψ ihφ;
-    | subst _ ihφ => exact sumNormal.subst ihφ;
-    | nec _ ihφ => exact sumNormal.nec ihφ;
-  . intro h;
+    | mem₁ h => exact sumNormal.mem₂ h
+    | mem₂ h => exact sumNormal.mem₁ h
+    | mdp _ _ ihφψ ihφ => exact sumNormal.mdp ihφψ ihφ
+    | subst _ ihφ => exact sumNormal.subst ihφ
+    | nec _ ihφ => exact sumNormal.nec ihφ
+  . intro h
     induction h with
-    | mem₁ h => exact sumNormal.mem₂ h;
-    | mem₂ h => exact sumNormal.mem₁ h;
-    | mdp _ _ ihφψ ihφ => exact sumNormal.mdp ihφψ ihφ;
-    | subst _ ihφ => exact sumNormal.subst ihφ;
-    | nec _ ihφ => exact sumNormal.nec ihφ;
+    | mem₁ h => exact sumNormal.mem₂ h
+    | mem₂ h => exact sumNormal.mem₁ h
+    | mdp _ _ ihφψ ihφ => exact sumNormal.mdp ihφψ ihφ
+    | subst _ ihφ => exact sumNormal.subst ihφ
+    | nec _ ihφ => exact sumNormal.nec ihφ
 
 variable [DecidableEq α]
 
 instance [Entailment.Cl L₁] : Entailment.Lukasiewicz (sumNormal L₁ L₂) where
-  imply₁ _ _ := by constructor; apply sumNormal.mem₁; simp;
-  imply₂ _ _ _ := by constructor; apply sumNormal.mem₁; simp;
-  elimContra _ _ := by constructor; apply sumNormal.mem₁; simp;
+  imply₁ _ _ := by constructor; apply sumNormal.mem₁; simp
+  imply₂ _ _ _ := by constructor; apply sumNormal.mem₁; simp
+  elimContra _ _ := by constructor; apply sumNormal.mem₁; simp
   mdp hφψ hφ := by
-    constructor;
-    apply sumNormal.mdp;
-    . exact PLift.down hφψ;
-    . exact PLift.down hφ;
+    constructor
+    apply sumNormal.mdp
+    . exact PLift.down hφψ
+    . exact PLift.down hφ
 
 instance [L₁.IsNormal] : (sumNormal L₁ L₂).IsNormal where
-  K _ _ := by constructor; apply sumNormal.mem₁; simp;
+  K _ _ := by constructor; apply sumNormal.mem₁; simp
   subst s hφ := by
-    constructor;
-    apply sumNormal.subst;
-    exact PLift.down hφ;
+    constructor
+    apply sumNormal.subst
+    exact PLift.down hφ
   nec hφ := by
-    constructor;
-    apply sumNormal.nec;
-    exact PLift.down hφ;
+    constructor
+    apply sumNormal.nec
+    exact PLift.down hφ
 
 instance [L₂.IsNormal] : (sumNormal L₁ L₂).IsNormal := by
-  rw [sumNormal.symm];
-  infer_instance;
+  rw [sumNormal.symm]
+  infer_instance
 
 instance : L₁ ⪯ sumNormal L₁ L₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ hφ;
-  exact mem₁! hφ;
+  apply weakerThan_iff.mpr
+  intro φ hφ
+  exact mem₁! hφ
 
 instance : L₂ ⪯ sumNormal L₁ L₂ := by
-  rw [sumNormal.symm];
-  infer_instance;
+  rw [sumNormal.symm]
+  infer_instance
 
 end sumNormal
 

--- a/Foundation/Modal/Logic/GL/Independency.lean
+++ b/Foundation/Modal/Logic/GL/Independency.lean
@@ -22,57 +22,57 @@ namespace GL
 variable {n : ℕ} {φ : Formula ℕ}
 
 lemma unprovable_notbox : Modal.GL ⊬ ∼□φ := by
-  apply Hilbert.Normal.iff_logic_provable_provable.not.mpr;
-  by_contra hC;
+  apply Hilbert.Normal.iff_logic_provable_provable.not.mpr
+  by_contra hC
   have : Hilbert.GL ⊢! ∼□φ ➝ ∼□⊥ := contra! (imply_box_distribute'! efq!)
-  have : Hilbert.GL ⊢! ∼□⊥ := this ⨀ hC;
-  have : Hilbert.Cl ⊢! (⊥ ➝ ⊥) ➝ ⊥ := by simpa using Logic.GL.provable_verTranslated_Cl this;
-  have := Hilbert.Cl.soundness this (λ _ => False);
-  tauto;
+  have : Hilbert.GL ⊢! ∼□⊥ := this ⨀ hC
+  have : Hilbert.Cl ⊢! (⊥ ➝ ⊥) ➝ ⊥ := by simpa using Logic.GL.provable_verTranslated_Cl this
+  have := Hilbert.Cl.soundness this (λ _ => False)
+  tauto
 
 lemma unprovable_independency : Modal.GL ⊬ independency φ := by
-  by_contra hC;
-  exact unprovable_notbox $ K!_left hC;
+  by_contra hC
+  exact unprovable_notbox $ K!_left hC
 
 lemma unprovable_not_independency_of_consistency : Modal.GL ⊬ ∼(independency (∼□⊥)) := by
-  by_contra hC;
-  rcases modal_disjunctive (A!_of_ANNNN! $ ANN!_of_NK! hC) with (h | h);
-  . apply unprovable_notbox h;
-  . apply Consistent.not_bot inferInstance (𝓢 := Hilbert.GL);
-    simpa using unnec! $ of_NN! h;
+  by_contra hC
+  rcases modal_disjunctive (A!_of_ANNNN! $ ANN!_of_NK! hC) with (h | h)
+  . apply unprovable_notbox h
+  . apply Consistent.not_bot inferInstance (𝓢 := Hilbert.GL)
+    simpa using unnec! $ of_NN! h
 
 
 /-
 theorem undecidable_independency_of_consistency : Independent Hilbert.GL (independency (∼□⊥)) := by
-  constructor;
-  . exact unprovable_independency;
-  . exact unprovable_not_independency_of_consistency;
+  constructor
+  . exact unprovable_independency
+  . exact unprovable_not_independency_of_consistency
 -/
 
 
 lemma unprovable_higherIndependency_of_consistency : Modal.GL ⊬ higherIndependency (∼□⊥) n := by
   induction n with
-  | zero => exact unprovable_notbox;
-  | succ n ih => exact unprovable_independency;
+  | zero => exact unprovable_notbox
+  | succ n ih => exact unprovable_independency
 
 lemma unprovable_not_higherIndependency_of_consistency : Modal.GL ⊬ ∼(higherIndependency (∼□⊥) n) := by
-  by_contra hC;
+  by_contra hC
   induction n with
   | zero =>
-    apply Consistent.not_bot inferInstance (𝓢 := Hilbert.GL);
-    apply unnec!;
-    apply of_NN!;
-    simpa [higherIndependency] using hC;
+    apply Consistent.not_bot inferInstance (𝓢 := Hilbert.GL)
+    apply unnec!
+    apply of_NN!
+    simpa [higherIndependency] using hC
   | succ n ih =>
-    rcases modal_disjunctive (A!_of_ANNNN! $ ANN!_of_NK! hC) with (h | h);
-    . exact unprovable_higherIndependency_of_consistency h;
-    . exact ih h;
+    rcases modal_disjunctive (A!_of_ANNNN! $ ANN!_of_NK! hC) with (h | h)
+    . exact unprovable_higherIndependency_of_consistency h
+    . exact ih h
 
 /-
 theorem undecidable_higherIndependency_of_consistency : Independent Hilbert.GL (higherIndependency (∼□⊥) n) := by
-  constructor;
-  . exact unprovable_higherIndependency_of_consistency;
-  . exact unprovable_not_higherIndependency_of_consistency;
+  constructor
+  . exact unprovable_higherIndependency_of_consistency
+  . exact unprovable_not_higherIndependency_of_consistency
 -/
 
 end GL

--- a/Foundation/Modal/Logic/GLPlusBoxBot/Basic.lean
+++ b/Foundation/Modal/Logic/GLPlusBoxBot/Basic.lean
@@ -16,7 +16,7 @@ protected abbrev BoxBot (n : ℕ∞) : F :=
 lemma BoxBot.eq_omega : (Axioms.BoxBot ⊤ : F) = ⊤ := rfl
 
 @[simp]
-lemma BoxBot.subst {s : Substitution α} : (Axioms.BoxBot n)⟦s⟧ = (Axioms.BoxBot n) := by cases n <;> simp;
+lemma BoxBot.subst {s : Substitution α} : (Axioms.BoxBot n)⟦s⟧ = (Axioms.BoxBot n) := by cases n <;> simp
 
 end LO.Modal.Axioms
 
@@ -30,35 +30,35 @@ variable {n : ℕ∞}
 protected def GLPlusBoxBot (n : ℕ∞) : Logic ℕ := sumQuasiNormal Modal.GL { (Modal.Axioms.BoxBot n) }
 
 instance : (Modal.GLPlusBoxBot n).IsQuasiNormal := by
-  dsimp [Modal.GLPlusBoxBot];
-  infer_instance;
+  dsimp [Modal.GLPlusBoxBot]
+  infer_instance
 
 instance : Modal.GL ⪯ Modal.GLPlusBoxBot n := by
-  dsimp [Modal.GLPlusBoxBot];
-  infer_instance;
+  dsimp [Modal.GLPlusBoxBot]
+  infer_instance
 
 @[simp]
 lemma Logic.GLPlusBoxBot.boxbot : Modal.GLPlusBoxBot n ⊢! (Modal.Axioms.BoxBot n) := by
-  apply Logic.sumQuasiNormal.mem₂!;
-  tauto;
+  apply Logic.sumQuasiNormal.mem₂!
+  tauto
 
 lemma iff_provable_GLBB_provable_GL {n : ℕ∞} {φ} : Modal.GLPlusBoxBot n ⊢! φ ↔ Modal.GL ⊢! (Modal.Axioms.BoxBot n) ➝ φ := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h using sumQuasiNormal.rec! with
     | mem₁ h => cl_prover [h]
-    | mem₂ h => simp_all;
-    | mdp ihφψ ihφ => cl_prover [ihφψ, ihφ];
-    | subst ihφ => simpa using Logic.subst! _ ihφ;
-  . intro h;
-    replace h : Modal.GLPlusBoxBot n ⊢! (Modal.Axioms.BoxBot n) ➝ φ := sumQuasiNormal.mem₁! h;
-    exact h ⨀ Logic.GLPlusBoxBot.boxbot;
+    | mem₂ h => simp_all
+    | mdp ihφψ ihφ => cl_prover [ihφψ, ihφ]
+    | subst ihφ => simpa using Logic.subst! _ ihφ
+  . intro h
+    replace h : Modal.GLPlusBoxBot n ⊢! (Modal.Axioms.BoxBot n) ➝ φ := sumQuasiNormal.mem₁! h
+    exact h ⨀ Logic.GLPlusBoxBot.boxbot
 
 @[simp]
 lemma eq_GLBB_omega_GL : (Modal.GLPlusBoxBot ⊤ : Logic ℕ) = Modal.GL := by
-  ext φ;
-  suffices Modal.GLPlusBoxBot ⊤ ⊢! φ ↔ Modal.GL ⊢! φ by simpa;
-  apply Iff.trans iff_provable_GLBB_provable_GL;
-  constructor <;> . intro h; cl_prover [h];
+  ext φ
+  suffices Modal.GLPlusBoxBot ⊤ ⊢! φ ↔ Modal.GL ⊢! φ by simpa
+  apply Iff.trans iff_provable_GLBB_provable_GL
+  constructor <;> . intro h; cl_prover [h]
 
 end LO.Modal

--- a/Foundation/Modal/Logic/Global.lean
+++ b/Foundation/Modal/Logic/Global.lean
@@ -9,12 +9,12 @@ variable {α}
 
 open Modal.Entailment in
 lemma normal_provable_of_K_provable {L : Logic ℕ} [L.IsNormal] (h : Modal.K ⊢! φ) : L ⊢! φ := by
-  simp only [Hilbert.Normal.iff_logic_provable_provable] at h;
+  simp only [Hilbert.Normal.iff_logic_provable_provable] at h
   induction h using Hilbert.Normal.rec! with
-  | axm s h => rcases h with rfl; simp;
-  | mdp hφψ hψ => exact hφψ ⨀ hψ;
-  | nec ihφ => apply nec!; exact ihφ;
-  | _ => simp;
+  | axm s h => rcases h with rfl; simp
+  | mdp hφψ hψ => exact hφψ ⨀ hψ
+  | nec ihφ => apply nec!; exact ihφ
+  | _ => simp
 
 
 namespace Formula
@@ -40,7 +40,7 @@ open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 variable {L : Logic α} {X Y : Set (Formula α)} {φ ψ : Formula α}
 
 instance : Entailment.Lukasiewicz (F := Formula α) (S := Logic α × Set (Formula α)) (L, X) where
-  mdp ihφψ ihφ := by simpa using GlobalConsequence.mdp ihφψ ihφ;
+  mdp ihφψ ihφ := by simpa using GlobalConsequence.mdp ihφψ ihφ
   imply₁ := GlobalConsequence.imply₁ X
   imply₂ := GlobalConsequence.imply₂ X
   elimContra := GlobalConsequence.ec X
@@ -50,8 +50,8 @@ instance : Entailment.Necessitation (F := Formula α) (S := Logic α × Set (For
 
 instance [L.IsNormal] : Entailment.K (F := Formula α) (S := Logic α × Set (Formula α)) (L, X) where
   K _ _ := by
-    apply GlobalConsequence.thm;
-    simp;
+    apply GlobalConsequence.thm
+    simp
 
 protected lemma thm! (h : L ⊢! φ) : (L, X) ⊢! φ := ⟨GlobalConsequence.thm h⟩
 
@@ -74,15 +74,15 @@ protected lemma rec!
   (imply₂! : ∀ {X φ ψ ξ}, motive X (Axioms.Imply₂ φ ψ ξ) ⟨GlobalConsequence.imply₂ X φ ψ ξ⟩)
   (ec! : ∀ {X φ ψ}, motive X (Axioms.ElimContra φ ψ) ⟨GlobalConsequence.ec X φ ψ⟩)
   : ∀ {X : Set (Formula α)} {φ}, (d : (L, X) ⊢! φ) → motive X φ d := by
-  rintro X φ ⟨d⟩;
+  rintro X φ ⟨d⟩
   induction d with
-  | ctx h => apply ctx! h;
-  | thm h => apply thm! h;
-  | mdp _ _ ihφψ ihφ => apply mdp! ihφψ ihφ;
-  | nec _ ihφ => apply nec! ihφ;
-  | imply₁ => apply imply₁!;
-  | imply₂ => apply imply₂!;
-  | ec => apply ec!;
+  | ctx h => apply ctx! h
+  | thm h => apply thm! h
+  | mdp _ _ ihφψ ihφ => apply mdp! ihφψ ihφ
+  | nec _ ihφ => apply nec! ihφ
+  | imply₁ => apply imply₁!
+  | imply₂ => apply imply₂!
+  | ec => apply ec!
 
 section
 
@@ -92,66 +92,66 @@ variable {L : Logic ℕ} [L.IsNormal] {X Y : Set (Formula ℕ)} {φ ψ : Formula
   Jeřábek, Fact 2.7
 -/
 lemma iff_finite_boxlt_provable : ((L, X) ⊢! φ) ↔ (∃ Γ : Finset (Formula _), ∃ n, ↑Γ ⊆ X ∧ L ⊢! (□^≤[n] Γ.conj) ➝ φ) := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h using GlobalConsequence.rec! with
     | thm! h =>
-      use ∅, 0;
-      constructor;
-      . simp;
-      . apply C!_of_conseq!;
-        exact h;
+      use ∅, 0
+      constructor
+      . simp
+      . apply C!_of_conseq!
+        exact h
     | @ctx! X ψ h =>
-      use {ψ}, 0;
-      constructor;
-      . simpa;
-      . simp;
+      use {ψ}, 0
+      constructor
+      . simpa
+      . simp
     | @mdp! _ _ φ ψ _ _ ihφψ ihφ =>
-      obtain ⟨Δ₁, n, ⟨hΔ₁, hφψ⟩⟩ := ihφψ;
-      obtain ⟨Δ₂, m, ⟨hΔ₂, hφ⟩⟩ := ihφ;
-      use Δ₁ ∪ Δ₂, n + m;
-      constructor;
-      . simp only [Finset.coe_union, Set.union_subset_iff];
-        tauto_set;
-      . replace hφψ : L ⊢! (□^≤[n + m](Δ₁ ∪ Δ₂).conj) ➝ φ ➝ ψ := C!_trans (C!_trans (boxlt_lt! (by omega)) (boxlt_regularity! (CFConj_FConj!_of_subset (by simp)))) hφψ;
-        replace hφ  : L ⊢! (□^≤[n + m](Δ₁ ∪ Δ₂).conj) ➝ φ := C!_trans (C!_trans (boxlt_lt! (by omega)) (boxlt_regularity! (CFConj_FConj!_of_subset (by simp)))) hφ;
-        cl_prover [hφψ, hφ];
+      obtain ⟨Δ₁, n, ⟨hΔ₁, hφψ⟩⟩ := ihφψ
+      obtain ⟨Δ₂, m, ⟨hΔ₂, hφ⟩⟩ := ihφ
+      use Δ₁ ∪ Δ₂, n + m
+      constructor
+      . simp only [Finset.coe_union, Set.union_subset_iff]
+        tauto_set
+      . replace hφψ : L ⊢! (□^≤[n + m](Δ₁ ∪ Δ₂).conj) ➝ φ ➝ ψ := C!_trans (C!_trans (boxlt_lt! (by omega)) (boxlt_regularity! (CFConj_FConj!_of_subset (by simp)))) hφψ
+        replace hφ  : L ⊢! (□^≤[n + m](Δ₁ ∪ Δ₂).conj) ➝ φ := C!_trans (C!_trans (boxlt_lt! (by omega)) (boxlt_regularity! (CFConj_FConj!_of_subset (by simp)))) hφ
+        cl_prover [hφψ, hφ]
     | @nec! _ φ h ih =>
-      obtain ⟨Δ, n, ⟨h₁, h₂⟩⟩ := ih;
-      use Δ, n + 1;
-      constructor;
-      . assumption;
-      . apply C!_trans ?_ $ box_regularity! h₂;
-        apply C!_trans ?_ collect_box_fconj!;
-        apply CFconjFconj!_of_provable;
-        intro ψ hψ;
-        simp only [Finset.mem_image, Finset.mem_range, Function.iterate_one, exists_exists_and_eq_and] at hψ;
-        obtain ⟨i, hi, rfl⟩ := hψ;
-        apply Context.by_axm!;
-        simp only [Finset.coe_image, Finset.coe_range, Set.mem_image, Set.mem_Iio];
-        use i + 1;
-        constructor;
-        . omega;
-        . simp;
+      obtain ⟨Δ, n, ⟨h₁, h₂⟩⟩ := ih
+      use Δ, n + 1
+      constructor
+      . assumption
+      . apply C!_trans ?_ $ box_regularity! h₂
+        apply C!_trans ?_ collect_box_fconj!
+        apply CFconjFconj!_of_provable
+        intro ψ hψ
+        simp only [Finset.mem_image, Finset.mem_range, Function.iterate_one, exists_exists_and_eq_and] at hψ
+        obtain ⟨i, hi, rfl⟩ := hψ
+        apply Context.by_axm!
+        simp only [Finset.coe_image, Finset.coe_range, Set.mem_image, Set.mem_Iio]
+        use i + 1
+        constructor
+        . omega
+        . simp
     | imply₁! | imply₂! | ec! =>
-      use ∅, 0;
-      constructor;
-      . simp;
-      . apply normal_provable_of_K_provable;
-        apply C!_of_conseq!;
-        simp;
-  . rintro ⟨Γ, n, hΓ, hφ⟩;
-    apply (GlobalConsequence.thm! hφ) ⨀ _;
-    apply FConj!_iff_forall_provable.mpr;
-    intro ψ hψ;
-    simp only [Finset.mem_image, Finset.mem_range] at hψ;
-    obtain ⟨i, hi, rfl⟩ := hψ;
-    apply multinec!;
-    apply FConj!_iff_forall_provable.mpr;
-    intro ψ hψ;
-    apply GlobalConsequence.ctx!;
-    apply hΓ;
-    simpa;
+      use ∅, 0
+      constructor
+      . simp
+      . apply normal_provable_of_K_provable
+        apply C!_of_conseq!
+        simp
+  . rintro ⟨Γ, n, hΓ, hφ⟩
+    apply (GlobalConsequence.thm! hφ) ⨀ _
+    apply FConj!_iff_forall_provable.mpr
+    intro ψ hψ
+    simp only [Finset.mem_image, Finset.mem_range] at hψ
+    obtain ⟨i, hi, rfl⟩ := hψ
+    apply multinec!
+    apply FConj!_iff_forall_provable.mpr
+    intro ψ hψ
+    apply GlobalConsequence.ctx!
+    apply hΓ
+    simpa
 
 end
 

--- a/Foundation/Modal/Logic/S/Basic.lean
+++ b/Foundation/Modal/Logic/S/Basic.lean
@@ -11,19 +11,19 @@ protected abbrev S := sumQuasiNormal Modal.GL {Axioms.T (.atom 0)}
 instance : Modal.S.IsQuasiNormal := inferInstance
 instance : Entailment.HasAxiomT Modal.S where
   T φ := by
-    constructor;
-    apply Logic.sumQuasiNormal.subst (φ := Axioms.T (.atom 0)) (s := λ _ => φ);
-    apply Logic.sumQuasiNormal.mem₂;
-    simp;
+    constructor
+    apply Logic.sumQuasiNormal.subst (φ := Axioms.T (.atom 0)) (s := λ _ => φ)
+    apply Logic.sumQuasiNormal.mem₂
+    simp
 
 instance : Modal.GL ⪱ Modal.S := by
-  constructor;
-  . infer_instance;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . simp;
-    . simpa using Logic.GL.unprovable_AxiomT;
+  constructor
+  . infer_instance
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . simp
+    . simpa using Logic.GL.unprovable_AxiomT
 
 section
 
@@ -33,35 +33,35 @@ private inductive S' : Logic ℕ
   | mdp  {φ ψ} : Modal.S' (φ ➝ ψ) → Modal.S' φ → Modal.S' ψ
 
 private lemma S'.eq_S : Modal.S' = Modal.S := by
-  ext φ;
-  constructor;
-  . intro h;
+  ext φ
+  constructor
+  . intro h
     induction h with
-    | mem_GL h => apply Logic.sumQuasiNormal.mem₁; exact h;
-    | axiomT φ => apply iff_provable.mp; simp;
+    | mem_GL h => apply Logic.sumQuasiNormal.mem₁; exact h
+    | axiomT φ => apply iff_provable.mp; simp
     | mdp hφψ hφ ihφψ ihφ =>
-      apply Logic.sumQuasiNormal.mdp;
-      . assumption;
-      . assumption;
-  . intro h;
+      apply Logic.sumQuasiNormal.mdp
+      . assumption
+      . assumption
+  . intro h
     induction h with
     | mem₁ h =>
-      apply Modal.S'.mem_GL h;
+      apply Modal.S'.mem_GL h
     | mem₂ h =>
-      simp only [iff_provable, Set.mem_singleton_iff] at h;
-      subst h;
-      exact Modal.S'.axiomT (.atom 0);
+      simp only [iff_provable, Set.mem_singleton_iff] at h
+      subst h
+      exact Modal.S'.axiomT (.atom 0)
     | mdp _ _ ihφψ ihφ =>
-      exact Modal.S'.mdp ihφψ ihφ;
+      exact Modal.S'.mdp ihφψ ihφ
     | subst hφ ihφ =>
-      clear hφ;
+      clear hφ
       induction ihφ with
       | mem_GL h =>
-        apply Modal.S'.mem_GL;
-        apply subst!;
-        exact h;
-      | axiomT _ => apply Modal.S'.axiomT;
-      | mdp _ _ ihφψ ihφ => apply Modal.S'.mdp ihφψ ihφ;
+        apply Modal.S'.mem_GL
+        apply subst!
+        exact h
+      | axiomT _ => apply Modal.S'.axiomT
+      | mdp _ _ ihφψ ihφ => apply Modal.S'.mdp ihφψ ihφ
 
 -- TODO: Remove `eq_S_S'`?
 protected def S.rec'
@@ -70,19 +70,19 @@ protected def S.rec'
   (axiomT : ∀ {φ}, motive (Axioms.T φ) (by simp))
   (mdp : ∀ {φ ψ}, {hφψ : Modal.S ⊢! φ ➝ ψ} → {hφ : Modal.S ⊢! φ} → (motive (φ ➝ ψ) hφψ) → (motive φ hφ) → motive ψ (hφψ ⨀ hφ))
   : ∀ {φ}, (h : Modal.S ⊢! φ) → motive φ h := by
-  intro φ h;
-  replace h := iff_provable.mp $ Modal.S'.eq_S ▸ h;
+  intro φ h
+  replace h := iff_provable.mp $ Modal.S'.eq_S ▸ h
   induction h with
-  | mem_GL h => apply mem_GL; assumption;
-  | axiomT h => exact axiomT;
+  | mem_GL h => apply mem_GL; assumption
+  | axiomT h => exact axiomT
   | mdp hφψ hφ ihφψ ihφ =>
-    apply mdp;
-    . apply ihφψ;
-    . apply ihφ;
-    . replace hφψ := iff_provable.mpr hφψ;
-      rwa [Modal.S'.eq_S] at hφψ;
-    . replace hφ := iff_provable.mpr hφ;
-      rwa [Modal.S'.eq_S] at hφ;
+    apply mdp
+    . apply ihφψ
+    . apply ihφ
+    . replace hφψ := iff_provable.mpr hφψ
+      rwa [Modal.S'.eq_S] at hφψ
+    . replace hφ := iff_provable.mpr hφ
+      rwa [Modal.S'.eq_S] at hφ
 
 end
 

--- a/Foundation/Modal/Logic/S/Consistent.lean
+++ b/Foundation/Modal/Logic/S/Consistent.lean
@@ -10,18 +10,18 @@ open Entailment
 open Kripke Formula.Kripke
 
 lemma iff_provable_GL_provable_box_S {A : Modal.Formula _} : Modal.GL ⊢! A ↔ Modal.S ⊢! □A := by
-  constructor;
-  . intro h;
-    apply Logic.sumQuasiNormal.mem₁!;
-    apply nec! h;
-  . intro h;
-    apply GL.arithmetical_completeness (T := 𝐈𝚺₁) (by simp);
-    intro f;
+  constructor
+  . intro h
+    apply Logic.sumQuasiNormal.mem₁!
+    apply nec! h
+  . intro h
+    apply GL.arithmetical_completeness (T := 𝐈𝚺₁) (by simp)
+    intro f
     exact Iff.mp Provability.SoundOnModel.sound (S.arithmetical_soundness h f)
 
 theorem S.no_boxbot : Modal.S ⊬ □⊥ := iff_provable_GL_provable_box_S.not.mp $ by
-  simp only [Hilbert.Normal.iff_logic_provable_provable];
-  apply Entailment.Consistent.not_bot inferInstance;
+  simp only [Hilbert.Normal.iff_logic_provable_provable]
+  apply Entailment.Consistent.not_bot inferInstance
 
 instance : Entailment.Consistent Modal.S := Entailment.Consistent.of_unprovable S.no_boxbot
 

--- a/Foundation/Modal/LogicSymbol.lean
+++ b/Foundation/Modal/LogicSymbol.lean
@@ -8,7 +8,7 @@ namespace LO
 @[notation_class]
 class Box (F : Type*) where
   box : F → F
-  box_injective : Function.Injective box := by simp [Function.Injective];
+  box_injective : Function.Injective box := by simp [Function.Injective]
 
 prefix:76 "□" => Box.box
 
@@ -33,7 +33,7 @@ noncomputable abbrev boxlt (n : ℕ) (φ : F) := Finset.range (n + 1) |>.image (
 notation:90 "□^≤[" n "]" φ => Box.boxlt n φ
 
 @[simp high]
-lemma boxlt_zero {φ : F} : (□^≤[0]φ) = φ := by simp [Box.boxlt];
+lemma boxlt_zero {φ : F} : (□^≤[0]φ) = φ := by simp [Box.boxlt]
 
 end
 
@@ -48,28 +48,28 @@ variable {φ ψ : F} {n : ℕ}
 
 @[simp]
 lemma box_injective' : □φ = □ψ ↔ φ = ψ := by
-  constructor;
-  . apply box_injective;
-  . simp_all;
+  constructor
+  . apply box_injective
+  . simp_all
 
 @[simp] lemma multibox_succ : □^[(n + 1)]φ = □(□^[n]φ) := by apply iterate_succ_apply'
 
-@[simp] lemma multibox_injective : Function.Injective (□^[n] · : F → F) := by apply Function.Injective.iterate (by simp);
+@[simp] lemma multibox_injective : Function.Injective (□^[n] · : F → F) := by apply Function.Injective.iterate (by simp)
 
 @[simp]
 lemma multimop_injective' : □^[n]φ = □^[n]ψ ↔ φ = ψ := by
-  constructor;
-  . apply multibox_injective;
-  . simp_all;
+  constructor
+  . apply multibox_injective
+  . simp_all
 
 lemma add : □^[n](□^[m]φ) = □^[(n + m)]φ := by
   induction n with
-  | zero => simp;
-  | succ n ih => rw [(show n + 1 + m = n + m + 1 by omega)]; simpa;
+  | zero => simp
+  | succ n ih => rw [(show n + 1 + m = n + m + 1 by omega)]; simpa
 
 @[simp]
 lemma eq_box_pred_multibox_multibox {n : ℕ+} : □□^[(n - 1)]φ = □^[n]φ := by
-  induction n <;> simp;
+  induction n <;> simp
 
 end Box
 
@@ -77,7 +77,7 @@ end Box
 @[notation_class]
 class Dia (F : Type*) where
   dia : F → F
-  dia_injective : Function.Injective dia := by simp [Function.Injective];
+  dia_injective : Function.Injective dia := by simp [Function.Injective]
 
 prefix:76 "◇" => Dia.dia
 
@@ -106,24 +106,24 @@ variable {φ ψ : F} {n : ℕ}
 
 @[simp]
 lemma dia_injective' : ◇φ = ◇ψ ↔ φ = ψ := by
-  constructor;
-  . apply dia_injective;
-  . simp_all;
+  constructor
+  . apply dia_injective
+  . simp_all
 
 @[simp] lemma multidia_succ : ◇^[(n + 1)]φ = ◇(◇^[n]φ) := by apply iterate_succ_apply'
 
-@[simp] lemma multidia_injective : Function.Injective (◇^[n] · : F → F) := by apply Function.Injective.iterate (by simp);
+@[simp] lemma multidia_injective : Function.Injective (◇^[n] · : F → F) := by apply Function.Injective.iterate (by simp)
 
 @[simp]
 lemma multidia_injective' : ◇^[n]φ = ◇^[n]ψ ↔ φ = ψ := by
-  constructor;
-  . apply multidia_injective;
-  . simp_all;
+  constructor
+  . apply multidia_injective
+  . simp_all
 
 lemma add : ◇^[n](◇^[m]φ) = ◇^[(n + m)]φ := by
   induction n with
-  | zero => simp;
-  | succ n ih => rw [(show n + 1 + m = n + m + 1 by omega)]; simpa;
+  | zero => simp
+  | succ n ih => rw [(show n + 1 + m = n + m + 1 by omega)]; simpa
 
 end Dia
 
@@ -172,14 +172,14 @@ protected abbrev prebox : Set F → Set F := Set.premultibox (n := 1)
 @[simp] lemma eq_box_multibox_one : s.multibox 1 = s.box := by rfl
 @[simp] lemma eq_prebox_premultibox_one : s.premultibox 1 = s.prebox:= by rfl
 
-lemma multibox_subset_mono (h : s ⊆ t) : s.multibox n ⊆ t.multibox n := by simp_all [Set.subset_def];
-lemma box_subset_mono (h : s ⊆ t) : s.box ⊆ t.box := by simpa using multibox_subset_mono (n := 1) h;
+lemma multibox_subset_mono (h : s ⊆ t) : s.multibox n ⊆ t.multibox n := by simp_all [Set.subset_def]
+lemma box_subset_mono (h : s ⊆ t) : s.box ⊆ t.box := by simpa using multibox_subset_mono (n := 1) h
 
-lemma premultibox_subset_mono (h : s ⊆ t) : s.premultibox n ⊆ t.premultibox n := by simp_all [Set.subset_def];
-lemma prebox_subset_mono (h : s ⊆ t) : s.prebox ⊆ t.prebox := by simpa using premultibox_subset_mono (n := 1) h;
+lemma premultibox_subset_mono (h : s ⊆ t) : s.premultibox n ⊆ t.premultibox n := by simp_all [Set.subset_def]
+lemma prebox_subset_mono (h : s ⊆ t) : s.prebox ⊆ t.prebox := by simpa using premultibox_subset_mono (n := 1) h
 
-lemma iff_mem_premultibox : φ ∈ s.premultibox n ↔ □^[n]φ ∈ s := by simp;
-@[simp] lemma iff_mem_multibox : □^[n]φ ∈ s.multibox n ↔ φ ∈ s := by simp;
+lemma iff_mem_premultibox : φ ∈ s.premultibox n ↔ □^[n]φ ∈ s := by simp
+@[simp] lemma iff_mem_multibox : □^[n]φ ∈ s.multibox n ↔ φ ∈ s := by simp
 
 end Set
 
@@ -202,7 +202,7 @@ lemma multibox_coe [DecidableEq F] : s.multibox n = s.toSet.multibox n := by sim
 lemma box_coe [DecidableEq F] : s.box = s.toSet.box := by simpa using multibox_coe (n := 1)
 
 lemma multibox_mem_coe [DecidableEq F] : φ ∈ s.multibox n ↔ φ ∈ s.toSet.multibox n := by constructor <;> simp_all
-lemma box_mem_coe [DecidableEq F] : φ ∈ s.box ↔ φ ∈ s.toSet.box := by simp;
+lemma box_mem_coe [DecidableEq F] : φ ∈ s.box ↔ φ ∈ s.toSet.box := by simp
 
 lemma premultibox_coe : s.premultibox n = s.toSet.premultibox n := by simp_all
 lemma prebox_coe : s.prebox = □''⁻¹(↑s : Set F) := by simpa using premultibox_coe (n := 1)
@@ -212,17 +212,17 @@ lemma prebox_coe : s.prebox = □''⁻¹(↑s : Set F) := by simpa using premult
 lemma premultibox_multibox_eq_of_subset_multibox
   [DecidableEq F]
   {s : Finset F} {t : Set F} (hs : ↑s ⊆ t.multibox n) : (s.premultibox n).multibox n = s := by
-  have := Set.eq_premultibox_multibox_of_subset_premultibox hs;
-  rw [←premultibox_coe, ←multibox_coe] at this;
-  exact Finset.coe_inj.mp this;
+  have := Set.eq_premultibox_multibox_of_subset_premultibox hs
+  rw [←premultibox_coe, ←multibox_coe] at this
+  exact Finset.coe_inj.mp this
 
 lemma prebox_box_eq_of_subset_box [DecidableEq F] {s : Finset F} {t : Set F} (hs : ↑s ⊆ t.box) : s.prebox.box = s
   := by simpa using premultibox_multibox_eq_of_subset_multibox (n := 1) hs
 -/
 
 lemma exists_multibox_of_mem_multibox [DecidableEq F] (h : φ ∈ s.multibox n) : ∃ ψ ∈ s, φ = □^[n]ψ := by
-  simp at h;
-  tauto;
+  simp at h
+  tauto
 lemma exists_box_of_mem_box [DecidableEq F] (h : φ ∈ s.box) : ∃ ψ ∈ s, φ = □ψ := exists_multibox_of_mem_multibox h
 
 end Finset
@@ -247,40 +247,40 @@ protected noncomputable abbrev premultibox [DecidableEq F] (n : ℕ) : List F �
 protected noncomputable abbrev prebox [DecidableEq F] : List F → List F := List.premultibox (n := 1)
 -- prefix:80 "□'⁻¹" => List.prebox
 
-@[simp] lemma eq_multibox_zero : s.multibox 0 = s := by induction s <;> simp_all [List.multibox];
+@[simp] lemma eq_multibox_zero : s.multibox 0 = s := by induction s <;> simp_all [List.multibox]
 @[simp] lemma eq_box_multibox_one : l.multibox 1 = l.box := by rfl
 @[simp] lemma eq_prebox_premultibox_one [DecidableEq F] : l.premultibox 1 = l.prebox := by rfl
 
-@[simp] lemma multibox_nil : ([] : List F).multibox n = [] := by simp;
+@[simp] lemma multibox_nil : ([] : List F).multibox n = [] := by simp
 @[simp] lemma box_nil : ([] : List F).box = [] := multibox_nil (n := 1)
-@[simp] lemma premultibox_nil [DecidableEq F] : ([] :List F).premultibox n = [] := by simp;
+@[simp] lemma premultibox_nil [DecidableEq F] : ([] :List F).premultibox n = [] := by simp
 @[simp] lemma prebox_nil [DecidableEq F] : ([] : List F).prebox = [] := premultibox_nil (n := 1)
 
-@[simp] lemma multibox_single : [φ].multibox n = [□^[n]φ] := by simp;
+@[simp] lemma multibox_single : [φ].multibox n = [□^[n]φ] := by simp
 @[simp] lemma box_single : [φ].box = [□φ] := multibox_single (n := 1)
 
 lemma multibox_mem_of (h : φ ∈ l) : □^[n]φ ∈ l.multibox n := by
   induction l with
-  | nil => simp at h;
+  | nil => simp at h
   | cons ψ l ih =>
-    rcases (by simpa using h) with (rfl | h);
-    . tauto;
-    . tauto;
+    rcases (by simpa using h) with (rfl | h)
+    . tauto
+    . tauto
 lemma box_mem_of (h : φ ∈ l) : □φ ∈ l.box := multibox_mem_of h
 
-lemma multibox_nonempty (h : l ≠ []) : l.multibox n ≠ [] := by induction l <;> simp_all;
+lemma multibox_nonempty (h : l ≠ []) : l.multibox n ≠ [] := by induction l <;> simp_all
 lemma box_nonempty (h : l ≠ []) : l.box ≠ [] := multibox_nonempty h
 
 lemma exists_multibox_of_mem_multibox (h : φ ∈ l.multibox n) : ∃ ψ ∈ l, φ = □^[n]ψ := by
   induction l with
-  | nil => simp at h;
+  | nil => simp at h
   | cons ψ l ih =>
-    simp only [mem_cons] at h;
-    rcases h with (h | h);
-    . use ψ; tauto;
-    . obtain ⟨ξ, hξ₁, hξ₂⟩ := ih h;
-      use ξ;
-      constructor <;> tauto;
+    simp only [mem_cons] at h
+    rcases h with (h | h)
+    . use ψ; tauto
+    . obtain ⟨ξ, hξ₁, hξ₂⟩ := ih h
+      use ξ
+      constructor <;> tauto
 lemma exists_box_of_mem_box (h : φ ∈ l.box) : ∃ ψ ∈ l, φ = □ψ := exists_multibox_of_mem_multibox h
 
 protected noncomputable abbrev multiboxFilter [DecidableEq F] (l : List F) (n : ℕ) := l.premultibox n |>.multibox n
@@ -288,50 +288,50 @@ protected noncomputable abbrev boxFilter [DecidableEq F] (l : List F) := l.multi
 
 lemma mem_of_mem_multiboxFilter [DecidableEq F] (h : φ ∈ l.multiboxFilter n) : φ ∈ l := by
   induction l with
-  | nil => simp [List.multiboxFilter] at h;
+  | nil => simp [List.multiboxFilter] at h
   | cons ψ l ih =>
-    obtain ⟨ξ, hξ, rfl⟩ := exists_multibox_of_mem_multibox h;
-    clear h;
-    simp only [Finset.mem_toList, toFinset_cons, Finset.mem_preimage, Finset.mem_insert, mem_toFinset] at hξ;
-    rcases hξ with (hξ | hξ);
-    . subst hξ; tauto;
-    . tauto;
+    obtain ⟨ξ, hξ, rfl⟩ := exists_multibox_of_mem_multibox h
+    clear h
+    simp only [Finset.mem_toList, toFinset_cons, Finset.mem_preimage, Finset.mem_insert, mem_toFinset] at hξ
+    rcases hξ with (hξ | hξ)
+    . subst hξ; tauto
+    . tauto
 lemma mem_of_mem_boxFilter [DecidableEq F] (h : φ ∈ l.boxFilter) : φ ∈ l := mem_of_mem_multiboxFilter h
 
 lemma mem_multiboxFilter_of_mem [DecidableEq F] (h : □^[n]φ ∈ l) : □^[n]φ ∈ l.multiboxFilter n := by
-  apply multibox_mem_of;
-  simpa;
+  apply multibox_mem_of
+  simpa
 lemma mem_boxFilter_of_mem [DecidableEq F] (h : □φ ∈ l) : □φ ∈ l.boxFilter := mem_multiboxFilter_of_mem h
 
 @[simp]
 lemma iff_mem_multibox_add : φ ∈ (l.multibox m |>.multibox n) ↔ φ ∈ l.multibox (n + m) := by
   induction l with
-  | nil => simp_all;
+  | nil => simp_all
   | cons ψ l ih =>
-    simp only [mem_cons, LO.Box.add];
-    constructor;
-    . intro h;
-      rcases h with (rfl | h);
-      . tauto;
-      . right;
-        apply ih.mp;
-        exact h;
-    . intro h;
-      rcases h with (rfl | h);
-      . tauto;
-      . right;
-        apply ih.mpr;
-        exact h;
+    simp only [mem_cons, LO.Box.add]
+    constructor
+    . intro h
+      rcases h with (rfl | h)
+      . tauto
+      . right
+        apply ih.mp
+        exact h
+    . intro h
+      rcases h with (rfl | h)
+      . tauto
+      . right
+        apply ih.mpr
+        exact h
 
 end List
 
 lemma Finset.mem_multibox_of_toList_multibox [DecidableEq F] {s : Finset F} (h : φ ∈ s.toList.multibox n) : φ ∈ (s.multibox n) := by
-  simp only [mem_image];
-  obtain ⟨φ, hφ, rfl⟩ := List.exists_multibox_of_mem_multibox h;
-  use φ;
-  constructor;
-  . simpa using hφ;
-  . tauto;
+  simp only [mem_image]
+  obtain ⟨φ, hφ, rfl⟩ := List.exists_multibox_of_mem_multibox h
+  use φ
+  constructor
+  . simpa using hφ
+  . tauto
 
 namespace Finset
 
@@ -358,14 +358,14 @@ protected abbrev predia : Set F → Set F := Set.premultidia (n := 1)
 @[simp] lemma eq_dia_multidia_one : s.multidia 1 = s.dia := by rfl
 @[simp] lemma eq_predia_premultidia_one : s.premultidia 1 = s.predia:= by rfl
 
-lemma multidia_subset_mono (h : s ⊆ t) : s.multidia n ⊆ t.multidia n := by simp_all [Set.subset_def];
-lemma dia_subset_mono (h : s ⊆ t) : s.dia ⊆ t.dia := by simpa using multidia_subset_mono (n := 1) h;
+lemma multidia_subset_mono (h : s ⊆ t) : s.multidia n ⊆ t.multidia n := by simp_all [Set.subset_def]
+lemma dia_subset_mono (h : s ⊆ t) : s.dia ⊆ t.dia := by simpa using multidia_subset_mono (n := 1) h
 
-lemma premultidia_subset_mono (h : s ⊆ t) : s.premultidia n ⊆ t.premultidia n := by simp_all [Set.subset_def];
-lemma predia_subset_mono (h : s ⊆ t) : s.predia ⊆ t.predia := by simpa using premultidia_subset_mono (n := 1) h;
+lemma premultidia_subset_mono (h : s ⊆ t) : s.premultidia n ⊆ t.premultidia n := by simp_all [Set.subset_def]
+lemma predia_subset_mono (h : s ⊆ t) : s.predia ⊆ t.predia := by simpa using premultidia_subset_mono (n := 1) h
 
-lemma iff_mem_premultidia : φ ∈ s.premultidia n ↔ ◇^[n]φ ∈ s := by simp;
-@[simp] lemma iff_mem_multidia : ◇^[n]φ ∈ s.multidia n ↔ φ ∈ s := by simp;
+lemma iff_mem_premultidia : φ ∈ s.premultidia n ↔ ◇^[n]φ ∈ s := by simp
+@[simp] lemma iff_mem_multidia : ◇^[n]φ ∈ s.multidia n ↔ φ ∈ s := by simp
 
 end Set
 
@@ -388,7 +388,7 @@ lemma multidia_coe [DecidableEq F] : s.multidia n = s.toSet.multidia n := by sim
 lemma dia_coe [DecidableEq F] : s.dia = s.toSet.dia := by simpa using multidia_coe (n := 1)
 
 lemma multidia_mem_coe [DecidableEq F] : φ ∈ s.multidia n ↔ φ ∈ s.toSet.multidia n := by constructor <;> simp_all
-lemma dia_mem_coe [DecidableEq F] : φ ∈ s.dia ↔ φ ∈ s.toSet.dia := by simp;
+lemma dia_mem_coe [DecidableEq F] : φ ∈ s.dia ↔ φ ∈ s.toSet.dia := by simp
 
 lemma premultidia_coe : s.premultidia n = s.toSet.premultidia n := by simp_all
 lemma predia_coe : s.predia = ◇''⁻¹(↑s : Set F) := by simpa using premultidia_coe (n := 1)
@@ -398,9 +398,9 @@ lemma predia_coe : s.predia = ◇''⁻¹(↑s : Set F) := by simpa using premult
 lemma premultidia_multidia_eq_of_subset_multidia
   [DecidableEq F]
   {s : Finset F} {t : Set F} (hs : ↑s ⊆ t.multidia n) : (s.premultidia n).multidia n = s := by
-  have := Set.eq_premultidia_multidia_of_subset_premultidia hs;
-  rw [←premultidia_coe, ←multidia_coe] at this;
-  exact Finset.coe_inj.mp this;
+  have := Set.eq_premultidia_multidia_of_subset_premultidia hs
+  rw [←premultidia_coe, ←multidia_coe] at this
+  exact Finset.coe_inj.mp this
 
 lemma predia_dia_eq_of_subset_dia [DecidableEq F] {s : Finset F} {t : Set F} (hs : ↑s ⊆ t.dia) : s.predia.dia = s
   := by simpa using premultidia_multidia_eq_of_subset_multidia (n := 1) hs
@@ -428,40 +428,40 @@ protected noncomputable abbrev premultidia [DecidableEq F] (n : ℕ) : List F �
 protected noncomputable abbrev predia [DecidableEq F] : List F → List F := List.premultidia (n := 1)
 -- prefix:80 "◇'⁻¹" => List.predia
 
-@[simp] lemma eq_multidia_zero : s.multidia 0 = s := by induction s <;> simp_all [List.multidia];
+@[simp] lemma eq_multidia_zero : s.multidia 0 = s := by induction s <;> simp_all [List.multidia]
 @[simp] lemma eq_dia_multidia_one : l.multidia 1 = l.dia := by rfl
 @[simp] lemma eq_predia_premultidia_one [DecidableEq F] : l.premultidia 1 = l.predia := by rfl
 
-@[simp] lemma multidia_nil : ([] : List F).multidia n = [] := by simp;
+@[simp] lemma multidia_nil : ([] : List F).multidia n = [] := by simp
 @[simp] lemma dia_nil : ([] : List F).dia = [] := multidia_nil (n := 1)
-@[simp] lemma premultidia_nil [DecidableEq F] : ([] :List F).premultidia n = [] := by simp;
+@[simp] lemma premultidia_nil [DecidableEq F] : ([] :List F).premultidia n = [] := by simp
 @[simp] lemma predia_nil [DecidableEq F] : ([] : List F).predia = [] := premultidia_nil (n := 1)
 
-@[simp] lemma multidia_single : [φ].multidia n = [◇^[n]φ] := by simp;
+@[simp] lemma multidia_single : [φ].multidia n = [◇^[n]φ] := by simp
 @[simp] lemma dia_single : [φ].dia = [◇φ] := multidia_single (n := 1)
 
 lemma multidia_mem_of (h : φ ∈ l) : ◇^[n]φ ∈ l.multidia n := by
   induction l with
-  | nil => simp at h;
+  | nil => simp at h
   | cons ψ l ih =>
-    rcases (by simpa using h) with (rfl | h);
-    . tauto;
-    . tauto;
+    rcases (by simpa using h) with (rfl | h)
+    . tauto
+    . tauto
 lemma dia_mem_of (h : φ ∈ l) : ◇φ ∈ l.dia := multidia_mem_of h
 
-lemma multidia_nonempty (h : l ≠ []) : l.multidia n ≠ [] := by induction l <;> simp_all;
+lemma multidia_nonempty (h : l ≠ []) : l.multidia n ≠ [] := by induction l <;> simp_all
 lemma dia_nonempty (h : l ≠ []) : l.dia ≠ [] := multidia_nonempty h
 
 lemma exists_multidia_of_mem_multidia (h : φ ∈ l.multidia n) : ∃ ψ ∈ l, φ = ◇^[n]ψ := by
   induction l with
-  | nil => simp at h;
+  | nil => simp at h
   | cons ψ l ih =>
-    simp only [mem_cons] at h;
-    rcases h with (h | h);
-    . use ψ; tauto;
-    . obtain ⟨ξ, hξ₁, hξ₂⟩ := ih h;
-      use ξ;
-      constructor <;> tauto;
+    simp only [mem_cons] at h
+    rcases h with (h | h)
+    . use ψ; tauto
+    . obtain ⟨ξ, hξ₁, hξ₂⟩ := ih h
+      use ξ
+      constructor <;> tauto
 lemma exists_dia_of_mem_dia (h : φ ∈ l.dia) : ∃ ψ ∈ l, φ = ◇ψ := exists_multidia_of_mem_multidia h
 
 protected noncomputable abbrev multidiaFilter [DecidableEq F] (l : List F) (n : ℕ) := l.premultidia n |>.multidia n
@@ -469,50 +469,50 @@ protected noncomputable abbrev diaFilter [DecidableEq F] (l : List F) := l.multi
 
 lemma mem_of_mem_multidiaFilter [DecidableEq F] (h : φ ∈ l.multidiaFilter n) : φ ∈ l := by
   induction l with
-  | nil => simp [List.multidiaFilter] at h;
+  | nil => simp [List.multidiaFilter] at h
   | cons ψ l ih =>
-    obtain ⟨ξ, hξ, rfl⟩ := exists_multidia_of_mem_multidia h;
-    clear h;
-    simp only [Finset.mem_toList, toFinset_cons, Finset.mem_preimage, Finset.mem_insert, mem_toFinset] at hξ;
-    rcases hξ with (hξ | hξ);
-    . subst hξ; tauto;
-    . tauto;
+    obtain ⟨ξ, hξ, rfl⟩ := exists_multidia_of_mem_multidia h
+    clear h
+    simp only [Finset.mem_toList, toFinset_cons, Finset.mem_preimage, Finset.mem_insert, mem_toFinset] at hξ
+    rcases hξ with (hξ | hξ)
+    . subst hξ; tauto
+    . tauto
 lemma mem_of_mem_diaFilter [DecidableEq F] (h : φ ∈ l.diaFilter) : φ ∈ l := mem_of_mem_multidiaFilter h
 
 lemma mem_multidiaFilter_of_mem [DecidableEq F] (h : ◇^[n]φ ∈ l) : ◇^[n]φ ∈ l.multidiaFilter n := by
-  apply multidia_mem_of;
-  simpa;
+  apply multidia_mem_of
+  simpa
 lemma mem_diaFilter_of_mem [DecidableEq F] (h : ◇φ ∈ l) : ◇φ ∈ l.diaFilter := mem_multidiaFilter_of_mem h
 
 @[simp]
 lemma iff_mem_multidia_add : φ ∈ (l.multidia m |>.multidia n) ↔ φ ∈ l.multidia (n + m) := by
   induction l with
-  | nil => simp_all;
+  | nil => simp_all
   | cons ψ l ih =>
-    simp only [mem_cons, LO.Dia.add];
-    constructor;
-    . intro h;
-      rcases h with (rfl | h);
-      . tauto;
-      . right;
-        apply ih.mp;
-        exact h;
-    . intro h;
-      rcases h with (rfl | h);
-      . tauto;
-      . right;
-        apply ih.mpr;
-        exact h;
+    simp only [mem_cons, LO.Dia.add]
+    constructor
+    . intro h
+      rcases h with (rfl | h)
+      . tauto
+      . right
+        apply ih.mp
+        exact h
+    . intro h
+      rcases h with (rfl | h)
+      . tauto
+      . right
+        apply ih.mpr
+        exact h
 
 end List
 
 lemma Finset.mem_multidia_of_toList_multibox [DecidableEq F] {s : Finset F} (h : φ ∈ s.toList.multidia n) : φ ∈ (s.multidia n) := by
-  simp only [mem_image];
-  obtain ⟨φ, hφ, rfl⟩ := List.exists_multidia_of_mem_multidia h;
-  use φ;
-  constructor;
-  . simpa using hφ;
-  . tauto;
+  simp only [mem_image]
+  obtain ⟨φ, hφ, rfl⟩ := List.exists_multidia_of_mem_multidia h
+  use φ
+  constructor
+  . simpa using hφ
+  . tauto
 
 end Dia
 

--- a/Foundation/Modal/Maximal/Basic.lean
+++ b/Foundation/Modal/Maximal/Basic.lean
@@ -20,14 +20,14 @@ postfix:75 "ᵀ" => trivTranslate
 namespace trivTranslate
 
 @[simp]
-lemma degree_zero : φᵀ.degree = 0 := by induction φ <;> simp [trivTranslate, degree, *];
+lemma degree_zero : φᵀ.degree = 0 := by induction φ <;> simp [trivTranslate, degree, *]
 
 @[simp]
 lemma toIP : φᵀ.toPropFormula = φᵀ := by
   induction φ using rec' with
-  | hbox => simp [trivTranslate, *];
-  | himp => simp [trivTranslate, toPropFormula, *];
-  | _ => rfl;
+  | hbox => simp [trivTranslate, *]
+  | himp => simp [trivTranslate, toPropFormula, *]
+  | _ => rfl
 
 end trivTranslate
 
@@ -44,14 +44,14 @@ namespace verTranslate
 @[simp]
 lemma degree_zero : φⱽ.degree = 0 := by
   induction φ using rec' with
-  | himp => simp [verTranslate, *];
-  | _ => rfl;
+  | himp => simp [verTranslate, *]
+  | _ => rfl
 
 @[simp]
 lemma toIP : φⱽ.toPropFormula = φⱽ := by
   induction φ using rec' with
-  | himp => simp [verTranslate, toPropFormula, *];
-  | _ => rfl;
+  | himp => simp [verTranslate, toPropFormula, *]
+  | _ => rfl
 
 end verTranslate
 
@@ -62,13 +62,13 @@ open Entailment
 open Formula (trivTranslate verTranslate)
 
 lemma Hilbert.provable_of_classical_provable {H : Modal.Hilbert.Normal ℕ} {φ : Propositional.Formula ℕ} : Propositional.Hilbert.Cl ⊢! φ → (H ⊢! φ.toModalFormula) := by
-  intro h;
+  intro h
   induction h using Propositional.Hilbert.rec! with
-  | axm _ h => rcases h with (rfl | rfl) <;> simp;
-  | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
+  | axm _ h => rcases h with (rfl | rfl) <;> simp
+  | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
   | _ =>
-    dsimp [Propositional.Formula.toModalFormula];
-    simp;
+    dsimp [Propositional.Formula.toModalFormula]
+    simp
 
 namespace Logic.Triv
 
@@ -77,31 +77,31 @@ variable {φ : Modal.Formula ℕ}
 lemma iff_trivTranslated : Hilbert.Triv ⊢! φ ⭤ φᵀ := by
   induction φ with
   | hbox φ ih =>
-    apply E!_intro;
+    apply E!_intro
     . exact C!_trans axiomT! (K!_left ih)
     . exact C!_trans (K!_right ih) axiomTc!
-  | himp _ _ ih₁ ih₂ => exact ECC!_of_E!_of_E! ih₁ ih₂;
+  | himp _ _ ih₁ ih₂ => exact ECC!_of_E!_of_E! ih₁ ih₂
   | _ => apply E!_id
 
 lemma iff_provable_Cl : Hilbert.Triv ⊢! φ ↔ Propositional.Hilbert.Cl ⊢! φᵀ.toPropFormula := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h using Hilbert.Normal.rec! with
     | axm s a =>
-      rcases a with (rfl | rfl | rfl) <;> simp [trivTranslate, Formula.toPropFormula];
+      rcases a with (rfl | rfl | rfl) <;> simp [trivTranslate, Formula.toPropFormula]
     | mdp ih₁ ih₂ =>
-      dsimp [trivTranslate] at ih₁ ih₂;
-      exact ih₁ ⨀ ih₂;
-    | nec ih => exact ih;
-    | _ => simp [trivTranslate, Formula.toPropFormula];
-  . intro h;
-    have d₁ : Hilbert.Triv ⊢! φᵀ ➝ φ := K!_right iff_trivTranslated;
-    have d₂ : Hilbert.Triv ⊢! φᵀ := by simpa only [trivTranslate.toIP] using Hilbert.provable_of_classical_provable h;
-    exact d₁ ⨀ d₂;
+      dsimp [trivTranslate] at ih₁ ih₂
+      exact ih₁ ⨀ ih₂
+    | nec ih => exact ih
+    | _ => simp [trivTranslate, Formula.toPropFormula]
+  . intro h
+    have d₁ : Hilbert.Triv ⊢! φᵀ ➝ φ := K!_right iff_trivTranslated
+    have d₂ : Hilbert.Triv ⊢! φᵀ := by simpa only [trivTranslate.toIP] using Hilbert.provable_of_classical_provable h
+    exact d₁ ⨀ d₂
 
 lemma iff_isTautology : Hilbert.Triv ⊢! φ ↔ φᵀ.toPropFormula.isTautology := by
-  apply Iff.trans Triv.iff_provable_Cl;
-  apply Propositional.Hilbert.Cl.iff_isTautology_provable.symm;
+  apply Iff.trans Triv.iff_provable_Cl
+  apply Propositional.Hilbert.Cl.iff_isTautology_provable.symm
 
 end Logic.Triv
 
@@ -113,30 +113,30 @@ variable {φ : Modal.Formula ℕ}
 lemma iff_verTranslated : Hilbert.Ver ⊢! φ ⭤ φⱽ := by
   induction φ with
   | hbox =>
-    apply E!_intro;
+    apply E!_intro
     . exact C!_of_conseq! verum!
     . exact C!_of_conseq! (by simp)
-  | himp _ _ ih₁ ih₂ => exact ECC!_of_E!_of_E! ih₁ ih₂;
+  | himp _ _ ih₁ ih₂ => exact ECC!_of_E!_of_E! ih₁ ih₂
   | _ => apply E!_id
 
 protected lemma iff_provable_Cl : Hilbert.Ver ⊢! φ ↔ Propositional.Hilbert.Cl ⊢! φⱽ.toPropFormula := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h using Hilbert.Normal.rec! with
     | axm s a =>
-      rcases a with (rfl | rfl | rfl) <;> simp [verTranslate, Formula.toPropFormula];
+      rcases a with (rfl | rfl | rfl) <;> simp [verTranslate, Formula.toPropFormula]
     | mdp ih₁ ih₂ =>
-      dsimp [verTranslate] at ih₁ ih₂;
-      exact ih₁ ⨀ ih₂;
-    | _ => simp [verTranslate, Formula.toPropFormula];
-  . intro h;
-    have d₁ : Hilbert.Ver ⊢! φⱽ ➝ φ := K!_right iff_verTranslated;
-    have d₂ : Hilbert.Ver ⊢! φⱽ := by simpa using Hilbert.provable_of_classical_provable h;
-    exact d₁ ⨀ d₂;
+      dsimp [verTranslate] at ih₁ ih₂
+      exact ih₁ ⨀ ih₂
+    | _ => simp [verTranslate, Formula.toPropFormula]
+  . intro h
+    have d₁ : Hilbert.Ver ⊢! φⱽ ➝ φ := K!_right iff_verTranslated
+    have d₂ : Hilbert.Ver ⊢! φⱽ := by simpa using Hilbert.provable_of_classical_provable h
+    exact d₁ ⨀ d₂
 
 lemma iff_isTautology : Hilbert.Ver ⊢! φ ↔ φⱽ.toPropFormula.isTautology := by
-  apply Iff.trans Ver.iff_provable_Cl;
-  apply Propositional.Hilbert.Cl.iff_isTautology_provable.symm;
+  apply Iff.trans Ver.iff_provable_Cl
+  apply Propositional.Hilbert.Cl.iff_isTautology_provable.symm
 
 end Logic.Ver
 

--- a/Foundation/Modal/Maximal/Makinson.lean
+++ b/Foundation/Modal/Maximal/Makinson.lean
@@ -22,47 +22,47 @@ section
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 
 lemma KD_subset_of_not_subset_Ver.lemma₁ (hL : L ⊢! φ) (hV : Modal.Ver ⊬ φ) : ∃ ψ, L ⊢! ◇ψ := by
-  obtain ⟨ψ, ⟨Γ, rfl⟩, h⟩ := Hilbert.NNFormula.exists_CNF φ;
-  replace h := Modal.Hilbert.Normal.iff_logic_provable_provable.mpr h;
-  generalize eγ : (⋀Γ.unattach).toFormula = γ at h;
+  obtain ⟨ψ, ⟨Γ, rfl⟩, h⟩ := Hilbert.NNFormula.exists_CNF φ
+  replace h := Modal.Hilbert.Normal.iff_logic_provable_provable.mpr h
+  generalize eγ : (⋀Γ.unattach).toFormula = γ at h
 
-  have : L ⊢! φ.toNNFormula.toFormula ⭤ γ := WeakerThan.pbl h;
+  have : L ⊢! φ.toNNFormula.toFormula ⭤ γ := WeakerThan.pbl h
 
-  have hγL : γ ∈ L := by sorry;
-  have hγV : γ ∉ Modal.Ver := by sorry;
+  have hγL : γ ∈ L := by sorry
+  have hγV : γ ∉ Modal.Ver := by sorry
 
   obtain ⟨⟨_, ⟨Δ, rfl⟩⟩, hδΓ, hδL, hδV⟩ : ∃ δ, δ ∈ Γ ∧ δ.1.toFormula ∈ L ∧ δ.1.toFormula ∉ Modal.Ver := by
-    sorry;
+    sorry
   have hΔ₁ : ∀ ψ ∈ Δ, ¬ψ.1.isPrebox := by
-    rintro ⟨ψ, _⟩ hψ₁ hψ₂;
-    obtain ⟨ξ, rfl⟩ := NNFormula.exists_isPrebox hψ₂;
-    have : Hilbert.Ver ⊢! □ξ.toFormula := by simp;
-    sorry;
+    rintro ⟨ψ, _⟩ hψ₁ hψ₂
+    obtain ⟨ξ, rfl⟩ := NNFormula.exists_isPrebox hψ₂
+    have : Hilbert.Ver ⊢! □ξ.toFormula := by simp
+    sorry
 
-  have : ∃ Γ: List (Formula ℕ), L ⊢! φ ⭤ ⋀Γ := by sorry;
-  sorry;
+  have : ∃ Γ: List (Formula ℕ), L ⊢! φ ⭤ ⋀Γ := by sorry
+  sorry
 
 lemma KD_subset_of_not_subset_Ver (hV : ¬L ⪯ Modal.Ver) : Modal.KD ⪯ L := by
-  apply weakerThan_iff.mpr;
-  intro φ hφ;
-  simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
-  replace hφ : Hilbert.KP ⊢! φ := Entailment.Equiv.iff.mp inferInstance _ |>.mpr hφ;
+  apply weakerThan_iff.mpr
+  intro φ hφ
+  simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
+  replace hφ : Hilbert.KP ⊢! φ := Entailment.Equiv.iff.mp inferInstance _ |>.mpr hφ
   induction hφ using Hilbert.Normal.rec! with
   | axm _ h =>
-    rcases h with (rfl | rfl);
-    . simp;
-    . obtain ⟨ψ, hψ₁, hψ₂⟩ := not_weakerThan_iff.mp hV;
-      obtain ⟨ξ, hξ⟩ := KD_subset_of_not_subset_Ver.lemma₁ hψ₁ hψ₂;
-      apply Entailment.mdp! (φ := ◇ξ);
-      . exact contra! $ axiomK'! $ nec! $ efq!;
-      . exact hξ;
-  | mdp hφψ hφ => exact hφψ ⨀ hφ;
-  | nec hφ => exact Entailment.nec! hφ;
-  | _ => simp;
+    rcases h with (rfl | rfl)
+    . simp
+    . obtain ⟨ψ, hψ₁, hψ₂⟩ := not_weakerThan_iff.mp hV
+      obtain ⟨ξ, hξ⟩ := KD_subset_of_not_subset_Ver.lemma₁ hψ₁ hψ₂
+      apply Entailment.mdp! (φ := ◇ξ)
+      . exact contra! $ axiomK'! $ nec! $ efq!
+      . exact hξ
+  | mdp hφψ hφ => exact hφψ ⨀ hφ
+  | nec hφ => exact Entailment.nec! hφ
+  | _ => simp
 
 lemma KD_subset_of_not_VerFamily (h : ¬L.VerFamily) : Modal.KD ⪯ L := by
-  apply KD_subset_of_not_subset_Ver;
-  tauto;
+  apply KD_subset_of_not_subset_Ver
+  tauto
 
 end
 
@@ -80,36 +80,36 @@ lemma KD_provability_of_classical_satisfiability (hl : φ.letterless) :
   (¬(v ⊧ (φᵀ.toPropFormula)) → Modal.KD ⊢! ∼φ)
   := by
   induction φ with
-  | hatom => simp at hl;
-  | hfalsum => simp [trivTranslate, toPropFormula];
+  | hatom => simp at hl
+  | hfalsum => simp [trivTranslate, toPropFormula]
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro h;
-      simp only [trivTranslate, toPropFormula] at h;
-      rcases imp_iff_not_or.mp h with (hφ | hψ);
-      . exact C_of_N $ ihφ (letterless.def_imp₁ hl) |>.2 hφ;
-      . exact C!_of_conseq! $ ihψ (letterless.def_imp₂ hl) |>.1 hψ;
-    . intro h;
-      simp only [trivTranslate, toPropFormula, Semantics.Realize, Formula.ClassicalSemantics.val] at h;
-      push_neg at h;
-      rcases h with ⟨hφ, hψ⟩;
-      replace hφ := ihφ (letterless.def_imp₁ hl) |>.1 hφ;
-      replace hψ := ihψ (letterless.def_imp₂ hl) |>.2 hψ;
+    constructor
+    . intro h
+      simp only [trivTranslate, toPropFormula] at h
+      rcases imp_iff_not_or.mp h with (hφ | hψ)
+      . exact C_of_N $ ihφ (letterless.def_imp₁ hl) |>.2 hφ
+      . exact C!_of_conseq! $ ihψ (letterless.def_imp₂ hl) |>.1 hψ
+    . intro h
+      simp only [trivTranslate, toPropFormula, Semantics.Realize, Formula.ClassicalSemantics.val] at h
+      push_neg at h
+      rcases h with ⟨hφ, hψ⟩
+      replace hφ := ihφ (letterless.def_imp₁ hl) |>.1 hφ
+      replace hψ := ihψ (letterless.def_imp₂ hl) |>.2 hψ
       -- TODO: need golf
-      apply FiniteContext.deduct'!;
-      replace hφ : [φ ➝ ψ] ⊢[Modal.KD]! φ := FiniteContext.of'! hφ;
-      replace hψ : [φ ➝ ψ] ⊢[Modal.KD]! ∼ψ := FiniteContext.of'! hψ;
-      exact hψ ⨀ (FiniteContext.by_axm! ⨀ hφ);
+      apply FiniteContext.deduct'!
+      replace hφ : [φ ➝ ψ] ⊢[Modal.KD]! φ := FiniteContext.of'! hφ
+      replace hψ : [φ ➝ ψ] ⊢[Modal.KD]! ∼ψ := FiniteContext.of'! hψ
+      exact hψ ⨀ (FiniteContext.by_axm! ⨀ hφ)
   | hbox φ ihφ =>
-    constructor;
-    . intro h;
-      apply nec!;
-      apply ihφ (letterless.def_box hl) |>.1;
-      tauto;
-    . intro h;
-      have : Modal.KD ⊢! □(∼φ) := nec! $ ihφ (letterless.def_box hl) |>.2 $ by tauto;
-      simp only [Hilbert.Normal.iff_logic_provable_provable] at ⊢ this;
-      exact negbox_dne'! $ dia_duality'!.mp $ axiomD'! this;
+    constructor
+    . intro h
+      apply nec!
+      apply ihφ (letterless.def_box hl) |>.1
+      tauto
+    . intro h
+      have : Modal.KD ⊢! □(∼φ) := nec! $ ihφ (letterless.def_box hl) |>.2 $ by tauto
+      simp only [Hilbert.Normal.iff_logic_provable_provable] at ⊢ this
+      exact negbox_dne'! $ dia_duality'!.mp $ axiomD'! this
 
 lemma provable_KD_of_classical_satisfiability (hl : φ.letterless) : (v ⊧ φᵀ.toPropFormula) → Modal.KD ⊢! φ :=
   KD_provability_of_classical_satisfiability hl |>.1
@@ -128,74 +128,74 @@ private lemma subset_Triv_of_KD_subset.lemma₁
   induction φ with
   | hatom a =>
     suffices v ⊧ (s.1 a) ↔ v ⊧ (s.1 a).toModalFormulaᵀ.toPropFormula by
-      simpa [trivTranslate, toPropFormula];
-    generalize eψ : s.1 a = ψ;
+      simpa [trivTranslate, toPropFormula]
+    generalize eψ : s.1 a = ψ
     have hψ : ψ.letterless := by
-      rw [←eψ];
-      exact s.2;
-    clear eψ;
+      rw [←eψ]
+      exact s.2
+    clear eψ
     induction ψ using Propositional.Formula.rec' with
-    | hatom => simp at hψ;
-    | hfalsum => tauto;
-    | hand => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula];
-    | himp => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula];
-    | hor => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula]; tauto;
-  | _ => simp_all [trivTranslate, toPropFormula];
+    | hatom => simp at hψ
+    | hfalsum => tauto
+    | hand => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula]
+    | himp => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula]
+    | hor => unfold Propositional.Formula.letterless at hψ; simp_all [trivTranslate, toPropFormula]; tauto
+  | _ => simp_all [trivTranslate, toPropFormula]
 
 lemma subset_Triv_of_KD_subset.lemma₂ {φ : Modal.Formula α} {s : Propositional.ZeroSubstitution _} :
   (∼((φᵀ.toPropFormula)⟦s.1⟧)).isTautology ↔
   ((∼φ⟦(s : Modal.ZeroSubstitution _).1⟧)ᵀ.toPropFormula).isTautology
   := by
-  constructor;
-  . intro h v hφ;
-    apply h v ?_;
-    exact lemma₁.mpr hφ;
-  . intro h v; exact lemma₁ (φ := ∼φ).mpr $ h v;
+  constructor
+  . intro h v hφ
+    apply h v ?_
+    exact lemma₁.mpr hφ
+  . intro h v; exact lemma₁ (φ := ∼φ).mpr $ h v
 
 @[instance]
 theorem subset_Triv_of_KD_subset [Modal.KD ⪯ L] : L ⪯ Modal.Triv := by
-  by_contra! hC;
-  obtain ⟨φ, hφ₁, hφ₂⟩ := not_weakerThan_iff.mp hC;
+  by_contra! hC
+  obtain ⟨φ, hφ₁, hφ₂⟩ := not_weakerThan_iff.mp hC
   replace hφ₂ := (not_imp_not.mpr Propositional.Hilbert.Cl.completeness)
     $ Modal.Logic.Triv.iff_provable_Cl.not.mp
     $ Hilbert.Normal.iff_logic_provable_provable.not.mp hφ₂
-  obtain ⟨s, h⟩ := ClassicalSemantics.exists_neg_zeroSubst_of_not_isTautology hφ₂;
-  let ψ := φ⟦(s : Modal.ZeroSubstitution _).1⟧;
-  have : Semantics.Valid (ClassicalSemantics.Valuation ℕ) (∼(ψᵀ.toPropFormula)) := subset_Triv_of_KD_subset.lemma₂.mp h;
+  obtain ⟨s, h⟩ := ClassicalSemantics.exists_neg_zeroSubst_of_not_isTautology hφ₂
+  let ψ := φ⟦(s : Modal.ZeroSubstitution _).1⟧
+  have : Semantics.Valid (ClassicalSemantics.Valuation ℕ) (∼(ψᵀ.toPropFormula)) := subset_Triv_of_KD_subset.lemma₂.mp h
   have : Modal.KD ⊢! ∼ψ := provable_not_KD_of_classical_unsatisfiable Formula.letterless_zeroSubst
     $ Semantics.Not.realize_not.mp
-    $ this (λ _ => True);
-  have : L ⊢! ∼ψ := WeakerThan.pbl this;
-  have : L ⊬ ∼ψ := L.not_neg_of! $ Logic.subst! _ hφ₁;
-  contradiction;
+    $ this (λ _ => True)
+  have : L ⊢! ∼ψ := WeakerThan.pbl this
+  have : L ⊬ ∼ψ := L.not_neg_of! $ Logic.subst! _ hφ₁
+  contradiction
 
 end
 
 
 theorem makinson : (L.VerFamily ∨ L.TrivFamily) ∧ ¬(L.VerFamily ∧ L.TrivFamily) := by
-  constructor;
-  . apply or_iff_not_imp_left.mpr;
-    rintro h;
-    constructor;
-    . exact KD_subset_of_not_VerFamily h;
-    . have := KD_subset_of_not_VerFamily h;
-      exact subset_Triv_of_KD_subset (L := L);
-  . by_contra hC;
-    have ⟨⟨hVer⟩, ⟨hKD, hTriv⟩⟩ := hC;
-    have : Modal.KD ⪯ Modal.Ver := by apply Entailment.WeakerThan.trans (𝓣 := L) <;> infer_instance;
-    have h₁ : Modal.Ver ⊢! ∼□⊥ := by apply Entailment.WeakerThan.pbl (show Modal.KD ⊢! ∼□⊥ by simp);
-    have h₂ : Modal.Ver ⊢! □⊥ := by simp;
-    have : Modal.Ver ⊢! ⊥ := h₁ ⨀ h₂;
-    apply Entailment.Consistent.not_bot inferInstance (𝓢 := Hilbert.Ver);
-    simpa;
+  constructor
+  . apply or_iff_not_imp_left.mpr
+    rintro h
+    constructor
+    . exact KD_subset_of_not_VerFamily h
+    . have := KD_subset_of_not_VerFamily h
+      exact subset_Triv_of_KD_subset (L := L)
+  . by_contra hC
+    have ⟨⟨hVer⟩, ⟨hKD, hTriv⟩⟩ := hC
+    have : Modal.KD ⪯ Modal.Ver := by apply Entailment.WeakerThan.trans (𝓣 := L) <;> infer_instance
+    have h₁ : Modal.Ver ⊢! ∼□⊥ := by apply Entailment.WeakerThan.pbl (show Modal.KD ⊢! ∼□⊥ by simp)
+    have h₂ : Modal.Ver ⊢! □⊥ := by simp
+    have : Modal.Ver ⊢! ⊥ := h₁ ⨀ h₂
+    apply Entailment.Consistent.not_bot inferInstance (𝓢 := Hilbert.Ver)
+    simpa
 
 lemma VerFamily.notTrivFamily [L.VerFamily] : ¬L.TrivFamily := by
-  apply not_and.mp $ makinson (L := L) |>.2;
-  assumption;
+  apply not_and.mp $ makinson (L := L) |>.2
+  assumption
 
 lemma TrivFamily.notVerFamily [L.TrivFamily] : ¬L.VerFamily := by
-  apply not_and'.mp $ makinson (L := L) |>.2;
-  assumption;
+  apply not_and'.mp $ makinson (L := L) |>.2
+  assumption
 
 end Logic
 

--- a/Foundation/Modal/Maximal/Unprovability.lean
+++ b/Foundation/Modal/Maximal/Unprovability.lean
@@ -19,10 +19,10 @@ namespace Logic
 namespace Triv
 
 lemma unprovable_AxiomL : Hilbert.Triv ⊬ (Axioms.L (.atom a)) := by
-  apply Logic.Triv.iff_provable_Cl.not.mpr;
-  apply Hilbert.Cl.not_provable_of_exists_valuation;
-  use (λ _ => False);
-  tauto;
+  apply Logic.Triv.iff_provable_Cl.not.mpr
+  apply Hilbert.Cl.not_provable_of_exists_valuation
+  use (λ _ => False)
+  tauto
 
 end Triv
 
@@ -30,10 +30,10 @@ end Triv
 namespace Ver
 
 lemma unprovable_AxiomP : Hilbert.Ver ⊬ Axioms.P := by
-  apply Logic.Ver.iff_provable_Cl.not.mpr;
-  apply Hilbert.Cl.not_provable_of_exists_valuation;
-  use (λ _ => False);
-  tauto;
+  apply Logic.Ver.iff_provable_Cl.not.mpr
+  apply Hilbert.Cl.not_provable_of_exists_valuation
+  use (λ _ => False)
+  tauto
 
 end Ver
 
@@ -41,60 +41,60 @@ end Ver
 namespace K4
 
 lemma provable_trivTranslated_Cl : Hilbert.K4 ⊢! φ → Hilbert.Cl ⊢! φᵀ.toPropFormula := by
-  intro h;
-  apply Logic.Triv.iff_provable_Cl.mp;
-  apply WeakerThan.pbl h;
+  intro h
+  apply Logic.Triv.iff_provable_Cl.mp
+  apply WeakerThan.pbl h
 
 lemma unprovable_AxiomL : Hilbert.K4 ⊬ (Axioms.L (.atom a)) := by
-  apply not_imp_not.mpr provable_trivTranslated_Cl;
-  apply Hilbert.Cl.not_provable_of_exists_valuation;
-  use (λ _ => False);
-  tauto;
+  apply not_imp_not.mpr provable_trivTranslated_Cl
+  apply Hilbert.Cl.not_provable_of_exists_valuation
+  use (λ _ => False)
+  tauto
 
 end K4
 
 instance : Hilbert.K4 ⪱ Hilbert.GL := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_provable_axioms;
-    rintro φ (rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.L (.atom 0));
-    constructor;
-    . exact axiomL!;
-    . exact K4.unprovable_AxiomL;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_provable_axioms
+    rintro φ (rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.L (.atom 0))
+    constructor
+    . exact axiomL!
+    . exact K4.unprovable_AxiomL
 
 
 namespace GL
 
 lemma provable_verTranslated_Cl : Hilbert.GL ⊢! φ → Hilbert.Cl ⊢! φⱽ.toPropFormula := by
-  intro h;
+  intro h
   induction h using Hilbert.Normal.rec! with
     | axm _ a =>
-      rcases a with (rfl | rfl | rfl) <;> simp [verTranslate, Formula.toPropFormula];
+      rcases a with (rfl | rfl | rfl) <;> simp [verTranslate, Formula.toPropFormula]
     | mdp ih₁ ih₂ =>
-      dsimp [verTranslate] at ih₁ ih₂;
-      exact ih₁ ⨀ ih₂;
-    | _ => simp [verTranslate, Formula.toPropFormula];
+      dsimp [verTranslate] at ih₁ ih₂
+      exact ih₁ ⨀ ih₂
+    | _ => simp [verTranslate, Formula.toPropFormula]
 
 lemma unprovable_AxiomT : (Hilbert.GL) ⊬ Axioms.T (.atom a) := by
-  apply not_imp_not.mpr provable_verTranslated_Cl;
-  apply Hilbert.Cl.not_provable_of_exists_valuation;
-  use (λ _ => False);
-  tauto;
+  apply not_imp_not.mpr provable_verTranslated_Cl
+  apply Hilbert.Cl.not_provable_of_exists_valuation
+  use (λ _ => False)
+  tauto
 
 instance : Entailment.Consistent (Hilbert.GL) := by
-  apply consistent_iff_exists_unprovable.mpr;
-  use (Axioms.T (atom 0));
-  apply unprovable_AxiomT;
+  apply consistent_iff_exists_unprovable.mpr
+  use (Axioms.T (atom 0))
+  apply unprovable_AxiomT
 
 end GL
 
 theorem not_S4_weakerThan_GL : ¬(Hilbert.S4) ⪯ (Hilbert.GL) := by
-  apply Entailment.not_weakerThan_iff.mpr;
-  use (Axioms.T (atom 0));
-  constructor;
-  . exact axiomT!;
-  . exact GL.unprovable_AxiomT;
+  apply Entailment.not_weakerThan_iff.mpr
+  use (Axioms.T (atom 0))
+  constructor
+  . exact axiomT!
+  . exact GL.unprovable_AxiomT
 
 end Logic
 

--- a/Foundation/Modal/MaximalConsistentSet.lean
+++ b/Foundation/Modal/MaximalConsistentSet.lean
@@ -23,242 +23,242 @@ abbrev Consistent (𝓢 : S) (T : FormulaSet α) := T *⊬[𝓢] ⊥
 abbrev Inconsistent (𝓢 : S) (T : FormulaSet α) := ¬(Consistent 𝓢 T)
 
 lemma def_consistent [Entailment.Minimal 𝓢] : Consistent 𝓢 T ↔ ∀ Γ : FormulaFinset _, (Γ.toSet ⊆ T) → Γ *⊬[𝓢] ⊥ := by
-  constructor;
-  . intro h Γ hΓ;
-    have := Context.provable_iff_finset.not.mp h;
-    push_neg at this;
-    exact this Γ (by tauto);
-  . intro h;
-    apply Context.provable_iff_finset.not.mpr;
-    push_neg;
-    simpa using h;
+  constructor
+  . intro h Γ hΓ
+    have := Context.provable_iff_finset.not.mp h
+    push_neg at this
+    exact this Γ (by tauto)
+  . intro h
+    apply Context.provable_iff_finset.not.mpr
+    push_neg
+    simpa using h
 
 lemma def_inconsistent [Entailment.Minimal 𝓢] : Inconsistent 𝓢 T ↔ ∃ (Γ : FormulaFinset _), (Γ.toSet ⊆ T) ∧ Γ *⊢[𝓢]! ⊥ := by
-  unfold Inconsistent;
-  apply not_iff_not.mp;
-  push_neg;
-  exact def_consistent;
+  unfold Inconsistent
+  apply not_iff_not.mp
+  push_neg
+  exact def_consistent
 
 lemma union_consistent [Entailment.Minimal 𝓢] : Consistent 𝓢 (T₁ ∪ T₂) → (Consistent 𝓢 T₁) ∧ (Consistent 𝓢 T₂) := by
-  intro h;
-  replace h := def_consistent.mp h;
+  intro h
+  replace h := def_consistent.mp h
   constructor <;> {
-    apply def_consistent.mpr;
-    intro Γ hΓ;
-    exact h Γ $ by tauto_set;
+    apply def_consistent.mpr
+    intro Γ hΓ
+    exact h Γ $ by tauto_set
   }
 
 variable [Entailment.Cl 𝓢]
 
 lemma emptyset_consistent [H_consis : Entailment.Consistent 𝓢] : Consistent 𝓢 ∅ := by
-  obtain ⟨f, hf⟩ := H_consis.exists_unprovable;
-  apply def_consistent.mpr;
-  intro Γ hΓ;
-  replace hΓ : Γ = ∅ := by simpa [Set.subset_empty_iff, Finset.coe_eq_empty] using hΓ;
-  subst hΓ;
-  by_contra hC;
-  apply hf;
-  apply Context.emptyPrf!;
-  apply of_O!;
-  simpa using hC;
+  obtain ⟨f, hf⟩ := H_consis.exists_unprovable
+  apply def_consistent.mpr
+  intro Γ hΓ
+  replace hΓ : Γ = ∅ := by simpa [Set.subset_empty_iff, Finset.coe_eq_empty] using hΓ
+  subst hΓ
+  by_contra hC
+  apply hf
+  apply Context.emptyPrf!
+  apply of_O!
+  simpa using hC
 
 lemma not_mem_of_mem_neg (T_consis : Consistent 𝓢 T) (h : ∼φ ∈ T) : φ ∉ T := by
-  by_contra hC;
-  apply def_consistent.mp T_consis {φ, ∼φ} ?_;
-  . apply Context.bot_of_mem_neg (φ := φ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    tauto;
+  by_contra hC
+  apply def_consistent.mp T_consis {φ, ∼φ} ?_
+  . apply Context.bot_of_mem_neg (φ := φ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    tauto
 
 lemma not_mem_neg_of_mem (T_consis : Consistent 𝓢 T) (h : φ ∈ T) : ∼φ ∉ T := by
-  by_contra hC;
-  apply def_consistent.mp T_consis {φ, ∼φ} ?_;
-  . apply Context.bot_of_mem_neg (φ := φ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    tauto;
+  by_contra hC
+  apply def_consistent.mp T_consis {φ, ∼φ} ?_
+  . apply Context.bot_of_mem_neg (φ := φ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    tauto
 
 lemma iff_insert_consistent : Consistent 𝓢 (insert φ T) ↔ ∀ {Γ : FormulaFinset α}, (↑Γ ⊆ T) → Γ *⊬[𝓢] φ ➝ ⊥ := by
-  constructor;
-  . intro h Γ hΓ;
-    have := def_consistent.mp h (insert φ Γ) ?_;
-    . revert this;
-      contrapose!;
-      simp only [not_not, Finset.coe_insert];
-      intro h;
-      exact Context.deductInv! h;
-    . simpa using Set.insert_subset_insert hΓ;
-  . intro h;
-    apply def_consistent.mpr;
-    intro Γ hΓ;
-    have := @h (Γ.erase φ) ?_;
-    . revert this;
-      contrapose!;
-      simp only [not_not, Finset.coe_erase];
-      intro h;
-      apply Context.deduct!;
-      apply Context.weakening! (Γ := Γ) ?_ h;
-      simp;
-    . simp_all;
+  constructor
+  . intro h Γ hΓ
+    have := def_consistent.mp h (insert φ Γ) ?_
+    . revert this
+      contrapose!
+      simp only [not_not, Finset.coe_insert]
+      intro h
+      exact Context.deductInv! h
+    . simpa using Set.insert_subset_insert hΓ
+  . intro h
+    apply def_consistent.mpr
+    intro Γ hΓ
+    have := @h (Γ.erase φ) ?_
+    . revert this
+      contrapose!
+      simp only [not_not, Finset.coe_erase]
+      intro h
+      apply Context.deduct!
+      apply Context.weakening! (Γ := Γ) ?_ h
+      simp
+    . simp_all
 
 lemma iff_insert_inconsistent : Inconsistent 𝓢 (insert φ T) ↔ ∃ Γ : FormulaFinset _, (Γ.toSet ⊆ T) ∧ Γ *⊢[𝓢]! φ ➝ ⊥ := by
-  unfold Inconsistent;
-  apply not_iff_not.mp;
-  push_neg;
-  exact iff_insert_consistent;
+  unfold Inconsistent
+  apply not_iff_not.mp
+  push_neg
+  exact iff_insert_consistent
 
 lemma provable_iff_insert_neg_not_consistent : Inconsistent 𝓢 (insert (∼φ) T) ↔ T *⊢[𝓢]! φ := by
-  constructor;
-  . intro h;
-    apply Context.provable_iff_finset.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h;
-    use Γ;
-    constructor;
-    . tauto;
-    . exact of_NN! $ N!_iff_CO!.mp hΓ₂;
-  . intro h;
-    apply iff_insert_inconsistent.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff_finset.mp h;
-    use Γ;
-    constructor;
-    . tauto;
-    . apply N!_iff_CO!.mp;
-      apply dni'!;
-      assumption;
+  constructor
+  . intro h
+    apply Context.provable_iff_finset.mpr
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h
+    use Γ
+    constructor
+    . tauto
+    . exact of_NN! $ N!_iff_CO!.mp hΓ₂
+  . intro h
+    apply iff_insert_inconsistent.mpr
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff_finset.mp h
+    use Γ
+    constructor
+    . tauto
+    . apply N!_iff_CO!.mp
+      apply dni'!
+      assumption
 
 lemma unprovable_iff_insert_neg_consistent : Consistent 𝓢 (insert (∼φ) T) ↔ T *⊬[𝓢] φ := by
-  simpa [not_not] using provable_iff_insert_neg_not_consistent.not;
+  simpa [not_not] using provable_iff_insert_neg_not_consistent.not
 
 lemma unprovable_iff_singleton_neg_consistent : Consistent 𝓢 {∼φ} ↔ 𝓢 ⊬ φ:= by
   apply Iff.trans (by simpa using unprovable_iff_insert_neg_consistent (T := ∅))
-  apply Context.provable_iff_provable.not.symm;
+  apply Context.provable_iff_provable.not.symm
 
 lemma neg_provable_iff_insert_not_consistent : Inconsistent 𝓢 (insert (φ) T) ↔ T *⊢[𝓢]! ∼φ := by
-  constructor;
-  . intro h;
-    apply Context.provable_iff_finset.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h;
-    use Γ;
-    constructor;
-    . assumption;
-    . apply N!_iff_CO!.mpr hΓ₂;
-  . intro h;
-    apply iff_insert_inconsistent.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff_finset.mp h;
-    use Γ;
-    constructor;
-    . assumption;
-    . apply N!_iff_CO!.mp;
-      assumption;
+  constructor
+  . intro h
+    apply Context.provable_iff_finset.mpr
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h
+    use Γ
+    constructor
+    . assumption
+    . apply N!_iff_CO!.mpr hΓ₂
+  . intro h
+    apply iff_insert_inconsistent.mpr
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff_finset.mp h
+    use Γ
+    constructor
+    . assumption
+    . apply N!_iff_CO!.mp
+      assumption
 
 lemma neg_unprovable_iff_insert_consistent : Consistent 𝓢 (insert (φ) T) ↔ T *⊬[𝓢] ∼φ := by
-  simpa [not_not] using neg_provable_iff_insert_not_consistent.not;
+  simpa [not_not] using neg_provable_iff_insert_not_consistent.not
 
 lemma unprovable_iff_singleton_consistent : Consistent 𝓢 {φ} ↔ 𝓢 ⊬ ∼φ := by
-  have e : insert (φ) ∅ = ({φ} : FormulaSet α) := by aesop;
-  have h₂ := neg_unprovable_iff_insert_consistent (𝓢 := 𝓢) (T := ∅) (φ := φ);
-  rw [e] at h₂;
-  suffices 𝓢 ⊬ ∼φ ↔ ∅ *⊬[𝓢] ∼φ by tauto;
-  exact Context.provable_iff_provable.not;
+  have e : insert (φ) ∅ = ({φ} : FormulaSet α) := by aesop
+  have h₂ := neg_unprovable_iff_insert_consistent (𝓢 := 𝓢) (T := ∅) (φ := φ)
+  rw [e] at h₂
+  suffices 𝓢 ⊬ ∼φ ↔ ∅ *⊬[𝓢] ∼φ by tauto
+  exact Context.provable_iff_provable.not
 
 /-
 omit [DecidableEq α] in
 lemma unprovable_falsum (T_consis : T.Consistent 𝓢) : Consistent 𝓢 := by
-  by_contra hC;
-  obtain ⟨Γ, hΓ₁, _⟩ := Context.provable_iff.mp $ hC;
-  have : Γ ⊬[𝓢] ⊥ := (def_consistent.mp T_consis) _ hΓ₁;
-  contradiction;
+  by_contra hC
+  obtain ⟨Γ, hΓ₁, _⟩ := Context.provable_iff.mp $ hC
+  have : Γ ⊬[𝓢] ⊥ := (def_consistent.mp T_consis) _ hΓ₁
+  contradiction
 -/
 
 lemma unprovable_either (T_consis : Consistent 𝓢 T) : ¬(T *⊢[𝓢]! φ ∧ T *⊢[𝓢]! ∼φ) := by
-  by_contra hC;
-  have ⟨hC₁, hC₂⟩ := hC;
-  have := neg_mdp hC₂ hC₁;
-  contradiction;
+  by_contra hC
+  have ⟨hC₁, hC₂⟩ := hC
+  have := neg_mdp hC₂ hC₁
+  contradiction
 
 lemma not_mem_falsum_of_consistent (T_consis : Consistent 𝓢 T) : ⊥ ∉ T := by
-  by_contra hC;
-  apply def_consistent.mp T_consis {⊥};
-  . simpa using hC;
-  . apply Context.by_axm!;
-    simp;
+  by_contra hC
+  apply def_consistent.mp T_consis {⊥}
+  . simpa using hC
+  . apply Context.by_axm!
+    simp
 
 lemma not_singleton_consistent [Entailment.Necessitation 𝓢] (T_consis : Consistent 𝓢 T) (h : ∼□φ ∈ T) : Consistent 𝓢 {∼φ} := by
-  apply def_consistent.mpr;
-  intro Γ hΓ;
-  rcases (Set.subset_singleton_iff_eq.mp hΓ) with hΓ | hΓ;
-  . by_contra! hC;
-    apply T_consis;
-    apply Context.weakening! _ hC;
-    simp [hΓ];
-  . by_contra! hC;
-    apply def_consistent.mp T_consis (Γ := {∼(□φ)}) $ by simpa;
+  apply def_consistent.mpr
+  intro Γ hΓ
+  rcases (Set.subset_singleton_iff_eq.mp hΓ) with hΓ | hΓ
+  . by_contra! hC
+    apply T_consis
+    apply Context.weakening! _ hC
+    simp [hΓ]
+  . by_contra! hC
+    apply def_consistent.mp T_consis (Γ := {∼(□φ)}) $ by simpa
     have : 𝓢 ⊢! ∼φ ➝ ⊥ := by
-      apply Context.provable_iff_provable.mpr;
-      apply Context.deduct!;
-      simpa [hΓ] using hC;
-    have : 𝓢 ⊢! φ := by cl_prover [this];
-    have : 𝓢 ⊢! □φ := nec! this;
-    have : 𝓢 ⊢! ∼□φ ➝ ⊥ := by cl_prover [this];
-    simpa using Context.deductInv! $ Context.provable_iff_provable.mp this;
+      apply Context.provable_iff_provable.mpr
+      apply Context.deduct!
+      simpa [hΓ] using hC
+    have : 𝓢 ⊢! φ := by cl_prover [this]
+    have : 𝓢 ⊢! □φ := nec! this
+    have : 𝓢 ⊢! ∼□φ ➝ ⊥ := by cl_prover [this]
+    simpa using Context.deductInv! $ Context.provable_iff_provable.mp this
 
 
 lemma either_consistent (T_consis : Consistent 𝓢 T) (φ) : Consistent 𝓢 (insert φ T) ∨ Consistent 𝓢 (insert (∼φ) T) := by
-  by_contra! hC;
-  obtain ⟨hC₁, hC₂⟩ := hC;
-  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp $ by simpa using hC₁;
-  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_inconsistent.mp $ by simpa using hC₂;
-  apply def_consistent.mp T_consis (Γ := Γ ∪ Δ) ?_;
-  . replace hΓ₂ : ↑(Γ ∪ Δ) *⊢[𝓢]! φ ➝ ⊥ := Context.weakening! (by simp) hΓ₂;
-    replace hΔ₂ : ↑(Γ ∪ Δ) *⊢[𝓢]! ∼φ ➝ ⊥ := Context.weakening! (by simp) hΔ₂;
-    exact of_C!_of_C!_of_A! hΓ₂ hΔ₂ (by simp);
-  . simp_all;
+  by_contra! hC
+  obtain ⟨hC₁, hC₂⟩ := hC
+  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp $ by simpa using hC₁
+  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_inconsistent.mp $ by simpa using hC₂
+  apply def_consistent.mp T_consis (Γ := Γ ∪ Δ) ?_
+  . replace hΓ₂ : ↑(Γ ∪ Δ) *⊢[𝓢]! φ ➝ ⊥ := Context.weakening! (by simp) hΓ₂
+    replace hΔ₂ : ↑(Γ ∪ Δ) *⊢[𝓢]! ∼φ ➝ ⊥ := Context.weakening! (by simp) hΔ₂
+    exact of_C!_of_C!_of_A! hΓ₂ hΔ₂ (by simp)
+  . simp_all
 
 open Classical in
 lemma intro_union_consistent(h : ∀ {Γ₁ Γ₂ : FormulaFinset _}, (Γ₁.toSet ⊆ T₁) → (Γ₂.toSet ⊆ T₂) → (Γ₁ ∪ Γ₂) *⊬[𝓢] ⊥)
   : Consistent 𝓢 (T₁ ∪ T₂) := by
-  apply def_consistent.mpr;
-  intro Δ hΔ;
-  let Δ₁ := (Δ.filter (· ∈ T₁));
-  let Δ₂ := (Δ.filter (· ∈ T₂));
-  apply not_imp_not.mpr $ Context.weakening! (𝓢 := 𝓢) (Γ := Δ) (Δ := Δ₁ ∪ Δ₂) (φ := ⊥) ?_;
-  . have := @h Δ₁ Δ₂ ?_ ?_;
-    . simpa using this;
-    . intro φ; simp [Δ₁];
-    . intro φ; simp [Δ₂];
-  . intro φ hφ;
-    have : φ ∈ T₁ ∪ T₂ := hΔ hφ;
-    simp_all [Δ₁, Δ₂];
+  apply def_consistent.mpr
+  intro Δ hΔ
+  let Δ₁ := (Δ.filter (· ∈ T₁))
+  let Δ₂ := (Δ.filter (· ∈ T₂))
+  apply not_imp_not.mpr $ Context.weakening! (𝓢 := 𝓢) (Γ := Δ) (Δ := Δ₁ ∪ Δ₂) (φ := ⊥) ?_
+  . have := @h Δ₁ Δ₂ ?_ ?_
+    . simpa using this
+    . intro φ; simp [Δ₁]
+    . intro φ; simp [Δ₂]
+  . intro φ hφ
+    have : φ ∈ T₁ ∪ T₂ := hΔ hφ
+    simp_all [Δ₁, Δ₂]
 
 lemma exists_consistent_maximal_of_consistent (T_consis : Consistent 𝓢 T)
   : ∃ Z, Consistent 𝓢 Z ∧ T ⊆ Z ∧ ∀ U, U *⊬[𝓢] ⊥ → Z ⊆ U → U = Z := by
   obtain ⟨Z, h₁, ⟨h₂, h₃⟩⟩ := zorn_subset_nonempty { T : FormulaSet α | Consistent 𝓢 T} (by
-    intro c hc chain hnc;
-    existsi (⋃₀ c);
-    simp only [Set.mem_setOf_eq];
-    constructor;
-    . apply def_consistent.mpr;
-      intro Γ hΓ;
-      by_contra hC;
+    intro c hc chain hnc
+    existsi (⋃₀ c)
+    simp only [Set.mem_setOf_eq]
+    constructor
+    . apply def_consistent.mpr
+      intro Γ hΓ
+      by_contra hC
       obtain ⟨U, hUc, hUs⟩ := Set.subset_mem_chain_of_finite c hnc chain (s := ↑Γ.toSet) (by simp) $ by
-        intro φ hφ;
-        apply hΓ hφ;
-      have : Consistent 𝓢 U := hc hUc;
+        intro φ hφ
+        apply hΓ hφ
+      have : Consistent 𝓢 U := hc hUc
       have : Inconsistent 𝓢 U := by
-        apply def_inconsistent.mpr;
-        use Γ;
-      contradiction;
-    . intro s a;
-      exact Set.subset_sUnion_of_mem a;
-  ) T T_consis;
-  use Z;
-  simp_all only [Set.mem_setOf_eq, Set.le_eq_subset, true_and];
-  constructor;
-  . assumption;
-  . intro U hU hZU;
-    apply Set.eq_of_subset_of_subset;
-    . exact h₃ hU hZU;
-    . assumption;
+        apply def_inconsistent.mpr
+        use Γ
+      contradiction
+    . intro s a
+      exact Set.subset_sUnion_of_mem a
+  ) T T_consis
+  use Z
+  simp_all only [Set.mem_setOf_eq, Set.le_eq_subset, true_and]
+  constructor
+  . assumption
+  . intro U hU hZU
+    apply Set.eq_of_subset_of_subset
+    . exact h₃ hU hZU
+    . assumption
 
 protected alias lindenbaum := exists_consistent_maximal_of_consistent
 
@@ -284,169 +284,169 @@ lemma maximal (Ω : MaximalConsistentSet 𝓢) : Ω.1 ⊂ U → Inconsistent �
 lemma maximal' (Ω : MaximalConsistentSet 𝓢) {φ : Formula α} (hp : φ ∉ Ω) : Inconsistent 𝓢 (insert φ Ω.1) := Ω.maximal (Set.ssubset_insert hp)
 
 lemma equality_def : Ω₁ = Ω₂ ↔ Ω₁.1 = Ω₂.1 := by
-  constructor;
-  . intro h; cases h; rfl;
-  . intro h; cases Ω₁; cases Ω₂; simp_all;
+  constructor
+  . intro h; cases h; rfl
+  . intro h; cases Ω₁; cases Ω₂; simp_all
 
 variable [DecidableEq α] [Entailment.Cl 𝓢]
 
 lemma exists_of_consistent (consisT : Consistent 𝓢 T) : ∃ Ω : MaximalConsistentSet 𝓢, (T ⊆ Ω.1) := by
-  have ⟨Ω, hΩ₁, hΩ₂, hΩ₃⟩ := FormulaSet.lindenbaum consisT;
-  use ⟨Ω, ?_, ?_⟩;
-  . assumption;
-  . rintro U ⟨hU₁, _⟩;
-    by_contra hC;
-    have := hΩ₃ U hC $ hU₁;
-    subst this;
-    simp_all;
+  have ⟨Ω, hΩ₁, hΩ₂, hΩ₃⟩ := FormulaSet.lindenbaum consisT
+  use ⟨Ω, ?_, ?_⟩
+  . assumption
+  . rintro U ⟨hU₁, _⟩
+    by_contra hC
+    have := hΩ₃ U hC $ hU₁
+    subst this
+    simp_all
 
 alias lindenbaum := exists_of_consistent
 
 instance [Entailment.Consistent 𝓢] : Nonempty (MaximalConsistentSet 𝓢) := ⟨lindenbaum emptyset_consistent |>.choose⟩
 
 lemma either_mem (Ω : MaximalConsistentSet 𝓢) (φ) : φ ∈ Ω ∨ ∼φ ∈ Ω := by
-  by_contra hC;
-  push_neg at hC;
-  rcases either_consistent (𝓢 := 𝓢) (Ω.consistent) φ;
-  . have := Ω.maximal (Set.ssubset_insert hC.1); contradiction;
-  . have := Ω.maximal (Set.ssubset_insert hC.2); contradiction;
+  by_contra hC
+  push_neg at hC
+  rcases either_consistent (𝓢 := 𝓢) (Ω.consistent) φ
+  . have := Ω.maximal (Set.ssubset_insert hC.1); contradiction
+  . have := Ω.maximal (Set.ssubset_insert hC.2); contradiction
 
 lemma membership_iff : (φ ∈ Ω) ↔ (Ω.1 *⊢[𝓢]! φ) := by
-  constructor;
-  . intro h; exact Context.by_axm! h;
-  . intro hp;
-    suffices ∼φ ∉ Ω.1 by apply or_iff_not_imp_right.mp $ (either_mem Ω φ); assumption;
-    by_contra hC;
-    have hnp : Ω.1 *⊢[𝓢]! ∼φ := Context.by_axm! hC;
-    have : Ω.1 *⊢[𝓢]! ⊥ := neg_mdp hnp hp;
-    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent;
-    contradiction;
+  constructor
+  . intro h; exact Context.by_axm! h
+  . intro hp
+    suffices ∼φ ∉ Ω.1 by apply or_iff_not_imp_right.mp $ (either_mem Ω φ); assumption
+    by_contra hC
+    have hnp : Ω.1 *⊢[𝓢]! ∼φ := Context.by_axm! hC
+    have : Ω.1 *⊢[𝓢]! ⊥ := neg_mdp hnp hp
+    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent
+    contradiction
 
 @[simp]
 lemma not_mem_falsum : ⊥ ∉ Ω := not_mem_falsum_of_consistent Ω.consistent
 
 @[simp]
-lemma mem_verum : ⊤ ∈ Ω := by apply membership_iff.mpr; apply verum!;
+lemma mem_verum : ⊤ ∈ Ω := by apply membership_iff.mpr; apply verum!
 
 @[simp]
 lemma iff_mem_neg : (∼φ ∈ Ω) ↔ (φ ∉ Ω) := by
-  constructor;
-  . intro hnp;
-    by_contra hp;
-    replace hp := membership_iff.mp hp;
-    replace hnp := membership_iff.mp hnp;
-    have : Ω.1 *⊢[𝓢]! ⊥ := neg_mdp hnp hp;
-    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent;
-    contradiction;
-  . intro hp;
+  constructor
+  . intro hnp
+    by_contra hp
+    replace hp := membership_iff.mp hp
+    replace hnp := membership_iff.mp hnp
+    have : Ω.1 *⊢[𝓢]! ⊥ := neg_mdp hnp hp
+    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent
+    contradiction
+  . intro hp
     have : Consistent 𝓢 (insert (∼φ) Ω.1) := by
-      haveI := provable_iff_insert_neg_not_consistent.not.mpr $ membership_iff.not.mp hp;
-      unfold FormulaSet.Inconsistent at this;
-      push_neg at this;
-      exact this;
-    have := not_imp_not.mpr (@maximal (Ω := Ω) (U := insert (∼φ) Ω.1)) (by simpa);
-    have : insert (∼φ) Ω.1 ⊆ Ω.1 := by simpa [Set.ssubset_def] using this;
-    apply this;
-    tauto_set;
+      haveI := provable_iff_insert_neg_not_consistent.not.mpr $ membership_iff.not.mp hp
+      unfold FormulaSet.Inconsistent at this
+      push_neg at this
+      exact this
+    have := not_imp_not.mpr (@maximal (Ω := Ω) (U := insert (∼φ) Ω.1)) (by simpa)
+    have : insert (∼φ) Ω.1 ⊆ Ω.1 := by simpa [Set.ssubset_def] using this
+    apply this
+    tauto_set
 
 lemma iff_forall_mem_provable : (∀ Ω : MaximalConsistentSet 𝓢, φ ∈ Ω) ↔ 𝓢 ⊢! φ := by
-  constructor;
-  . contrapose!;
-    intro h;
-    obtain ⟨Ω, hΩ⟩ := lindenbaum $ unprovable_iff_singleton_neg_consistent.mpr h;
-    use Ω;
-    apply iff_mem_neg.mp;
-    tauto;
-  . intro h Ω;
-    apply membership_iff.mpr;
-    exact Context.of! h;
+  constructor
+  . contrapose!
+    intro h
+    obtain ⟨Ω, hΩ⟩ := lindenbaum $ unprovable_iff_singleton_neg_consistent.mpr h
+    use Ω
+    apply iff_mem_neg.mp
+    tauto
+  . intro h Ω
+    apply membership_iff.mpr
+    exact Context.of! h
 
 @[grind]
-lemma mem_of_prove (h : 𝓢 ⊢! φ) : φ ∈ Ω := by apply iff_forall_mem_provable.mpr h;
+lemma mem_of_prove (h : 𝓢 ⊢! φ) : φ ∈ Ω := by apply iff_forall_mem_provable.mpr h
 
 @[simp]
-lemma iff_mem_negneg : (∼∼φ ∈ Ω) ↔ (φ ∈ Ω) := by simp;
+lemma iff_mem_negneg : (∼∼φ ∈ Ω) ↔ (φ ∈ Ω) := by simp
 
 @[simp, grind]
 lemma iff_mem_imp : ((φ ➝ ψ) ∈ Ω) ↔ (φ ∈ Ω) → (ψ ∈ Ω) := by
-  constructor;
-  . intro hpq hp;
-    replace dpq := membership_iff.mp hpq;
-    replace dp  := membership_iff.mp hp;
-    apply membership_iff.mpr;
-    exact dpq ⨀ dp;
-  . intro h;
-    replace h : φ ∉ Ω.1 ∨ ψ ∈ Ω := or_iff_not_imp_left.mpr (by simpa using h);
+  constructor
+  . intro hpq hp
+    replace dpq := membership_iff.mp hpq
+    replace dp  := membership_iff.mp hp
+    apply membership_iff.mpr
+    exact dpq ⨀ dp
+  . intro h
+    replace h : φ ∉ Ω.1 ∨ ψ ∈ Ω := or_iff_not_imp_left.mpr (by simpa using h)
     cases h with
     | inl h =>
-      apply membership_iff.mpr;
-      exact C_of_N $ membership_iff.mp $ iff_mem_neg.mpr h;
+      apply membership_iff.mpr
+      exact C_of_N $ membership_iff.mp $ iff_mem_neg.mpr h
     | inr h =>
-      apply membership_iff.mpr;
+      apply membership_iff.mpr
       exact imply₁! ⨀ (membership_iff.mp h)
 
 lemma mdp (hφψ : φ ➝ ψ ∈ Ω) (hψ : φ ∈ Ω) : ψ ∈ Ω := iff_mem_imp.mp hφψ hψ
 
 @[simp]
 lemma iff_mem_and : ((φ ⋏ ψ) ∈ Ω) ↔ (φ ∈ Ω) ∧ (ψ ∈ Ω) := by
-  constructor;
-  . intro hpq;
-    replace hpq := membership_iff.mp hpq;
-    constructor;
-    . apply membership_iff.mpr; exact K!_left hpq;
-    . apply membership_iff.mpr; exact K!_right hpq;
-  . rintro ⟨hp, hq⟩;
-    apply membership_iff.mpr;
-    exact K!_intro (membership_iff.mp hp) (membership_iff.mp hq);
+  constructor
+  . intro hpq
+    replace hpq := membership_iff.mp hpq
+    constructor
+    . apply membership_iff.mpr; exact K!_left hpq
+    . apply membership_iff.mpr; exact K!_right hpq
+  . rintro ⟨hp, hq⟩
+    apply membership_iff.mpr
+    exact K!_intro (membership_iff.mp hp) (membership_iff.mp hq)
 
 @[simp]
 lemma iff_mem_or : ((φ ⋎ ψ) ∈ Ω) ↔ (φ ∈ Ω) ∨ (ψ ∈ Ω) := by
-  constructor;
-  . intro hpq;
-    replace hpq := membership_iff.mp hpq;
-    by_contra hC;
-    push_neg at hC;
-    have ⟨hp, hq⟩ := hC;
-    replace hp := membership_iff.mp $ iff_mem_neg.mpr hp;
-    replace hq := membership_iff.mp $ iff_mem_neg.mpr hq;
-    have : Ω.1 *⊢[𝓢]! ⊥ := of_C!_of_C!_of_A! (N!_iff_CO!.mp hp) (N!_iff_CO!.mp hq) hpq;
-    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent;
-    contradiction;
-  . rintro (hp | hq);
-    . apply membership_iff.mpr;
-      exact A!_intro_left (membership_iff.mp hp);
-    . apply membership_iff.mpr;
-      exact A!_intro_right (membership_iff.mp hq);
+  constructor
+  . intro hpq
+    replace hpq := membership_iff.mp hpq
+    by_contra hC
+    push_neg at hC
+    have ⟨hp, hq⟩ := hC
+    replace hp := membership_iff.mp $ iff_mem_neg.mpr hp
+    replace hq := membership_iff.mp $ iff_mem_neg.mpr hq
+    have : Ω.1 *⊢[𝓢]! ⊥ := of_C!_of_C!_of_A! (N!_iff_CO!.mp hp) (N!_iff_CO!.mp hq) hpq
+    have : Ω.1 *⊬[𝓢] ⊥ := Ω.consistent
+    contradiction
+  . rintro (hp | hq)
+    . apply membership_iff.mpr
+      exact A!_intro_left (membership_iff.mp hp)
+    . apply membership_iff.mpr
+      exact A!_intro_right (membership_iff.mp hq)
 
 lemma iff_congr : (Ω.1 *⊢[𝓢]! (φ ⭤ ψ)) → ((φ ∈ Ω) ↔ (ψ ∈ Ω)) := by
-  intro hpq;
-  constructor;
-  . intro hp; exact iff_mem_imp.mp (membership_iff.mpr $ K!_left hpq) hp;
-  . intro hq; exact iff_mem_imp.mp (membership_iff.mpr $ K!_right hpq) hq;
+  intro hpq
+  constructor
+  . intro hp; exact iff_mem_imp.mp (membership_iff.mpr $ K!_left hpq) hp
+  . intro hq; exact iff_mem_imp.mp (membership_iff.mpr $ K!_right hpq) hq
 
 
 lemma intro_equality {h : ∀ φ, φ ∈ Ω₁.1 → φ ∈ Ω₂.1} : Ω₁ = Ω₂ := by
   exact equality_def.mpr $ Set.eq_of_subset_of_subset
     (by intro φ hp; exact h φ hp)
     (by
-      intro φ;
-      contrapose;
-      intro hp;
-      apply iff_mem_neg.mp;
-      apply h;
-      apply iff_mem_neg.mpr hp;
+      intro φ
+      contrapose
+      intro hp
+      apply iff_mem_neg.mp
+      apply h
+      apply iff_mem_neg.mpr hp
     )
 
 lemma neg_imp (h : ψ ∈ Ω₂ → φ ∈ Ω₁) : (∼φ ∈ Ω₁) → (∼ψ ∈ Ω₂) := by
-  contrapose;
-  intro nhnψ hnφ;
-  have : φ ∈ Ω₁ := h $ iff_mem_negneg.mp $ iff_mem_neg.mpr nhnψ;
-  have : ⊥ ∈ Ω₁ := mdp hnφ this;
-  simpa;
+  contrapose
+  intro nhnψ hnφ
+  have : φ ∈ Ω₁ := h $ iff_mem_negneg.mp $ iff_mem_neg.mpr nhnψ
+  have : ⊥ ∈ Ω₁ := mdp hnφ this
+  simpa
 
 lemma neg_iff (h : φ ∈ Ω₁ ↔ ψ ∈ Ω₂) : (∼φ ∈ Ω₁) ↔ (∼ψ ∈ Ω₂) := ⟨neg_imp $ h.mpr, neg_imp $ h.mp⟩
 
-lemma iff_mem_conj : (⋀Γ ∈ Ω) ↔ (∀ φ ∈ Γ, φ ∈ Ω) := by simp [membership_iff, Conj₂!_iff_forall_provable];
+lemma iff_mem_conj : (⋀Γ ∈ Ω) ↔ (∀ φ ∈ Γ, φ ∈ Ω) := by simp [membership_iff, Conj₂!_iff_forall_provable]
 
 
 section
@@ -454,141 +454,141 @@ section
 variable [Entailment.K 𝓢]
 
 lemma iff_mem_multibox : (□^[n]φ ∈ Ω) ↔ (∀ {Ω' : MaximalConsistentSet 𝓢}, (Ω.1.premultibox n ⊆ Ω'.1) → (φ ∈ Ω')) := by
-  constructor;
-  . intro hp Ω' hΩ'; apply hΩ'; simpa;
-  . contrapose!;
-    intro hp;
+  constructor
+  . intro hp Ω' hΩ'; apply hΩ'; simpa
+  . contrapose!
+    intro hp
     obtain ⟨Ω', hΩ'⟩ := lindenbaum (𝓢 := 𝓢) (T := insert (∼φ) (Ω.1.premultibox n)) (by
-      apply unprovable_iff_insert_neg_consistent.mpr;
-      by_contra hC;
-      obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp hC;
-      have : 𝓢 ⊢! □^[n]⋀Γ ➝ □^[n]φ := imply_multibox_distribute'! hΓ₂;
+      apply unprovable_iff_insert_neg_consistent.mpr
+      by_contra hC
+      obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp hC
+      have : 𝓢 ⊢! □^[n]⋀Γ ➝ □^[n]φ := imply_multibox_distribute'! hΓ₂
       have : 𝓢 ⊬ □^[n]⋀Γ ➝ □^[n]φ := by
-        have := Context.provable_iff.not.mp $ membership_iff.not.mp hp;
-        push_neg at this;
+        have := Context.provable_iff.not.mp $ membership_iff.not.mp hp
+        push_neg at this
         have : 𝓢 ⊬ ⋀(Γ.multibox n) ➝ □^[n]φ := FiniteContext.provable_iff.not.mp $ this (Γ.multibox n) (by
-          intro ψ hq;
-          obtain ⟨χ, hr₁, rfl⟩ := List.exists_multibox_of_mem_multibox hq;
-          simpa using hΓ₁ χ hr₁;
-        );
-        revert this;
-        contrapose;
-        simp only [not_not];
-        exact C!_trans collect_multibox_conj!;
-      contradiction;
-    );
-    existsi Ω';
-    constructor;
-    . exact Set.Subset.trans (by tauto_set) hΩ';
-    . apply iff_mem_neg.mp;
-      apply hΩ';
+          intro ψ hq
+          obtain ⟨χ, hr₁, rfl⟩ := List.exists_multibox_of_mem_multibox hq
+          simpa using hΓ₁ χ hr₁
+        )
+        revert this
+        contrapose
+        simp only [not_not]
+        exact C!_trans collect_multibox_conj!
+      contradiction
+    )
+    existsi Ω'
+    constructor
+    . exact Set.Subset.trans (by tauto_set) hΩ'
+    . apply iff_mem_neg.mp
+      apply hΩ'
       simp only [Set.mem_insert_iff, true_or]
 
 lemma iff_mem_box : (□φ ∈ Ω) ↔ (∀ {Ω' : MaximalConsistentSet 𝓢}, (Ω.1.prebox ⊆ Ω'.1) → (φ ∈ Ω')) := iff_mem_multibox (n := 1)
 
 
 lemma multibox_dn_iff : (□^[n](∼∼φ) ∈ Ω) ↔ (□^[n]φ ∈ Ω) := by
-  simp only [iff_mem_multibox];
-  constructor;
-  . intro h Ω hΩ;
-    exact iff_mem_negneg.mp $ h hΩ;
-  . intro h Ω hΩ;
-    exact iff_mem_negneg.mpr $ h hΩ;
+  simp only [iff_mem_multibox]
+  constructor
+  . intro h Ω hΩ
+    exact iff_mem_negneg.mp $ h hΩ
+  . intro h Ω hΩ
+    exact iff_mem_negneg.mpr $ h hΩ
 
 lemma box_dn_iff : (□(∼∼φ) ∈ Ω) ↔ (□φ ∈ Ω) := multibox_dn_iff (n := 1)
 
 
 lemma mem_multibox_dual : □^[n]φ ∈ Ω ↔ ∼(◇^[n](∼φ)) ∈ Ω := by
-  simp only [membership_iff];
-  constructor;
-  . intro h;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply Context.provable_iff.mpr;
-    use Γ;
-    constructor;
-    . assumption;
-    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_left multibox_duality!);
-  . intro h;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply Context.provable_iff.mpr;
-    use Γ;
-    constructor;
-    . assumption;
-    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_right multibox_duality!);
+  simp only [membership_iff]
+  constructor
+  . intro h
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply Context.provable_iff.mpr
+    use Γ
+    constructor
+    . assumption
+    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_left multibox_duality!)
+  . intro h
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply Context.provable_iff.mpr
+    use Γ
+    constructor
+    . assumption
+    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_right multibox_duality!)
 
 lemma mem_box_dual : □φ ∈ Ω ↔ (∼(◇(∼φ)) ∈ Ω) := mem_multibox_dual (n := 1)
 
 lemma mem_multidia_dual : ◇^[n]φ ∈ Ω ↔ ∼(□^[n](∼φ)) ∈ Ω := by
-  simp only [membership_iff];
-  constructor;
-  . intro h;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply Context.provable_iff.mpr;
-    existsi Γ;
-    constructor;
-    . assumption;
-    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_left multidia_duality!);
-  . intro h;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply Context.provable_iff.mpr;
-    existsi Γ;
-    constructor;
-    . assumption;
-    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_right multidia_duality!);
+  simp only [membership_iff]
+  constructor
+  . intro h
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply Context.provable_iff.mpr
+    existsi Γ
+    constructor
+    . assumption
+    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_left multidia_duality!)
+  . intro h
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply Context.provable_iff.mpr
+    existsi Γ
+    constructor
+    . assumption
+    . exact FiniteContext.provable_iff.mpr $ C!_trans (FiniteContext.provable_iff.mp hΓ₂) (K!_right multidia_duality!)
 lemma mem_dia_dual : ◇φ ∈ Ω ↔ (∼(□(∼φ)) ∈ Ω) := mem_multidia_dual (n := 1)
 
 lemma iff_mem_multidia : (◇^[n]φ ∈ Ω) ↔ (∃ Ω' : MaximalConsistentSet 𝓢, (Ω.1.premultibox n ⊆ Ω'.1) ∧ (φ ∈ Ω'.1)) := by
-  constructor;
-  . intro h;
-    have := mem_multidia_dual.mp h;
-    have := iff_mem_neg.mp this;
-    have := iff_mem_multibox.not.mp this;
-    push_neg at this;
-    obtain ⟨Ω', h₁, h₂⟩ := this;
-    use Ω';
-    constructor;
-    . exact h₁;
-    . exact iff_mem_negneg.mp $ iff_mem_neg.mpr h₂;
-  . rintro ⟨Ω', h₁, h₂⟩;
-    apply mem_multidia_dual.mpr;
-    apply iff_mem_neg.mpr;
-    apply iff_mem_multibox.not.mpr;
-    push_neg;
-    use Ω';
-    constructor;
-    . exact h₁;
-    . exact iff_mem_neg.mp $ iff_mem_negneg.mpr h₂;
+  constructor
+  . intro h
+    have := mem_multidia_dual.mp h
+    have := iff_mem_neg.mp this
+    have := iff_mem_multibox.not.mp this
+    push_neg at this
+    obtain ⟨Ω', h₁, h₂⟩ := this
+    use Ω'
+    constructor
+    . exact h₁
+    . exact iff_mem_negneg.mp $ iff_mem_neg.mpr h₂
+  . rintro ⟨Ω', h₁, h₂⟩
+    apply mem_multidia_dual.mpr
+    apply iff_mem_neg.mpr
+    apply iff_mem_multibox.not.mpr
+    push_neg
+    use Ω'
+    constructor
+    . exact h₁
+    . exact iff_mem_neg.mp $ iff_mem_negneg.mpr h₂
 lemma iff_mem_dia : (◇φ ∈ Ω) ↔ (∃ Ω' : MaximalConsistentSet 𝓢, (Ω.1.prebox ⊆ Ω'.1) ∧ (φ ∈ Ω'.1)) := iff_mem_multidia (n := 1)
 
 lemma multibox_multidia : (∀ {φ : Formula α}, (□^[n]φ ∈ Ω₁.1 → φ ∈ Ω₂.1)) ↔ (∀ {φ : Formula α}, (φ ∈ Ω₂.1 → ◇^[n]φ ∈ Ω₁.1)) := by
-  constructor;
-  . intro h φ;
-    contrapose;
-    intro h₂;
-    apply iff_mem_neg.mp;
-    apply h;
-    apply iff_mem_negneg.mp;
-    apply (neg_iff $ mem_multidia_dual).mp;
-    exact iff_mem_neg.mpr h₂;
-  . intro h φ;
-    contrapose;
-    intro h₂;
-    apply iff_mem_neg.mp;
-    apply (neg_iff $ mem_multibox_dual).mpr;
-    apply iff_mem_negneg.mpr;
-    apply h;
-    exact iff_mem_neg.mpr h₂;
+  constructor
+  . intro h φ
+    contrapose
+    intro h₂
+    apply iff_mem_neg.mp
+    apply h
+    apply iff_mem_negneg.mp
+    apply (neg_iff $ mem_multidia_dual).mp
+    exact iff_mem_neg.mpr h₂
+  . intro h φ
+    contrapose
+    intro h₂
+    apply iff_mem_neg.mp
+    apply (neg_iff $ mem_multibox_dual).mpr
+    apply iff_mem_negneg.mpr
+    apply h
+    exact iff_mem_neg.mpr h₂
 
 variable {Γ : List (Formula α)}
 
 lemma iff_mem_multibox_conj : (□^[n]⋀Γ ∈ Ω) ↔ (∀ φ ∈ Γ, □^[n]φ ∈ Ω) := by
-  simp only [iff_mem_multibox, iff_mem_conj];
-  constructor;
-  . intro h φ hφ Ω' hΩ';
-    exact h hΩ' _ hφ;
-  . intro h Ω' hΩ' φ hφ;
-    apply h _ hφ;
-    tauto;
+  simp only [iff_mem_multibox, iff_mem_conj]
+  constructor
+  . intro h φ hφ Ω' hΩ'
+    exact h hΩ' _ hφ
+  . intro h Ω' hΩ' φ hφ
+    apply h _ hφ
+    tauto
 
 lemma iff_mem_box_conj : (□⋀Γ ∈ Ω) ↔ (∀ φ ∈ Γ, □φ ∈ Ω) := iff_mem_multibox_conj (n := 1)
 

--- a/Foundation/Modal/ModalCompanion/Basic.lean
+++ b/Foundation/Modal/ModalCompanion/Basic.lean
@@ -32,28 +32,28 @@ abbrev smallestMC (IL : Propositional.Logic ℕ) : Modal.Logic ℕ := Modal.Logi
 
 instance : Modal.Entailment.S4 IL.smallestMC where
   T φ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.sumNormal.mem₁!;
-    simp [Modal.Logic.iff_provable, Entailment.theory];
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.sumNormal.mem₁!
+    simp [Modal.Logic.iff_provable, Entailment.theory]
   Four φ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.sumNormal.mem₁!;
-    simp [Modal.Logic.iff_provable, Entailment.theory];
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.sumNormal.mem₁!
+    simp [Modal.Logic.iff_provable, Entailment.theory]
 
 lemma smallestMC.mdp_S4 (hφψ : Modal.S4 ⊢! φ ➝ ψ) (hφ : IL.smallestMC ⊢! φ) : IL.smallestMC ⊢! ψ := by
-  exact (Modal.Logic.sumNormal.mem₁! hφψ) ⨀ hφ;
+  exact (Modal.Logic.sumNormal.mem₁! hφψ) ⨀ hφ
 
 abbrev largestMC (IL : Propositional.Logic ℕ) : Modal.Logic ℕ := Modal.Logic.sumNormal IL.smallestMC ({ Modal.Axioms.Grz (.atom 0) })
 
 instance : Modal.Entailment.Grz IL.largestMC where
   Grz φ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (φ := Modal.Axioms.Grz (.atom 0)) (s := λ _ => φ);
-    apply Modal.Logic.sumNormal.mem₂!;
-    simp;
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.subst! (φ := Modal.Axioms.Grz (.atom 0)) (s := λ _ => φ)
+    apply Modal.Logic.sumNormal.mem₂!
+    simp
 
 instance : IL.smallestMC ⪯ IL.smallestMC := inferInstance
 
@@ -70,50 +70,50 @@ lemma Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
   [Complete IL IC] [Sound IL.smallestMC MC]
   : ModalCompanion IL (IL.smallestMC) := Modal.instModalCompanion
   (by
-    intro φ hφ;
-    apply Modal.Logic.sumNormal.mem₂!;
-    use φ;
-    simpa;
+    intro φ hφ
+    apply Modal.Logic.sumNormal.mem₂!
+    use φ
+    simpa
   )
   (by
-    intro φ;
-    contrapose!;
-    intro h;
-    obtain ⟨F, hF, hF₂⟩ : ∃ F ∈ IC, ¬F ⊧ φ := Propositional.Kripke.exists_frame_of_not_validOnFrameClass $ (not_imp_not.mpr $ Complete.complete) h;
-    obtain ⟨V, x, hφ⟩ := Propositional.Formula.Kripke.ValidOnFrame.exists_valuation_world_of_not hF₂;
+    intro φ
+    contrapose!
+    intro h
+    obtain ⟨F, hF, hF₂⟩ : ∃ F ∈ IC, ¬F ⊧ φ := Propositional.Kripke.exists_frame_of_not_validOnFrameClass $ (not_imp_not.mpr $ Complete.complete) h
+    obtain ⟨V, x, hφ⟩ := Propositional.Formula.Kripke.ValidOnFrame.exists_valuation_world_of_not hF₂
     have h₁ : ∀ ψ x, Propositional.Formula.Kripke.Satisfies ⟨F, V⟩ x ψ ↔ (Modal.Formula.Kripke.Satisfies ⟨⟨F.World, F.Rel⟩, V⟩ x (ψᵍ)) := by
-      intro ψ x;
+      intro ψ x
       induction ψ using Propositional.Formula.rec' generalizing x with
       | hatom a =>
-        unfold goedelTranslate;
-        constructor;
-        . intro _ _ h;
-          exact V.hereditary h $ by assumption;
-        . intro h;
-          exact h x F.refl;
-      | hfalsum =>  rfl;
+        unfold goedelTranslate
+        constructor
+        . intro _ _ h
+          exact V.hereditary h $ by assumption
+        . intro h
+          exact h x F.refl
+      | hfalsum =>  rfl
       | hor φ ψ ihp ihq =>
-        unfold goedelTranslate;
-        constructor;
-        . rintro (hp | hq);
-          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; left;
-            exact ihp x |>.mp hp;
-          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; right;
-            exact ihq x |>.mp hq;
-        . intro h;
+        unfold goedelTranslate
+        constructor
+        . rintro (hp | hq)
+          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; left
+            exact ihp x |>.mp hp
+          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; right
+            exact ihq x |>.mp hq
+        . intro h
           rcases Modal.Formula.Kripke.Satisfies.or_def.mp h with (hp | hq)
-          . left; exact ihp x |>.mpr hp;
-          . right; exact ihq x |>.mpr hq;
-      | _ => simp_all [Propositional.Formula.Kripke.Satisfies, Modal.Formula.Kripke.Satisfies];
-    apply Sound.not_provable_of_countermodel (𝓜 := MC);
-    apply Modal.Kripke.not_validOnFrameClass_of_exists_frame;
-    use { World := F.World, Rel := F.Rel };
-    constructor;
-    . apply hIC_MC;
-      exact hF;
-    . apply Modal.Formula.Kripke.ValidOnFrame.not_of_exists_valuation_world;
-      use V, x;
-      exact (h₁ φ x).not.mp hφ;
+          . left; exact ihp x |>.mpr hp
+          . right; exact ihq x |>.mpr hq
+      | _ => simp_all [Propositional.Formula.Kripke.Satisfies, Modal.Formula.Kripke.Satisfies]
+    apply Sound.not_provable_of_countermodel (𝓜 := MC)
+    apply Modal.Kripke.not_validOnFrameClass_of_exists_frame
+    use { World := F.World, Rel := F.Rel }
+    constructor
+    . apply hIC_MC
+      exact hF
+    . apply Modal.Formula.Kripke.ValidOnFrame.not_of_exists_valuation_world
+      use V, x
+      exact (h₁ φ x).not.mp hφ
   )
 
 lemma Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
@@ -122,51 +122,51 @@ lemma Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
   [Complete IL IC] [Sound IL.largestMC MC]
   : ModalCompanion IL (IL.largestMC) := Modal.instModalCompanion
   (by
-    intro φ hφ;
-    apply Modal.Logic.sumNormal.mem₁!;
-    apply Modal.Logic.sumNormal.mem₂!;
-    use φ;
-    simpa;
+    intro φ hφ
+    apply Modal.Logic.sumNormal.mem₁!
+    apply Modal.Logic.sumNormal.mem₂!
+    use φ
+    simpa
   )
   (by
-    intro φ;
-    contrapose;
-    intro h;
-    obtain ⟨F, hF, hF₂⟩ : ∃ F ∈ IC, ¬F ⊧ φ := Propositional.Kripke.exists_frame_of_not_validOnFrameClass $ (not_imp_not.mpr $ Complete.complete) h;
-    obtain ⟨V, x, hφ⟩ := Propositional.Formula.Kripke.ValidOnFrame.exists_valuation_world_of_not hF₂;
+    intro φ
+    contrapose
+    intro h
+    obtain ⟨F, hF, hF₂⟩ : ∃ F ∈ IC, ¬F ⊧ φ := Propositional.Kripke.exists_frame_of_not_validOnFrameClass $ (not_imp_not.mpr $ Complete.complete) h
+    obtain ⟨V, x, hφ⟩ := Propositional.Formula.Kripke.ValidOnFrame.exists_valuation_world_of_not hF₂
     have h₁ : ∀ ψ x, Propositional.Formula.Kripke.Satisfies ⟨F, V⟩ x ψ ↔ (Modal.Formula.Kripke.Satisfies ⟨⟨F.World, F.Rel⟩, V⟩ x (ψᵍ)) := by
-      intro ψ x;
+      intro ψ x
       induction ψ using Propositional.Formula.rec' generalizing x with
       | hatom a =>
-        unfold goedelTranslate;
-        constructor;
-        . intro _ _ h;
-          exact V.hereditary h $ by assumption;
-        . intro h;
-          exact h x F.refl;
-      | hfalsum =>  rfl;
+        unfold goedelTranslate
+        constructor
+        . intro _ _ h
+          exact V.hereditary h $ by assumption
+        . intro h
+          exact h x F.refl
+      | hfalsum =>  rfl
       | hor φ ψ ihp ihq =>
-        unfold goedelTranslate;
-        constructor;
-        . rintro (hp | hq);
-          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; left;
-            exact ihp x |>.mp hp;
-          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; right;
-            exact ihq x |>.mp hq;
-        . intro h;
+        unfold goedelTranslate
+        constructor
+        . rintro (hp | hq)
+          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; left
+            exact ihp x |>.mp hp
+          . apply Modal.Formula.Kripke.Satisfies.or_def.mpr; right
+            exact ihq x |>.mp hq
+        . intro h
           rcases Modal.Formula.Kripke.Satisfies.or_def.mp h with (hp | hq)
-          . left; exact ihp x |>.mpr hp;
-          . right; exact ihq x |>.mpr hq;
-      | _ => simp_all [Propositional.Formula.Kripke.Satisfies, Modal.Formula.Kripke.Satisfies];
-    apply Sound.not_provable_of_countermodel (𝓜 := MC);
-    apply Modal.Kripke.not_validOnFrameClass_of_exists_frame;
-    use { World := F.World, Rel := F.Rel };
-    constructor;
-    . apply hIC_MC;
-      exact hF;
-    . apply Modal.Formula.Kripke.ValidOnFrame.not_of_exists_valuation_world;
-      use V, x;
-      exact (h₁ φ x).not.mp hφ;
+          . left; exact ihp x |>.mpr hp
+          . right; exact ihq x |>.mpr hq
+      | _ => simp_all [Propositional.Formula.Kripke.Satisfies, Modal.Formula.Kripke.Satisfies]
+    apply Sound.not_provable_of_countermodel (𝓜 := MC)
+    apply Modal.Kripke.not_validOnFrameClass_of_exists_frame
+    use { World := F.World, Rel := F.Rel }
+    constructor
+    . apply hIC_MC
+      exact hF
+    . apply Modal.Formula.Kripke.ValidOnFrame.not_of_exists_valuation_world
+      use V, x
+      exact (h₁ φ x).not.mp hφ
   )
 
 end
@@ -183,66 +183,66 @@ variable {φ ψ χ : Propositional.Formula ℕ}
 
 @[simp]
 lemma goedelTranslated_efq : 𝓜𝓢 ⊢! (⊥ ➝ φ)ᵍ := by
-  apply nec!;
-  simp [goedelTranslate];
+  apply nec!
+  simp [goedelTranslate]
 
 lemma goedelTranslated_axiomTc : 𝓜𝓢 ⊢! φᵍ ➝ □φᵍ := by
   induction φ using Propositional.Formula.rec' with
-  | hfalsum => simp only [goedelTranslate, efq!];
+  | hfalsum => simp only [goedelTranslate, efq!]
   | hand φ ψ ihp ihq => exact C!_trans (CKK!_of_C!_of_C! ihp ihq) collect_box_and!
   | hor φ ψ ihp ihq => exact C!_trans (left_A!_intro (right_A!_intro_left ihp) (right_A!_intro_right ihq)) collect_box_or!
-  | _ => simp only [goedelTranslate, axiomFour!];
+  | _ => simp only [goedelTranslate, axiomFour!]
 
 lemma goedelTranslated_implyS : 𝓜𝓢 ⊢! (φ ➝ ψ ➝ φ)ᵍ := by
-  exact nec! $ C!_trans goedelTranslated_axiomTc $ axiomK'! $ nec! $ imply₁!;
+  exact nec! $ C!_trans goedelTranslated_axiomTc $ axiomK'! $ nec! $ imply₁!
 
 lemma goedelTranslated_implyK : 𝓜𝓢 ⊢! ((φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ)ᵍ := by
-  apply nec! $ C!_trans (C!_trans (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ C!_trans (axiomK'! $ nec! imply₂!) axiomK!;
-  apply provable_iff_provable.mpr;
-  apply deduct_iff.mpr;
-  apply deduct_iff.mpr;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! φᵍ := by_axm!;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! (φᵍ ➝ □(ψᵍ ➝ χᵍ)) := by_axm!;
-  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! □(ψᵍ ➝ χᵍ) := (by assumption) ⨀ (by assumption);
-  exact axiomT'! this;
+  apply nec! $ C!_trans (C!_trans (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ C!_trans (axiomK'! $ nec! imply₂!) axiomK!
+  apply provable_iff_provable.mpr
+  apply deduct_iff.mpr
+  apply deduct_iff.mpr
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! φᵍ := by_axm!
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! (φᵍ ➝ □(ψᵍ ➝ χᵍ)) := by_axm!
+  have : [φᵍ, φᵍ ➝ □(ψᵍ ➝ χᵍ)] ⊢[𝓜𝓢]! □(ψᵍ ➝ χᵍ) := (by assumption) ⨀ (by assumption)
+  exact axiomT'! this
 
 lemma goedelTranslated_AndIntro : 𝓜𝓢 ⊢! (φ ➝ ψ ➝ φ ⋏ ψ)ᵍ := by
   exact nec! $ C!_trans goedelTranslated_axiomTc $ axiomK'! $ nec! $ and₃!
 
 lemma goedelTranslated_OrElim : 𝓜𝓢 ⊢! (((φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ)))ᵍ := by
-  exact nec! $ C!_trans axiomFour! $ axiomK'! $ nec! $ C!_trans (axiomK'! $ nec! $ or₃!) axiomK!;
+  exact nec! $ C!_trans axiomFour! $ axiomK'! $ nec! $ C!_trans (axiomK'! $ nec! $ or₃!) axiomK!
 
 lemma provable_goedelTranslated_of_provable
   (IH : Propositional.Hilbert ℕ) (𝓜𝓢 : MS) [Entailment.S4 𝓜𝓢]
   (hAx : ∀ φ ∈ IH.axiomInstances, 𝓜𝓢 ⊢! φᵍ)
   : IH ⊢! φ → 𝓜𝓢 ⊢! φᵍ := by
-  intro h;
+  intro h
   induction h using Propositional.Hilbert.rec! with
   | @axm φ _ ih =>
-    apply hAx;
-    use φ;
-    tauto;
+    apply hAx
+    use φ
+    tauto
   | mdp ihpq ihp =>
-    exact axiomT'! $ axiomK''! ihpq $ nec! $ ihp;
-  | verum => exact nec! C!_id;
-  | andElimL => exact nec! and₁!;
-  | andElimR => exact nec! and₂!;
-  | orIntroL => exact nec! or₁!;
-  | orIntroR => exact nec! or₂!;
-  | K_intro => exact goedelTranslated_AndIntro;
-  | orElim => exact goedelTranslated_OrElim;
-  | implyS => exact goedelTranslated_implyS;
-  | implyK => exact goedelTranslated_implyK;
+    exact axiomT'! $ axiomK''! ihpq $ nec! $ ihp
+  | verum => exact nec! C!_id
+  | andElimL => exact nec! and₁!
+  | andElimR => exact nec! and₂!
+  | orIntroL => exact nec! or₁!
+  | orIntroR => exact nec! or₂!
+  | K_intro => exact goedelTranslated_AndIntro
+  | orElim => exact goedelTranslated_OrElim
+  | implyS => exact goedelTranslated_implyS
+  | implyK => exact goedelTranslated_implyK
 
 end Modal
 
 /-
 lemma dp_of_mdp [ModalDisjunctive mH] [ModalCompanion iH mH] [Entailment.S4 mH] : iH ⊢! φ ⋎ ψ → iH ⊢! φ ∨ iH ⊢! ψ := by
-    intro hpq;
-    have : mH ⊢! □φᵍ ⋎ □ψᵍ := of_C!_of_C!_of_A! (right_A!_intro_left axiomTc_GTranslate!) (right_A!_intro_right axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
+    intro hpq
+    have : mH ⊢! □φᵍ ⋎ □ψᵍ := of_C!_of_C!_of_A! (right_A!_intro_left axiomTc_GTranslate!) (right_A!_intro_right axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq)
     cases ModalDisjunctive.modal_disjunctive this with
-    | inl h => left; exact ModalCompanion.companion.mpr h;
-    | inr h => right; exact ModalCompanion.companion.mpr h;
+    | inl h => left; exact ModalCompanion.companion.mpr h
+    | inr h => right; exact ModalCompanion.companion.mpr h
 
 theorem disjunctive_of_modalDisjunctive [ModalDisjunctive mH] [ModalCompanion iH mH] [Entailment.S4 mH] : Disjunctive iH := ⟨dp_of_mdp (iH := iH) (mH := mH)⟩
 -/

--- a/Foundation/Modal/ModalCompanion/Cl.lean
+++ b/Foundation/Modal/ModalCompanion/Cl.lean
@@ -17,34 +17,34 @@ namespace Propositional
 
 lemma Logic.Cl.smallestMC.mem_diabox_box : (smallestMC 𝐂𝐥) ⊢! (◇□(.atom 0) ➝ □(.atom 0)) := by
   have : (smallestMC 𝐂𝐥) ⊢! □(.atom 0) ⋎ □(∼□(.atom 0)) := by
-    apply Logic.sumNormal.mem₂!;
-    use Axioms.LEM (.atom 0);
-    constructor;
-    . simp [theory];
-    . tauto;
-  apply _ ⨀ this;
-  apply C!_trans ?_ CANC!;
-  apply C!_trans ?_ or_comm!;
-  apply CAA!_of_C!_of_C!;
-  . simp;
-  . apply CN!_of_CN!_right;
-    exact diaDuality_mp!;
+    apply Logic.sumNormal.mem₂!
+    use Axioms.LEM (.atom 0)
+    constructor
+    . simp [theory]
+    . tauto
+  apply _ ⨀ this
+  apply C!_trans ?_ CANC!
+  apply C!_trans ?_ or_comm!
+  apply CAA!_of_C!_of_C!
+  . simp
+  . apply CN!_of_CN!_right
+    exact diaDuality_mp!
 
 instance : Entailment.HasAxiomFive (smallestMC 𝐂𝐥) where
   Five φ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := (smallestMC 𝐂𝐥)) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ);
-    have := Modal.Logic.subst! (s := λ _ => ∼(.atom 0)) $ Logic.Cl.smallestMC.mem_diabox_box;
-    apply _ ⨀ this;
-    apply C!_trans ?_ CANC!;
-    apply C!_trans CCAN! ?_;
-    apply C!_trans ?_ or_comm!;
-    apply CAA!_of_C!_of_C!;
-    . apply CN!_of_CN!_left;
-      exact diaDuality_mp!;
-    . apply CN!_of_CN!_right;
-      exact diaDuality_mp!;
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.subst! (L := (smallestMC 𝐂𝐥)) (φ := Modal.Axioms.Five (.atom 0)) (s := λ a => φ)
+    have := Modal.Logic.subst! (s := λ _ => ∼(.atom 0)) $ Logic.Cl.smallestMC.mem_diabox_box
+    apply _ ⨀ this
+    apply C!_trans ?_ CANC!
+    apply C!_trans CCAN! ?_
+    apply C!_trans ?_ or_comm!
+    apply CAA!_of_C!_of_C!
+    . apply CN!_of_CN!_left
+      exact diaDuality_mp!
+    . apply CN!_of_CN!_right
+      exact diaDuality_mp!
 
 end Propositional
 
@@ -63,43 +63,43 @@ section S5
 namespace Logic
 
 lemma S5.is_smallestMC_of_Cl : Modal.S5 = (smallestMC 𝐂𝐥) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
-    | axm _ h => rcases h with (rfl | rfl | rfl) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
+    | axm _ h => rcases h with (rfl | rfl | rfl) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | nec ihφ => exact nec! ihφ;
-    | subst ihφ => apply subst! _ ihφ;
+    | mem₁ h => apply WeakerThan.pbl h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | nec ihφ => exact nec! ihφ
+    | subst ihφ => apply subst! _ ihφ
     | mem₂ h =>
-      apply Hilbert.Normal.iff_logic_provable_provable.mpr;
-      rcases h with ⟨φ, hφ, rfl⟩;
-      apply rm_diabox'!;
-      apply WeakerThan.pbl (𝓢 := Hilbert.S4);
-      exact (diaK'! $ goedelTranslated_axiomTc) ⨀ (iff_provable_Cl_provable_dia_gS4.mp hφ);
+      apply Hilbert.Normal.iff_logic_provable_provable.mpr
+      rcases h with ⟨φ, hφ, rfl⟩
+      apply rm_diabox'!
+      apply WeakerThan.pbl (𝓢 := Hilbert.S4)
+      exact (diaK'! $ goedelTranslated_axiomTc) ⨀ (iff_provable_Cl_provable_dia_gS4.mp hφ)
 
 instance : Sound (smallestMC 𝐂𝐥) FrameClass.S5 := by
-  rw [←Logic.S5.is_smallestMC_of_Cl];
-  infer_instance;
+  rw [←Logic.S5.is_smallestMC_of_Cl]
+  infer_instance
 
 instance modalCompanion_Cl_S5 : ModalCompanion 𝐂𝐥 Modal.S5 := by
-  rw [Logic.S5.is_smallestMC_of_Cl];
+  rw [Logic.S5.is_smallestMC_of_Cl]
   apply Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.Cl)
     (MC := Modal.Kripke.FrameClass.S5)
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 end Logic
 
@@ -109,52 +109,52 @@ end S5
 section S5Grz
 
 lemma Logic.gS5Grz_of_Cl : 𝐂𝐥 ⊢! φ → Modal.S5Grz ⊢! φᵍ := by
-  intro h;
-  apply WeakerThan.pbl $ modalCompanion_Cl_S5.companion.mp h;
+  intro h
+  apply WeakerThan.pbl $ modalCompanion_Cl_S5.companion.mp h
 
 lemma Logic.S5Grz.is_largestMC_of_Cl : Modal.S5Grz = (Logic.largestMC 𝐂𝐥) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm _ h =>
-      rcases h with (rfl | rfl | rfl | rfl);
-      . simp;
-      . simp;
-      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐂𝐥));
-        simp;
-      . simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
+      rcases h with (rfl | rfl | rfl | rfl)
+      . simp
+      . simp
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐂𝐥))
+        simp
+      . simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl $ Logic.S5.is_smallestMC_of_Cl ▸ h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | subst ih => apply subst! _ ih;
-    | nec ih => apply nec! ih;
-    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
+    | mem₁ h => apply WeakerThan.pbl $ Logic.S5.is_smallestMC_of_Cl ▸ h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | subst ih => apply subst! _ ih
+    | nec ih => apply nec! ih
+    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp
 
 instance : Sound (Logic.largestMC 𝐂𝐥) FrameClass.finite_Triv := by
-  rw [←Logic.S5Grz.is_largestMC_of_Cl];
-  infer_instance;
+  rw [←Logic.S5Grz.is_largestMC_of_Cl]
+  infer_instance
 
 instance modalCompanion_Cl_S5Grz : ModalCompanion 𝐂𝐥 Modal.S5Grz := by
-  rw [Logic.S5Grz.is_largestMC_of_Cl];
+  rw [Logic.S5Grz.is_largestMC_of_Cl]
   apply Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.finite_Cl)
-    (MC := Modal.Kripke.FrameClass.finite_Triv);
-  . intro F hF; simp_all only [Set.mem_setOf_eq]; exact {};
+    (MC := Modal.Kripke.FrameClass.finite_Triv)
+  . intro F hF; simp_all only [Set.mem_setOf_eq]; exact {}
 
 instance modalCompanion_Cl_Triv : ModalCompanion 𝐂𝐥 Modal.Triv := by
-  convert modalCompanion_Cl_S5Grz;
-  apply Logic.iff_equal_provable_equiv.mpr;
+  convert modalCompanion_Cl_S5Grz
+  apply Logic.iff_equal_provable_equiv.mpr
   apply Entailment.Equiv.symm
-  infer_instance;
+  infer_instance
 
 end S5Grz
 
@@ -162,8 +162,8 @@ end S5Grz
 section boxdot
 
 theorem embedding_Cl_Ver {φ : Propositional.Formula ℕ} : 𝐂𝐥 ⊢! φ ↔ Hilbert.Ver ⊢! φᵍᵇ := by
-  apply Iff.trans modalCompanion_Cl_Triv.companion;
-  simpa using Logic.iff_boxdotTranslated_Ver_Triv.symm;
+  apply Iff.trans modalCompanion_Cl_Triv.companion
+  simpa using Logic.iff_boxdotTranslated_Ver_Triv.symm
 
 end boxdot
 

--- a/Foundation/Modal/ModalCompanion/Int.lean
+++ b/Foundation/Modal/ModalCompanion/Int.lean
@@ -16,48 +16,48 @@ open Modal.Kripke
 section S4
 
 lemma Logic.gS4_of_Int : Hilbert.Int ⊢! φ → Hilbert.S4 ⊢! φᵍ := by
-  apply provable_goedelTranslated_of_provable Hilbert.Int Hilbert.S4;
-  rintro _ ⟨φ, ⟨_⟩, ⟨s, rfl⟩⟩;
-  apply nec! $ efq!;
+  apply provable_goedelTranslated_of_provable Hilbert.Int Hilbert.S4
+  rintro _ ⟨φ, ⟨_⟩, ⟨s, rfl⟩⟩
+  apply nec! $ efq!
 
 lemma Modal.S4.is_smallestMC_of_Int : Modal.S4 = (smallestMC 𝐈𝐧𝐭) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm _ h =>
       rcases h with (rfl | rfl | rfl) <;>
-      . apply Logic.sumNormal.mem₁!;
-        simp;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => apply Logic.sumNormal.mem₁!; simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
+      . apply Logic.sumNormal.mem₁!
+        simp
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | nec ihφ => exact nec! ihφ
+    | _ => apply Logic.sumNormal.mem₁!; simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => tauto;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | subst ih => apply Modal.Logic.subst! _ ih;
-    | nec ih => apply Entailment.nec! ih;
+    | mem₁ h => tauto
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | subst ih => apply Modal.Logic.subst! _ ih
+    | nec ih => apply Entailment.nec! ih
     | mem₂ h =>
-      rcases h with ⟨φ, hφ, rfl⟩;
-      simp only [theory, Propositional.Logic.iff_provable, Set.mem_setOf_eq] at hφ;
-      simpa using Logic.gS4_of_Int hφ;
+      rcases h with ⟨φ, hφ, rfl⟩
+      simp only [theory, Propositional.Logic.iff_provable, Set.mem_setOf_eq] at hφ
+      simpa using Logic.gS4_of_Int hφ
 
 instance : Sound (smallestMC 𝐈𝐧𝐭) FrameClass.S4 := by
-  rw [←Modal.S4.is_smallestMC_of_Int];
-  infer_instance;
+  rw [←Modal.S4.is_smallestMC_of_Int]
+  infer_instance
 
 instance modalCompanion_Int_S4 : ModalCompanion 𝐈𝐧𝐭 Modal.S4 := by
-  rw [Modal.S4.is_smallestMC_of_Int];
+  rw [Modal.S4.is_smallestMC_of_Int]
   apply Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.all
-    FrameClass.S4;
-  intro F _;
-  constructor;
+    FrameClass.S4
+  intro F _
+  constructor
 
 end S4
 
@@ -68,37 +68,37 @@ section Grz
 lemma Logic.gGrz_of_Int : Hilbert.Int ⊢! φ → Hilbert.Grz ⊢! φᵍ := λ h ↦ WeakerThan.pbl $ gS4_of_Int h
 
 lemma Logic.Grz.is_largestMC_of_Int : Modal.Grz = (Logic.largestMC 𝐈𝐧𝐭) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
-    | axm _ h => rcases h with (rfl | rfl | rfl) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
+    | axm _ h => rcases h with (rfl | rfl | rfl) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl $ Modal.S4.is_smallestMC_of_Int ▸ h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | subst ih => apply subst! _ ih;
-    | nec ih => apply nec! ih;
-    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
+    | mem₁ h => apply WeakerThan.pbl $ Modal.S4.is_smallestMC_of_Int ▸ h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | subst ih => apply subst! _ ih
+    | nec ih => apply nec! ih
+    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp
 
 instance : Sound (Logic.largestMC 𝐈𝐧𝐭) FrameClass.finite_Grz := by
-  rw [←Logic.Grz.is_largestMC_of_Int];
-  infer_instance;
+  rw [←Logic.Grz.is_largestMC_of_Int]
+  infer_instance
 
 instance modalCompanion_Int_Grz : ModalCompanion 𝐈𝐧𝐭 Modal.Grz := by
-  rw [Logic.Grz.is_largestMC_of_Int];
+  rw [Logic.Grz.is_largestMC_of_Int]
   apply Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.finite_all
     FrameClass.finite_Grz
-  rintro F hF;
-  simp_all only [Set.mem_setOf_eq];
+  rintro F hF
+  simp_all only [Set.mem_setOf_eq]
   exact {}
 
 end Grz
@@ -107,18 +107,18 @@ end Grz
 section glivenko
 
 lemma Logic.iff_provable_Cl_provable_dia_gS4 : 𝐂𝐥 ⊢! φ ↔ Hilbert.S4 ⊢! ◇φᵍ := by
-  constructor;
-  . intro h;
-    suffices Hilbert.S4 ⊢! □◇φᵍ by exact axiomT'! this;
-    have := modalCompanion_Int_S4.companion.mp $ iff_negneg_Int_Cl.mpr h;
-    simp only [goedelTranslate, Hilbert.Normal.iff_logic_provable_provable] at this;
-    cl_prover [this];
-  . intro h;
-    replace h : Hilbert.S4 ⊢! □◇φᵍ := nec! h;
-    apply iff_negneg_Int_Cl.mp;
-    apply modalCompanion_Int_S4.companion.mpr;
-    simp only [Hilbert.Normal.iff_logic_provable_provable];
-    cl_prover [h];
+  constructor
+  . intro h
+    suffices Hilbert.S4 ⊢! □◇φᵍ by exact axiomT'! this
+    have := modalCompanion_Int_S4.companion.mp $ iff_negneg_Int_Cl.mpr h
+    simp only [goedelTranslate, Hilbert.Normal.iff_logic_provable_provable] at this
+    cl_prover [this]
+  . intro h
+    replace h : Hilbert.S4 ⊢! □◇φᵍ := nec! h
+    apply iff_negneg_Int_Cl.mp
+    apply modalCompanion_Int_S4.companion.mpr
+    simp only [Hilbert.Normal.iff_logic_provable_provable]
+    cl_prover [h]
 
 end glivenko
 

--- a/Foundation/Modal/ModalCompanion/KC.lean
+++ b/Foundation/Modal/ModalCompanion/KC.lean
@@ -25,117 +25,117 @@ section S4Point2
 open Formula.Kripke in
 lemma Logic.S4Point2.goedelTranslated_axiomWLEM : Hilbert.S4Point2 ⊢! □(∼φᵍ) ⋎ □(∼□(∼φᵍ)) := by
   suffices Hilbert.S4Point2 ⊢! □(∼(□φᵍ)) ⋎ □(∼□(∼□(φᵍ))) by
-    apply A!_replace this;
-    . apply axiomK'!;
-      apply nec!;
-      apply contra!;
-      exact goedelTranslated_axiomTc;
-    . apply axiomK'!;
-      apply nec!;
-      apply contra!;
-      apply axiomK'!;
-      apply nec!;
-      apply contra!;
+    apply A!_replace this
+    . apply axiomK'!
+      apply nec!
+      apply contra!
+      exact goedelTranslated_axiomTc
+    . apply axiomK'!
+      apply nec!
+      apply contra!
+      apply axiomK'!
+      apply nec!
+      apply contra!
       exact axiomT!
-  apply Complete.complete (𝓜 := FrameClass.S4Point2);
-  rintro F hF V x;
-  replace hF := Set.mem_setOf_eq.mp hF;
+  apply Complete.complete (𝓜 := FrameClass.S4Point2)
+  rintro F hF V x
+  replace hF := Set.mem_setOf_eq.mp hF
 
-  apply Formula.Kripke.Satisfies.or_def.mpr;
-  by_contra! hC;
-  rcases hC with ⟨h₁, h₂⟩;
+  apply Formula.Kripke.Satisfies.or_def.mpr
+  by_contra! hC
+  rcases hC with ⟨h₁, h₂⟩
 
-  replace h₁ := Formula.Kripke.Satisfies.dia_def.mp h₁;
-  obtain ⟨y, Rxy, h₁⟩ := h₁;
+  replace h₁ := Formula.Kripke.Satisfies.dia_def.mp h₁
+  obtain ⟨y, Rxy, h₁⟩ := h₁
 
-  replace h₂ := Formula.Kripke.Satisfies.dia_def.mp h₂;
-  obtain ⟨z, Rxz, h₂⟩ := h₂;
+  replace h₂ := Formula.Kripke.Satisfies.dia_def.mp h₂
+  obtain ⟨z, Rxz, h₂⟩ := h₂
 
-  obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz;
+  obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rxy Rxz
 
-  have := Formula.Kripke.Satisfies.box_def.not.mp $ h₂ u Rzu;
-  push_neg at this;
-  obtain ⟨v, Ruv, h⟩ := this;
+  have := Formula.Kripke.Satisfies.box_def.not.mp $ h₂ u Rzu
+  push_neg at this
+  obtain ⟨v, Ruv, h⟩ := this
 
   have := h₁ v $ IsTrans.trans _ _ _ Ryu Ruv
-  contradiction;
+  contradiction
 
 namespace Logic
 
 instance : Entailment.HasAxiomPoint2 (smallestMC 𝐊𝐂) where
   Point2 φ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := (smallestMC 𝐊𝐂)) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ);
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.subst! (L := (smallestMC 𝐊𝐂)) (φ := Modal.Axioms.Point2 (.atom 0)) (s := λ a => φ)
     have : (smallestMC 𝐊𝐂) ⊢! □(∼□(.atom 0)) ⋎ □(∼□(∼□(.atom 0))) := by
-      apply Logic.sumNormal.mem₂!;
-      use Axioms.WeakLEM (.atom 0);
-      constructor;
-      . simp [theory];
-      . tauto;
-    apply ?_ ⨀ this;
-    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4);
-    apply Complete.complete (𝓜 := FrameClass.S4);
-    rintro F ⟨_, _⟩ V x h₁ h₂ y Rxy;
-    replace h₁ := Satisfies.or_def.mp h₁;
-    replace h₂ := Satisfies.dia_def.mp h₂;
-    obtain ⟨z, Rxz, h₂⟩ := h₂;
+      apply Logic.sumNormal.mem₂!
+      use Axioms.WeakLEM (.atom 0)
+      constructor
+      . simp [theory]
+      . tauto
+    apply ?_ ⨀ this
+    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4)
+    apply Complete.complete (𝓜 := FrameClass.S4)
+    rintro F ⟨_, _⟩ V x h₁ h₂ y Rxy
+    replace h₁ := Satisfies.or_def.mp h₁
+    replace h₂ := Satisfies.dia_def.mp h₂
+    obtain ⟨z, Rxz, h₂⟩ := h₂
 
-    rcases h₁ with (h₁ | h₁);
-    . have := h₁ z Rxz;
-      contradiction;
+    rcases h₁ with (h₁ | h₁)
+    . have := h₁ z Rxz
+      contradiction
     . have := Satisfies.box_def.not.mp $ Satisfies.not_def.mp $ h₁ y Rxy
-      push_neg at this;
-      obtain ⟨u, Ryu, h⟩ := this;
-      apply Satisfies.dia_def.mpr;
-      use u;
-      constructor;
-      . assumption;
+      push_neg at this
+      obtain ⟨u, Ryu, h⟩ := this
+      apply Satisfies.dia_def.mpr
+      use u
+      constructor
+      . assumption
       . apply Satisfies.negneg_def.mp h u
-        apply IsRefl.refl;
+        apply IsRefl.refl
 
 lemma S4Point2.is_smallestMC_of_KC : Modal.S4Point2 = (smallestMC 𝐊𝐂) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm s h =>
-      rcases h with (rfl | rfl | rfl | rfl) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
+      rcases h with (rfl | rfl | rfl | rfl) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | nec ihφ => exact nec! ihφ;
-    | subst ihφ => apply subst! _ ihφ;
+    | mem₁ h => apply WeakerThan.pbl h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | nec ihφ => exact nec! ihφ
+    | subst ihφ => apply subst! _ ihφ
     | mem₂ h =>
-      apply Hilbert.Normal.iff_logic_provable_provable.mpr;
-      rcases h with ⟨φ, hφ, rfl⟩;
-      apply provable_goedelTranslated_of_provable Hilbert.KC Hilbert.S4Point2;
-      . rintro _ ⟨_, (rfl | rfl), ⟨s, rfl⟩⟩;
-        . simp;
-        . simpa using Logic.S4Point2.goedelTranslated_axiomWLEM;
-      . simpa [theory] using hφ;
+      apply Hilbert.Normal.iff_logic_provable_provable.mpr
+      rcases h with ⟨φ, hφ, rfl⟩
+      apply provable_goedelTranslated_of_provable Hilbert.KC Hilbert.S4Point2
+      . rintro _ ⟨_, (rfl | rfl), ⟨s, rfl⟩⟩
+        . simp
+        . simpa using Logic.S4Point2.goedelTranslated_axiomWLEM
+      . simpa [theory] using hφ
 
 instance : Sound (smallestMC 𝐊𝐂) FrameClass.S4Point2 := by
-  rw [←Logic.S4Point2.is_smallestMC_of_KC];
-  infer_instance;
+  rw [←Logic.S4Point2.is_smallestMC_of_KC]
+  infer_instance
 
 instance modalCompanion_KC_S4Point2 : ModalCompanion 𝐊𝐂 Modal.S4Point2 := by
-  rw [Logic.S4Point2.is_smallestMC_of_KC];
+  rw [Logic.S4Point2.is_smallestMC_of_KC]
   apply Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     (IL := 𝐊𝐂)
     (IC := Propositional.Kripke.FrameClass.KC)
     (MC := Modal.Kripke.FrameClass.S4Point2)
-  rintro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  exact {};
+  rintro F hF
+  simp_all only [Set.mem_setOf_eq]
+  exact {}
 
 end Logic
 
@@ -145,41 +145,41 @@ end S4Point2
 section GrzPoint2
 
 lemma Logic.gGrzPoint2_of_KC : 𝐊𝐂 ⊢! φ → Modal.GrzPoint2 ⊢! φᵍ := by
-  intro h;
-  apply WeakerThan.pbl $ modalCompanion_KC_S4Point2.companion.mp h;
+  intro h
+  apply WeakerThan.pbl $ modalCompanion_KC_S4Point2.companion.mp h
 
 lemma Logic.GrzPoint2.is_largestMC_of_KC : Modal.GrzPoint2 = (Logic.largestMC 𝐊𝐂) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm s h =>
-      rcases h with (rfl | rfl | rfl);
-      . simp;
-      . simp;
-      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐊𝐂));
-        simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
+      rcases h with (rfl | rfl | rfl)
+      . simp
+      . simp
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐊𝐂))
+        simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl $ Logic.S4Point2.is_smallestMC_of_KC ▸ h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | subst ih => apply subst! _ ih;
-    | nec ih => apply nec! ih;
-    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
+    | mem₁ h => apply WeakerThan.pbl $ Logic.S4Point2.is_smallestMC_of_KC ▸ h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | subst ih => apply subst! _ ih
+    | nec ih => apply nec! ih
+    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp
 
 instance : Sound (Logic.largestMC 𝐊𝐂) FrameClass.finite_GrzPoint2 := by
-  rw [←Logic.GrzPoint2.is_largestMC_of_KC];
-  infer_instance;
+  rw [←Logic.GrzPoint2.is_largestMC_of_KC]
+  infer_instance
 
 instance modalCompanion_KC_GrzPoint2 : ModalCompanion 𝐊𝐂 Modal.GrzPoint2 := by
-  rw [Logic.GrzPoint2.is_largestMC_of_KC];
+  rw [Logic.GrzPoint2.is_largestMC_of_KC]
   exact Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     Propositional.Kripke.FrameClass.finite_KC
     Modal.Kripke.FrameClass.finite_GrzPoint2

--- a/Foundation/Modal/ModalCompanion/LC.lean
+++ b/Foundation/Modal/ModalCompanion/LC.lean
@@ -16,84 +16,84 @@ open Modal.Formula.Kripke
 section S4Point3
 
 lemma Logic.S4Point3.goedelTranslated_axiomDummett : Hilbert.S4Point3 ⊢! □(□ψᵍ ➝ χᵍ) ➝ □(ψᵍ ➝ χᵍ) := by
-  apply axiomK'!;
-  apply nec!;
-  apply C!_swap;
-  apply deduct'!;
-  apply deduct!;
-  have h₁ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! ψᵍ ➝ □ψᵍ := of'! $ goedelTranslated_axiomTc;
-  have h₂ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! ψᵍ := by_axm!;
-  have h₃ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! □ψᵍ ➝ χᵍ := by_axm!;
-  exact h₃ ⨀ (h₁ ⨀ h₂);
+  apply axiomK'!
+  apply nec!
+  apply C!_swap
+  apply deduct'!
+  apply deduct!
+  have h₁ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! ψᵍ ➝ □ψᵍ := of'! $ goedelTranslated_axiomTc
+  have h₂ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! ψᵍ := by_axm!
+  have h₃ : [□ψᵍ ➝ χᵍ, ψᵍ] ⊢[Hilbert.S4Point3]! □ψᵍ ➝ χᵍ := by_axm!
+  exact h₃ ⨀ (h₁ ⨀ h₂)
 
 @[simp]
 private lemma Logic.S4Point.lemma₁ : Hilbert.S4 ⊢! □(□φ ➝ □ψ) ➝ □(□φ ➝ ψ) := by
-  apply Complete.complete (𝓜 := FrameClass.S4);
-  rintro F ⟨_, _⟩ V x h₁ y Rxy h₂;
-  apply @h₁ y Rxy h₂;
-  apply IsRefl.refl;
+  apply Complete.complete (𝓜 := FrameClass.S4)
+  rintro F ⟨_, _⟩ V x h₁ y Rxy h₂
+  apply @h₁ y Rxy h₂
+  apply IsRefl.refl
 
 namespace Logic
 
 
 instance : Entailment.HasAxiomPoint3 (smallestMC 𝐋𝐂) where
   Point3 φ ψ := by
-    constructor;
-    apply Modal.Logic.iff_provable.mp;
-    apply Modal.Logic.subst! (L := (smallestMC 𝐋𝐂)) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a);
+    constructor
+    apply Modal.Logic.iff_provable.mp
+    apply Modal.Logic.subst! (L := (smallestMC 𝐋𝐂)) (φ := Modal.Axioms.Point3 (.atom 0) (.atom 1)) (s := λ a => match a with | 0 => φ | 1 => ψ | _ => .atom a)
     have : (smallestMC 𝐋𝐂) ⊢! □(□.atom 0 ➝ □.atom 1) ⋎ □(□.atom 1 ➝ □.atom 0) := by
-      apply Logic.sumNormal.mem₂!;
-      use Axioms.Dummett (.atom 0) (.atom 1);
-      constructor;
-      . simp [theory];
-      . tauto;
-    apply ?_ ⨀ this;
+      apply Logic.sumNormal.mem₂!
+      use Axioms.Dummett (.atom 0) (.atom 1)
+      constructor
+      . simp [theory]
+      . tauto
+    apply ?_ ⨀ this
     apply CAA!_of_C!_of_C! <;>
-    . apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4);
-      simp;
+    . apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4)
+      simp
 
 lemma S4Point3.is_smallestMC_of_LC : Modal.S4Point3 = (smallestMC 𝐋𝐂) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm s h =>
-      rcases h with (rfl | rfl | rfl | rfl) <;> simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
+      rcases h with (rfl | rfl | rfl | rfl) <;> simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | nec ihφ => exact nec! ihφ;
-    | subst ihφ => apply subst! _ ihφ;
+    | mem₁ h => apply WeakerThan.pbl h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | nec ihφ => exact nec! ihφ
+    | subst ihφ => apply subst! _ ihφ
     | mem₂ h =>
-      apply Hilbert.Normal.iff_logic_provable_provable.mpr;
-      rcases h with ⟨φ, hφ, rfl⟩;
-      apply provable_goedelTranslated_of_provable Hilbert.LC Hilbert.S4Point3;
-      . rintro _ ⟨_, ⟨(rfl | rfl), ⟨s, rfl⟩⟩⟩;
-        . simp;
+      apply Hilbert.Normal.iff_logic_provable_provable.mpr
+      rcases h with ⟨φ, hφ, rfl⟩
+      apply provable_goedelTranslated_of_provable Hilbert.LC Hilbert.S4Point3
+      . rintro _ ⟨_, ⟨(rfl | rfl), ⟨s, rfl⟩⟩⟩
+        . simp
         . apply A!_replace axiomPoint3! <;>
-          apply Logic.S4Point3.goedelTranslated_axiomDummett;
-      . simpa [theory] using hφ;
+          apply Logic.S4Point3.goedelTranslated_axiomDummett
+      . simpa [theory] using hφ
 
 instance : Sound (smallestMC 𝐋𝐂) FrameClass.S4Point3 := by
-  rw [←Logic.S4Point3.is_smallestMC_of_LC];
-  infer_instance;
+  rw [←Logic.S4Point3.is_smallestMC_of_LC]
+  infer_instance
 
 instance modalCompanion_LC_S4Point3 : ModalCompanion 𝐋𝐂 Modal.S4Point3 := by
-  rw [Logic.S4Point3.is_smallestMC_of_LC];
+  rw [Logic.S4Point3.is_smallestMC_of_LC]
   apply Modal.instModalCompanion_of_smallestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.LC)
     (MC := Modal.Kripke.FrameClass.S4Point3)
-  intro F hF;
-  simp_all only [Set.mem_setOf_eq];
-  constructor;
+  intro F hF
+  simp_all only [Set.mem_setOf_eq]
+  constructor
 
 end Logic
 
@@ -103,41 +103,41 @@ end S4Point3
 section GrzPoint3
 
 lemma Logic.gGrzPoint3_of_LC : 𝐋𝐂 ⊢! φ → Modal.GrzPoint3 ⊢! φᵍ := by
-  intro h;
-  apply WeakerThan.pbl $ modalCompanion_LC_S4Point3.companion.mp h;
+  intro h
+  apply WeakerThan.pbl $ modalCompanion_LC_S4Point3.companion.mp h
 
 lemma Logic.GrzPoint3.is_largestMC_of_LC : Modal.GrzPoint3 = (Logic.largestMC 𝐋𝐂) := by
-  apply Logic.iff_equal_provable_equiv.mpr;
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro _ hφ;
-    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ;
+  apply Logic.iff_equal_provable_equiv.mpr
+  apply Entailment.Equiv.antisymm_iff.mpr
+  constructor
+  . apply Entailment.weakerThan_iff.mpr
+    intro _ hφ
+    simp only [Hilbert.Normal.iff_logic_provable_provable] at hφ
     induction hφ using Modal.Hilbert.Normal.rec! with
     | axm s h =>
-      rcases h with (rfl | rfl | rfl);
-      . simp;
-      . simp;
-      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐋𝐂));
-        simp;
-    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ;
-    | nec ihφ => exact nec! ihφ;
-    | _ => simp;
-  . apply Entailment.weakerThan_iff.mpr;
-    intro φ hφ;
+      rcases h with (rfl | rfl | rfl)
+      . simp
+      . simp
+      . apply WeakerThan.pbl (𝓢 := (smallestMC 𝐋𝐂))
+        simp
+    | mdp ihφψ ihφ => exact ihφψ ⨀ ihφ
+    | nec ihφ => exact nec! ihφ
+    | _ => simp
+  . apply Entailment.weakerThan_iff.mpr
+    intro φ hφ
     induction hφ using Logic.sumNormal.rec! with
-    | mem₁ h => apply WeakerThan.pbl $ Logic.S4Point3.is_smallestMC_of_LC ▸ h;
-    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ;
-    | subst ih => apply subst! _ ih;
-    | nec ih => apply nec! ih;
-    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp;
+    | mem₁ h => apply WeakerThan.pbl $ Logic.S4Point3.is_smallestMC_of_LC ▸ h
+    | mdp ihφψ ihψ => exact ihφψ ⨀ ihψ
+    | subst ih => apply subst! _ ih
+    | nec ih => apply nec! ih
+    | mem₂ h => rcases h with ⟨φ, hφ, rfl⟩; simp
 
 instance : Sound (Logic.largestMC 𝐋𝐂) FrameClass.finite_GrzPoint3 := by
-  rw [←Logic.GrzPoint3.is_largestMC_of_LC];
-  infer_instance;
+  rw [←Logic.GrzPoint3.is_largestMC_of_LC]
+  infer_instance
 
 instance modalCompanion_LC_GrzPoint3 : ModalCompanion 𝐋𝐂 Modal.GrzPoint3 := by
-  rw [Logic.GrzPoint3.is_largestMC_of_LC];
+  rw [Logic.GrzPoint3.is_largestMC_of_LC]
   exact Modal.instModalCompanion_of_largestMC_via_KripkeSemantics
     (IC := Propositional.Kripke.FrameClass.finite_LC)
     (MC := FrameClass.finite_GrzPoint3)

--- a/Foundation/Modal/Modality/S5.lean
+++ b/Foundation/Modal/Modality/S5.lean
@@ -19,118 +19,118 @@ open Modalities
 
 protected abbrev modalities : Modalities := {-, ∼, □, ◇, ∼□, ∼◇}
 
-lemma modal_reduction_0 : ModalReduction Modal.S5 0 Modal.S5.modalities := ModalReduction.reducible_0_of_mem $ by simp;
+lemma modal_reduction_0 : ModalReduction Modal.S5 0 Modal.S5.modalities := ModalReduction.reducible_0_of_mem $ by simp
 
 lemma modal_reduction_1 : ModalReduction Modal.S5 1 Modal.S5.modalities := ModalReduction.reducible_1_of_mem (by simp) (by simp) (by simp)
 
 instance : (□□) ≅[Modal.S5] (□) := by
-  apply iff_equivalence_bi_translate.mpr;
-  constructor;
-  . apply translation_of_axiomInstance (a := 0); simp;
-  . apply translation_of_axiomInstance (a := 0);
-    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4);
-    simp;
+  apply iff_equivalence_bi_translate.mpr
+  constructor
+  . apply translation_of_axiomInstance (a := 0); simp
+  . apply translation_of_axiomInstance (a := 0)
+    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4)
+    simp
 instance : (□◇) ≅[Modal.S5] (◇) := by
-  apply iff_equivalence_bi_translate.mpr;
-  constructor;
-  . apply translation_of_axiomInstance (a := 0); simp;
-  . apply translation_of_axiomInstance (a := 0); simp;
+  apply iff_equivalence_bi_translate.mpr
+  constructor
+  . apply translation_of_axiomInstance (a := 0); simp
+  . apply translation_of_axiomInstance (a := 0); simp
 instance : (◇◇) ≅[Modal.S5] (◇) := by
-  apply iff_equivalence_bi_translate.mpr;
-  constructor;
-  . apply translation_of_axiomInstance (a := 0);
-    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4);
-    simp;
-  . apply translation_of_axiomInstance (a := 0);
-    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4);
-    simp;
+  apply iff_equivalence_bi_translate.mpr
+  constructor
+  . apply translation_of_axiomInstance (a := 0)
+    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4)
+    simp
+  . apply translation_of_axiomInstance (a := 0)
+    apply Entailment.WeakerThan.pbl (𝓢 := Modal.S4)
+    simp
 instance : (◇□) ≅[Modal.S5] (□) := by
-  apply iff_equivalence_bi_translate.mpr;
-  constructor;
-  . apply translation_of_axiomInstance (a := 0); simp;
-  . apply translation_of_axiomInstance (a := 0); simp;
+  apply iff_equivalence_bi_translate.mpr
+  constructor
+  . apply translation_of_axiomInstance (a := 0); simp
+  . apply translation_of_axiomInstance (a := 0); simp
 
 lemma modal_reduction_2 : ModalReduction Modal.S5 2 S5.modalities := by
-  apply ModalReduction.of_allOfSize;
-  intro m hm;
+  apply ModalReduction.of_allOfSize
+  intro m hm
   simp only [
     allOfSize, Finset.image_singleton, Finset.union_assoc, Finset.mem_union,
     Finset.mem_image, Finset.mem_singleton, exists_eq_or_imp, exists_eq_left
-  ] at hm;
-  rcases hm with (rfl | rfl | rfl) | (rfl | rfl | rfl) | (rfl | rfl | rfl);
-  . reduce_to (-);
-  . reduce_to (∼□);
-  . reduce_to (∼◇);
-  . reduce_to (∼◇);
-  . reduce_to (□);
-  . reduce_to (◇);
-  . reduce_to (∼□);
-  . reduce_to (□);
-  . reduce_to (◇);
+  ] at hm
+  rcases hm with (rfl | rfl | rfl) | (rfl | rfl | rfl) | (rfl | rfl | rfl)
+  . reduce_to (-)
+  . reduce_to (∼□)
+  . reduce_to (∼◇)
+  . reduce_to (∼◇)
+  . reduce_to (□)
+  . reduce_to (◇)
+  . reduce_to (∼□)
+  . reduce_to (□)
+  . reduce_to (◇)
 
 instance : (∼□∼) ≅[Modal.S5] (◇)  := by trans (∼∼◇); exact equivalence_expand_left (□∼) (∼◇) (∼); exact equivalence_expand_right (∼∼) (-) (◇)
 instance : (∼□□) ≅[Modal.S5] (∼□) := equivalence_expand_left (□□) (□) (∼)
 instance : (∼◇◇) ≅[Modal.S5] (∼◇) := equivalence_expand_left (◇◇) (◇) (∼)
 instance : (∼□◇) ≅[Modal.S5] (∼◇) := equivalence_expand_left (□◇) (◇) (∼)
 instance : (∼◇□) ≅[Modal.S5] (∼□) := equivalence_expand_left (◇□) (□) (∼)
-instance : (◇∼∼) ≅[Modal.S5] (◇)  := by trans (∼□∼); exact equivalence_expand_right (◇∼) (∼□) (∼); infer_instance;
+instance : (◇∼∼) ≅[Modal.S5] (◇)  := by trans (∼□∼); exact equivalence_expand_right (◇∼) (∼□) (∼); infer_instance
 instance : (◇∼□) ≅[Modal.S5] (∼□) := by trans (∼□□); exact equivalence_expand_right (◇∼) (∼□) (□); exact equivalence_expand_left (□□) (□) (∼)
-instance : (◇∼◇) ≅[Modal.S5] (∼◇) := by trans (∼□◇); exact equivalence_expand_right (◇∼) (∼□) (◇); infer_instance;
-instance : (◇□□) ≅[Modal.S5] (□)  := by trans (◇□); exact equivalence_expand_left (□□) (□) (◇); infer_instance;
-instance : (◇□◇) ≅[Modal.S5] (◇)  := by trans (◇◇); exact equivalence_expand_left (□◇) (◇) (◇);  infer_instance;
-instance : (◇□∼) ≅[Modal.S5] (∼◇) := by trans (□∼); exact equivalence_expand_right (◇□) (□) (∼); infer_instance;
-instance : (◇◇∼) ≅[Modal.S5] (∼□) := by trans (◇∼); exact equivalence_expand_right (◇◇) (◇) (∼); infer_instance;
-instance : (◇◇□) ≅[Modal.S5] (◇□) := by trans (◇□); exact equivalence_expand_right (◇◇) (◇) (□); infer_instance;
-instance : (◇◇◇) ≅[Modal.S5] (◇)  := by trans (◇◇); exact equivalence_expand_left (◇◇) (◇) (◇); infer_instance;
+instance : (◇∼◇) ≅[Modal.S5] (∼◇) := by trans (∼□◇); exact equivalence_expand_right (◇∼) (∼□) (◇); infer_instance
+instance : (◇□□) ≅[Modal.S5] (□)  := by trans (◇□); exact equivalence_expand_left (□□) (□) (◇); infer_instance
+instance : (◇□◇) ≅[Modal.S5] (◇)  := by trans (◇◇); exact equivalence_expand_left (□◇) (◇) (◇);  infer_instance
+instance : (◇□∼) ≅[Modal.S5] (∼◇) := by trans (□∼); exact equivalence_expand_right (◇□) (□) (∼); infer_instance
+instance : (◇◇∼) ≅[Modal.S5] (∼□) := by trans (◇∼); exact equivalence_expand_right (◇◇) (◇) (∼); infer_instance
+instance : (◇◇□) ≅[Modal.S5] (◇□) := by trans (◇□); exact equivalence_expand_right (◇◇) (◇) (□); infer_instance
+instance : (◇◇◇) ≅[Modal.S5] (◇)  := by trans (◇◇); exact equivalence_expand_left (◇◇) (◇) (◇); infer_instance
 
 lemma modal_reduction_3 : ModalReduction Modal.S5 3 S5.modalities := by
-  intro m hm;
-  rcases split_left₁' hm with ⟨m₂, hm₂, (rfl | rfl | rfl)⟩;
-  . obtain ⟨m', _, _⟩ := modal_reduction_2 m₂ hm₂;
-    use m';
-    constructor;
-    . assumption;
-    . trans m₂;
-      . apply translation_expand_right (□) (-);
-      . assumption;
-  . rcases split_left₁' hm₂ with ⟨m₂, hm₂', (rfl | rfl | rfl)⟩;
-    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl);
-      . reduce_to (□);
-      . reduce_to (◇);
-      . reduce_to (∼◇);
-    . obtain ⟨m', _, _⟩ := modal_reduction_2 (◇m₂) (by simpa);
-      use m';
-      constructor;
-      . assumption;
+  intro m hm
+  rcases split_left₁' hm with ⟨m₂, hm₂, (rfl | rfl | rfl)⟩
+  . obtain ⟨m', _, _⟩ := modal_reduction_2 m₂ hm₂
+    use m'
+    constructor
+    . assumption
+    . trans m₂
+      . apply translation_expand_right (□) (-)
+      . assumption
+  . rcases split_left₁' hm₂ with ⟨m₂, hm₂', (rfl | rfl | rfl)⟩
+    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl)
+      . reduce_to (□)
+      . reduce_to (◇)
+      . reduce_to (∼◇)
+    . obtain ⟨m', _, _⟩ := modal_reduction_2 (◇m₂) (by simpa)
+      use m'
+      constructor
+      . assumption
       . trans (◇m₂)
-        . apply translation_expand_right (◇◇) (◇);
-        . assumption;
-    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl);
-      . reduce_to (∼□);
-      . reduce_to (∼◇);
-      . reduce_to (◇);
-  . obtain ⟨m₁, m₂, hm₁, hm₂', rfl⟩ := split_left₁ hm₂;
-    rcases iff_size_1.mp hm₁ with (rfl | rfl | rfl);
-    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl);
-      . reduce_to (∼□);
-      . reduce_to (∼◇);
-      . reduce_to (◇);
-    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl);
-      . reduce_to (∼□);
-      . reduce_to (∼◇);
-      . reduce_to (□);
-    . use m₂;
-      constructor;
-      . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl) <;> tauto;
-      . apply translation_expand_right (∼∼) (-);
+        . apply translation_expand_right (◇◇) (◇)
+        . assumption
+    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl)
+      . reduce_to (∼□)
+      . reduce_to (∼◇)
+      . reduce_to (◇)
+  . obtain ⟨m₁, m₂, hm₁, hm₂', rfl⟩ := split_left₁ hm₂
+    rcases iff_size_1.mp hm₁ with (rfl | rfl | rfl)
+    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl)
+      . reduce_to (∼□)
+      . reduce_to (∼◇)
+      . reduce_to (◇)
+    . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl)
+      . reduce_to (∼□)
+      . reduce_to (∼◇)
+      . reduce_to (□)
+    . use m₂
+      constructor
+      . rcases iff_size_1.mp hm₂' with (rfl | rfl | rfl) <;> tauto
+      . apply translation_expand_right (∼∼) (-)
 
 theorem modal_reduction : ∀ n, ModalReduction Modal.S5 n S5.modalities := ModalReduction.forall_of_reducible_to_max (by simp) $ by
-  intro n hn;
+  intro n hn
   match n with
-  | 0 => exact modal_reduction_0;
-  | 1 => exact modal_reduction_1;
-  | 2 => exact modal_reduction_2;
-  | 3 => exact modal_reduction_3;
+  | 0 => exact modal_reduction_0
+  | 1 => exact modal_reduction_1
+  | 2 => exact modal_reduction_2
+  | 3 => exact modal_reduction_3
 
 end S5
 

--- a/Foundation/Modal/NNFormula.lean
+++ b/Foundation/Modal/NNFormula.lean
@@ -65,7 +65,7 @@ lemma verum_eq : (verum : NNFormula α) = ⊤ := rfl
 
 @[simp] lemma imp_inj (φ₁ ψ₁ φ₂ ψ₂ : Formula α) : φ₁ ➝ φ₂ = ψ₁ ➝ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Arrow.arrow]
 
-@[simp] lemma neg_inj (φ ψ : Formula α) : ∼φ = ∼ψ ↔ φ = ψ := by simp [NegAbbrev.neg];
+@[simp] lemma neg_inj (φ ψ : Formula α) : ∼φ = ∼ψ ↔ φ = ψ := by simp [NegAbbrev.neg]
 
 lemma neg_eq : neg φ = ∼φ := rfl
 
@@ -76,28 +76,28 @@ lemma neg_eq : neg φ = ∼φ := rfl
 lemma negneg : ∼∼φ = φ := by
   induction φ with
   | and φ ψ ihφ ihψ =>
-    simp only [←neg_eq, neg, and.injEq];
-    exact ⟨ihφ, ihψ⟩;
+    simp only [←neg_eq, neg, and.injEq]
+    exact ⟨ihφ, ihψ⟩
   | or φ ψ ihφ ihψ =>
-    simp only [←neg_eq, neg, or.injEq];
-    exact ⟨ihφ, ihψ⟩;
+    simp only [←neg_eq, neg, or.injEq]
+    exact ⟨ihφ, ihψ⟩
   | box φ ihφ =>
-    simp only [←neg_eq, neg, box.injEq];
-    exact ihφ;
+    simp only [←neg_eq, neg, box.injEq]
+    exact ihφ
   | dia φ ihφ =>
-    simp only [←neg_eq, neg, dia.injEq];
-    exact ihφ;
-  | _ => tauto;
+    simp only [←neg_eq, neg, dia.injEq]
+    exact ihφ
+  | _ => tauto
 
 instance : ModalDeMorgan (NNFormula α) where
-  verum := by tauto;
-  falsum := by tauto;
-  and := by tauto;
-  or := by tauto;
-  box := by tauto;
-  dia := by tauto;
+  verum := by tauto
+  falsum := by tauto
+  and := by tauto
+  or := by tauto
+  box := by tauto
+  dia := by tauto
   neg := λ _ => negneg
-  imply := by tauto;
+  imply := by tauto
 
 section toString
 
@@ -235,12 +235,12 @@ def ofNat : Nat → Option (NNFormula α)
     | 6 =>
       have : c < e + 1 := Nat.lt_succ.mpr $ Nat.unpair_right_le _
       do
-        let φ ← ofNat c;
+        let φ ← ofNat c
         return □φ
     | 7 =>
       have : c < e + 1 := Nat.lt_succ.mpr $ Nat.unpair_right_le _
       do
-        let φ ← ofNat c;
+        let φ ← ofNat c
         return ◇φ
     | _ => none
 
@@ -248,7 +248,7 @@ instance : Encodable (NNFormula α) where
   encode := toNat
   decode := ofNat
   encodek := by
-    intro φ;
+    intro φ
     induction φ using rec' <;> simp [toNat, ofNat, encodek, *]
 
 end Encodable
@@ -284,12 +284,12 @@ namespace isModalCNFPart
 
 variable {a : α} {φ ψ : NNFormula α}
 
-lemma def_atom : isModalCNFPart (.atom a) := by use [⟨(.atom a), by tauto⟩]; tauto;
-lemma def_natom : isModalCNFPart (.natom a) := by use [⟨(.natom a), by tauto⟩]; tauto;
-lemma def_verum : isModalCNFPart (⊤ : NNFormula α) := by use [⟨⊤, by tauto⟩]; tauto;
-lemma def_falsum : isModalCNFPart (⊥ : NNFormula α) := by use [⟨⊥, by tauto⟩]; tauto;
-lemma def_box : isModalCNFPart (□φ) := by use [⟨□φ, by tauto⟩]; tauto;
-lemma def_dia : isModalCNFPart (◇φ) := by use [⟨◇φ, by tauto⟩]; tauto;
+lemma def_atom : isModalCNFPart (.atom a) := by use [⟨(.atom a), by tauto⟩]; tauto
+lemma def_natom : isModalCNFPart (.natom a) := by use [⟨(.natom a), by tauto⟩]; tauto
+lemma def_verum : isModalCNFPart (⊤ : NNFormula α) := by use [⟨⊤, by tauto⟩]; tauto
+lemma def_falsum : isModalCNFPart (⊥ : NNFormula α) := by use [⟨⊥, by tauto⟩]; tauto
+lemma def_box : isModalCNFPart (□φ) := by use [⟨□φ, by tauto⟩]; tauto
+lemma def_dia : isModalCNFPart (◇φ) := by use [⟨◇φ, by tauto⟩]; tauto
 
 end isModalCNFPart
 
@@ -298,12 +298,12 @@ def isModalCNF (φ : NNFormula α) := ∃ Γ : List { ψ // isModalCNFPart ψ },
 
 namespace isModalCNF
 
-@[simp] lemma def_atom {a : α} : isModalCNF (.atom a) := by use [⟨(.atom a), isModalCNFPart.def_atom⟩]; simp;
-@[simp] lemma def_natom {a : α} : isModalCNF (.natom a) := by use [⟨(.natom a), isModalCNFPart.def_natom⟩]; simp;
-@[simp] lemma def_falsum : isModalCNF (⊥ : NNFormula α) := by use [⟨⊥, isModalCNFPart.def_falsum⟩]; simp;
-@[simp] lemma def_verum : isModalCNF (⊤ : NNFormula α) := by use [⟨⊤, isModalCNFPart.def_verum⟩]; simp;
-@[simp] lemma def_box {φ : NNFormula α} : isModalCNF (□φ) := by use [⟨□φ, isModalCNFPart.def_box⟩]; simp;
-@[simp] lemma def_dia {φ : NNFormula α} : isModalCNF (◇φ) := by use [⟨◇φ, isModalCNFPart.def_dia⟩]; simp;
+@[simp] lemma def_atom {a : α} : isModalCNF (.atom a) := by use [⟨(.atom a), isModalCNFPart.def_atom⟩]; simp
+@[simp] lemma def_natom {a : α} : isModalCNF (.natom a) := by use [⟨(.natom a), isModalCNFPart.def_natom⟩]; simp
+@[simp] lemma def_falsum : isModalCNF (⊥ : NNFormula α) := by use [⟨⊥, isModalCNFPart.def_falsum⟩]; simp
+@[simp] lemma def_verum : isModalCNF (⊤ : NNFormula α) := by use [⟨⊤, isModalCNFPart.def_verum⟩]; simp
+@[simp] lemma def_box {φ : NNFormula α} : isModalCNF (□φ) := by use [⟨□φ, isModalCNFPart.def_box⟩]; simp
+@[simp] lemma def_dia {φ : NNFormula α} : isModalCNF (◇φ) := by use [⟨◇φ, isModalCNFPart.def_dia⟩]; simp
 
 end isModalCNF
 
@@ -318,10 +318,10 @@ namespace isModalDNFPart
 lemma of_degree_zero {φ : NNFormula α} (h : φ.degree = 0) : isModalDNFPart φ := by
   induction φ using rec' with
   | hAnd φ ψ ihφ ihψ =>
-    constructor;
-    . apply ihφ; simp_all [degree];
-    . apply ihψ; simp_all [degree];
-  | _ => tauto;
+    constructor
+    . apply ihφ; simp_all [degree]
+    . apply ihψ; simp_all [degree]
+  | _ => tauto
 
 end isModalDNFPart
 

--- a/Foundation/Modal/Neighborhood/AxiomC.lean
+++ b/Foundation/Modal/Neighborhood/AxiomC.lean
@@ -13,23 +13,23 @@ class Frame.IsRegular (F : Frame) : Prop where
 lemma Frame.regular [Frame.IsRegular F] {X Y : Set F} : (F.box X) ∩ (F.box Y) ⊆ F.box (X ∩ Y) := by apply IsRegular.regular
 
 instance : Frame.simple_blackhole.IsRegular := ⟨by
-  intro X Y e;
-  simp_all;
+  intro X Y e
+  simp_all
 ⟩
 
 @[simp]
 lemma valid_axiomC_of_isRegular [F.IsRegular] : F ⊧ Axioms.C (.atom 0) (.atom 1) := by
-  intro V x;
+  intro V x
   simp only [
     Satisfies, Model.truthset.eq_imp, Model.truthset.eq_and, Model.truthset.eq_box,
     Model.truthset.eq_atom, Set.mem_union, Set.mem_compl_iff, Set.mem_inter_iff, Set.mem_setOf_eq
-  ];
-  apply not_or_of_imp;
-  rintro ⟨h₁, h₂⟩;
-  apply F.regular;
-  constructor;
-  . apply h₁;
-  . apply h₂;
+  ]
+  apply not_or_of_imp
+  rintro ⟨h₁, h₂⟩
+  apply F.regular
+  constructor
+  . apply h₁
+  . apply h₂
 
 
 section
@@ -41,19 +41,19 @@ open Entailment
 open MaximalConsistentSet
 
 instance : (minimalCanonicalFrame 𝓢).IsRegular := by
-  constructor;
-  rintro X Y Γ ⟨hX, hY⟩;
-  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hX;
-  obtain ⟨ψ, rfl, hψ⟩ := minimalCanonicalFrame.exists_box Y Γ hY;
-  rw [(show proofset 𝓢 φ ∩ proofset 𝓢 ψ = proofset 𝓢 (φ ⋏ ψ) by simp)];
-  have : proofset 𝓢 (□φ ⋏ □ψ) ⊆ proofset 𝓢 (□(φ ⋏ ψ)) := proofset.imp_subset |>.mp (by simp);
+  constructor
+  rintro X Y Γ ⟨hX, hY⟩
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hX
+  obtain ⟨ψ, rfl, hψ⟩ := minimalCanonicalFrame.exists_box Y Γ hY
+  rw [(show proofset 𝓢 φ ∩ proofset 𝓢 ψ = proofset 𝓢 (φ ⋏ ψ) by simp)]
+  have : proofset 𝓢 (□φ ⋏ □ψ) ⊆ proofset 𝓢 (□(φ ⋏ ψ)) := proofset.imp_subset |>.mp (by simp)
   have : Γ ∈ proofset 𝓢 (□(φ ⋏ ψ)) := this $ by
-    simp only [proofset.eq_and, Set.mem_inter_iff];
-    constructor;
-    . apply hφ ▸ hX;
-    . apply hψ ▸ hY;
-  convert this;
-  convert Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) (φ ⋏ ψ);
+    simp only [proofset.eq_and, Set.mem_inter_iff]
+    constructor
+    . apply hφ ▸ hX
+    . apply hψ ▸ hY
+  convert this
+  convert Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) (φ ⋏ ψ)
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomGeach.lean
+++ b/Foundation/Modal/Neighborhood/AxiomGeach.lean
@@ -51,11 +51,11 @@ section
 variable {a : ℕ}
 
 lemma valid_axiomGeach_of_isGeachConvergent [F.IsGeachConvergent g] : F ⊧ Axioms.Geach g (.atom a) := by
-  intro V x;
-  apply Satisfies.def_imp.mpr;
+  intro V x
+  apply Satisfies.def_imp.mpr
   suffices x ∈ F.dia^[g.i] (F.box^[g.m] (V a)) → x ∈ F.box^[g.j] (F.dia^[g.n] (V a)) by
-    simpa [Semantics.Realize, Satisfies];
-  apply F.gconv;
+    simpa [Semantics.Realize, Satisfies]
+  apply F.gconv
 
 @[simp] lemma valid_axiomT_of_isReflexive [F.IsReflexive] : F ⊧ Axioms.T (.atom a) := valid_axiomGeach_of_isGeachConvergent (g := ⟨0, 0, 1, 0⟩)
 @[simp] lemma valid_axiomFour_of_isTransitive [F.IsTransitive] : F ⊧ Axioms.Four (.atom a) := valid_axiomGeach_of_isGeachConvergent (g := ⟨0, 2, 1, 0⟩)
@@ -63,24 +63,24 @@ lemma valid_axiomGeach_of_isGeachConvergent [F.IsGeachConvergent g] : F ⊧ Axio
 
 
 lemma isGeachConvergent_of_valid_axiomGeach (h : F ⊧ Axioms.Geach g (.atom a)) : F.IsGeachConvergent g := by
-  constructor;
-  intro X x hx;
+  constructor
+  intro X x hx
   have : x ∈ F.dia^[g.i] (F.box^[g.m] X) → x ∈ F.box^[g.j] (F.dia^[g.n] X) := by
-    simpa [Semantics.Realize, Satisfies] using Satisfies.def_imp.mp $ @h (λ _ => X) x;
-  apply this;
-  apply hx;
+    simpa [Semantics.Realize, Satisfies] using Satisfies.def_imp.mp $ @h (λ _ => X) x
+  apply this
+  apply hx
 
 lemma isReflexive_of_valid_axiomT (h : F ⊧ Axioms.T (.atom a)) : F.IsReflexive := by
-  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 0, 1, 0⟩) h;
-  infer_instance;
+  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 0, 1, 0⟩) h
+  infer_instance
 
 lemma isTransitive_of_valid_axiomFour (h : F ⊧ Axioms.Four (.atom a)) : F.IsTransitive := by
-  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 2, 1, 0⟩) h;
-  infer_instance;
+  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 2, 1, 0⟩) h
+  infer_instance
 
 lemma isSerial_of_valid_axiomD (h : F ⊧ Axioms.D (.atom a)) : F.IsSerial := by
-  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 0, 1, 1⟩) h;
-  infer_instance;
+  have := isGeachConvergent_of_valid_axiomGeach (g := ⟨0, 0, 1, 1⟩) h
+  infer_instance
 
 end
 
@@ -95,23 +95,23 @@ open Entailment
 open MaximalConsistentSet
 
 instance [Entailment.ET 𝓢] : (minimalCanonicalFrame 𝓢).IsReflexive := by
-  constructor;
-  intro X Γ hΓ;
-  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ;
-  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 φ := proofset.imp_subset.mp (by simp);
-  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ);
+  constructor
+  intro X Γ hΓ
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ
+  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 φ := proofset.imp_subset.mp (by simp)
+  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ)
 
 instance [Entailment.E4 𝓢] : (minimalCanonicalFrame 𝓢).IsTransitive := by
-  constructor;
-  intro X Γ hΓ;
-  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ;
-  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 (□□φ) := proofset.imp_subset.mp (by simp);
-  have := Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ);
+  constructor
+  intro X Γ hΓ
+  obtain ⟨φ, rfl, hφ⟩ := minimalCanonicalFrame.exists_box X Γ hΓ
+  have : proofset 𝓢 (□φ) ⊆ proofset 𝓢 (□□φ) := proofset.imp_subset.mp (by simp)
+  have := Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mp $ this (hφ ▸ hΓ)
   rw [
     ←(Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) (□φ)),
     ←(Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) φ)
-  ] at this;
-  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mpr this;
+  ] at this
+  exact Frame.IsCanonical.iff_mem (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) |>.mpr this
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomM.lean
+++ b/Foundation/Modal/Neighborhood/AxiomM.lean
@@ -12,20 +12,20 @@ class Frame.IsMonotonic (F : Frame) : Prop where
 lemma Frame.mono [Frame.IsMonotonic F] {X Y : Set F} : F.box (X ∩ Y) ⊆ F.box X ∩ F.box Y := by apply IsMonotonic.mono
 
 instance : Frame.simple_blackhole.IsMonotonic := ⟨by
-  intro X Y e he;
+  intro X Y e he
   constructor <;>
-  . simp_all only [Set.mem_setOf_eq, Set.mem_singleton_iff];
-    tauto_set;
+  . simp_all only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+    tauto_set
 ⟩
 
 @[simp]
 lemma valid_axiomM_of_isMonotonic [F.IsMonotonic] : F ⊧ Axioms.M (.atom 0) (.atom 1) := by
-  intro V x;
+  intro V x
   simp only [
     Satisfies, Model.truthset.eq_imp, Model.truthset.eq_box, Model.truthset.eq_and,
     Model.truthset.eq_atom, Set.mem_union, Set.mem_compl_iff, Set.mem_setOf_eq, Set.mem_inter_iff
   ]
-  apply not_or_of_imp;
-  apply Frame.mono;
+  apply not_or_of_imp
+  apply Frame.mono
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/AxiomN.lean
+++ b/Foundation/Modal/Neighborhood/AxiomN.lean
@@ -15,20 +15,20 @@ lemma Frame.contains_unit [Frame.ContainsUnit F] : F.box Set.univ = Set.univ := 
 
 @[simp]
 lemma Frame.univ_mem [Frame.ContainsUnit F] (x) : Set.univ ∈ F.𝒩 x := by
-  haveI := @F.contains_unit.symm.subset;
-  simpa using @this x;
+  haveI := @F.contains_unit.symm.subset
+  simpa using @this x
 
 instance : Frame.simple_blackhole.ContainsUnit := ⟨by ext x; simp⟩
 
 @[simp]
 lemma valid_axiomN_of_ContainsUnit [F.ContainsUnit] : F ⊧ Axioms.N := by
-  intro V x;
-  simp [Satisfies, F.contains_unit];
+  intro V x
+  simp [Satisfies, F.contains_unit]
 
 lemma containsUnit_of_valid_axiomN (h : F ⊧ Axioms.N) : F.ContainsUnit := by
-  constructor;
-  ext x;
-  simpa [Satisfies] using @h (λ _ => Set.univ) x;
+  constructor
+  ext x
+  simpa [Satisfies] using @h (λ _ => Set.univ) x
 
 
 section
@@ -41,17 +41,17 @@ open MaximalConsistentSet
 open MaximalConsistentSet.proofset
 
 instance : (minimalCanonicalFrame 𝓢).ContainsUnit := by
-  constructor;
-  dsimp [minimalCanonicalFrame, Frame.mk_ℬ, Frame.box];
-  split;
-  . rename_i h;
-    apply iff_provable_eq_univ.mp;
-    apply nec!;
-    apply iff_provable_eq_univ.mpr;
-    apply h.choose_spec.symm;
-  . rename_i h;
-    push_neg at h;
-    simpa using @h ⊤;
+  constructor
+  dsimp [minimalCanonicalFrame, Frame.mk_ℬ, Frame.box]
+  split
+  . rename_i h
+    apply iff_provable_eq_univ.mp
+    apply nec!
+    apply iff_provable_eq_univ.mpr
+    apply h.choose_spec.symm
+  . rename_i h
+    push_neg at h
+    simpa using @h ⊤
 
 end
 

--- a/Foundation/Modal/Neighborhood/AxiomP.lean
+++ b/Foundation/Modal/Neighborhood/AxiomP.lean
@@ -15,17 +15,17 @@ instance : Frame.simple_blackhole.NotContainsEmpty := ⟨by simp only [Set.mem_s
 
 @[simp]
 lemma valid_axiomP_of_notContainsEmpty [F.NotContainsEmpty] : F ⊧ Axioms.P := by
-  intro V x;
+  intro V x
   simp only [
     Satisfies, Model.truthset.eq_neg, Model.truthset.eq_box, Model.truthset.eq_bot,
     Set.mem_compl_iff, Set.mem_setOf_eq
-  ];
-  apply Frame.not_contains_empty;
+  ]
+  apply Frame.not_contains_empty
 
 lemma notContainsEmpty_of_valid_axiomP (h : F ⊧ Axioms.P) : F.NotContainsEmpty := by
-  constructor;
-  intro x;
-  have := @h (λ _ => ∅) x;
-  simpa [Satisfies] using this;
+  constructor
+  intro x
+  have := @h (λ _ => ∅) x
+  simpa [Satisfies] using this
 
 end LO.Modal.Neighborhood

--- a/Foundation/Modal/Neighborhood/Basic.lean
+++ b/Foundation/Modal/Neighborhood/Basic.lean
@@ -26,12 +26,12 @@ instance {F : Frame} : Nonempty F.World := F.world_nonempty
 @[reducible] def dia (F : Frame) := λ X => (F.box Xᶜ)ᶜ
 
 lemma eq_ℬ_𝒩 {F : Frame} {X Y : Set F.World} : (F.box X) = Y ↔ (∀ x, X ∈ F.𝒩 x ↔ x ∈ Y) := by
-  constructor;
-  . rintro rfl;
-    tauto;
-  . rintro h;
-    ext x;
-    apply h;
+  constructor
+  . rintro rfl
+    tauto
+  . rintro h
+    ext x
+    apply h
 
 def mk_ℬ (World : Type) [Nonempty World] (B : Set World → Set World) : Frame where
   World := World
@@ -58,8 +58,8 @@ instance : CoeSort Model Type := ⟨λ M => M.toFrame.World⟩
 
 @[simp]
 lemma Model.nonempty_univ_world {M : Model} : Set.Nonempty (Set.univ (α := M.World)) := by
-  use M.world_nonempty.some;
-  tauto;
+  use M.world_nonempty.some
+  tauto
 
 @[grind]
 def Model.truthset (M : Model) : Formula ℕ → Set M.World
@@ -78,13 +78,13 @@ instance : CoeFun Model (λ M => Formula ℕ → Set M.World) := ⟨λ M => trut
 @[simp, grind] lemma eq_bot  : M ⊥ = ∅ := rfl
 @[simp, grind] lemma eq_top  : M ⊤ = Set.univ := by simp [truthset]
 @[simp, grind] lemma eq_imp  : M (φ ➝ ψ) = (M φ)ᶜ ∪ (M ψ) := rfl
-@[simp, grind] lemma eq_or   : M (φ ⋎ ψ) = (M φ) ∪ (M ψ) := by simp [truthset];
-@[simp, grind] lemma eq_and  : M (φ ⋏ ψ) = (M φ) ∩ (M ψ) := by simp [truthset];
+@[simp, grind] lemma eq_or   : M (φ ⋎ ψ) = (M φ) ∪ (M ψ) := by simp [truthset]
+@[simp, grind] lemma eq_and  : M (φ ⋏ ψ) = (M φ) ∩ (M ψ) := by simp [truthset]
 @[simp, grind] lemma eq_neg  : M (∼φ) = (M φ)ᶜ := by simp [truthset]
 @[simp, grind] lemma eq_iff  : M (φ ⭤ ψ) = (M φ ∩ M ψ) ∪ ((M φ)ᶜ ∩ (M ψ)ᶜ) := calc
-  M (φ ⭤ ψ) = M (φ ➝ ψ) ∩ (M (ψ ➝ φ))             := by simp [LogicalConnective.iff];
-  _         = ((M φ)ᶜ ∪ (M ψ)) ∩ ((M ψ)ᶜ ∪ (M φ)) := by simp;
-  _         = (M φ ∩ M ψ) ∪ ((M φ)ᶜ ∩ (M ψ)ᶜ)     := by tauto_set;
+  M (φ ⭤ ψ) = M (φ ➝ ψ) ∩ (M (ψ ➝ φ))             := by simp [LogicalConnective.iff]
+  _         = ((M φ)ᶜ ∪ (M ψ)) ∩ ((M ψ)ᶜ ∪ (M φ)) := by simp
+  _         = (M φ ∩ M ψ) ∪ ((M φ)ᶜ ∩ (M ψ)ᶜ)     := by tauto_set
 
 @[simp, grind]
 lemma eq_multibox {n : ℕ} : M (□^[n] φ) = M.box^[n] (M φ) := by
@@ -107,7 +107,7 @@ lemma eq_multidia {n : ℕ} : M (◇^[n] φ) = M.dia^[n] (M φ) := by
 lemma eq_subst :
   letI U : Valuation M.toFrame := λ a => M ((atom a)⟦s⟧)
   M (φ⟦s⟧) = (⟨M.toFrame, U⟩ : Model) φ := by
-  induction φ <;> simp_all;
+  induction φ <;> simp_all
 
 end Model.truthset
 
@@ -127,15 +127,15 @@ protected instance semantics {M : Model} : Semantics (Formula ℕ) M.World := �
 
 variable {M : Model} {x : M.World} {φ ψ ξ : Formula ℕ}
 
-@[grind] lemma def_top : x ⊧ ⊤ := by simp [Semantics.Realize, Satisfies];
-@[grind] lemma def_bot : ¬x ⊧ ⊥ := by simp [Semantics.Realize, Satisfies];
-@[grind] lemma def_neg : x ⊧ ∼φ ↔ ¬x ⊧ φ := by simp [Semantics.Realize, Satisfies];
-@[grind] lemma def_imp : x ⊧ φ ➝ ψ ↔ (x ⊧ φ → x ⊧ ψ) := by simp [Semantics.Realize, Satisfies]; tauto;
-@[grind] lemma def_and : x ⊧ φ ⋏ ψ ↔ (x ⊧ φ ∧ x ⊧ ψ) := by simp [Semantics.Realize, Satisfies];
-@[grind] lemma def_or  : x ⊧ φ ⋎ ψ ↔ (x ⊧ φ ∨ x ⊧ ψ) := by simp [Semantics.Realize, Satisfies];
+@[grind] lemma def_top : x ⊧ ⊤ := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_bot : ¬x ⊧ ⊥ := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_neg : x ⊧ ∼φ ↔ ¬x ⊧ φ := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_imp : x ⊧ φ ➝ ψ ↔ (x ⊧ φ → x ⊧ ψ) := by simp [Semantics.Realize, Satisfies]; tauto
+@[grind] lemma def_and : x ⊧ φ ⋏ ψ ↔ (x ⊧ φ ∧ x ⊧ ψ) := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_or  : x ⊧ φ ⋎ ψ ↔ (x ⊧ φ ∨ x ⊧ ψ) := by simp [Semantics.Realize, Satisfies]
 
-@[grind] lemma def_box : x ⊧ □φ ↔ M φ ∈ (M.𝒩 x) := by simp [Semantics.Realize, Satisfies];
-@[grind] lemma def_dia : x ⊧ ◇φ ↔ (M φ)ᶜ ∈ (M.𝒩 x)ᶜ := by simp [Semantics.Realize, Satisfies];
+@[grind] lemma def_box : x ⊧ □φ ↔ M φ ∈ (M.𝒩 x) := by simp [Semantics.Realize, Satisfies]
+@[grind] lemma def_dia : x ⊧ ◇φ ↔ (M φ)ᶜ ∈ (M.𝒩 x)ᶜ := by simp [Semantics.Realize, Satisfies]
 
 @[grind] lemma def_multibox' : x ⊧ □^[n]φ ↔ x ∈ M.box^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
 @[grind] lemma def_mutlidia' : x ⊧ ◇^[n]φ ↔ x ∈ M.dia^[n] (M φ) := by simp [Semantics.Realize, Satisfies]
@@ -155,13 +155,13 @@ protected instance : Semantics.Tarski (M.World) where
 @[simp] protected lemma elimContra : x ⊧ Axioms.ElimContra φ ψ := by grind
 protected lemma mdp (hφψ : x ⊧ φ ➝ ψ) (hψ : x ⊧ φ) : x ⊧ ψ := by grind
 
-lemma dia_dual : x ⊧ ◇φ ↔ x ⊧ ∼□(∼φ) := by simp [Semantics.Realize, Satisfies];
-lemma box_dual : x ⊧ □φ ↔ x ⊧ ∼◇(∼φ) := by simp [Semantics.Realize, Satisfies];
+lemma dia_dual : x ⊧ ◇φ ↔ x ⊧ ∼□(∼φ) := by simp [Semantics.Realize, Satisfies]
+lemma box_dual : x ⊧ □φ ↔ x ⊧ ∼◇(∼φ) := by simp [Semantics.Realize, Satisfies]
 
 lemma iff_subst_self {M : Model} {x : M.World} (s) :
   letI U : Valuation M.toFrame := λ a => M ((atom a)⟦s⟧)
   Satisfies ⟨M.toFrame, U⟩ x φ ↔ Satisfies M x (φ⟦s⟧) := by
-  simp [Satisfies, Model.truthset.eq_subst];
+  simp [Satisfies, Model.truthset.eq_subst]
 
 end Satisfies
 
@@ -176,32 +176,32 @@ protected instance semantics : Semantics (Formula ℕ) Model := ⟨fun M ↦ Val
 
 @[simp]
 lemma iff_eq_truthset_univ : M ⊧ φ ↔ (M φ = Set.univ) := by
-  constructor;
-  . intro hφ;
-    ext x;
-    simp only [Set.mem_univ, iff_true];
-    apply hφ;
-  . intro h x;
+  constructor
+  . intro hφ
+    ext x
+    simp only [Set.mem_univ, iff_true]
+    apply hφ
+  . intro h x
     simp [Satisfies, h]
 
 instance : Semantics.Bot Model where
   realize_bot M := by
-    simp only [iff_eq_truthset_univ, Neighborhood.Model.truthset.eq_bot];
-    apply Set.nonempty_iff_ne_empty.mp ?_ |>.symm;
-    simp;
+    simp only [iff_eq_truthset_univ, Neighborhood.Model.truthset.eq_bot]
+    apply Set.nonempty_iff_ne_empty.mp ?_ |>.symm
+    simp
 
 instance : Semantics.Top Model where
-  realize_top M := by simp;
+  realize_top M := by simp
 
 lemma valid_iff : M ⊧ φ ⭤ ψ ↔ (M φ = M ψ) := by
-  constructor;
-  . intro h;
-    ext x;
-    have := @h x;
-    simp [Satisfies] at this;
-    tauto;
-  . intro h x;
-    simp [Satisfies, h];
+  constructor
+  . intro h
+    ext x
+    have := @h x
+    simp [Satisfies] at this
+    tauto
+  . intro h x
+    simp [Satisfies, h]
 
 @[simp] protected lemma imply₁ : M ⊧ Axioms.Imply₁ φ ψ := λ _ ↦ Satisfies.imply₁
 
@@ -210,15 +210,15 @@ lemma valid_iff : M ⊧ φ ⭤ ψ ↔ (M φ = M ψ) := by
 @[simp] protected lemma elimContra : M ⊧ Axioms.ElimContra φ ψ := λ _ ↦ Satisfies.elimContra
 
 protected lemma mdp (hφψ : M ⊧ φ ➝ ψ) (hψ : M ⊧ φ) : M ⊧ ψ := by
-  intro x;
-  apply Satisfies.mdp;
-  . exact hφψ x;
-  . exact hψ x;
+  intro x
+  apply Satisfies.mdp
+  . exact hφψ x
+  . exact hψ x
 
 protected lemma re (hφ : M ⊧ φ ⭤ ψ) : M ⊧ □φ ⭤ □ψ := by
-  rw [valid_iff] at ⊢ hφ;
-  ext x;
-  simp_all;
+  rw [valid_iff] at ⊢ hφ
+  ext x
+  simp_all
 
 end ValidOnModel
 
@@ -234,22 +234,22 @@ protected instance semantics : Semantics (Formula ℕ) Frame := ⟨fun F ↦ Val
 
 instance : Semantics.Bot Frame where
   realize_bot F := by
-    by_contra! hC;
-    simpa using hC (λ _ => {});
+    by_contra! hC
+    simpa using hC (λ _ => {})
 
 instance : Semantics.Top Frame where
-  realize_top F := by intro; simp;
+  realize_top F := by intro; simp
 
 protected lemma mdp (hφψ : F ⊧ φ ➝ ψ) (hφ : F ⊧ φ) : F ⊧ ψ := by
-  intro V;
-  apply ValidOnModel.mdp;
-  . exact hφψ V;
-  . exact hφ V;
+  intro V
+  apply ValidOnModel.mdp
+  . exact hφψ V
+  . exact hφ V
 
 protected lemma re (hφ : F ⊧ φ ⭤ ψ) : F ⊧ □φ ⭤ □ψ := by
-  intro V;
-  apply ValidOnModel.re;
-  exact hφ V;
+  intro V
+  apply ValidOnModel.re
+  exact hφ V
 
 @[simp] protected lemma imply₁ : F ⊧ Axioms.Imply₁ φ ψ := λ _ ↦ ValidOnModel.imply₁
 
@@ -259,15 +259,15 @@ protected lemma re (hφ : F ⊧ φ ⭤ ψ) : F ⊧ □φ ⭤ □ψ := by
 
 
 lemma iff_not_exists_valuation_world : (¬F ⊧ φ) ↔ (∃ V : Valuation F, ∃ x : (⟨F, V⟩ : Model).World, ¬Satisfies _ x φ) := by
-  simp [ValidOnFrame, Satisfies, ValidOnModel, Semantics.Realize];
+  simp [ValidOnFrame, Satisfies, ValidOnModel, Semantics.Realize]
 
 alias ⟨exists_valuation_world_of_not, not_of_exists_valuation_world⟩ := iff_not_exists_valuation_world
 
 protected lemma subst (s) (h : F ⊧ φ) : F ⊧ φ⟦s⟧ := by
-  by_contra hC;
-  obtain ⟨V, x, hx⟩ := exists_valuation_world_of_not hC;
-  apply Satisfies.iff_subst_self s |>.not.mpr hx;
-  exact h (λ a => Model.truthset ⟨F, V⟩ (atom a⟦s⟧)) x;
+  by_contra hC
+  obtain ⟨V, x, hx⟩ := exists_valuation_world_of_not hC
+  apply Satisfies.iff_subst_self s |>.not.mpr hx
+  exact h (λ a => Model.truthset ⟨F, V⟩ (atom a⟦s⟧)) x
 
 end ValidOnFrame
 
@@ -276,15 +276,15 @@ section
 variable {C : FrameClass} {φ ψ χ : Formula ℕ}
 
 lemma iff_not_validOnFrameClass_exists_model_world : (¬C ⊧ φ) ↔ (∃ M : Model, ∃ x : M.World, M.toFrame ∈ C ∧ ¬(x ⊧ φ)) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_model_world_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_model_world⟩ := iff_not_validOnFrameClass_exists_model_world
 
 lemma iff_not_validOnFrameClass_exists_frame : (¬C ⊧ φ) ↔ (∃ F ∈ C, ¬F ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_frame_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_frame⟩ := iff_not_validOnFrameClass_exists_frame
 
 end

--- a/Foundation/Modal/Neighborhood/Completeness.lean
+++ b/Foundation/Modal/Neighborhood/Completeness.lean
@@ -22,22 +22,22 @@ variable {φ ψ : Formula α} {Γ : MaximalConsistentSet 𝓢}
 
 omit [DecidableEq α] [Entailment.Cl 𝓢] in
 @[grind]
-lemma iff_mem : φ ∈ Γ ↔ Γ ∈ ‖φ‖ := by simp [proofset];
+lemma iff_mem : φ ∈ Γ ↔ Γ ∈ ‖φ‖ := by simp [proofset]
 
-lemma eq_top : ‖⊤‖ = Set.univ := by simp [proofset];
+lemma eq_top : ‖⊤‖ = Set.univ := by simp [proofset]
 
-lemma eq_bot : ‖⊥‖ = ∅ := by simp [proofset];
+lemma eq_bot : ‖⊥‖ = ∅ := by simp [proofset]
 
-lemma eq_neg : ‖∼φ‖ = ‖φ‖ᶜ := by simp [proofset]; tauto;
+lemma eq_neg : ‖∼φ‖ = ‖φ‖ᶜ := by simp [proofset]; tauto
 
 lemma eq_imp : ‖φ ➝ ψ‖ = (‖φ‖ᶜ ∪ ‖ψ‖) := by
-  ext;
-  simp [proofset];
-  tauto;
+  ext
+  simp [proofset]
+  tauto
 
-lemma eq_and : ‖φ ⋏ ψ‖ = ‖φ‖ ∩ ‖ψ‖ := by simp [proofset]; tauto;
+lemma eq_and : ‖φ ⋏ ψ‖ = ‖φ‖ ∩ ‖ψ‖ := by simp [proofset]; tauto
 
-lemma eq_or : ‖φ ⋎ ψ‖ = ‖φ‖ ∪ ‖ψ‖ := by simp [proofset]; tauto;
+lemma eq_or : ‖φ ⋎ ψ‖ = ‖φ‖ ∪ ‖ψ‖ := by simp [proofset]; tauto
 
 attribute [simp, grind]
   eq_top
@@ -48,54 +48,54 @@ attribute [simp, grind]
   eq_or
 
 lemma iff_provable_eq_univ : 𝓢 ⊢! φ ↔ ‖φ‖ = Set.univ := by
-  constructor;
-  . intro h;
-    apply Set.eq_univ_of_forall;
-    intro Γ;
-    apply iff_mem.mp;
-    grind;
-  . intro h;
-    apply iff_forall_mem_provable.mp;
-    intro Γ;
-    apply iff_mem.mpr;
-    rw [h];
-    tauto;
+  constructor
+  . intro h
+    apply Set.eq_univ_of_forall
+    intro Γ
+    apply iff_mem.mp
+    grind
+  . intro h
+    apply iff_forall_mem_provable.mp
+    intro Γ
+    apply iff_mem.mpr
+    rw [h]
+    tauto
 
 @[grind]
 lemma imp_subset : 𝓢 ⊢! φ ➝ ψ ↔ ‖φ‖ ⊆ ‖ψ‖ := by
-  constructor;
-  . intro h Γ;
-    apply iff_mem_imp.mp $ iff_forall_mem_provable.mpr h Γ;
-  . intro h;
-    apply iff_forall_mem_provable.mp;
-    intro Γ;
-    apply iff_mem_imp.mpr $ @h Γ;
+  constructor
+  . intro h Γ
+    apply iff_mem_imp.mp $ iff_forall_mem_provable.mpr h Γ
+  . intro h
+    apply iff_forall_mem_provable.mp
+    intro Γ
+    apply iff_mem_imp.mpr $ @h Γ
 
 @[grind]
 lemma iff_subset : 𝓢 ⊢! φ ⭤ ψ ↔ ‖φ‖ = ‖ψ‖ := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     apply Set.eq_of_subset_of_subset <;>
-    . apply imp_subset.mp;
-      cl_prover [h];
-  . intro h;
-    have ⟨h₁, h₂⟩ := Set.Subset.antisymm_iff.mp h;
-    replace h₁ := imp_subset.mpr h₁;
-    replace h₂ := imp_subset.mpr h₂;
-    cl_prover [h₁, h₂];
+    . apply imp_subset.mp
+      cl_prover [h]
+  . intro h
+    have ⟨h₁, h₂⟩ := Set.Subset.antisymm_iff.mp h
+    replace h₁ := imp_subset.mpr h₁
+    replace h₂ := imp_subset.mpr h₂
+    cl_prover [h₁, h₂]
 
 lemma eq_boxed_of_eq [Entailment.E 𝓢] : ‖φ‖ = ‖ψ‖ → ‖□φ‖ = ‖□ψ‖ := by
-  intro h;
-  apply iff_subset.mp;
-  apply re!;
-  apply iff_subset.mpr;
-  assumption;
+  intro h
+  apply iff_subset.mp
+  apply re!
+  apply iff_subset.mpr
+  assumption
 
 @[grind]
 lemma box_subset_of_subset [Entailment.EM 𝓢] : ‖φ‖ ⊆ ‖ψ‖ → ‖□φ‖ ⊆ ‖□ψ‖ := by
-  intro h;
-  apply imp_subset.mp;
-  exact Entailment.rm! $ imp_subset.mpr h;
+  intro h
+  apply imp_subset.mp
+  exact Entailment.rm! $ imp_subset.mpr h
 
 end MaximalConsistentSet.proofset
 
@@ -124,23 +124,23 @@ variable {F : Frame} [canonical : F.IsCanonical 𝓢]
 
 @[simp]
 lemma eq_empty : (canonical.eq_world ▸ (∅ : Set (MaximalConsistentSet 𝓢))) = ∅ := by
-  have := canonical.eq_world;
-  grind;
+  have := canonical.eq_world
+  grind
 
 @[simp]
 lemma eq_union {X Y : Set (MaximalConsistentSet 𝓢)} : (canonical.eq_world ▸ (X ∪ Y)) = ((canonical.eq_world ▸ X) ∪ (canonical.eq_world ▸ Y)) := by
-  have := canonical.eq_world;
-  grind;
+  have := canonical.eq_world
+  grind
 
 @[simp]
 lemma eq_comp {X : Set (MaximalConsistentSet 𝓢)} : (canonical.eq_world ▸ Xᶜ) = (canonical.eq_world ▸ X)ᶜ := by
-  haveI := canonical.eq_world;
-  grind;
+  haveI := canonical.eq_world
+  grind
 
 @[simp]
 lemma iff_mem {Γ : MaximalConsistentSet 𝓢} {X : Set _} : Γ ∈ X ↔ (canonical.eq_world ▸ Γ) ∈ (canonical.eq_world ▸ X) := by
-  have := canonical.eq_world;
-  grind;
+  have := canonical.eq_world
+  grind
 
 end Frame.IsCanonical
 
@@ -153,7 +153,7 @@ namespace canonicalModel
 
 variable {F : Frame} [canonical : F.IsCanonical 𝓢]
 
-@[simp] lemma eq_model_box : (canonicalModel F 𝓢).box = F.box := by tauto;
+@[simp] lemma eq_model_box : (canonicalModel F 𝓢).box = F.box := by tauto
 
 end canonicalModel
 
@@ -163,30 +163,30 @@ variable [Entailment.Cl 𝓢]
 lemma truthlemma : canonical.eq_world ▸ (proofset 𝓢 φ) = ((canonicalModel F 𝓢).truthset φ) := by
   induction φ with
   | hatom => simp [canonicalModel]
-  | hfalsum => simp [canonicalModel];
-  | himp φ ψ ihφ ihψ => simp_all [MaximalConsistentSet.proofset.eq_imp, ←ihφ, ←ihψ];
+  | hfalsum => simp [canonicalModel]
+  | himp φ ψ ihφ ihψ => simp_all [MaximalConsistentSet.proofset.eq_imp, ←ihφ, ←ihψ]
   | hbox φ ihφ =>
-    rw [Model.truthset.eq_box, ←ihφ, ←(canonical.box_proofset φ)];
-    rfl;
+    rw [Model.truthset.eq_box, ←ihφ, ←(canonical.box_proofset φ)]
+    rfl
 
 lemma complete_of_canonical_frame (C : FrameClass) (F : Frame) [canonical : F.IsCanonical 𝓢] (hC : F ∈ C)
   : LO.Complete 𝓢 C := by
-  constructor;
-  intro φ;
-  contrapose!;
-  intro hφ;
-  have := FormulaSet.unprovable_iff_singleton_neg_consistent.mpr hφ;
-  obtain ⟨Γ, hΓ⟩ := lindenbaum this;
-  apply not_validOnFrameClass_of_exists_model_world;
-  use (canonicalModel F 𝓢), (canonical.eq_world ▸ Γ);
-  constructor;
-  . assumption;
-  . simp only [Semantics.Realize, Satisfies, ←truthlemma];
+  constructor
+  intro φ
+  contrapose!
+  intro hφ
+  have := FormulaSet.unprovable_iff_singleton_neg_consistent.mpr hφ
+  obtain ⟨Γ, hΓ⟩ := lindenbaum this
+  apply not_validOnFrameClass_of_exists_model_world
+  use (canonicalModel F 𝓢), (canonical.eq_world ▸ Γ)
+  constructor
+  . assumption
+  . simp only [Semantics.Realize, Satisfies, ←truthlemma]
     suffices Γ ∈ (proofset 𝓢 (∼φ)) by
-      apply canonical.iff_mem.not.mp;
-      simpa using this;
-    apply hΓ;
-    tauto;
+      apply canonical.iff_mem.not.mp
+      simpa using this
+    apply hΓ
+    tauto
 
 
 
@@ -203,63 +203,63 @@ variable {𝓢 : S} [Entailment.E 𝓢] [Entailment.Consistent 𝓢]
 
 instance : (minimalCanonicalFrame 𝓢).IsCanonical 𝓢 where
   box_proofset := by
-    intro φ;
-    dsimp [minimalCanonicalFrame, Frame.mk_ℬ, Frame.box];
-    split;
-    . rename_i h;
-      apply proofset.eq_boxed_of_eq;
-      apply h.choose_spec.symm;
-    . tauto;
+    intro φ
+    dsimp [minimalCanonicalFrame, Frame.mk_ℬ, Frame.box]
+    split
+    . rename_i h
+      apply proofset.eq_boxed_of_eq
+      apply h.choose_spec.symm
+    . tauto
 
 lemma exists_box (X) (Γ : (minimalCanonicalFrame 𝓢).World) (hΓ : Γ ∈ Frame.box _ X)
   : ∃ φ, X = proofset 𝓢 φ ∧ Frame.box _ X = proofset 𝓢 (□φ)
   := by
-    simp [Frame.mk_ℬ, Frame.box] at hΓ;
-    split at hΓ;
-    . rename_i h;
-      obtain ⟨φ, hφ⟩ := h;
-      use φ;
-      constructor;
-      . assumption;
-      . convert Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) φ;
-    . contradiction;
+    simp [Frame.mk_ℬ, Frame.box] at hΓ
+    split at hΓ
+    . rename_i h
+      obtain ⟨φ, hφ⟩ := h
+      use φ
+      constructor
+      . assumption
+      . convert Frame.IsCanonical.box_proofset (F := minimalCanonicalFrame 𝓢) (𝓢 := 𝓢) φ
+    . contradiction
 
 /-
 lemma exists_dia (X) (Γ : (CanonicalBox.minimal 𝓢).model.World) (hΓ : Γ ∈ Frame.box _ X)
   : ∃ φ, X = proofset 𝓢 φ ∧ Frame.dia _ X = proofset 𝓢 (◇φ)
   := by
-    obtain ⟨φ, hφ, hΓ⟩ := exists_box X Γ hΓ;
-    use φ;
-    constructor;
-    . assumption;
-    . ext Γ;
-      rw [(show ◇φ = ∼□(∼φ) by rfl)];
+    obtain ⟨φ, hφ, hΓ⟩ := exists_box X Γ hΓ
+    use φ
+    constructor
+    . assumption
+    . ext Γ
+      rw [(show ◇φ = ∼□(∼φ) by rfl)]
       simp only [
         CanonicalBox.minimal, CanonicalBox.model, CanonicalBox.frame, Frame.mk_ℬ,
         Frame.dia, Frame.box, Set.mem_setOf_eq, Set.setOf_mem_eq, Set.mem_compl_iff,
         proofset.eq_neg
-      ];
-      constructor;
-      . intro h;
-        split at h;
-        . rename_i h₂;
-          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [this] at h; simpa;
-          apply proofset.eq_boxed_of_eq;
-          rw [←h₂.choose_spec, hφ];
-          simp;
-        . exfalso;
-          rename_i h₂;
-          push_neg at h₂;
-          apply @h₂ (∼φ);
-          simpa;
-      . intro h;
-        split;
-        . rename_i h₂;
-          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [←this] at h; simpa;
-          apply proofset.eq_boxed_of_eq;
-          rw [←h₂.choose_spec, hφ];
-          simp;
-        . tauto;
+      ]
+      constructor
+      . intro h
+        split at h
+        . rename_i h₂
+          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [this] at h; simpa
+          apply proofset.eq_boxed_of_eq
+          rw [←h₂.choose_spec, hφ]
+          simp
+        . exfalso
+          rename_i h₂
+          push_neg at h₂
+          apply @h₂ (∼φ)
+          simpa
+      . intro h
+        split
+        . rename_i h₂
+          suffices proofset 𝓢 (□h₂.choose) = proofset 𝓢 (□(∼φ)) by rw [←this] at h; simpa
+          apply proofset.eq_boxed_of_eq
+          rw [←h₂.choose_spec, hφ]
+          simp
+        . tauto
 -/
 
 end minimalCanonicalFrame

--- a/Foundation/Modal/Neighborhood/Hilbert.lean
+++ b/Foundation/Modal/Neighborhood/Hilbert.lean
@@ -15,15 +15,15 @@ namespace Hilbert.Neighborhood
 section Frame
 
 lemma soundness_of_axioms_validOnFrame (hC : F ⊧* H.axioms) : H ⊢! φ → F ⊧ φ := by
-  intro hφ;
+  intro hφ
   induction hφ using Hilbert.WithRE.rec! with
-  | imply₁ | imply₂ | ec => simp;
-  | mdp ihφψ ihφ => exact ValidOnFrame.mdp ihφψ ihφ;
-  | re ihφ => exact ValidOnFrame.re ihφ;
+  | imply₁ | imply₂ | ec => simp
+  | mdp ihφψ ihφ => exact ValidOnFrame.mdp ihφψ ihφ
+  | re ihφ => exact ValidOnFrame.re ihφ
   | axm s h =>
-    apply ValidOnFrame.subst s;
-    apply hC.RealizeSet;
-    assumption;
+    apply ValidOnFrame.subst s
+    apply hC.RealizeSet
+    assumption
 
 instance instSound_of_axioms_validOnFrame (hV : F ⊧* H.axioms) : Sound H F := ⟨fun {_} => soundness_of_axioms_validOnFrame hV⟩
 
@@ -33,28 +33,28 @@ end Frame
 section FrameClass
 
 lemma soundness_of_validates_axioms (hC : C ⊧* H.axioms) : H ⊢! φ → C ⊧ φ := by
-  intro hφ F hF;
+  intro hφ F hF
   induction hφ using Hilbert.WithRE.rec! with
-  | imply₁ | imply₂ | ec => simp;
-  | mdp ihφψ ihφ => exact ValidOnFrame.mdp ihφψ ihφ;
-  | re ihφ => exact ValidOnFrame.re ihφ;
+  | imply₁ | imply₂ | ec => simp
+  | mdp ihφψ ihφ => exact ValidOnFrame.mdp ihφψ ihφ
+  | re ihφ => exact ValidOnFrame.re ihφ
   | axm s h =>
-    intro V x;
-    apply ValidOnFrame.subst s $ @hC.RealizeSet _ h F hF;
+    intro V x
+    apply ValidOnFrame.subst s $ @hC.RealizeSet _ h F hF
 
 instance instSound_of_validates_axioms (hV : C ⊧* H.axioms) : Sound H C := ⟨fun {_} => soundness_of_validates_axioms hV⟩
 
 lemma consistent_of_sound_frameclass
   (C : Neighborhood.FrameClass) (C_nonempty: C.Nonempty := by simp) [sound : Sound H C]
   : Entailment.Consistent H := by
-  apply Entailment.Consistent.of_unprovable (f := ⊥);
-  apply not_imp_not.mpr sound.sound;
-  apply Semantics.set_models_iff.not.mpr;
-  push_neg;
-  use C_nonempty.choose;
-  constructor;
+  apply Entailment.Consistent.of_unprovable (f := ⊥)
+  apply not_imp_not.mpr sound.sound
+  apply Semantics.set_models_iff.not.mpr
+  push_neg
+  use C_nonempty.choose
+  constructor
   . exact C_nonempty.choose_spec
-  . simp;
+  . simp
 
 end FrameClass
 

--- a/Foundation/Modal/Neighborhood/Logic/E.lean
+++ b/Foundation/Modal/Neighborhood/Logic/E.lean
@@ -16,24 +16,24 @@ end Neighborhood
 
 namespace Hilbert.E.Neighborhood
 
-instance : Sound Hilbert.E FrameClass.E := instSound_of_validates_axioms $ by simp;
+instance : Sound Hilbert.E FrameClass.E := instSound_of_validates_axioms $ by simp
 
 instance : Entailment.Consistent Hilbert.E := consistent_of_sound_frameclass FrameClass.E $ by
-  use ⟨Unit, λ _ => {}⟩;
-  simp;
+  use ⟨Unit, λ _ => {}⟩
+  simp
 
 instance : Complete Hilbert.E FrameClass.E := complete_of_canonical_frame FrameClass.E (minimalCanonicalFrame (Hilbert.E)) (by tauto)
 
 instance : Hilbert.E ⪱ Hilbert.EK := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.K (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.K (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 3,
         𝒩 := λ w =>
@@ -46,37 +46,37 @@ instance : Hilbert.E ⪱ Hilbert.EK := by
           | 0 => {0}
           | 1 => {0, 1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
-      . tauto;
-      . simp! [M, Semantics.Realize, Satisfies];
-        constructor;
-        . intro;
-          ext x;
-          simp;
-          omega;
-        . tauto_set;
+      }
+      use M, 0
+      constructor
+      . tauto
+      . simp! [M, Semantics.Realize, Satisfies]
+        constructor
+        . intro
+          ext x
+          simp
+          omega
+        . tauto_set
 
 instance : Hilbert.E ⪱ Hilbert.EN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
     use Axioms.N
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_model_world;
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 1,
         𝒩 := λ w => ∅,
         Val := λ w => Set.univ
-      };
-      use M, 0;
-      constructor;
-      . tauto;
-      . simp! [M, Semantics.Realize, Satisfies];
+      }
+      use M, 0
+      constructor
+      . tauto
+      . simp! [M, Semantics.Realize, Satisfies]
 
 end Hilbert.E.Neighborhood
 

--- a/Foundation/Modal/Neighborhood/Logic/E4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/E4.lean
@@ -6,7 +6,7 @@ import Foundation.Modal.Neighborhood.Logic.E
 
 @[simp]
 lemma Set.inter_eq_univ {s t : Set α} : s ∩ t = Set.univ ↔ s = Set.univ ∧ t = Set.univ := by
-  simpa using @Set.sInter_eq_univ _ {s, t};
+  simpa using @Set.sInter_eq_univ _ {s, t}
 
 namespace LO.Modal
 
@@ -17,8 +17,8 @@ open Formula.Neighborhood
 namespace Neighborhood
 
 instance : Frame.simple_blackhole.IsTransitive := by
-  constructor;
-  simp [Frame.box];
+  constructor
+  simp [Frame.box]
 
 @[reducible] protected alias Frame.IsE4 := Frame.IsTransitive
 protected abbrev FrameClass.E4 : FrameClass := { F | F.IsE4 }
@@ -35,32 +35,32 @@ abbrev Frame.trivial_nontransitive : Frame := ⟨
 ⟩
 
 instance : Frame.trivial_nontransitive.IsRegular := by
-  constructor;
-  rintro X Y x ⟨hx, hy⟩;
-  match x with | 0 | 1 => simp_all;
+  constructor
+  rintro X Y x ⟨hx, hy⟩
+  match x with | 0 | 1 => simp_all
 
 instance : Frame.trivial_nontransitive.IsMonotonic := by
-  constructor;
+  constructor
   rintro X Y x; match x with | 0 | 1 => simp
 
 instance : Frame.trivial_nontransitive.IsReflexive := by
-  constructor;
-  rintro X x; match x with | 0 | 1 => first | tauto_set | simp_all;
+  constructor
+  rintro X x; match x with | 0 | 1 => first | tauto_set | simp_all
 
 @[simp]
 lemma Frame.trivial_nontransitive.not_transitive : ¬Frame.trivial_nontransitive.IsTransitive := by
-  by_contra hC;
-  have := @(hC.trans Set.univ);
-  have := @this 1 ?_;
-  . have := Set.Subset.antisymm_iff.mp this |>.2;
-    have := @this 0;
-    simp at this;
-  . simp [Frame.box];
+  by_contra hC
+  have := @(hC.trans Set.univ)
+  have := @this 1 ?_
+  . have := Set.Subset.antisymm_iff.mp this |>.2
+    have := @this 0
+    simp at this
+  . simp [Frame.box]
 
 @[simp]
 lemma Frame.trivial_nontransitive.not_valid_axiomFour : ¬Frame.trivial_nontransitive ⊧ Axioms.Four (.atom 0) := by
-  apply not_imp_not.mpr isTransitive_of_valid_axiomFour;
-  simp;
+  apply not_imp_not.mpr isTransitive_of_valid_axiomFour
+  simp
 
 end
 
@@ -72,34 +72,34 @@ namespace Hilbert
 namespace E4.Neighborhood
 
 instance : Sound Hilbert.E4 FrameClass.E4 := instSound_of_validates_axioms $ by
-  simp only [Semantics.RealizeSet.singleton_iff];
-  intro F hF;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply valid_axiomFour_of_isTransitive;
+  simp only [Semantics.RealizeSet.singleton_iff]
+  intro F hF
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply valid_axiomFour_of_isTransitive
 
 instance : Entailment.Consistent Hilbert.E4 := consistent_of_sound_frameclass FrameClass.E4 $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 instance : Complete Hilbert.E4 FrameClass.E4 := complete_of_canonical_frame FrameClass.E4 (minimalCanonicalFrame (Hilbert.E4)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 end E4.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.E4 := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_frame;
-      use Frame.trivial_nontransitive;
-      simp;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_frame
+      use Frame.trivial_nontransitive
+      simp
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EC.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EC.lean
@@ -22,31 +22,31 @@ namespace Hilbert
 namespace EC.Neighborhood
 
 instance : Sound Hilbert.EC FrameClass.EC := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ rfl F hF;
-  simp_all;
+  constructor
+  rintro _ rfl F hF
+  simp_all
 
 instance : Entailment.Consistent Hilbert.EC := consistent_of_sound_frameclass FrameClass.EC $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 instance : Complete Hilbert.EC FrameClass.EC := complete_of_canonical_frame FrameClass.EC (minimalCanonicalFrame (Hilbert.EC)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 end EC.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.EC := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.C (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.C (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w =>
@@ -58,10 +58,10 @@ instance : Hilbert.E ⪱ Hilbert.EC := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
-      . tauto;
+      }
+      use M, 0
+      constructor
+      . tauto
       . simp [M, Semantics.Realize, Satisfies]
 
 end Hilbert

--- a/Foundation/Modal/Neighborhood/Logic/ECN.lean
+++ b/Foundation/Modal/Neighborhood/Logic/ECN.lean
@@ -21,30 +21,30 @@ namespace Hilbert
 namespace ECN.Neighborhood
 
 instance : Sound Hilbert.ECN FrameClass.ECN := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.ECN := consistent_of_sound_frameclass FrameClass.ECN $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  constructor;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  constructor
 
 instance : Complete Hilbert.ECN FrameClass.ECN := complete_of_canonical_frame FrameClass.ECN (minimalCanonicalFrame (Hilbert.ECN)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end ECN.Neighborhood
 
 instance : Hilbert.EC ⪱ Hilbert.ECN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.N;
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EC);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.N
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EC)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 3,
         𝒩 := λ w =>
@@ -57,36 +57,36 @@ instance : Hilbert.EC ⪱ Hilbert.ECN := by
           | 0 => {0, 1}
           | 1 => {1, 2}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           regular := by
-            rintro X Y w ⟨hwX, hwY⟩;
+            rintro X Y w ⟨hwX, hwY⟩
             match w with
-            | 0 => simp_all [M];
+            | 0 => simp_all [M]
             | 1 =>
               rcases hwX with (rfl | rfl) <;>
               rcases hwY with (rfl | rfl) <;>
-              simp_all [M];
+              simp_all [M]
             | 2 =>
               rcases hwX with (rfl | rfl | rfl) <;>
               rcases hwY with (rfl | rfl | rfl) <;>
               simp [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        tauto_set;
+      . simp! [M, Semantics.Realize, Satisfies]
+        tauto_set
 
 instance : Hilbert.EN ⪱ Hilbert.ECN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.C (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EN);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.C (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EN)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w =>
@@ -98,16 +98,16 @@ instance : Hilbert.EN ⪱ Hilbert.ECN := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           contains_unit := by
-            ext x;
+            ext x
             match x with | 0 | 1 => simp_all [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        tauto_set;
+      . simp! [M, Semantics.Realize, Satisfies]
+        tauto_set
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/ED.lean
+++ b/Foundation/Modal/Neighborhood/Logic/ED.lean
@@ -13,10 +13,10 @@ open Formula.Neighborhood
 namespace Neighborhood
 
 instance : Frame.simple_blackhole.IsSerial := by
-  constructor;
-  intro X x;
-  simp only [Frame.box, Set.mem_singleton_iff, Set.mem_setOf_eq, Frame.dia, Set.compl_univ_iff, Set.mem_compl_iff];
-  tauto_set;
+  constructor
+  intro X x
+  simp only [Frame.box, Set.mem_singleton_iff, Set.mem_setOf_eq, Frame.dia, Set.compl_univ_iff, Set.mem_compl_iff]
+  tauto_set
 
 
 @[reducible] protected alias Frame.IsED := Frame.IsSerial
@@ -31,35 +31,35 @@ namespace Hilbert
 namespace ED.Neighborhood
 
 instance : Sound Hilbert.ED FrameClass.ED := instSound_of_validates_axioms $ by
-  simp only [Semantics.RealizeSet.singleton_iff];
-  intro F hF;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  simp;
+  simp only [Semantics.RealizeSet.singleton_iff]
+  intro F hF
+  replace hF := Set.mem_setOf_eq.mp hF
+  simp
 
 instance : Entailment.Consistent Hilbert.ED := consistent_of_sound_frameclass FrameClass.ED $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 end ED.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.ED := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.D (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_frame;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.D (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_frame
       use ⟨Fin 2, λ w => match w with | 0 => {{0}} | 1 => Set.univ⟩
-      constructor;
-      . tauto;
-      . apply not_imp_not.mpr isSerial_of_valid_axiomD;
-        by_contra! hC;
-        have := @hC.serial {1} 1;
-        simp [Frame.box, Frame.dia] at this;
+      constructor
+      . tauto
+      . apply not_imp_not.mpr isSerial_of_valid_axiomD
+        by_contra! hC
+        have := @hC.serial {1} 1
+        simp [Frame.box, Frame.dia] at this
 
 
 end Hilbert

--- a/Foundation/Modal/Neighborhood/Logic/EM.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EM.lean
@@ -20,31 +20,31 @@ namespace Hilbert
 namespace EM.Neighborhood
 
 instance : Sound Hilbert.EM FrameClass.EM := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ rfl F hF;
-  simp_all;
+  constructor
+  rintro _ rfl F hF
+  simp_all
 
 instance : Entailment.Consistent Hilbert.EM := consistent_of_sound_frameclass FrameClass.EM $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 instance : Complete Hilbert.EM FrameClass.EM := complete_of_canonical_frame FrameClass.EM (maximalCanonicalFrame (Hilbert.EM)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 end EM.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.EM := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.M (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.M (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 3,
         𝒩 := λ w =>
@@ -57,14 +57,14 @@ instance : Hilbert.E ⪱ Hilbert.EM := by
           | 0 => {0, 1}
           | 1 => {1, 2}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
-      . tauto;
-      . simp! [M, Semantics.Realize, Satisfies];
-        ext x;
-        simp;
-        omega;
+      }
+      use M, 0
+      constructor
+      . tauto
+      . simp! [M, Semantics.Realize, Satisfies]
+        ext x
+        simp
+        omega
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EMC.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMC.lean
@@ -22,45 +22,45 @@ abbrev EK_counterframe_for_M_and_C : Frame := {
 }
 
 lemma EK_counterframe_for_M_and_C.validate_axiomK : EK_counterframe_for_M_and_C ⊧ Axioms.K (atom 0) (atom 1) := by
-  intro V x;
-  apply Satisfies.def_imp.mpr;
-  intro h₁; replace h₁ := Satisfies.def_box.mp h₁;
-  apply Satisfies.def_imp.mpr;
-  intro h₂; replace h₂ := Satisfies.def_box.mp h₂;
-  apply Satisfies.def_box.mpr;
-  simp_all only [Fin.isValue, Model.truthset.eq_imp, Model.truthset.eq_atom, Set.mem_insert_iff, Set.mem_singleton_iff];
+  intro V x
+  apply Satisfies.def_imp.mpr
+  intro h₁; replace h₁ := Satisfies.def_box.mp h₁
+  apply Satisfies.def_imp.mpr
+  intro h₂; replace h₂ := Satisfies.def_box.mp h₂
+  apply Satisfies.def_box.mpr
+  simp_all only [Fin.isValue, Model.truthset.eq_imp, Model.truthset.eq_atom, Set.mem_insert_iff, Set.mem_singleton_iff]
   rcases h₂ with h₂ | h₂ <;> rcases h₁ with h₁ | h₁ <;>
-  . have := h₁.subset;
-    have := @this 3 $ by simp [h₂];
-    simp at this;
+  . have := h₁.subset
+    have := @this 3 $ by simp [h₂]
+    simp at this
 
 lemma EK_counterframe_for_M_and_C.validate_axiomC : ¬EK_counterframe_for_M_and_C ⊧ Axioms.C (atom 0) (atom 1) := by
-  apply ValidOnFrame.not_of_exists_valuation_world;
+  apply ValidOnFrame.not_of_exists_valuation_world
   use (λ a =>
     match a with
     | 0 => {0, 1}
     | 1 => {0, 2}
     | _ => ∅
-  ), 0;
-  simp [Satisfies];
+  ), 0
+  simp [Satisfies]
 
 lemma EK_counterframe_for_M_and_C.validate_axiomM : ¬EK_counterframe_for_M_and_C ⊧ Axioms.M ((atom 0) ⋎ (atom 1)) (atom 1) := by
-  apply ValidOnFrame.not_of_exists_valuation_world;
+  apply ValidOnFrame.not_of_exists_valuation_world
   use (λ a =>
     match a with
     | 0 => {0, 1}
     | 1 => {0, 2}
     | _ => ∅
-  ), 0;
+  ), 0
   suffices (({0, 2} : Set (Fin 4)) ⊆ {2, 0, 1}) ∧ ({2, 0, 1} : Set (Fin 4)) ≠ {0, 2} by
-    simp [Satisfies];
-    grind;
-  constructor;
-  . intro x;
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff];
-    tauto;
-  . by_contra hC;
-    have := hC.subset;
+    simp [Satisfies]
+    grind
+  constructor
+  . intro x
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
+    tauto
+  . by_contra hC
+    have := hC.subset
     simpa using @this 1 (by simp)
 
 end Neighborhood
@@ -71,30 +71,30 @@ namespace Hilbert
 namespace EMC.Neighborhood
 
 instance : Sound Hilbert.EMC FrameClass.EMC := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMC := consistent_of_sound_frameclass FrameClass.EMC $ by
-  use Frame.simple_blackhole;
-  simp;
-  constructor;
+  use Frame.simple_blackhole
+  simp
+  constructor
 
 instance : Complete Hilbert.EMC FrameClass.EMC := complete_of_canonical_frame FrameClass.EMC (maximalCanonicalFrame (Hilbert.EMC)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end EMC.Neighborhood
 
 instance : Hilbert.EC ⪱ Hilbert.EMC := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.M (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EC);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.M (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EC)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 3,
         𝒩 := λ w =>
@@ -107,38 +107,38 @@ instance : Hilbert.EC ⪱ Hilbert.EMC := by
           | 0 => {0, 1}
           | 1 => {1, 2}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           regular := by
-            rintro X Y w ⟨hwX, hwY⟩;
+            rintro X Y w ⟨hwX, hwY⟩
             match w with
-            | 0 => simp_all [M];
+            | 0 => simp_all [M]
             | 1 =>
               rcases hwX with (rfl | rfl) <;>
               rcases hwY with (rfl | rfl) <;>
-              simp_all [M];
+              simp_all [M]
             | 2 =>
               rcases hwX with (rfl | rfl | rfl) <;>
               rcases hwY with (rfl | rfl | rfl) <;>
               simp [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        ext x;
-        simp!;
-        omega;
+      . simp! [M, Semantics.Realize, Satisfies]
+        ext x
+        simp!
+        omega
 
 instance : Hilbert.EM ⪱ Hilbert.EMC := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.C (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.C (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w =>
@@ -150,47 +150,47 @@ instance : Hilbert.EM ⪱ Hilbert.EMC := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           -- TODO: need golf!
           mono := by
-            rintro X Y w hw;
-            constructor;
+            rintro X Y w hw
+            constructor
             . match w with
               | 0 | 1 =>
-                rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl;
+                rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl
                 case inr.inl =>
                   rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl <;>
-                  . simp [M] at hw; tauto_set;
-                all_goals simp_all [M];
+                  . simp [M] at hw; tauto_set
+                all_goals simp_all [M]
             . match w with
               | 0 | 1 =>
-                rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl;
+                rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl
                 case inr.inl =>
                   rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl <;>
-                  . simp [M] at hw; tauto_set;
-                all_goals simp_all [M];
+                  . simp [M] at hw; tauto_set
+                all_goals simp_all [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        tauto_set;
+      . simp! [M, Semantics.Realize, Satisfies]
+        tauto_set
 
 
 section
 
 instance : Hilbert.EK ⪱ Hilbert.EMC := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_provable_axioms;
-    rintro φ rfl; simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.C (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply not_imp_not.mpr $ soundness_of_axioms_validOnFrame (F := EK_counterframe_for_M_and_C) ?_;
-      . apply EK_counterframe_for_M_and_C.validate_axiomC;
-      . simp only [Semantics.RealizeSet.singleton_iff];
-        apply EK_counterframe_for_M_and_C.validate_axiomK;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_provable_axioms
+    rintro φ rfl; simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.C (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply not_imp_not.mpr $ soundness_of_axioms_validOnFrame (F := EK_counterframe_for_M_and_C) ?_
+      . apply EK_counterframe_for_M_and_C.validate_axiomC
+      . simp only [Semantics.RealizeSet.singleton_iff]
+        apply EK_counterframe_for_M_and_C.validate_axiomK
 
 end
 

--- a/Foundation/Modal/Neighborhood/Logic/EMC4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMC4.lean
@@ -22,34 +22,34 @@ namespace Hilbert
 namespace E4.Neighborhood
 
 instance : Sound Hilbert.EMC4 FrameClass.EMC4 := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMC4 := consistent_of_sound_frameclass FrameClass.EMC4 $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  constructor;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  constructor
 
 instance : Complete Hilbert.EMC4 FrameClass.EMC4 := complete_of_canonical_frame FrameClass.EMC4 (maximalCanonicalFrame (Hilbert.EMC4)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end E4.Neighborhood
 
 instance : Hilbert.EMC ⪱ Hilbert.EMC4 := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMC);
-      apply not_validOnFrameClass_of_exists_frame;
-      use Frame.trivial_nontransitive;
-      constructor;
-      . constructor;
-      . simp;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMC)
+      apply not_validOnFrameClass_of_exists_frame
+      use Frame.trivial_nontransitive
+      constructor
+      . constructor
+      . simp
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EMCN.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMCN.lean
@@ -23,57 +23,57 @@ namespace Hilbert
 namespace EMCN.Neighborhood
 
 instance : Sound Hilbert.EMCN FrameClass.EMCN := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl | rfl) F (rfl | rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl | rfl) F (rfl | rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMCN := consistent_of_sound_frameclass FrameClass.EMCN $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  constructor;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  constructor
 
 instance : Complete Hilbert.EMCN FrameClass.EMCN := complete_of_canonical_frame FrameClass.EMCN (maximalCanonicalFrame (Hilbert.EMCN)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end EMCN.Neighborhood
 
 instance : Hilbert.EMC ⪱ Hilbert.EMCN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.N;
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMC);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.N
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMC)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 1,
         𝒩 := λ w => ∅,
         Val := λ w => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           mono := by
-            rintro X Y w hw;
-            simp_all [M];
+            rintro X Y w hw
+            simp_all [M]
           regular := by
-            rintro X Y w ⟨hwX, hwY⟩;
+            rintro X Y w ⟨hwX, hwY⟩
             simp_all [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
+      . simp! [M, Semantics.Realize, Satisfies]
 
 instance : Hilbert.ECN ⪱ Hilbert.EMCN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.M (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ECN);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.M (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ECN)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w => {∅, {0, 1}},
@@ -82,33 +82,33 @@ instance : Hilbert.ECN ⪱ Hilbert.EMCN := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           contains_unit := by
-            ext x;
-            match x with | 0 | 1 => simp_all [M, Set.Fin2.eq_univ];
+            ext x
+            match x with | 0 | 1 => simp_all [M, Set.Fin2.eq_univ]
           regular := by
-            rintro X Y w ⟨hwX, hwY⟩;
-            simp_all only [Fin.isValue, Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff, M];
+            rintro X Y w ⟨hwX, hwY⟩
+            simp_all only [Fin.isValue, Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff, M]
             rcases hwX with (rfl | rfl) <;>
             rcases hwY with (rfl | rfl) <;>
-            simp;
+            simp
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        tauto_set;
+      . simp! [M, Semantics.Realize, Satisfies]
+        tauto_set
 
 instance : Hilbert.EMN ⪱ Hilbert.EMCN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.C (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMN);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.C (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMN)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w =>
@@ -120,35 +120,35 @@ instance : Hilbert.EMN ⪱ Hilbert.EMCN := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           mono := by
-            rintro X Y e he;
-            constructor;
+            rintro X Y e he
+            constructor
             . match e with
-              | 0 => rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl <;> simp_all [M];
+              | 0 => rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl <;> simp_all [M]
               | 1 =>
-                rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl;
+                rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl
                 case inr.inr.inl =>
                   rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl <;>
-                  . simp [M] at he; tauto_set;
-                all_goals simp_all [M];
+                  . simp [M] at he; tauto_set
+                all_goals simp_all [M]
             . match e with
-              | 0 => rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl <;> simp_all [M];
+              | 0 => rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl <;> simp_all [M]
               | 1 =>
-                rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl;
+                rcases Set.Fin2.all_cases Y with rfl | rfl | rfl | rfl
                 case inr.inr.inl =>
                   rcases Set.Fin2.all_cases X with rfl | rfl | rfl | rfl <;>
-                  . simp [M] at he; tauto_set;
-                all_goals simp_all [M];
+                  . simp [M] at he; tauto_set
+                all_goals simp_all [M]
           contains_unit := by
-            ext e;
-            match e with | 0 | 1 => simp_all [M, Set.Fin2.eq_univ];
+            ext e
+            match e with | 0 | 1 => simp_all [M, Set.Fin2.eq_univ]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
-        tauto_set;
+      . simp! [M, Semantics.Realize, Satisfies]
+        tauto_set
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EMN.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMN.lean
@@ -23,50 +23,50 @@ namespace Hilbert
 namespace EMN.Neighborhood
 
 instance : Sound Hilbert.EMN FrameClass.EMN := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F (rfl | rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl) F (rfl | rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMN := consistent_of_sound_frameclass FrameClass.EMN $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  constructor;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  constructor
 
 instance : Complete Hilbert.EMN FrameClass.EMN := complete_of_canonical_frame FrameClass.EMN (maximalCanonicalFrame (Hilbert.EMN)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end EMN.Neighborhood
 
 instance : Hilbert.EM ⪱ Hilbert.EMN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.N;
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.N
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 1,
         𝒩 := λ w => ∅,
         Val := λ w => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact { mono := by rintro X Y w hw; simp_all [M] }
-      . simp! [M, Semantics.Realize, Satisfies];
+      . simp! [M, Semantics.Realize, Satisfies]
 
 instance : Hilbert.EN ⪱ Hilbert.EMN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.M (.atom 0) (.atom 1));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EN);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.M (.atom 0) (.atom 1))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EN)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 2,
         𝒩 := λ w =>
@@ -78,15 +78,15 @@ instance : Hilbert.EN ⪱ Hilbert.EMN := by
           | 0 => {0}
           | 1 => {1}
           | _ => Set.univ
-      };
-      use M, 0;
-      constructor;
+      }
+      use M, 0
+      constructor
       . exact {
           contains_unit := by
-            ext x;
+            ext x
             match x with | 0 | 1 => simp_all [M]
         }
-      . simp! [M, Semantics.Realize, Satisfies];
+      . simp! [M, Semantics.Realize, Satisfies]
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EMT.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMT.lean
@@ -10,9 +10,9 @@ open Formula.Neighborhood
 namespace Neighborhood
 
 instance : Frame.simple_blackhole.IsReflexive := by
-  constructor;
-  intro X x;
-  simp_all;
+  constructor
+  intro X x
+  simp_all
 
 protected class Frame.IsEMT (F : Frame) extends F.IsMonotonic, F.IsReflexive where
 protected abbrev FrameClass.EMT : FrameClass := { F | F.IsEMT }
@@ -25,36 +25,36 @@ namespace Hilbert
 namespace EMT.Neighborhood
 
 instance : Sound Hilbert.EMT FrameClass.EMT := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMT := consistent_of_sound_frameclass FrameClass.EMT $ by
-  use Frame.simple_blackhole;
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  use Frame.simple_blackhole
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 instance : Complete Hilbert.EMT FrameClass.EMT := complete_of_canonical_frame FrameClass.EMT (maximalCanonicalFrame (Hilbert.EMT)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end EMT.Neighborhood
 
 instance : Hilbert.EM ⪱ Hilbert.EMT := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.T (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM);
-      apply not_validOnFrameClass_of_exists_frame;
-      use ⟨Fin 1, λ _ => Set.univ⟩;
-      constructor;
-      . exact ⟨by tauto⟩;
-      . apply not_imp_not.mpr isReflexive_of_valid_axiomT;
-        by_contra! hC;
-        simpa [Frame.box] using @hC.refl ∅;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.T (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EM)
+      apply not_validOnFrameClass_of_exists_frame
+      use ⟨Fin 1, λ _ => Set.univ⟩
+      constructor
+      . exact ⟨by tauto⟩
+      . apply not_imp_not.mpr isReflexive_of_valid_axiomT
+        by_contra! hC
+        simpa [Frame.box] using @hC.refl ∅
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EMT4.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EMT4.lean
@@ -20,34 +20,34 @@ namespace Hilbert
 namespace EMT4.Neighborhood
 
 instance : Sound Hilbert.EMT4 FrameClass.EMT4 := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.EMT4 := consistent_of_sound_frameclass FrameClass.EMT4 $ by
-  use Frame.simple_blackhole;
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  use Frame.simple_blackhole
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 instance : Complete Hilbert.EMT4 FrameClass.EMT4 := complete_of_canonical_frame FrameClass.EMT4 (maximalCanonicalFrame (Hilbert.EMT4)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  constructor;
+  apply Set.mem_setOf_eq.mpr
+  constructor
 
 end EMT4.Neighborhood
 
 instance : Hilbert.EMT ⪱ Hilbert.EMT4 := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.Four (.atom 0));
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMT);
-      apply not_validOnFrameClass_of_exists_frame;
-      use Frame.trivial_nontransitive;
-      constructor;
-      . constructor;
-      . simp;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.Four (.atom 0))
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EMT)
+      apply not_validOnFrameClass_of_exists_frame
+      use Frame.trivial_nontransitive
+      constructor
+      . constructor
+      . simp
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EN.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EN.lean
@@ -24,78 +24,78 @@ namespace Hilbert
 namespace EN.Neighborhood
 
 instance : Sound Hilbert.EN FrameClass.EN := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F hF;
-  simp_all;
+  constructor
+  rintro _ (rfl | rfl) F hF
+  simp_all
 
 instance : Entailment.Consistent Hilbert.EN := consistent_of_sound_frameclass FrameClass.EN $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 instance : Complete Hilbert.EN FrameClass.EN := complete_of_canonical_frame FrameClass.EN (minimalCanonicalFrame (Hilbert.EN)) $ by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 end EN.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.EN := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.N;
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_model_world;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.N
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Model := {
         World := Fin 1,
         𝒩 := λ w => ∅,
         Val := λ w => Set.univ
-      };
-      use M, 0;
-      constructor;
-      . tauto;
-      . simp! [M, Semantics.Realize, Satisfies];
+      }
+      use M, 0
+      constructor
+      . tauto
+      . simp! [M, Semantics.Realize, Satisfies]
 
 end Hilbert
 
 instance : 𝐄 ⪱ 𝐄𝐍 := inferInstance
 instance : Modal.N ⪱ 𝐄𝐍 := by
-  constructor;
+  constructor
   . suffices ∀ φ, Hilbert.N ⊢! φ → Hilbert.EN ⊢! φ by
-      apply Entailment.weakerThan_iff.mpr;
-      simpa;
-    intro φ hφ;
+      apply Entailment.weakerThan_iff.mpr
+      simpa
+    intro φ hφ
     induction hφ using Hilbert.Normal.rec! with
-    | axm s h => simp at h;
-    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-    | nec ihφ => apply Entailment.nec! ihφ;
-    | _ => simp;
+    | axm s h => simp at h
+    | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+    | nec ihφ => apply Entailment.nec! ihφ
+    | _ => simp
   . suffices ∃ φ, Hilbert.EN ⊢! φ ∧ Hilbert.N ⊬ φ by
-      apply Entailment.not_weakerThan_iff.mpr;
-      simpa using this;
-    use □(.atom 0) ⭤ □(∼∼.atom 0);
-    constructor;
-    . apply re!;
-      cl_prover;
-    . apply Sound.not_provable_of_countermodel (𝓜 := PLoN.AllFrameClass);
-      apply Formula.PLoN.ValidOnFrameClass.not_of_exists_model;
+      apply Entailment.not_weakerThan_iff.mpr
+      simpa using this
+    use □(.atom 0) ⭤ □(∼∼.atom 0)
+    constructor
+    . apply re!
+      cl_prover
+    . apply Sound.not_provable_of_countermodel (𝓜 := PLoN.AllFrameClass)
+      apply Formula.PLoN.ValidOnFrameClass.not_of_exists_model
       let M : PLoN.Model := {
         World := Fin 2,
         Rel ξ x y := if ξ = ∼∼(.atom 0) then True else False,
         Valuation x a := x = 0
-      };
-      use M;
-      constructor;
-      . tauto;
+      }
+      use M
+      constructor
+      . tauto
       . suffices (∃ x : M.World, ∀ y : M.World, (PLoN.Frame.Rel' (.atom 0) x y) → y = 0) ∧ ∃ x : M.World, x ≠ 0 by
-          simpa [M, Semantics.Realize, Formula.PLoN.ValidOnModel, Formula.PLoN.Satisfies] using this;
-        constructor;
-        . use 0;
-          simp [M, PLoN.Frame.Rel'];
-        . use 1;
-          simp [M];
+          simpa [M, Semantics.Realize, Formula.PLoN.ValidOnModel, Formula.PLoN.Satisfies] using this
+        constructor
+        . use 0
+          simp [M, PLoN.Frame.Rel']
+        . use 1
+          simp [M]
 
 end LO.Modal

--- a/Foundation/Modal/Neighborhood/Logic/END.lean
+++ b/Foundation/Modal/Neighborhood/Logic/END.lean
@@ -20,49 +20,49 @@ namespace Hilbert
 namespace END.Neighborhood
 
 instance : Sound Hilbert.END FrameClass.END := instSound_of_validates_axioms $ by
-  constructor;
-  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp;
+  constructor
+  rintro _ (rfl | rfl) F (rfl | rfl) <;> simp
 
 instance : Entailment.Consistent Hilbert.END := consistent_of_sound_frameclass FrameClass.END $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  constructor;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  constructor
 
 end END.Neighborhood
 
 instance : Hilbert.ED ⪱ Hilbert.END := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.N;
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ED);
-      apply not_validOnFrameClass_of_exists_frame;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.N
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ED)
+      apply not_validOnFrameClass_of_exists_frame
       let F : Frame := {
         World := Fin 1,
         𝒩 := λ w => ∅,
-      };
-      use F;
-      constructor;
-      . constructor;
-        intro X x;
-        simp [Frame.box, Frame.dia, F];
-      . apply not_imp_not.mpr containsUnit_of_valid_axiomN;
-        by_contra! hC;
-        simpa [F] using F.univ_mem 0;
+      }
+      use F
+      constructor
+      . constructor
+        intro X x
+        simp [Frame.box, Frame.dia, F]
+      . apply not_imp_not.mpr containsUnit_of_valid_axiomN
+        by_contra! hC
+        simpa [F] using F.univ_mem 0
 
 instance : Hilbert.EP ⪱ Hilbert.END := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_provable_axioms;
-    rintro _ rfl;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.D (.atom 0);
-    constructor;
-    . simp;
-    . exact EP.unprovable_AxiomD;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_provable_axioms
+    rintro _ rfl
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.D (.atom 0)
+    constructor
+    . simp
+    . exact EP.unprovable_AxiomD
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/EP.lean
+++ b/Foundation/Modal/Neighborhood/Logic/EP.lean
@@ -13,9 +13,9 @@ open Formula.Neighborhood
 namespace Neighborhood
 
 instance : Frame.simple_blackhole.NotContainsEmpty := by
-  constructor;
-  simp only [Set.mem_singleton_iff, forall_const];
-  tauto_set;
+  constructor
+  simp only [Set.mem_singleton_iff, forall_const]
+  tauto_set
 
 
 @[reducible] protected alias Frame.IsEP := Frame.NotContainsEmpty
@@ -30,34 +30,34 @@ namespace Hilbert
 namespace EP.Neighborhood
 
 instance : Sound Hilbert.EP FrameClass.EP := instSound_of_validates_axioms $ by
-  simp only [Semantics.RealizeSet.singleton_iff];
-  intro F hF;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  simp;
+  simp only [Semantics.RealizeSet.singleton_iff]
+  intro F hF
+  replace hF := Set.mem_setOf_eq.mp hF
+  simp
 
 instance : Entailment.Consistent Hilbert.EP := consistent_of_sound_frameclass FrameClass.EP $ by
-  use Frame.simple_blackhole;
-  simp only [Set.mem_setOf_eq];
-  infer_instance;
+  use Frame.simple_blackhole
+  simp only [Set.mem_setOf_eq]
+  infer_instance
 
 end EP.Neighborhood
 
 instance : Hilbert.E ⪱ Hilbert.EP := by
-  constructor;
-  . apply Hilbert.WithRE.weakerThan_of_subset_axioms;
-    simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use (Axioms.P);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E);
-      apply not_validOnFrameClass_of_exists_frame;
+  constructor
+  . apply Hilbert.WithRE.weakerThan_of_subset_axioms
+    simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use (Axioms.P)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.E)
+      apply not_validOnFrameClass_of_exists_frame
       use ⟨Fin 1, λ _ => {∅}⟩
-      constructor;
-      . tauto;
-      . apply not_imp_not.mpr notContainsEmpty_of_valid_axiomP;
-        by_contra! hC;
-        simpa using hC.not_contains_empty;
+      constructor
+      . tauto
+      . apply not_imp_not.mpr notContainsEmpty_of_valid_axiomP
+        by_contra! hC
+        simpa using hC.not_contains_empty
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Logic/Incomparability/ED_EP.lean
+++ b/Foundation/Modal/Neighborhood/Logic/Incomparability/ED_EP.lean
@@ -12,44 +12,44 @@ namespace Hilbert
 
 @[simp]
 lemma EP.unprovable_AxiomD : Hilbert.EP ⊬ Axioms.D (.atom a) := by
-  apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EP);
-  apply not_validOnFrameClass_of_exists_frame;
+  apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.EP)
+  apply not_validOnFrameClass_of_exists_frame
   use ⟨Fin 2, λ w => match w with | 0 => {{0}} | 1 => {{0},{1},{0,1}}⟩
-  constructor;
-  . constructor;
-    intro x;
+  constructor
+  . constructor
+    intro x
     match x with
-    | 0 | 1 => simp; tauto_set;
-  . apply not_imp_not.mpr isSerial_of_valid_axiomD;
-    by_contra! hC;
-    have := @hC |>.serial {1} 1;
-    simp [Frame.box, Frame.dia] at this;
-    tauto_set;
+    | 0 | 1 => simp; tauto_set
+  . apply not_imp_not.mpr isSerial_of_valid_axiomD
+    by_contra! hC
+    have := @hC |>.serial {1} 1
+    simp [Frame.box, Frame.dia] at this
+    tauto_set
 
 instance : Incomparable Hilbert.ED Hilbert.EP := by
-  apply Incomparable.of_unprovable;
-  . use (Axioms.D (.atom 0));
-    constructor;
-    . simp;
-    . exact EP.unprovable_AxiomD;
-  . use (Axioms.P);
-    constructor;
-    . simp;
-    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ED);
-      apply not_validOnFrameClass_of_exists_frame;
-      use ⟨Fin 2, λ x => match x with | 0 => {∅, {1}} | 1 => {∅, {0}}⟩;
-      constructor;
-      . constructor;
-        intro X x;
+  apply Incomparable.of_unprovable
+  . use (Axioms.D (.atom 0))
+    constructor
+    . simp
+    . exact EP.unprovable_AxiomD
+  . use (Axioms.P)
+    constructor
+    . simp
+    . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.ED)
+      apply not_validOnFrameClass_of_exists_frame
+      use ⟨Fin 2, λ x => match x with | 0 => {∅, {1}} | 1 => {∅, {0}}⟩
+      constructor
+      . constructor
+        intro X x
         match x with
         | 0 | 1 =>
-          rintro (rfl | rfl);
-          . simp; tauto_set;
-          . simp;
-      . apply not_imp_not.mpr notContainsEmpty_of_valid_axiomP;
-        by_contra! hC;
-        have := hC |>.not_contains_empty;
-        simpa using @this 1;
+          rintro (rfl | rfl)
+          . simp; tauto_set
+          . simp
+      . apply not_imp_not.mpr notContainsEmpty_of_valid_axiomP
+        by_contra! hC
+        have := hC |>.not_contains_empty
+        simpa using @this 1
 
 end Hilbert
 

--- a/Foundation/Modal/Neighborhood/Supplementation.lean
+++ b/Foundation/Modal/Neighborhood/Supplementation.lean
@@ -18,83 +18,83 @@ lemma iff_exists_subset {X : Set (F.World)} {w : F.World} : w ∈ F♯.box X ↔
   simp [Frame.Supplementation, Frame.box, Frame.mk_ℬ, Set.mem_sUnion, Set.mem_setOf_eq, exists_exists_and_eq_and]
 
 lemma subset (X : Set (F.World)) : F.box X ⊆ F♯.box X := by
-  intro x;
-  simp [Frame.Supplementation, Frame.box, Frame.mk_ℬ];
-  tauto;
+  intro x
+  simp [Frame.Supplementation, Frame.box, Frame.mk_ℬ]
+  tauto
 
 lemma monotonic {X Y : Set (F.World)} (h : X ⊆ Y) : F♯.box X ⊆ F♯.box Y := by
-  intro x hX;
-  obtain ⟨X', hX', hX⟩ := iff_exists_subset.mp hX;
-  apply iff_exists_subset.mpr;
-  use X';
-  constructor;
-  . apply Set.Subset.trans hX' h;
-  . assumption;
+  intro x hX
+  obtain ⟨X', hX', hX⟩ := iff_exists_subset.mp hX
+  apply iff_exists_subset.mpr
+  use X'
+  constructor
+  . apply Set.Subset.trans hX' h
+  . assumption
 
 lemma monotonic_iterated {X Y : Set (F.World)} (h : X ⊆ Y) (n) : F♯.box^[n] X ⊆ F♯.box^[n] Y := by
   induction n with
-  | zero => simpa;
+  | zero => simpa
   | succ n ih =>
-    rw [Function.iterate_succ'];
-    apply monotonic;
-    apply ih;
+    rw [Function.iterate_succ']
+    apply monotonic
+    apply ih
 
 lemma itl_reduce : F♯♯.box X = F♯.box X := by
-  ext x;
+  ext x
   simp only [Supplementation, mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion, exists_exists_and_eq_and]
-  constructor;
-  . rintro ⟨Y, RYX, Z, RZY, hZ⟩;
-    use Z;
-    constructor;
-    . tauto_set;
-    . assumption;
-  . tauto;
+  constructor
+  . rintro ⟨Y, RYX, Z, RZY, hZ⟩
+    use Z
+    constructor
+    . tauto_set
+    . assumption
+  . tauto
 
 instance : F♯.IsMonotonic := by
-  constructor;
-  rintro X Y x hx;
-  obtain ⟨W, hW₁, hW₂⟩ := iff_exists_subset.mp hx;
+  constructor
+  rintro X Y x hx
+  obtain ⟨W, hW₁, hW₂⟩ := iff_exists_subset.mp hx
   constructor <;>
-  . apply iff_exists_subset.mpr;
-    use W;
-    constructor;
-    . tauto_set;
-    . assumption;
+  . apply iff_exists_subset.mpr
+    use W
+    constructor
+    . tauto_set
+    . assumption
 
 instance [F.IsReflexive] : F♯.IsReflexive := by
-  constructor;
-  intro X w hw;
-  replace ⟨Y, hY₁, hY₂⟩ := iff_exists_subset.mp hw;
-  apply hY₁;
-  apply F.refl;
-  exact hY₂;
+  constructor
+  intro X w hw
+  replace ⟨Y, hY₁, hY₂⟩ := iff_exists_subset.mp hw
+  apply hY₁
+  apply F.refl
+  exact hY₂
 
 instance [F.ContainsUnit] : F♯.ContainsUnit := by
-  constructor;
-  ext x;
-  suffices ∃ a, a ∈ F.𝒩 x by simpa [Supplementation, mk_ℬ];
-  use Set.univ;
-  simp;
+  constructor
+  ext x
+  suffices ∃ a, a ∈ F.𝒩 x by simpa [Supplementation, mk_ℬ]
+  use Set.univ
+  simp
 
 instance [F.IsTransitive] : F♯.IsTransitive := by
-  constructor;
-  intro X w hw;
-  obtain ⟨Y, hYX, hY⟩ := iff_exists_subset.mp hw;
+  constructor
+  intro X w hw
+  obtain ⟨Y, hYX, hY⟩ := iff_exists_subset.mp hw
   apply monotonic_iterated hYX 2
-  apply monotonic $ subset Y;
-  apply subset (F.box Y) $ F.trans hY;
+  apply monotonic $ subset Y
+  apply subset (F.box Y) $ F.trans hY
 
 instance [F.IsRegular] : F♯.IsRegular := by
-  constructor;
-  rintro X Y w ⟨hX, hY⟩;
-  apply iff_exists_subset.mpr;
-  obtain ⟨X', _⟩ := iff_exists_subset.mp hX;
-  obtain ⟨Y', _⟩ := iff_exists_subset.mp hY;
-  use X' ∩ Y';
-  constructor;
-  . tauto_set;
-  . apply @Frame.regular F _ X' Y';
-    tauto;
+  constructor
+  rintro X Y w ⟨hX, hY⟩
+  apply iff_exists_subset.mpr
+  obtain ⟨X', _⟩ := iff_exists_subset.mp hX
+  obtain ⟨Y', _⟩ := iff_exists_subset.mp hY
+  use X' ∩ Y'
+  constructor
+  . tauto_set
+  . apply @Frame.regular F _ X' Y'
+    tauto
 
 end Frame.Supplementation
 
@@ -113,34 +113,34 @@ variable [Entailment.EM 𝓢]
 
 instance : (maximalCanonicalFrame 𝓢).IsCanonical 𝓢 where
   box_proofset := by
-    intro φ;
-    apply Set.eq_of_subset_of_subset;
-    . intro Γ;
+    intro φ
+    apply Set.eq_of_subset_of_subset
+    . intro Γ
       simp only [
         Frame.Supplementation, Frame.mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion,
         exists_exists_and_eq_and, forall_exists_index, and_imp
-      ];
-      intro X hX h;
-      split at h;
-      . rename_i hψ;
-        rw [hψ.choose_spec] at hX;
-        apply box_subset_of_subset hX;
-        apply h;
-      . contradiction;
-    . intro Γ;
+      ]
+      intro X hX h
+      split at h
+      . rename_i hψ
+        rw [hψ.choose_spec] at hX
+        apply box_subset_of_subset hX
+        apply h
+      . contradiction
+    . intro Γ
       simp only [
         Frame.Supplementation, Frame.mk_ℬ, Set.mem_setOf_eq, Set.mem_sUnion,
         exists_exists_and_eq_and
-      ];
-      intro hΓ;
-      use proofset 𝓢 φ;
+      ]
+      intro hΓ
+      use proofset 𝓢 φ
       constructor
-      . rfl;
-      . split;
-        . rename_i hψ;
-          rw [←eq_boxed_of_eq hψ.choose_spec];
-          apply hΓ;
-        . simp_all;
+      . rfl
+      . split
+        . rename_i hψ
+          rw [←eq_boxed_of_eq hψ.choose_spec]
+          apply hΓ
+        . simp_all
 
 end
 

--- a/Foundation/Modal/PLoN/Basic.lean
+++ b/Foundation/Modal/PLoN/Basic.lean
@@ -64,21 +64,21 @@ variable {M : PLoN.Model} {x : M.World} {φ ψ : Formula ℕ}
 
 @[simp] protected lemma iff_models : x ⊧ φ ↔ PLoN.Satisfies M x φ := by rfl
 
-lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺[φ] y → y ⊧ φ := by simp [PLoN.Satisfies];
+lemma box_def : x ⊧ □φ ↔ ∀ y, x ≺[φ] y → y ⊧ φ := by simp [PLoN.Satisfies]
 
 protected lemma not_def : x ⊧ ∼φ ↔ ¬(x ⊧ φ) := by
   induction φ generalizing x with
-  | _ => simp_all [Satisfies];
+  | _ => simp_all [Satisfies]
 
-protected lemma imp_def : x ⊧ φ ➝ ψ ↔ (x ⊧ φ) → (x ⊧ ψ) := by tauto;
+protected lemma imp_def : x ⊧ φ ➝ ψ ↔ (x ⊧ φ) → (x ⊧ ψ) := by tauto
 
-protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies]; tauto;
+protected lemma or_def : x ⊧ φ ⋎ ψ ↔ x ⊧ φ ∨ x ⊧ ψ := by simp [Satisfies]; tauto
 
-protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies];
+protected lemma and_def : x ⊧ φ ⋏ ψ ↔ x ⊧ φ ∧ x ⊧ ψ := by simp [Satisfies]
 
-protected lemma bot_def : ¬(x ⊧ ⊥) := by simp [Satisfies];
+protected lemma bot_def : ¬(x ⊧ ⊥) := by simp [Satisfies]
 
-protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies];
+protected lemma top_def : x ⊧ ⊤ := by simp [Satisfies]
 
 instance : Semantics.Tarski M.World where
   realize_top := λ _ => Satisfies.top_def
@@ -90,7 +90,7 @@ instance : Semantics.Tarski M.World where
 
 protected lemma def_iff : x ⊧ φ ⭤ ψ ↔ ((x ⊧ φ) ↔ (x ⊧ ψ)) := by
   simp [LogicalConnective.iff]
-  tauto;
+  tauto
 
 end Satisfies
 
@@ -109,42 +109,42 @@ protected lemma iff_models {M : PLoN.Model} {φ : Formula ℕ}
 
 instance : Semantics.Bot (PLoN.Model) where
   realize_bot _ := by
-    simp [Formula.PLoN.ValidOnModel];
-    use ﹫;
+    simp [Formula.PLoN.ValidOnModel]
+    use ﹫
 
 variable {M : PLoN.Model}
 
-protected lemma imply₁ : M ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnModel]; tauto;
+protected lemma imply₁ : M ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnModel]; tauto
 
-protected lemma imply₂ : M ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnModel]; tauto;
+protected lemma imply₂ : M ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnModel]; tauto
 
-protected lemma elimContra : M ⊧ (Axioms.ElimContra φ ψ) := by simp [ValidOnModel]; tauto;
+protected lemma elimContra : M ⊧ (Axioms.ElimContra φ ψ) := by simp [ValidOnModel]; tauto
 
 protected lemma nec (h : M ⊧ φ) : M ⊧ □φ := by
-  intro x y Rxy;
-  apply h;
+  intro x y Rxy
+  apply h
 
 protected lemma re : ¬∀ M : Model, ∀ φ ψ, M ⊧ φ ⭤ ψ → M ⊧ □φ ⭤ □ψ := by
-  push_neg;
+  push_neg
   let M : Model := {
     World := Fin 2,
     Rel ξ x y := if ξ = (.atom 1) then True else False,
     Valuation x a := x = 0
-  };
-  use M, (.atom 0), (.atom 1);
-  constructor;
-  . simp [ValidOnModel];
-    tauto;
+  }
+  use M, (.atom 0), (.atom 1)
+  constructor
+  . simp [ValidOnModel]
+    tauto
   . suffices (∃ x : M.World, ∀ y : M.World, x ≺[atom 0] y → y = 0) ∧ ∃ x : M.World, x ≠ 0 by
-      simpa [M, ValidOnModel, Semantics.Realize, Satisfies] using this;
-    constructor;
-    . use 0;
-      intro x;
+      simpa [M, ValidOnModel, Semantics.Realize, Satisfies] using this
+    constructor
+    . use 0
+      intro x
       match x with
-      | 0 => tauto;
-      | 1 => simp [M, Frame.Rel'];
-    . use 1;
-      simp [M];
+      | 0 => tauto
+      | 1 => simp [M, Frame.Rel']
+    . use 1
+      simp [M]
 
 
 end ValidOnModel
@@ -163,21 +163,21 @@ protected lemma iff_models {F : PLoN.Frame} {φ : Formula ℕ}
 variable {F : Frame}
 
 instance : Semantics.Bot (PLoN.Frame) where
-  realize_bot _ := by simp [Formula.PLoN.ValidOnFrame];
+  realize_bot _ := by simp [Formula.PLoN.ValidOnFrame]
 
 protected lemma nec (h : F ⊧ φ) : F ⊧ □φ := by
-  intro V x y _;
-  exact h V y;
+  intro V x y _
+  exact h V y
 
 protected lemma mdp (hpq : F ⊧ φ ➝ ψ) (hp : F ⊧ φ) : F ⊧ ψ := by
-  intro V x;
-  exact (hpq V x) (hp V x);
+  intro V x
+  exact (hpq V x) (hp V x)
 
-protected lemma imply₁ : F ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnFrame]; tauto;
+protected lemma imply₁ : F ⊧ (Axioms.Imply₁ φ ψ) := by simp [ValidOnFrame]; tauto
 
-protected lemma imply₂ : F ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnFrame]; tauto;
+protected lemma imply₂ : F ⊧ (Axioms.Imply₂ φ ψ χ) := by simp [ValidOnFrame]; tauto
 
-protected lemma elimContra : F ⊧ (Axioms.ElimContra φ ψ) := by intro V; exact ValidOnModel.elimContra;
+protected lemma elimContra : F ⊧ (Axioms.ElimContra φ ψ) := by intro V; exact ValidOnModel.elimContra
 
 end ValidOnFrame
 
@@ -194,33 +194,33 @@ variable {C : FrameClass}
 protected lemma iff_models {C : PLoN.FrameClass} {φ : Formula ℕ} : C ⊧ φ ↔ Formula.PLoN.ValidOnFrameClass C φ := by rfl
 
 protected lemma nec (h : C ⊧ φ) : C ⊧ □φ := by
-  intro _ hF;
-  apply PLoN.ValidOnFrame.nec;
-  exact h hF;
+  intro _ hF
+  apply PLoN.ValidOnFrame.nec
+  exact h hF
 
 protected lemma mdp (hpq : C ⊧ φ ➝ ψ) (hp : C ⊧ φ) : C ⊧ ψ := by
-  intro _ hF;
+  intro _ hF
   exact PLoN.ValidOnFrame.mdp (hpq hF) (hp hF)
 
-protected lemma imply₁ : C ⊧ (Axioms.Imply₁ φ ψ) := by intro _ _; exact PLoN.ValidOnFrame.imply₁;
+protected lemma imply₁ : C ⊧ (Axioms.Imply₁ φ ψ) := by intro _ _; exact PLoN.ValidOnFrame.imply₁
 
-protected lemma imply₂ : C ⊧ (Axioms.Imply₂ φ ψ χ) := by intro _ _; exact PLoN.ValidOnFrame.imply₂;
+protected lemma imply₂ : C ⊧ (Axioms.Imply₂ φ ψ χ) := by intro _ _; exact PLoN.ValidOnFrame.imply₂
 
-protected lemma elimContra : C ⊧ (Axioms.ElimContra φ ψ) := by intro _ _; exact PLoN.ValidOnFrame.elimContra;
+protected lemma elimContra : C ⊧ (Axioms.ElimContra φ ψ) := by intro _ _; exact PLoN.ValidOnFrame.elimContra
 
 
 lemma iff_not_exists_frame : (¬C ⊧ φ) ↔ (∃ F ∈ C, ¬F ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 
 alias ⟨exists_frame_of_not, not_of_exists_frame⟩ := iff_not_exists_frame
 
 
 lemma iff_not_exists_model : (¬C ⊧ φ) ↔ (∃ M : PLoN.Model, M.toFrame ∈ C ∧ ¬M ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 
 alias ⟨exists_model_of_not, not_of_exists_model⟩ := iff_not_exists_model
 
@@ -247,25 +247,25 @@ abbrev AllFrameClass (α) : FrameClass α := Set.univ
 
 lemma AllFrameClass.nonempty : (AllFrameClass.{_, 0} α).Nonempty := by
   use terminalFrame α
-  trivial;
+  trivial
 
 open Formula
 
 lemma N_defines : (Hilbert.N).DefinesPLoNFrameClass (AllFrameClass α) := by
-  intro F;
-  simp [Hilbert.theorems, Entailment.theory, PLoN.ValidOnFrame, PLoN.ValidOnModel];
-  intro φ hp;
+  intro F
+  simp [Hilbert.theorems, Entailment.theory, PLoN.ValidOnFrame, PLoN.ValidOnModel]
+  intro φ hp
   induction hp using Hilbert.Deduction.inducition_with_necOnly! with
-  | hMaxm h => simp at h;
+  | hMaxm h => simp at h
   | hMdp ihpq ihp =>
-    intro V w;
+    intro V w
     exact (ihpq V w) (ihp V w)
   | hNec ihp =>
-    intro V w w' _;
-    exact ihp V w';
+    intro V w w' _
+    exact ihp V w'
   | _ =>
-    simp_all [PLoN.Satisfies];
-    try tauto;
+    simp_all [PLoN.Satisfies]
+    try tauto
 
 end PLoN
 -/

--- a/Foundation/Modal/PLoN/Completeness.lean
+++ b/Foundation/Modal/PLoN/Completeness.lean
@@ -27,64 +27,64 @@ variable {φ : Formula ℕ}
 lemma truthlemma : ∀ {X : (canonicalModel 𝓢).World}, X ⊧ φ ↔ (φ ∈ X) := by
   induction φ with
   | hfalsum =>
-    simp only [Semantics.Realize, PLoN.Satisfies, false_iff];
-    exact not_mem_falsum;
+    simp only [Semantics.Realize, PLoN.Satisfies, false_iff]
+    exact not_mem_falsum
   | hatom =>
-    simp_all [Semantics.Realize, PLoN.Satisfies];
+    simp_all [Semantics.Realize, PLoN.Satisfies]
   | himp φ ψ ihp ihq =>
-    intro Ω;
-    constructor;
-    . intro h;
-      apply iff_mem_imp.mpr;
-      intro hp; replace hp := ihp.mpr hp;
-      exact ihq.mp $ h hp;
-    . intro h;
-      have := iff_mem_imp.mp h;
-      intro hp; replace hp := ihp.mp hp;
+    intro Ω
+    constructor
+    . intro h
+      apply iff_mem_imp.mpr
+      intro hp; replace hp := ihp.mpr hp
+      exact ihq.mp $ h hp
+    . intro h
+      have := iff_mem_imp.mp h
+      intro hp; replace hp := ihp.mp hp
       exact ihq.mpr $ this hp
   | hbox φ ih =>
-    intro X;
-    constructor;
-    . intro h;
-      by_contra hC;
-      obtain ⟨Y, hY⟩ := lindenbaum (𝓢 := 𝓢) (T := {∼φ}) (not_singleton_consistent X.consistent (iff_mem_neg.mpr hC));
-      suffices ¬X ⊧ □φ by contradiction;
+    intro X
+    constructor
+    . intro h
+      by_contra hC
+      obtain ⟨Y, hY⟩ := lindenbaum (𝓢 := 𝓢) (T := {∼φ}) (not_singleton_consistent X.consistent (iff_mem_neg.mpr hC))
+      suffices ¬X ⊧ □φ by contradiction
       suffices ∃ Y, (X ≺[φ] Y) ∧ (¬Y ⊧ φ) by
-        apply PLoN.Satisfies.box_def.not.mpr;
-        push_neg;
-        exact this;
-      use Y;
-      constructor;
-      . constructor;
-        . exact iff_mem_neg.mpr hC;
-        . tauto_set;
-      . apply (@ih Y).not.mpr;
-        apply iff_mem_neg.mp;
-        tauto_set;
-    . intro h Y RXY;
-      have : □φ ∉ X := iff_mem_neg.mp RXY.1;
-      contradiction;
+        apply PLoN.Satisfies.box_def.not.mpr
+        push_neg
+        exact this
+      use Y
+      constructor
+      . constructor
+        . exact iff_mem_neg.mpr hC
+        . tauto_set
+      . apply (@ih Y).not.mpr
+        apply iff_mem_neg.mp
+        tauto_set
+    . intro h Y RXY
+      have : □φ ∉ X := iff_mem_neg.mp RXY.1
+      contradiction
 
 class Canonical (𝓢 : S) [Entailment.Consistent 𝓢] [Entailment.Cl 𝓢] (C : FrameClass) : Prop where
   canonical : (canonicalFrame 𝓢) ∈ C
 
 instance [Canonical 𝓢 C] : Complete 𝓢 C := ⟨by
-  intro φ;
-  contrapose;
-  intro h;
-  apply PLoN.ValidOnFrameClass.not_of_exists_model;
-  use (canonicalModel 𝓢);
-  constructor;
-  . exact Canonical.canonical;
+  intro φ
+  contrapose
+  intro h
+  apply PLoN.ValidOnFrameClass.not_of_exists_model
+  use (canonicalModel 𝓢)
+  constructor
+  . exact Canonical.canonical
   . suffices ∃ X, ¬(PLoN.Satisfies (canonicalModel 𝓢) X φ) by
-      simpa [PLoN.ValidOnModel];
+      simpa [PLoN.ValidOnModel]
     obtain ⟨Y, hY⟩ := lindenbaum (𝓢 := 𝓢) (T := {∼φ}) $ by
-      apply unprovable_iff_singleton_neg_consistent.mpr;
-      exact h;
-    use Y;
-    apply truthlemma.not.mpr;
-    apply iff_mem_neg.mp;
-    tauto_set;
+      apply unprovable_iff_singleton_neg_consistent.mpr
+      exact h
+    use Y
+    apply truthlemma.not.mpr
+    apply iff_mem_neg.mp
+    tauto_set
 ⟩
 
 end PLoN

--- a/Foundation/Modal/PLoN/Hilbert.lean
+++ b/Foundation/Modal/PLoN/Hilbert.lean
@@ -14,31 +14,31 @@ variable {C : PLoN.FrameClass}
 variable {H : Hilbert.Normal ℕ} {Γ : Set (Formula ℕ)} {φ : Formula ℕ}
 
 lemma soundness_of_defined_by_AxiomInstances [defined : C.DefinedBy H.axiomInstances] : H ⊢! φ → C ⊧ φ := by
-  intro hφ F hF;
+  intro hφ F hF
   induction hφ using Hilbert.Normal.rec! with
   | axm s h =>
-    apply defined.defines F |>.mp hF;
-    aesop;
-  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp;
-  | nec ih => exact ValidOnFrame.nec ih;
-  | imply₁ => exact ValidOnFrame.imply₁;
-  | imply₂ => exact ValidOnFrame.imply₂;
-  | ec => exact ValidOnFrame.elimContra;
+    apply defined.defines F |>.mp hF
+    aesop
+  | mdp ihpq ihp => exact ValidOnFrame.mdp ihpq ihp
+  | nec ih => exact ValidOnFrame.nec ih
+  | imply₁ => exact ValidOnFrame.imply₁
+  | imply₂ => exact ValidOnFrame.imply₂
+  | ec => exact ValidOnFrame.elimContra
 
 instance [C.DefinedBy H.axiomInstances] : Sound H C := ⟨fun {_} => soundness_of_defined_by_AxiomInstances⟩
 
 lemma consistent_of_FrameClass_aux [nonempty : C.IsNonempty] [sound : Sound H C] : H ⊬ ⊥ := by
-  apply not_imp_not.mpr sound.sound;
-  apply ValidOnFrameClass.not_of_exists_frame;
-  obtain ⟨F, hF⟩ := nonempty;
-  use F;
-  constructor;
-  . assumption;
-  . simp;
+  apply not_imp_not.mpr sound.sound
+  apply ValidOnFrameClass.not_of_exists_frame
+  obtain ⟨F, hF⟩ := nonempty
+  use F
+  constructor
+  . assumption
+  . simp
 
 lemma consistent_of_FrameClass (C : PLoN.FrameClass) [C.IsNonempty] [Sound H C] : Entailment.Consistent H := by
-  apply Entailment.Consistent.of_unprovable;
-  exact consistent_of_FrameClass_aux (C := C);
+  apply Entailment.Consistent.of_unprovable
+  exact consistent_of_FrameClass_aux (C := C)
 
 end PLoN.Hilbert
 

--- a/Foundation/Modal/PLoN/Logic/N.lean
+++ b/Foundation/Modal/PLoN/Logic/N.lean
@@ -12,8 +12,8 @@ namespace PLoN
 abbrev AllFrameClass : PLoN.FrameClass := Set.univ
 
 instance : AllFrameClass.IsNonempty := by
-  use ⟨Unit, λ _ _ _ => True⟩;
-  tauto;
+  use ⟨Unit, λ _ _ _ => True⟩
+  tauto
 
 end PLoN
 
@@ -33,14 +33,14 @@ instance : Complete Hilbert.N PLoN.AllFrameClass := inferInstance
 end N
 
 instance : Hilbert.N ⪱ Hilbert.K := by
-  constructor;
-  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.K (.atom 0) (.atom 1);
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.Normal.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.K (.atom 0) (.atom 1)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := PLoN.AllFrameClass)
-      apply Formula.PLoN.ValidOnFrameClass.not_of_exists_model;
+      apply Formula.PLoN.ValidOnFrameClass.not_of_exists_model
       use {
         World := Fin 2,
         Rel := λ ξ x y =>
@@ -52,28 +52,28 @@ instance : Hilbert.N ⪱ Hilbert.K := by
           | 0 => w = 1
           | 1 => w = 0
           | _ => False,
-      };
-      constructor;
-      . tauto;
-      . simp only [ValidOnModel.iff_models, ValidOnModel, not_forall];
-        use 0;
-        apply Formula.PLoN.Satisfies.imp_def.not.mpr;
-        push_neg;
-        constructor;
-        . intro x R0x;
-          simp_all [Satisfies, Frame.Rel'];
-        . apply Formula.PLoN.Satisfies.imp_def.not.mpr;
-          push_neg;
-          constructor;
-          . intro x R0x;
-            simp_all [Satisfies, Frame.Rel'];
-            omega;
-          . apply Satisfies.box_def.not.mpr;
-            push_neg;
-            use 1;
-            constructor;
+      }
+      constructor
+      . tauto
+      . simp only [ValidOnModel.iff_models, ValidOnModel, not_forall]
+        use 0
+        apply Formula.PLoN.Satisfies.imp_def.not.mpr
+        push_neg
+        constructor
+        . intro x R0x
+          simp_all [Satisfies, Frame.Rel']
+        . apply Formula.PLoN.Satisfies.imp_def.not.mpr
+          push_neg
+          constructor
+          . intro x R0x
+            simp_all [Satisfies, Frame.Rel']
+            omega
+          . apply Satisfies.box_def.not.mpr
+            push_neg
+            use 1
+            constructor
             . simp [Frame.Rel']
-            . simp [Semantics.Realize, Satisfies];
+            . simp [Semantics.Realize, Satisfies]
 
 end Hilbert
 

--- a/Foundation/Modal/Tableau.lean
+++ b/Foundation/Modal/Tableau.lean
@@ -44,160 +44,160 @@ section
 variable [Entailment.Cl 𝓢]
 
 lemma equality_def {t₁ t₂ : Tableau α} : t₁ = t₂ ↔ t₁.1 = t₂.1 ∧ t₁.2 = t₂.2 := by
-  constructor;
-  . intro h; cases h; simp;
-  . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all;
+  constructor
+  . intro h; cases h; simp
+  . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all
 
 lemma disjoint_of_consistent (hCon : t.Consistent 𝓢) : t.Disjoint := by
-  constructor;
-  . by_contra hC;
-    obtain ⟨T, hT₁, hT₂, hT⟩ := by simpa [Disjoint] using hC;
-    obtain ⟨φ, hφ⟩ := Set.nonempty_def.mp $ Set.nonempty_iff_ne_empty.mpr hT;
+  constructor
+  . by_contra hC
+    obtain ⟨T, hT₁, hT₂, hT⟩ := by simpa [Disjoint] using hC
+    obtain ⟨φ, hφ⟩ := Set.nonempty_def.mp $ Set.nonempty_iff_ne_empty.mpr hT
     apply hCon (Γ := {φ}) (Δ := {φ})
       (by simp only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hT₁; assumption)
-      (by simp only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hT₂; assumption);
-    simp;
-  . by_contra hC;
-    apply hCon (Γ := {⊥}) (Δ := ∅) (by simpa) (by simp) $ by simp;
+      (by simp only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hT₂; assumption)
+    simp
+  . by_contra hC
+    apply hCon (Γ := {⊥}) (Δ := ∅) (by simpa) (by simp) $ by simp
 
 lemma mem₂_of_not_mem₁ (hMax : t.Maximal) : φ ∉ t.1 → φ ∈ t.2 := by
-  intro h;
+  intro h
   cases hMax with
-  | inl h' => contradiction;
-  | inr _ => assumption;
+  | inl h' => contradiction
+  | inr _ => assumption
 
 lemma mem₁_of_not_mem₂ (hMax : t.Maximal) : φ ∉ t.2 → φ ∈ t.1 := by
-  intro h;
+  intro h
   cases hMax with
-  | inl _ => assumption;
-  | inr h' => contradiction;
+  | inl _ => assumption
+  | inr h' => contradiction
 
 lemma iff_not_mem₁_mem₂ (hCon : t.Consistent 𝓢) (hMax : t.Maximal) : φ ∉ t.1 ↔ φ ∈ t.2 := by
-  constructor;
-  . apply mem₂_of_not_mem₁ hMax;
-  . apply Set.disjoint_right.mp $ disjoint_of_consistent hCon |>.1;
+  constructor
+  . apply mem₂_of_not_mem₁ hMax
+  . apply Set.disjoint_right.mp $ disjoint_of_consistent hCon |>.1
 
 lemma iff_not_mem₂_mem₁ (hCon : t.Consistent 𝓢) (hMax : t.Maximal) : φ ∉ t.2 ↔ φ ∈ t.1 := by
-  constructor;
-  . apply mem₁_of_not_mem₂ hMax;
-  . apply Set.disjoint_left.mp $ disjoint_of_consistent hCon |>.1;
+  constructor
+  . apply mem₁_of_not_mem₂ hMax
+  . apply Set.disjoint_left.mp $ disjoint_of_consistent hCon |>.1
 
 lemma maximal_duality
   {t₁ t₂ : Tableau α}
   (hCon₁ : t₁.Consistent 𝓢) (hCon₂ : t₂.Consistent 𝓢)
   (hMax₁ : t₁.Maximal) (hMax₂ : t₂.Maximal)
   : t₁.1 = t₂.1 ↔ t₁.2 = t₂.2 := by
-  constructor;
-  . intro h;
-    apply Set.eq_of_subset_of_subset;
-    . intro φ hp;
-      apply iff_not_mem₁_mem₂ hCon₂ hMax₂ |>.mp; rw [←h];
-      apply iff_not_mem₁_mem₂ hCon₁ hMax₁ |>.mpr hp;
-    . intro φ hp;
-      apply iff_not_mem₁_mem₂ hCon₁ hMax₁ |>.mp; rw [h];
-      apply iff_not_mem₁_mem₂ hCon₂ hMax₂ |>.mpr hp;
-  . intro h;
-    apply Set.eq_of_subset_of_subset;
-    . intro φ hp;
-      apply iff_not_mem₂_mem₁ hCon₂ hMax₂ |>.mp; rw [←h];
-      apply iff_not_mem₂_mem₁ hCon₁ hMax₁ |>.mpr hp;
-    . intro φ hp;
-      apply iff_not_mem₂_mem₁ hCon₁ hMax₁ |>.mp; rw [h];
-      apply iff_not_mem₂_mem₁ hCon₂ hMax₂ |>.mpr hp;
+  constructor
+  . intro h
+    apply Set.eq_of_subset_of_subset
+    . intro φ hp
+      apply iff_not_mem₁_mem₂ hCon₂ hMax₂ |>.mp; rw [←h]
+      apply iff_not_mem₁_mem₂ hCon₁ hMax₁ |>.mpr hp
+    . intro φ hp
+      apply iff_not_mem₁_mem₂ hCon₁ hMax₁ |>.mp; rw [h]
+      apply iff_not_mem₁_mem₂ hCon₂ hMax₂ |>.mpr hp
+  . intro h
+    apply Set.eq_of_subset_of_subset
+    . intro φ hp
+      apply iff_not_mem₂_mem₁ hCon₂ hMax₂ |>.mp; rw [←h]
+      apply iff_not_mem₂_mem₁ hCon₁ hMax₁ |>.mpr hp
+    . intro φ hp
+      apply iff_not_mem₂_mem₁ hCon₁ hMax₁ |>.mp; rw [h]
+      apply iff_not_mem₂_mem₁ hCon₂ hMax₂ |>.mpr hp
 
 variable [DecidableEq α]
 
 lemma iff_consistent_insert₁
   : Tableau.Consistent 𝓢 ((insert φ T), U) ↔ ∀ {Γ Δ : Finset (Formula α)}, (↑Γ ⊆ T) → (↑Δ ⊆ U) → 𝓢 ⊬ φ ⋏ Γ.conj ➝ Δ.disj := by
-  constructor;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := insert φ Γ) (Δ := Δ) ?_ hΔ;
-    . exact C!_trans (by simp) hC;
-    . simp only [Finset.coe_insert];
-      apply Set.insert_subset_insert;
-      exact hΓ;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    simp_all only [];
-    apply h (Γ := Γ.erase φ) (Δ := Δ) (by simpa) hΔ;
-    refine C!_trans ?_ hC;
+  constructor
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := insert φ Γ) (Δ := Δ) ?_ hΔ
+    . exact C!_trans (by simp) hC
+    . simp only [Finset.coe_insert]
+      apply Set.insert_subset_insert
+      exact hΓ
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    simp_all only []
+    apply h (Γ := Γ.erase φ) (Δ := Δ) (by simpa) hΔ
+    refine C!_trans ?_ hC
     . exact C!_trans CKFConjinsertFConj! $ CFConj_FConj!_of_subset $ Finset.insert_erase_subset φ Γ
 
 lemma iff_inconsistent_insert₁ : Tableau.Inconsistent 𝓢 ((insert φ T), U) ↔ ∃ Γ Δ : Finset (Formula α), (↑Γ ⊆ T) ∧ (↑Δ ⊆ U) ∧ 𝓢 ⊢! φ ⋏ Γ.conj ➝ Δ.disj := by
-  unfold Tableau.Inconsistent;
-  constructor;
-  . contrapose; push_neg; apply iff_consistent_insert₁.mpr;
-  . contrapose; push_neg; apply iff_consistent_insert₁.mp;
+  unfold Tableau.Inconsistent
+  constructor
+  . contrapose; push_neg; apply iff_consistent_insert₁.mpr
+  . contrapose; push_neg; apply iff_consistent_insert₁.mp
 
 lemma iff_consistent_insert₂ : Tableau.Consistent 𝓢 (T, (insert φ U)) ↔ ∀ {Γ Δ : Finset (Formula α)}, (↑Γ ⊆ T) → (↑Δ ⊆ U) → 𝓢 ⊬ Γ.conj ➝ φ ⋎ Δ.disj := by
-  constructor;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := Γ) (Δ := insert φ Δ) hΓ ?_;
-    . exact C!_trans hC $ by simp;
-    . simp only [Finset.coe_insert];
-      apply Set.insert_subset_insert;
-      exact hΔ;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := Γ) (Δ := Δ.erase φ) hΓ (by simpa);
+  constructor
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := Γ) (Δ := insert φ Δ) hΓ ?_
+    . exact C!_trans hC $ by simp
+    . simp only [Finset.coe_insert]
+      apply Set.insert_subset_insert
+      exact hΔ
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := Γ) (Δ := Δ.erase φ) hΓ (by simpa)
     exact C!_trans hC $ by
-      refine C!_trans ?_ $ CinsertFDisjAFDisj! (𝓢 := 𝓢) (Γ := Δ.erase φ);
-      apply CDisj₂Disj₂_of_subset;
-      simp only [Finset.mem_toList, Finset.mem_insert, Finset.mem_erase, ne_eq];
-      tauto;
+      refine C!_trans ?_ $ CinsertFDisjAFDisj! (𝓢 := 𝓢) (Γ := Δ.erase φ)
+      apply CDisj₂Disj₂_of_subset
+      simp only [Finset.mem_toList, Finset.mem_insert, Finset.mem_erase, ne_eq]
+      tauto
 
 lemma iff_not_consistent_insert₂ : Tableau.Inconsistent 𝓢 (T, (insert φ U)) ↔ ∃ Γ Δ : Finset (Formula α), (↑Γ ⊆ T) ∧ (↑Δ ⊆ U) ∧ 𝓢 ⊢! Γ.conj ➝ φ ⋎ Δ.disj := by
-  unfold Tableau.Inconsistent;
-  constructor;
-  . contrapose; push_neg; apply iff_consistent_insert₂.mpr;
-  . contrapose; push_neg; apply iff_consistent_insert₂.mp;
+  unfold Tableau.Inconsistent
+  constructor
+  . contrapose; push_neg; apply iff_consistent_insert₂.mpr
+  . contrapose; push_neg; apply iff_consistent_insert₂.mp
 
 lemma iff_consistent_empty_singleton₂ : Tableau.Consistent 𝓢 (∅, {φ}) ↔ 𝓢 ⊬ φ := by
-  convert iff_consistent_insert₂ (𝓢 := 𝓢) (T := ∅) (U := ∅) (φ := φ);
-  . simp;
-  . constructor;
-    . contrapose;
-      push_neg;
-      rintro ⟨Γ, Δ, hΓ, hΔ, h⟩;
-      simp_all only [Set.subset_empty_iff, Finset.coe_eq_empty, Finset.conj_empty, Finset.disj_empty, not_not];
-      simpa using A!_cases C!_id efq! ((by simpa using h) ⨀ verum!);
-    . contrapose!;
-      intro h;
-      use ∅, ∅;
-      refine ⟨by tauto, by tauto, ?_⟩;
-      simp only [Finset.conj_empty, Finset.disj_empty, not_not];
-      apply C!_of_conseq!;
-      apply A!_intro_left (by simpa using h);
+  convert iff_consistent_insert₂ (𝓢 := 𝓢) (T := ∅) (U := ∅) (φ := φ)
+  . simp
+  . constructor
+    . contrapose
+      push_neg
+      rintro ⟨Γ, Δ, hΓ, hΔ, h⟩
+      simp_all only [Set.subset_empty_iff, Finset.coe_eq_empty, Finset.conj_empty, Finset.disj_empty, not_not]
+      simpa using A!_cases C!_id efq! ((by simpa using h) ⨀ verum!)
+    . contrapose!
+      intro h
+      use ∅, ∅
+      refine ⟨by tauto, by tauto, ?_⟩
+      simp only [Finset.conj_empty, Finset.disj_empty, not_not]
+      apply C!_of_conseq!
+      apply A!_intro_left (by simpa using h)
 
 lemma iff_inconsistent_singleton₂ : Tableau.Inconsistent 𝓢 (∅, {φ}) ↔ 𝓢 ⊢! φ := by
-  convert iff_consistent_empty_singleton₂ (𝓢 := 𝓢) (φ := φ) |>.not;
-  tauto;
+  convert iff_consistent_empty_singleton₂ (𝓢 := 𝓢) (φ := φ) |>.not
+  tauto
 
 lemma either_expand_consistent_of_consistent (hCon : t.Consistent 𝓢) (φ : Formula α) : Tableau.Consistent 𝓢 ((insert φ t.1), t.2) ∨ Tableau.Consistent 𝓢 (t.1, (insert φ t.2)) := by
-  by_contra hC;
-  push_neg at hC;
-  have ⟨hC₁, hC₂⟩ := hC;
+  by_contra hC
+  push_neg at hC
+  have ⟨hC₁, hC₂⟩ := hC
 
-  obtain ⟨Γ₁, Δ₁, hΓ₁, hΔ₁, h₁⟩ := iff_inconsistent_insert₁.mp hC₁;
-  replace h₁ := left_K!_symm h₁;
+  obtain ⟨Γ₁, Δ₁, hΓ₁, hΔ₁, h₁⟩ := iff_inconsistent_insert₁.mp hC₁
+  replace h₁ := left_K!_symm h₁
 
-  obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_consistent_insert₂.mp hC₂;
-  apply @hCon (Γ := Γ₁ ∪ Γ₂) (Δ := Δ₁ ∪ Δ₂) ?_ ?_;
-  . exact C!_trans (C!_trans (by simp) (cut! h₁ h₂)) (by simp);
-  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto;
-  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto;
+  obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_consistent_insert₂.mp hC₂
+  apply @hCon (Γ := Γ₁ ∪ Γ₂) (Δ := Δ₁ ∪ Δ₂) ?_ ?_
+  . exact C!_trans (C!_trans (by simp) (cut! h₁ h₂)) (by simp)
+  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto
+  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto
 
 lemma consistent_empty [H_consis : Entailment.Consistent 𝓢] : Tableau.Consistent 𝓢 ⟨∅, ∅⟩ := by
-  intro Γ Δ hΓ hΔ;
-  by_contra hC;
-  obtain ⟨ψ, hψ⟩ := H_consis.exists_unprovable;
-  apply hψ;
-  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ;
-  subst hΓ hΔ;
-  simp only [Finset.conj_empty, Finset.disj_empty] at hC;
-  exact of_O! (hC ⨀ C!_id);
+  intro Γ Δ hΓ hΔ
+  by_contra hC
+  obtain ⟨ψ, hψ⟩ := H_consis.exists_unprovable
+  apply hψ
+  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ
+  subst hΓ hΔ
+  simp only [Finset.conj_empty, Finset.disj_empty] at hC
+  exact of_O! (hC ⨀ C!_id)
 
 end
 
@@ -229,115 +229,115 @@ variable {𝓢}
 @[simp] lemma eq_lindenbaum_indexed_zero [Encodable α] {t : Tableau α} : t[0] = t := by simp [lindenbaum_indexed]
 
 lemma consistent_lindenbaum_next [Entailment.Cl 𝓢] (consistent : t.Consistent 𝓢) (φ : Formula α) : (t.lindenbaum_next 𝓢 φ).Consistent 𝓢 := by
-  unfold lindenbaum_next;
-  split;
-  . assumption;
-  . rcases (either_expand_consistent_of_consistent consistent φ) with (h | h);
-    . contradiction;
-    . assumption;
+  unfold lindenbaum_next
+  split
+  . assumption
+  . rcases (either_expand_consistent_of_consistent consistent φ) with (h | h)
+    . contradiction
+    . assumption
 
 variable [Encodable α]
 
 lemma consistent_lindenbaum_indexed_succ [Entailment.Cl 𝓢] {i : ℕ} : t[i].Consistent 𝓢 → t[i + 1].Consistent 𝓢 := by
-  simp only [lindenbaum_indexed];
-  split;
-  . intro h; apply consistent_lindenbaum_next h;
-  . tauto;
+  simp only [lindenbaum_indexed]
+  split
+  . intro h; apply consistent_lindenbaum_next h
+  . tauto
 
 lemma either_mem_lindenbaum_indexed (t) (φ : Formula α) : φ ∈ t[(encode φ) + 1].1 ∨ φ ∈ t[(encode φ) + 1].2 := by
-  simp only [lindenbaum_indexed, encodek, lindenbaum_next];
-  split <;> tauto;
+  simp only [lindenbaum_indexed, encodek, lindenbaum_next]
+  split <;> tauto
 
 lemma consistent_lindenbaum_indexed [Entailment.Cl 𝓢] (consistent : t.Consistent 𝓢) (i : ℕ) : t[i].Consistent 𝓢 := by
   induction i with
-  | zero => simpa;
-  | succ i ih => apply consistent_lindenbaum_indexed_succ; assumption;
+  | zero => simpa
+  | succ i ih => apply consistent_lindenbaum_indexed_succ; assumption
 
 variable {m n : ℕ}
 
 lemma subset₁_lindenbaum_indexed_of_lt (h : m ≤ n) : t[m].1 ⊆ t[n].1 := by
   induction h with
-  | refl => simp;
+  | refl => simp
   | step h ih =>
-    simp [lindenbaum_indexed, lindenbaum_next];
-    split;
-    . split <;> tauto;
-    . tauto;
+    simp [lindenbaum_indexed, lindenbaum_next]
+    split
+    . split <;> tauto
+    . tauto
 
 lemma subset₂_lindenbaum_indexed_of_lt (h : m ≤ n) : t[m].2 ⊆ t[n].2 := by
   induction h with
-  | refl => simp;
+  | refl => simp
   | step h ih =>
-    simp [lindenbaum_indexed, lindenbaum_next];
-    split;
-    . split <;> tauto;
-    . tauto;
+    simp [lindenbaum_indexed, lindenbaum_next]
+    split
+    . split <;> tauto
+    . tauto
 
 lemma exists_list_lindenbaum_index₁ {Γ : List _} (hΓ : ↑Γ.toFinset ⊆ ⋃ i, t[i].1): ∃ m, ∀ φ ∈ Γ, φ ∈ t[m].1 := by
   induction Γ with
-  | nil => simp;
+  | nil => simp
   | cons φ Γ ih =>
-    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp];
-    replace hΓ := Set.insert_subset_iff.mp hΓ;
-    obtain ⟨_, ⟨i, _⟩, _⟩ := hΓ.1;
-    obtain ⟨m, hm⟩ := ih hΓ.2;
-    use (i + m);
-    constructor;
-    . apply subset₁_lindenbaum_indexed_of_lt (m := i);
-      . omega;
-      . simp_all;
-    . intro ψ hq;
-      exact subset₁_lindenbaum_indexed_of_lt (by simp) $ hm ψ hq;
+    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp]
+    replace hΓ := Set.insert_subset_iff.mp hΓ
+    obtain ⟨_, ⟨i, _⟩, _⟩ := hΓ.1
+    obtain ⟨m, hm⟩ := ih hΓ.2
+    use (i + m)
+    constructor
+    . apply subset₁_lindenbaum_indexed_of_lt (m := i)
+      . omega
+      . simp_all
+    . intro ψ hq
+      exact subset₁_lindenbaum_indexed_of_lt (by simp) $ hm ψ hq
 
 lemma exists_finset_lindenbaum_index₁ {Γ : Finset _} (hΓ : ↑Γ ⊆ ⋃ i, t[i].1): ∃ m, ∀ φ ∈ Γ, φ ∈ t[m].1 := by
-  obtain ⟨m, hΓ⟩ := exists_list_lindenbaum_index₁ (Γ := Γ.toList) (t := t) (by simpa);
-  use m;
-  intro φ hφ;
-  apply hΓ;
-  simpa;
+  obtain ⟨m, hΓ⟩ := exists_list_lindenbaum_index₁ (Γ := Γ.toList) (t := t) (by simpa)
+  use m
+  intro φ hφ
+  apply hΓ
+  simpa
 
 lemma exists_list_lindenbaum_index₂ {Δ : List _} (hΔ : ↑Δ.toFinset ⊆ ⋃ i, t[i].2) : ∃ n, ∀ φ ∈ Δ, φ ∈ t[n].2 := by
   induction Δ with
-  | nil => simp;
+  | nil => simp
   | cons φ Δ ih =>
-    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp];
-    replace hΔ := Set.insert_subset_iff.mp hΔ;
-    obtain ⟨_, ⟨i, _⟩, _⟩ := hΔ.1;
-    obtain ⟨n, hn⟩ := ih hΔ.2;
-    use (i + n);
-    constructor;
-    . apply subset₂_lindenbaum_indexed_of_lt (m := i);
-      . omega;
+    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp]
+    replace hΔ := Set.insert_subset_iff.mp hΔ
+    obtain ⟨_, ⟨i, _⟩, _⟩ := hΔ.1
+    obtain ⟨n, hn⟩ := ih hΔ.2
+    use (i + n)
+    constructor
+    . apply subset₂_lindenbaum_indexed_of_lt (m := i)
+      . omega
       . simp_all
-    . intro ψ hq;
-      exact subset₂_lindenbaum_indexed_of_lt (by simp) $ hn ψ hq;
+    . intro ψ hq
+      exact subset₂_lindenbaum_indexed_of_lt (by simp) $ hn ψ hq
 
 lemma exists_finset_lindenbaum_index₂ {Δ : Finset _} (hΓ : ↑Δ ⊆ ⋃ i, t[i].2) : ∃ n, ∀ φ ∈ Δ, φ ∈ t[n].2 := by
-  obtain ⟨m, hΔ⟩ := exists_list_lindenbaum_index₂ (Δ := Δ.toList) (𝓢 := 𝓢) (t := t) (by simpa);
-  use m;
-  intro φ hφ;
-  apply hΔ;
-  simpa;
+  obtain ⟨m, hΔ⟩ := exists_list_lindenbaum_index₂ (Δ := Δ.toList) (𝓢 := 𝓢) (t := t) (by simpa)
+  use m
+  intro φ hφ
+  apply hΔ
+  simpa
 
 lemma exists_consistent_saturated_tableau [Entailment.Cl 𝓢] (hCon : t.Consistent 𝓢) : ∃ u, t ⊆ u ∧ (u.Consistent 𝓢) ∧ (u.Maximal) := by
-  use t∞;
-  refine ⟨?subset, ?consistent, ?maximal⟩;
-  case subset => constructor <;> apply Set.subset_iUnion_of_subset 0 (by simp);
+  use t∞
+  refine ⟨?subset, ?consistent, ?maximal⟩
+  case subset => constructor <;> apply Set.subset_iUnion_of_subset 0 (by simp)
   case maximal =>
-    intro φ;
-    rcases either_mem_lindenbaum_indexed (𝓢 := 𝓢) t φ with (h | h);
-    . left; simp only [lindenbaum_max, Set.mem_iUnion]; use (encode φ + 1);
-    . right; simp only [lindenbaum_max, Set.mem_iUnion];  use (encode φ + 1);
+    intro φ
+    rcases either_mem_lindenbaum_indexed (𝓢 := 𝓢) t φ with (h | h)
+    . left; simp only [lindenbaum_max, Set.mem_iUnion]; use (encode φ + 1)
+    . right; simp only [lindenbaum_max, Set.mem_iUnion];  use (encode φ + 1)
   case consistent =>
-    intro Γ Δ hΓ hΔ;
-    simp_all only [lindenbaum_max];
-    obtain ⟨m, hΓ⟩ := exists_finset_lindenbaum_index₁ hΓ;
-    obtain ⟨n, hΔ⟩ := exists_finset_lindenbaum_index₂ hΔ;
-    rcases (lt_trichotomy m n) with hm | hmn | hn;
-    . exact consistent_lindenbaum_indexed hCon n (by intro φ hp; exact subset₁_lindenbaum_indexed_of_lt hm.le $ hΓ φ hp) hΔ;
-    . subst hmn;
-      exact consistent_lindenbaum_indexed hCon m hΓ hΔ;
-    . exact consistent_lindenbaum_indexed hCon m hΓ (by intro φ hp; exact subset₂_lindenbaum_indexed_of_lt hn.le $ hΔ φ hp);
+    intro Γ Δ hΓ hΔ
+    simp_all only [lindenbaum_max]
+    obtain ⟨m, hΓ⟩ := exists_finset_lindenbaum_index₁ hΓ
+    obtain ⟨n, hΔ⟩ := exists_finset_lindenbaum_index₂ hΔ
+    rcases (lt_trichotomy m n) with hm | hmn | hn
+    . exact consistent_lindenbaum_indexed hCon n (by intro φ hp; exact subset₁_lindenbaum_indexed_of_lt hm.le $ hΓ φ hp) hΔ
+    . subst hmn
+      exact consistent_lindenbaum_indexed hCon m hΓ hΔ
+    . exact consistent_lindenbaum_indexed hCon m hΓ (by intro φ hp; exact subset₂_lindenbaum_indexed_of_lt hn.le $ hΔ φ hp)
 
 protected alias lindenbaum := exists_consistent_saturated_tableau
 
@@ -359,8 +359,8 @@ variable {t t₁ t₂  : MaximalConsistentTableau 𝓢} {φ ψ : Formula α}
 @[simp] lemma consistent (t : MaximalConsistentTableau 𝓢) : t.1.Consistent 𝓢 := t.2.2
 
 lemma lindenbaum {t₀ : Tableau α} [Entailment.Cl 𝓢] [Encodable α] (hCon : t₀.Consistent 𝓢) : ∃ (t : MaximalConsistentTableau 𝓢), t₀ ⊆ t.1 := by
-  obtain ⟨t, ht, hCon, hMax⟩ := Tableau.lindenbaum hCon;
-  exact ⟨⟨t, hMax, hCon⟩, ht⟩;
+  obtain ⟨t, ht, hCon, hMax⟩ := Tableau.lindenbaum hCon
+  exact ⟨⟨t, hMax, hCon⟩, ht⟩
 
 instance [Entailment.Consistent 𝓢] [Entailment.Cl 𝓢] [DecidableEq α] [Encodable α] : Nonempty (MaximalConsistentTableau 𝓢) := ⟨lindenbaum consistent_empty |>.choose⟩
 
@@ -375,89 +375,89 @@ lemma iff_not_mem₁_mem₂ : φ ∉ t.1.1 ↔ φ ∈ t.1.2 := Tableau.iff_not_m
 lemma iff_not_mem₂_mem₁ : φ ∉ t.1.2 ↔ φ ∈ t.1.1 := Tableau.iff_not_mem₂_mem₁ t.consistent t.maximal
 
 lemma neither : ¬(φ ∈ t.1.1 ∧ φ ∈ t.1.2) := by
-  push_neg;
-  intro h;
-  exact iff_not_mem₂_mem₁.mpr h;
+  push_neg
+  intro h
+  exact iff_not_mem₂_mem₁.mpr h
 
 lemma maximal_duality: t₁.1.1 = t₂.1.1 ↔ t₁.1.2 = t₂.1.2 :=
   Tableau.maximal_duality t₁.consistent t₂.consistent t₁.maximal t₂.maximal
 
 lemma equality_of₁ (e₁ : t₁.1.1 = t₂.1.1) : t₁ = t₂ := by
-  have e := Tableau.equality_def.mpr ⟨e₁, (maximal_duality.mp e₁)⟩;
+  have e := Tableau.equality_def.mpr ⟨e₁, (maximal_duality.mp e₁)⟩
   calc
-    t₁ = ⟨t₁.1, t₁.maximal, t₁.consistent⟩ := by rfl;
-    _  = ⟨t₂.1, t₂.maximal, t₂.consistent⟩ := by simp [e];
-    _  = t₂                                := by rfl;
+    t₁ = ⟨t₁.1, t₁.maximal, t₁.consistent⟩ := by rfl
+    _  = ⟨t₂.1, t₂.maximal, t₂.consistent⟩ := by simp [e]
+    _  = t₂                                := by rfl
 
 lemma equality_of₂ (e₂ : t₁.1.2 = t₂.1.2) : t₁ = t₂ := equality_of₁ $ maximal_duality.mpr e₂
 
 lemma ne₁_of_ne : t₁ ≠ t₂ → t₁.1.1 ≠ t₂.1.1 := by
-  contrapose;
-  push_neg;
-  exact equality_of₁;
+  contrapose
+  push_neg
+  exact equality_of₁
 
 lemma ne₂_of_ne : t₁ ≠ t₂ → t₁.1.2 ≠ t₂.1.2 := by
-  contrapose;
-  push_neg;
-  exact equality_of₂;
+  contrapose
+  push_neg
+  exact equality_of₂
 
 lemma intro_equality (h₁ : ∀ {φ}, φ ∈ t₁.1.1 → φ ∈ t₂.1.1) (h₂ : ∀ {φ}, φ ∈ t₁.1.2 → φ ∈ t₂.1.2) : t₁ = t₂ := by
-  apply equality_of₁;
-  apply Set.eq_of_subset_of_subset;
-  . intro φ hφ;
-    exact h₁ hφ;
-  . intro φ;
-    contrapose;
-    intro hφ;
-    apply iff_not_mem₁_mem₂.mpr;
-    exact h₂ $ iff_not_mem₁_mem₂.mp hφ;
+  apply equality_of₁
+  apply Set.eq_of_subset_of_subset
+  . intro φ hφ
+    exact h₁ hφ
+  . intro φ
+    contrapose
+    intro hφ
+    apply iff_not_mem₁_mem₂.mpr
+    exact h₂ $ iff_not_mem₁_mem₂.mp hφ
 
 section
 
 variable [DecidableEq α] [Encodable α]
 
 lemma iff_provable_include₁ : T *⊢[𝓢]! φ ↔ ∀ t : MaximalConsistentTableau 𝓢, (T ⊆ t.1.1) → φ ∈ t.1.1 := by
-  constructor;
-  . intro h t hT;
-    by_contra hφ;
-    replace hφ := iff_not_mem₁_mem₂.mp hφ;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply t.consistent (Γ := Γ.toFinset) (Δ := {φ}) ?_ ?_;
-    . apply FConj_DT.mpr;
-      simpa using iff_FiniteContext_Context.mp hΓ₂;
-    . intro ψ hψ;
-      apply hT;
-      apply hΓ₁;
-      simpa using hψ;
-    . simpa;
-  . intro h;
-    by_contra! hC;
+  constructor
+  . intro h t hT
+    by_contra hφ
+    replace hφ := iff_not_mem₁_mem₂.mp hφ
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply t.consistent (Γ := Γ.toFinset) (Δ := {φ}) ?_ ?_
+    . apply FConj_DT.mpr
+      simpa using iff_FiniteContext_Context.mp hΓ₂
+    . intro ψ hψ
+      apply hT
+      apply hΓ₁
+      simpa using hψ
+    . simpa
+  . intro h
+    by_contra! hC
     obtain ⟨t, ht⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨T, {φ}⟩) $ by
-      intro Γ Δ hΓ hΔ;
-      revert hC;
-      contrapose;
-      simp only [not_not];
-      intro h;
-      replace h : T *⊢[𝓢]! Δ.disj := Context.weakening! (by simpa using hΓ) $ FConj_DT.mp h;
-      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
-      . simp only [Finset.coe_eq_empty] at hΔ;
-        subst hΔ;
-        exact of_O! $ by simpa using h;
-      . simp only [Finset.coe_eq_singleton] at hΔ;
-        subst hΔ;
-        simpa using h;
-    apply iff_not_mem₂_mem₁.mpr $ h t ht.1;
-    apply ht.2;
-    simp;
+      intro Γ Δ hΓ hΔ
+      revert hC
+      contrapose
+      simp only [not_not]
+      intro h
+      replace h : T *⊢[𝓢]! Δ.disj := Context.weakening! (by simpa using hΓ) $ FConj_DT.mp h
+      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ)
+      . simp only [Finset.coe_eq_empty] at hΔ
+        subst hΔ
+        exact of_O! $ by simpa using h
+      . simp only [Finset.coe_eq_singleton] at hΔ
+        subst hΔ
+        simpa using h
+    apply iff_not_mem₂_mem₁.mpr $ h t ht.1
+    apply ht.2
+    simp
 
 lemma iff_provable_mem₁ : 𝓢 ⊢! φ ↔ ∀ t : MaximalConsistentTableau 𝓢, φ ∈ t.1.1 := by
-  constructor;
-  . intro h t;
-    apply iff_provable_include₁ (T := ∅) |>.mp;
-    . exact Context.of! h;
-    . simp;
-  . intro h;
-    exact Context.emptyPrf! $ iff_provable_include₁.mpr $ by tauto;
+  constructor
+  . intro h t
+    apply iff_provable_include₁ (T := ∅) |>.mp
+    . exact Context.of! h
+    . simp
+  . intro h
+    exact Context.emptyPrf! $ iff_provable_include₁.mpr $ by tauto
 
 end
 
@@ -468,23 +468,23 @@ variable [DecidableEq α] [Encodable α] {n : ℕ}
 
 omit [Encodable α] in
 lemma mdp_mem₁ (hφψ : φ ➝ ψ ∈ t.1.1) (hφ : φ ∈ t.1.1) : ψ ∈ t.1.1 := by
-  apply iff_not_mem₂_mem₁.mp;
-  by_contra hq₂;
-  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ ?_;
-  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    tauto;
-  . simpa;
+  apply iff_not_mem₂_mem₁.mp
+  by_contra hq₂
+  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ ?_
+  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    tauto
+  . simpa
 
 lemma mdp_mem₁_provable (hφψ : 𝓢 ⊢! φ ➝ ψ) (hφ : φ ∈ t.1.1) : ψ ∈ t.1.1 := mdp_mem₁ (iff_provable_mem₁.mp hφψ t) hφ
 
 lemma mdp_mem₂_provable (hφψ : 𝓢 ⊢! φ ➝ ψ) : ψ ∈ t.1.2 → φ ∈ t.1.2 := by
-  contrapose;
-  intro hφ;
-  apply iff_not_mem₂_mem₁.mpr;
-  apply mdp_mem₁_provable hφψ;
-  apply iff_not_mem₂_mem₁.mp hφ;
+  contrapose
+  intro hφ
+  apply iff_not_mem₂_mem₁.mpr
+  apply mdp_mem₁_provable hφψ
+  apply iff_not_mem₂_mem₁.mp hφ
 
 @[simp] lemma mem₁_verum : ⊤ ∈ t.1.1 := iff_provable_mem₁.mp verum! t
 
@@ -499,265 +499,265 @@ omit [Encodable α] [DecidableEq α] in
 
 
 private lemma of_mem₁_and : φ ⋏ ψ ∈ t.1.1 → (φ ∈ t.1.1 ∧ ψ ∈ t.1.1) := by
-  intro h;
-  constructor <;> exact mdp_mem₁_provable (by simp) h;
+  intro h
+  constructor <;> exact mdp_mem₁_provable (by simp) h
 
 private lemma of_mem₂_and : φ ⋏ ψ ∈ t.1.2 → (φ ∈ t.1.2 ∨ ψ ∈ t.1.2) := by
-  contrapose;
-  intro hφψ;
-  apply iff_not_mem₂_mem₁.mpr;
-  push_neg at hφψ;
-  have hφ := iff_not_mem₂_mem₁.mp hφψ.1;
-  have hψ := iff_not_mem₂_mem₁.mp hφψ.2;
-  exact mdp_mem₁ (mdp_mem₁_provable and₃! hφ) hψ;
+  contrapose
+  intro hφψ
+  apply iff_not_mem₂_mem₁.mpr
+  push_neg at hφψ
+  have hφ := iff_not_mem₂_mem₁.mp hφψ.1
+  have hψ := iff_not_mem₂_mem₁.mp hφψ.2
+  exact mdp_mem₁ (mdp_mem₁_provable and₃! hφ) hψ
 
 lemma iff_mem₁_and : φ ⋏ ψ ∈ t.1.1 ↔ (φ ∈ t.1.1 ∧ ψ ∈ t.1.1) := by
-  constructor;
-  . apply of_mem₁_and;
-  . contrapose;
-    push_neg;
-    intro hφψ hφ;
-    rcases of_mem₂_and $ iff_not_mem₁_mem₂.mp hφψ with (hφ | hψ);
-    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction;
-    . exact iff_not_mem₁_mem₂.mpr hψ;
+  constructor
+  . apply of_mem₁_and
+  . contrapose
+    push_neg
+    intro hφψ hφ
+    rcases of_mem₂_and $ iff_not_mem₁_mem₂.mp hφψ with (hφ | hψ)
+    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction
+    . exact iff_not_mem₁_mem₂.mpr hψ
 
 lemma iff_mem₂_and : φ ⋏ ψ ∈ t.1.2 ↔ (φ ∈ t.1.2 ∨ ψ ∈ t.1.2) := by
-  constructor;
-  . apply of_mem₂_and;
-  . contrapose;
-    push_neg;
-    intro hφψ;
-    rcases of_mem₁_and $ iff_not_mem₂_mem₁.mp hφψ with ⟨hφ, hψ⟩;
-    constructor <;> { apply iff_not_mem₂_mem₁.mpr; assumption; };
+  constructor
+  . apply of_mem₂_and
+  . contrapose
+    push_neg
+    intro hφψ
+    rcases of_mem₁_and $ iff_not_mem₂_mem₁.mp hφψ with ⟨hφ, hψ⟩
+    constructor <;> { apply iff_not_mem₂_mem₁.mpr; assumption; }
 
 lemma iff_mem₁_conj₂ {Γ : List (Formula α)} : ⋀Γ ∈ t.1.1 ↔ ∀ φ ∈ Γ, φ ∈ t.1.1 := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ Γ_nil ih =>
-    simp only [(List.conj₂_cons_nonempty Γ_nil), List.mem_cons];
-    constructor;
-    . rintro h φ (rfl | hp);
-      . exact iff_mem₁_and.mp h |>.1;
-      . exact ih.mp (iff_mem₁_and.mp h |>.2) _ hp;
-    . intro h;
-      apply iff_mem₁_and.mpr;
-      simp_all;
-  | _ => simp;
+    simp only [(List.conj₂_cons_nonempty Γ_nil), List.mem_cons]
+    constructor
+    . rintro h φ (rfl | hp)
+      . exact iff_mem₁_and.mp h |>.1
+      . exact ih.mp (iff_mem₁_and.mp h |>.2) _ hp
+    . intro h
+      apply iff_mem₁_and.mpr
+      simp_all
+  | _ => simp
 
 lemma iff_mem₁_fconj {Γ : Finset (Formula α)} : Γ.conj ∈ t.1.1 ↔ ↑Γ ⊆ t.1.1 := by
-  constructor;
-  . intro h φ hφ;
-    apply iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mp;
-    . apply mdp_mem₁_provable ?_ h; simp;
-    . simpa;
-  . intro h;
+  constructor
+  . intro h φ hφ
+    apply iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mp
+    . apply mdp_mem₁_provable ?_ h; simp
+    . simpa
+  . intro h
     apply mdp_mem₁_provable ?_ $ iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mpr $ by
-      intro φ hφ;
-      apply h;
-      simp_all;
-    simp;
+      intro φ hφ
+      apply h
+      simp_all
+    simp
 
 lemma iff_mem₂_conj₂ {Γ : List _} : ⋀Γ ∈ t.1.2 ↔ (∃ φ ∈ Γ, φ ∈ t.1.2) := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ hΓ ih =>
-    rw [List.conj₂_cons_nonempty hΓ];
-    constructor;
-    . intro h;
-      rcases iff_mem₂_and.mp h with (hφ | hΓ);
-      . exact ⟨φ, by tauto, hφ⟩;
-      . obtain ⟨ψ, hψ₁, hψ₂⟩ := ih.mp hΓ;
-        exact ⟨ψ, by tauto, hψ₂⟩;
-    . rintro ⟨ψ, (hψ₁ | hψ₁), hψ₂⟩;
-      . apply iff_mem₂_and.mpr;
-        left;
-        assumption;
-      . apply iff_mem₂_and.mpr;
-        right;
-        apply ih.mpr;
-        exact ⟨ψ, by simpa, hψ₂⟩;
-  | _ => simp;
+    rw [List.conj₂_cons_nonempty hΓ]
+    constructor
+    . intro h
+      rcases iff_mem₂_and.mp h with (hφ | hΓ)
+      . exact ⟨φ, by tauto, hφ⟩
+      . obtain ⟨ψ, hψ₁, hψ₂⟩ := ih.mp hΓ
+        exact ⟨ψ, by tauto, hψ₂⟩
+    . rintro ⟨ψ, (hψ₁ | hψ₁), hψ₂⟩
+      . apply iff_mem₂_and.mpr
+        left
+        assumption
+      . apply iff_mem₂_and.mpr
+        right
+        apply ih.mpr
+        exact ⟨ψ, by simpa, hψ₂⟩
+  | _ => simp
 
 lemma iff_mem₂_fconj {Γ : Finset (Formula α)} : Γ.conj ∈ t.1.2 ↔ (∃ φ ∈ Γ, φ ∈ t.1.2)  := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     obtain ⟨φ, hφ₁, hφ₂⟩ := iff_mem₂_conj₂ (Γ := Γ.toList) (t := t) |>.mp $ by
-      apply mdp_mem₂_provable (ψ := Γ.conj);
-      . simp;
-      . assumption;
-    use φ;
-    constructor;
-    . simpa using hφ₁;
-    . simpa;
-  . rintro ⟨ψ, hψ₁, hψ₂⟩;
-    apply iff_mem₂_conj₂.mpr;
-    use ψ;
-    constructor <;> simpa;
+      apply mdp_mem₂_provable (ψ := Γ.conj)
+      . simp
+      . assumption
+    use φ
+    constructor
+    . simpa using hφ₁
+    . simpa
+  . rintro ⟨ψ, hψ₁, hψ₂⟩
+    apply iff_mem₂_conj₂.mpr
+    use ψ
+    constructor <;> simpa
 
 omit [Encodable α] in
 private lemma of_mem₁_or : φ ⋎ ψ ∈ t.1.1 → (φ ∈ t.1.1 ∨ ψ ∈ t.1.1) := by
-  intro h;
-  by_contra! hC;
-  apply t.consistent (Γ := {φ ⋎ ψ}) (Δ := {φ, ψ}) ?_ ?_;
-  . apply CFConj_CDisj!_of_A (φ := φ) (ψ := ψ) <;> simp;
-  . simpa;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    constructor;
-    . exact iff_not_mem₁_mem₂.mp hC.1;
-    . exact iff_not_mem₁_mem₂.mp hC.2;
+  intro h
+  by_contra! hC
+  apply t.consistent (Γ := {φ ⋎ ψ}) (Δ := {φ, ψ}) ?_ ?_
+  . apply CFConj_CDisj!_of_A (φ := φ) (ψ := ψ) <;> simp
+  . simpa
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    constructor
+    . exact iff_not_mem₁_mem₂.mp hC.1
+    . exact iff_not_mem₁_mem₂.mp hC.2
 
 private lemma of_mem₂_or : φ ⋎ ψ ∈ t.1.2 → (φ ∈ t.1.2 ∧ ψ ∈ t.1.2) := by
-  contrapose;
-  suffices (φ ∉ t.1.2 ∨ ψ ∉ t.1.2) → φ ⋎ ψ ∉ t.1.2 by tauto;
-  rintro (hφ | hψ);
-  . apply iff_not_mem₂_mem₁.mpr;
-    exact mdp_mem₁_provable or₁! $ iff_not_mem₂_mem₁.mp hφ;
-  . apply iff_not_mem₂_mem₁.mpr;
-    exact mdp_mem₁_provable or₂! $ iff_not_mem₂_mem₁.mp hψ;
+  contrapose
+  suffices (φ ∉ t.1.2 ∨ ψ ∉ t.1.2) → φ ⋎ ψ ∉ t.1.2 by tauto
+  rintro (hφ | hψ)
+  . apply iff_not_mem₂_mem₁.mpr
+    exact mdp_mem₁_provable or₁! $ iff_not_mem₂_mem₁.mp hφ
+  . apply iff_not_mem₂_mem₁.mpr
+    exact mdp_mem₁_provable or₂! $ iff_not_mem₂_mem₁.mp hψ
 
 lemma iff_mem₁_or : φ ⋎ ψ ∈ t.1.1 ↔ (φ ∈ t.1.1 ∨ ψ ∈ t.1.1) := by
-  constructor;
-  . apply of_mem₁_or;
-  . contrapose;
-    push_neg;
-    intro hφψ;
-    rcases of_mem₂_or $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩;
-    constructor <;> { apply iff_not_mem₁_mem₂.mpr; assumption; };
+  constructor
+  . apply of_mem₁_or
+  . contrapose
+    push_neg
+    intro hφψ
+    rcases of_mem₂_or $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩
+    constructor <;> { apply iff_not_mem₁_mem₂.mpr; assumption; }
 
 lemma iff_mem₂_or : φ ⋎ ψ ∈ t.1.2 ↔ (φ ∈ t.1.2 ∧ ψ ∈ t.1.2) := by
-  constructor;
-  . apply of_mem₂_or;
-  . contrapose;
-    push_neg;
-    intro hφψ hφ;
-    rcases of_mem₁_or $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ);
-    . have := iff_not_mem₂_mem₁.mpr hφ; contradiction;
-    . exact iff_not_mem₂_mem₁.mpr hψ;
+  constructor
+  . apply of_mem₂_or
+  . contrapose
+    push_neg
+    intro hφψ hφ
+    rcases of_mem₁_or $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ)
+    . have := iff_not_mem₂_mem₁.mpr hφ; contradiction
+    . exact iff_not_mem₂_mem₁.mpr hψ
 
 lemma iff_mem₁_disj  {Γ : List _} : ⋁Γ ∈ t.1.1 ↔ (∃ φ ∈ Γ, φ ∈ t.1.1) := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ hΓ ih =>
-    rw [List.disj₂_cons_nonempty hΓ];
-    constructor;
-    . intro h;
-      rcases iff_mem₁_or.mp h with (hφ | hΓ);
-      . exact ⟨φ, by tauto, hφ⟩;
-      . obtain ⟨ψ, hψ₁, hψ₂⟩ := ih.mp hΓ;
-        exact ⟨ψ, by tauto, hψ₂⟩;
-    . rintro ⟨ψ, (hψ₁ | hψ₁), hψ₂⟩;
-      . apply iff_mem₁_or.mpr;
-        left;
-        assumption;
-      . apply iff_mem₁_or.mpr;
-        right;
-        apply ih.mpr;
-        exact ⟨ψ, by simpa, hψ₂⟩;
-  | _ => simp;
+    rw [List.disj₂_cons_nonempty hΓ]
+    constructor
+    . intro h
+      rcases iff_mem₁_or.mp h with (hφ | hΓ)
+      . exact ⟨φ, by tauto, hφ⟩
+      . obtain ⟨ψ, hψ₁, hψ₂⟩ := ih.mp hΓ
+        exact ⟨ψ, by tauto, hψ₂⟩
+    . rintro ⟨ψ, (hψ₁ | hψ₁), hψ₂⟩
+      . apply iff_mem₁_or.mpr
+        left
+        assumption
+      . apply iff_mem₁_or.mpr
+        right
+        apply ih.mpr
+        exact ⟨ψ, by simpa, hψ₂⟩
+  | _ => simp
 
 lemma iff_mem₂_disj {Γ : List _} : ⋁Γ ∈ t.1.2 ↔ (∀ φ ∈ Γ, φ ∈ t.1.2) := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ hΓ ih =>
-    rw [List.disj₂_cons_nonempty hΓ];
-    constructor;
-    . intro h;
-      rcases iff_mem₂_or.mp h with ⟨hφ, hΓ⟩;
-      rintro ψ (hψ | hΓ);
-      . assumption;
-      . apply ih.mp hΓ;
-        assumption;
-    . intro h;
-      apply iff_mem₂_or.mpr;
-      constructor;
-      . apply h; tauto;
-      . apply ih.mpr;
-        intro ψ hψ;
-        apply h;
-        tauto;
-  | _ => simp;
+    rw [List.disj₂_cons_nonempty hΓ]
+    constructor
+    . intro h
+      rcases iff_mem₂_or.mp h with ⟨hφ, hΓ⟩
+      rintro ψ (hψ | hΓ)
+      . assumption
+      . apply ih.mp hΓ
+        assumption
+    . intro h
+      apply iff_mem₂_or.mpr
+      constructor
+      . apply h; tauto
+      . apply ih.mpr
+        intro ψ hψ
+        apply h
+        tauto
+  | _ => simp
 
 lemma iff_mem₂_fdisj {Γ : Finset _} : Γ.disj ∈ t.1.2 ↔ (↑Γ ⊆ t.1.2) := by
-  constructor;
-  . intro h φ hφ;
-    apply iff_mem₂_disj (Γ := Γ.toList) (t := t) |>.mp;
-    . apply mdp_mem₂_provable ?_ h; simp;
-    . simpa;
-  . intro h;
+  constructor
+  . intro h φ hφ
+    apply iff_mem₂_disj (Γ := Γ.toList) (t := t) |>.mp
+    . apply mdp_mem₂_provable ?_ h; simp
+    . simpa
+  . intro h
     apply mdp_mem₂_provable ?_ $ iff_mem₂_disj (Γ := Γ.toList) (t := t) |>.mpr $ by
-      intro φ hφ;
-      apply h;
-      simp_all;
-    simp;
+      intro φ hφ
+      apply h
+      simp_all
+    simp
 
 omit [Encodable α] in
 private lemma of_mem₁_imp : φ ➝ ψ ∈ t.1.1 → (φ ∈ t.1.2 ∨ ψ ∈ t.1.1) := by
-  intro h;
-  by_contra hC;
-  push_neg at hC;
+  intro h
+  by_contra hC
+  push_neg at hC
   exact hC.2 $ mdp_mem₁ h $ iff_not_mem₂_mem₁.mp hC.1
 
 private lemma of_mem₂_imp : φ ➝ ψ ∈ t.1.2 → (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
-  intro h;
-  by_contra hC;
-  replace hC := not_and_or.mp hC;
-  rcases hC with (hφ | hψ);
-  . have : φ ⋎ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp (A!_replace_right lem! CNC!) t;
-    rcases of_mem₁_or this with (_ | _);
-    . contradiction;
-    . have := iff_not_mem₁_mem₂.mpr h;
-      contradiction;
-  . have : ψ ➝ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp imply₁! t;
-    have : φ ➝ ψ ∉ t.1.2 := iff_not_mem₂_mem₁.mpr $ mdp_mem₁ this (iff_not_mem₂_mem₁.mp hψ);
-    contradiction;
+  intro h
+  by_contra hC
+  replace hC := not_and_or.mp hC
+  rcases hC with (hφ | hψ)
+  . have : φ ⋎ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp (A!_replace_right lem! CNC!) t
+    rcases of_mem₁_or this with (_ | _)
+    . contradiction
+    . have := iff_not_mem₁_mem₂.mpr h
+      contradiction
+  . have : ψ ➝ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp imply₁! t
+    have : φ ➝ ψ ∉ t.1.2 := iff_not_mem₂_mem₁.mpr $ mdp_mem₁ this (iff_not_mem₂_mem₁.mp hψ)
+    contradiction
 
 lemma iff_mem₁_imp : φ ➝ ψ ∈ t.1.1 ↔ (φ ∈ t.1.2 ∨ ψ ∈ t.1.1) := by
-  constructor;
-  . apply of_mem₁_imp;
-  . contrapose;
-    push_neg;
-    intro hφψ;
-    rcases of_mem₂_imp $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩;
-    constructor;
-    . exact iff_not_mem₂_mem₁.mpr hφ;
-    . exact iff_not_mem₁_mem₂.mpr hψ;
+  constructor
+  . apply of_mem₁_imp
+  . contrapose
+    push_neg
+    intro hφψ
+    rcases of_mem₂_imp $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩
+    constructor
+    . exact iff_not_mem₂_mem₁.mpr hφ
+    . exact iff_not_mem₁_mem₂.mpr hψ
 
 lemma iff_mem₁_imp' : φ ➝ ψ ∈ t.1.1 ↔ (φ ∈ t.1.1 → ψ ∈ t.1.1) := by
-  simp [iff_mem₁_imp, or_iff_not_imp_left, iff_not_mem₂_mem₁];
+  simp [iff_mem₁_imp, or_iff_not_imp_left, iff_not_mem₂_mem₁]
 
 lemma iff_mem₂_imp : φ ➝ ψ ∈ t.1.2 ↔ (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
-  constructor;
-  . apply of_mem₂_imp;
-  . contrapose;
-    push_neg;
-    intro hφψ hφ;
-    rcases of_mem₁_imp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ);
-    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction;
-    . exact iff_not_mem₂_mem₁.mpr hψ;
+  constructor
+  . apply of_mem₂_imp
+  . contrapose
+    push_neg
+    intro hφψ hφ
+    rcases of_mem₁_imp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ)
+    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction
+    . exact iff_not_mem₂_mem₁.mpr hψ
 
 
 omit [Encodable α] in
 private lemma of_mem₁_neg : ∼φ ∈ t.1.1 → (φ ∈ t.1.2) := by
-  intro h;
-  rcases of_mem₁_imp h with (hφ | hb);
-  . assumption;
-  . exfalso;
-    exact not_mem₁_falsum hb;
+  intro h
+  rcases of_mem₁_imp h with (hφ | hb)
+  . assumption
+  . exfalso
+    exact not_mem₁_falsum hb
 
 private lemma of_mem₂_neg : ∼φ ∈ t.1.2 → (φ ∈ t.1.1) := by
-  intro h;
-  rcases of_mem₂_imp h with ⟨hφ, hb⟩;
-  exact hφ;
+  intro h
+  rcases of_mem₂_imp h with ⟨hφ, hb⟩
+  exact hφ
 
 lemma iff_mem₁_neg : ∼φ ∈ t.1.1 ↔ φ ∈ t.1.2 := by
-  constructor;
-  . apply of_mem₁_neg;
-  . contrapose;
-    intro h;
+  constructor
+  . apply of_mem₁_neg
+  . contrapose
+    intro h
     exact iff_not_mem₂_mem₁.mpr $ of_mem₂_neg $ iff_not_mem₁_mem₂.mp h
 
 lemma iff_mem₂_neg : ∼φ ∈ t.1.2 ↔ φ ∈ t.1.1 := by
-  constructor;
-  . apply of_mem₂_neg;
-  . contrapose;
-    intro h;
+  constructor
+  . apply of_mem₂_neg
+  . contrapose
+    intro h
     exact iff_not_mem₁_mem₂.mpr $ of_mem₁_neg $ iff_not_mem₂_mem₁.mp h
 
 
@@ -767,50 +767,50 @@ variable [Entailment.K 𝓢]
 
 omit [Entailment.Cl 𝓢] [Entailment.K 𝓢] [DecidableEq α] [Encodable α] in
 private lemma of_mem₁_multibox : (□^[n]φ ∈ t.1.1) → (∀ {t' : MaximalConsistentTableau 𝓢}, (t.1.1.premultibox n ⊆ t'.1.1) → (φ ∈ t'.1.1)) := by
-  intro h t' ht';
-  apply ht';
-  tauto;
+  intro h t' ht'
+  apply ht'
+  tauto
 
 private lemma of_mem₂_multibox : (□^[n]φ ∈ t.1.2) → (∃ t' : MaximalConsistentTableau 𝓢, (t.1.1.premultibox n ⊆ t'.1.1) ∧ (φ ∈ t'.1.2)) := by
-  intro h;
+  intro h
   obtain ⟨t', ht'⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨t.1.1.premultibox n, {φ}⟩) $ by
-    intro Γ Δ hΓ hΔ;
-    by_contra! hC;
-    apply t.consistent (Γ := Γ.multibox n) (Δ := {□^[n]φ}) ?_ ?_;
-    . simp only [Finset.disj_singleton];
-      exact C!_trans collect_multibox_fconj! $ imply_multibox_distribute'! $ C!_trans hC (left_Fdisj!_intro' hΔ);
-    . rintro ψ hψ;
-      simp at hΓ;
-      obtain ⟨ξ, hξ, rfl⟩ := Finset.exists_multibox_of_mem_multibox hψ;
-      simpa using hΓ $ by simpa;
-    . simpa;
-  use t';
-  constructor;
-  . exact ht'.1;
-  . apply ht'.2;
-    tauto;
+    intro Γ Δ hΓ hΔ
+    by_contra! hC
+    apply t.consistent (Γ := Γ.multibox n) (Δ := {□^[n]φ}) ?_ ?_
+    . simp only [Finset.disj_singleton]
+      exact C!_trans collect_multibox_fconj! $ imply_multibox_distribute'! $ C!_trans hC (left_Fdisj!_intro' hΔ)
+    . rintro ψ hψ
+      simp at hΓ
+      obtain ⟨ξ, hξ, rfl⟩ := Finset.exists_multibox_of_mem_multibox hψ
+      simpa using hΓ $ by simpa
+    . simpa
+  use t'
+  constructor
+  . exact ht'.1
+  . apply ht'.2
+    tauto
 
 lemma iff_mem₁_multibox : (□^[n]φ ∈ t.1.1) ↔ (∀ {t' : MaximalConsistentTableau 𝓢}, (t.1.1.premultibox n ⊆ t'.1.1) → (φ ∈ t'.1.1)) := by
-  constructor;
-  . apply of_mem₁_multibox;
-  . contrapose;
-    push_neg;
-    intro hφ;
-    obtain ⟨t', ht'₁, ht'₂⟩ := of_mem₂_multibox $ iff_not_mem₁_mem₂.mp hφ;
-    use t';
-    constructor;
-    . exact ht'₁;
-    . exact iff_not_mem₁_mem₂.mpr ht'₂;
+  constructor
+  . apply of_mem₁_multibox
+  . contrapose
+    push_neg
+    intro hφ
+    obtain ⟨t', ht'₁, ht'₂⟩ := of_mem₂_multibox $ iff_not_mem₁_mem₂.mp hφ
+    use t'
+    constructor
+    . exact ht'₁
+    . exact iff_not_mem₁_mem₂.mpr ht'₂
 
 lemma iff_mem₁_box : (□φ ∈ t.1.1) ↔ (∀ {t' : MaximalConsistentTableau 𝓢}, (t.1.1.prebox ⊆ t'.1.1) → (φ ∈ t'.1.1)) := iff_mem₁_multibox (n := 1)
 
 lemma iff_mem₂_multibox : (□^[n]φ ∈ t.1.2) ↔ (∃ t' : MaximalConsistentTableau 𝓢, (t.1.1.premultibox n ⊆ t'.1.1) ∧ (φ ∈ t'.1.2)) := by
-  constructor;
-  . apply of_mem₂_multibox;
-  . contrapose;
-    push_neg;
-    intro hφ t' ht';
-    exact iff_not_mem₂_mem₁.mpr $ of_mem₁_multibox (iff_not_mem₂_mem₁.mp hφ) ht';
+  constructor
+  . apply of_mem₂_multibox
+  . contrapose
+    push_neg
+    intro hφ t' ht'
+    exact iff_not_mem₂_mem₁.mpr $ of_mem₁_multibox (iff_not_mem₂_mem₁.mp hφ) ht'
 
 lemma iff_mem₂_box : (□φ ∈ t.1.2) ↔ (∃ t' : MaximalConsistentTableau 𝓢, (t.1.1.prebox ⊆ t'.1.1) ∧ (φ ∈ t'.1.2)) := iff_mem₂_multibox (n := 1)
 
@@ -822,45 +822,45 @@ end Saturated
 section
 
 lemma _root_.Set.exists_of_ne {s t : Set α} (h : s ≠ t) : ∃ x, ((x ∈ s ∧ x ∉ t) ∨ (x ∉ s ∧ x ∈ t)) := by
-  revert h;
-  contrapose;
-  push_neg;
-  intro h;
-  ext x;
-  rcases h x with ⟨h₁, h₂⟩;
-  constructor;
-  . assumption;
-  . tauto;
+  revert h
+  contrapose
+  push_neg
+  intro h
+  ext x
+  rcases h x with ⟨h₁, h₂⟩
+  constructor
+  . assumption
+  . tauto
 
 variable [DecidableEq α] [Encodable α]
 
 lemma exists₁₂_of_ne {y z : MaximalConsistentTableau 𝓢} (eyz : y ≠ z) : ∃ φ₂, φ₂ ∈ y.1.1 ∧ φ₂ ∈ z.1.2 := by
-  obtain ⟨ξ, hξ⟩ := Set.exists_of_ne $ ne₁_of_ne eyz;
-  rcases hξ with (⟨hξy₁, hξy₂⟩ | ⟨hξz₁, hξy₂⟩);
-  . use ξ;
-    constructor;
-    . exact hξy₁;
-    . exact iff_not_mem₁_mem₂.mp hξy₂;
-  . use ∼ξ;
-    constructor;
-    . apply iff_mem₁_neg.mpr;
-      exact iff_not_mem₁_mem₂.mp hξz₁;
-    . apply iff_mem₂_neg.mpr;
-      exact hξy₂;
+  obtain ⟨ξ, hξ⟩ := Set.exists_of_ne $ ne₁_of_ne eyz
+  rcases hξ with (⟨hξy₁, hξy₂⟩ | ⟨hξz₁, hξy₂⟩)
+  . use ξ
+    constructor
+    . exact hξy₁
+    . exact iff_not_mem₁_mem₂.mp hξy₂
+  . use ∼ξ
+    constructor
+    . apply iff_mem₁_neg.mpr
+      exact iff_not_mem₁_mem₂.mp hξz₁
+    . apply iff_mem₂_neg.mpr
+      exact hξy₂
 
 lemma exists₂₁_of_ne {y z : MaximalConsistentTableau 𝓢} (eyz : y ≠ z) : ∃ φ₁, φ₁ ∈ y.1.2 ∧ φ₁ ∈ z.1.1 := by
-  obtain ⟨ξ, hξ⟩ := Set.exists_of_ne $ ne₂_of_ne eyz;
-  rcases hξ with (⟨hξy₁, hξy₂⟩ | ⟨hξz₁, hξy₂⟩);
-  . use ξ;
-    constructor;
-    . exact hξy₁;
-    . exact iff_not_mem₂_mem₁.mp hξy₂;
-  . use ∼ξ;
-    constructor;
-    . apply iff_mem₂_neg.mpr;
-      exact iff_not_mem₂_mem₁.mp hξz₁;
-    . apply iff_mem₁_neg.mpr;
-      exact hξy₂;
+  obtain ⟨ξ, hξ⟩ := Set.exists_of_ne $ ne₂_of_ne eyz
+  rcases hξ with (⟨hξy₁, hξy₂⟩ | ⟨hξz₁, hξy₂⟩)
+  . use ξ
+    constructor
+    . exact hξy₁
+    . exact iff_not_mem₂_mem₁.mp hξy₂
+  . use ∼ξ
+    constructor
+    . apply iff_mem₂_neg.mpr
+      exact iff_not_mem₂_mem₁.mp hξz₁
+    . apply iff_mem₁_neg.mpr
+      exact hξy₂
 
 end
 

--- a/Foundation/Modal/VanBentham/StandardTranslation.lean
+++ b/Foundation/Modal/VanBentham/StandardTranslation.lean
@@ -90,38 +90,38 @@ lemma correspondence_satisfies : x ⊧ φ ↔ M ⊧/![x] φ¹ := by
   induction φ using NNFormula.rec' generalizing x with
   | hBox φ ihφ =>
     suffices x ⊧ □φ ↔ ∀ y, x ≺ y → M ⊧/![y] (φ¹) by
-      simp [standardTranslation];
-      convert this;
-      simp;
-    constructor;
-    . intro h y Rxy;
-      exact ihφ.mp $ h y Rxy;
-    . intro h y Rxy;
-      exact ihφ.mpr $ h y Rxy;
+      simp [standardTranslation]
+      convert this
+      simp
+    constructor
+    . intro h y Rxy
+      exact ihφ.mp $ h y Rxy
+    . intro h y Rxy
+      exact ihφ.mpr $ h y Rxy
   | hDia φ ihφ =>
     suffices x ⊧ ◇φ ↔ ∃ y, x ≺ y ∧ M ⊧/![y] (φ¹) by
-      simp [standardTranslation];
-      convert this;
-      simp;
-    constructor;
-    . rintro ⟨y, Rxy, hy⟩;
-      use y;
-      constructor;
-      . assumption;
-      . exact ihφ.mp hy;
-    . rintro ⟨y, Rxy, hy⟩;
-      use y;
-      constructor;
-      . assumption;
-      . exact ihφ.mpr hy;
-  | _ => simp_all [standardTranslation];
+      simp [standardTranslation]
+      convert this
+      simp
+    constructor
+    . rintro ⟨y, Rxy, hy⟩
+      use y
+      constructor
+      . assumption
+      . exact ihφ.mp hy
+    . rintro ⟨y, Rxy, hy⟩
+      use y
+      constructor
+      . assumption
+      . exact ihφ.mpr hy
+  | _ => simp_all [standardTranslation]
 
 /-- BdRV Prop 2.47 (ii) -/
 lemma correspondence_validOnModel : M ⊧ φ ↔ M ⊧ₘ₀ ∀' φ¹ := by
-  suffices M ⊧ φ ↔ ∀ x : M.World, M ⊧/![x] φ¹ by simpa [FirstOrder.models₀_iff];
-  constructor;
-  . intro h x; apply correspondence_satisfies.mp $ h x;
-  . intro h x; exact correspondence_satisfies.mpr $ h x;
+  suffices M ⊧ φ ↔ ∀ x : M.World, M ⊧/![x] φ¹ by simpa [FirstOrder.models₀_iff]
+  constructor
+  . intro h x; apply correspondence_satisfies.mp $ h x
+  . intro h x; exact correspondence_satisfies.mpr $ h x
 
 end Kripke.FirstOrder
 

--- a/Foundation/Propositional/ClassicalSemantics/Basic.lean
+++ b/Foundation/Propositional/ClassicalSemantics/Basic.lean
@@ -35,67 +35,67 @@ instance : Semantics.Tarski (Valuation α) where
 @[simp] protected lemma realize_atom : v ⊧ (.atom a) ↔ v a := iff_of_eq rfl
 
 lemma eq_fml_of_eq_atom {v u : Valuation α} (h : ∀ {a : α}, v a ↔ u a) : (∀ {φ : Formula α}, v ⊧ φ ↔ u ⊧ φ) := by
-  intro φ;
+  intro φ
   induction φ with
-  | hatom => apply h;
+  | hatom => apply h
   | _ => simp [*]
 
 lemma iff_subst_self (s) :
   ((λ a => val v ((.atom a)⟦s⟧)) : Valuation α) ⊧ φ ↔ v ⊧ (φ⟦s⟧) := by
   induction φ with
-  | hatom a => simp [val, models_iff_val];
-  | hfalsum => simp;
+  | hatom a => simp [val, models_iff_val]
+  | hfalsum => simp
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro hφψ hφ;
-      apply ihψ.mp;
-      apply hφψ;
-      apply ihφ.mpr;
-      exact hφ;
-    . intro hφψs hφ;
-      apply ihψ.mpr;
-      apply hφψs;
-      apply ihφ.mp;
-      exact hφ;
+    constructor
+    . intro hφψ hφ
+      apply ihψ.mp
+      apply hφψ
+      apply ihφ.mpr
+      exact hφ
+    . intro hφψs hφ
+      apply ihψ.mpr
+      apply hφψs
+      apply ihφ.mp
+      exact hφ
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . apply ihφ.mp hφ;
-      . apply ihψ.mp hψ;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . apply ihφ.mpr hφ;
-      . apply ihψ.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . apply ihφ.mp hφ
+      . apply ihψ.mp hψ
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . apply ihφ.mpr hφ
+      . apply ihψ.mpr hψ
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . left; apply ihφ.mp hφ;
-      . right; apply ihψ.mp hψ;
-    . rintro (hφ | hψ);
-      . left; apply ihφ.mpr hφ;
-      . right; apply ihψ.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . left; apply ihφ.mp hφ
+      . right; apply ihψ.mp hψ
+    . rintro (hφ | hψ)
+      . left; apply ihφ.mpr hφ
+      . right; apply ihψ.mpr hψ
 
 lemma equiv_of_letterless (hl : φ.letterless) : ∀ v w : Valuation _, v ⊧ φ ↔ w ⊧ φ := by
-  intro v w;
+  intro v w
   induction φ with
-  | hatom a => simp at hl;
-  | hfalsum => simp;
+  | hatom a => simp at hl
+  | hfalsum => simp
   | himp φ ψ ihφ ihψ =>
-    simp only [Formula.letterless] at hl;
-    replace ihφ := ihφ hl.1;
-    replace ihψ := ihψ hl.2;
-    simp_all;
+    simp only [Formula.letterless] at hl
+    replace ihφ := ihφ hl.1
+    replace ihψ := ihψ hl.2
+    simp_all
   | hand φ ψ ihφ ihψ =>
-    simp only [Formula.letterless] at hl;
-    replace ihφ := ihφ hl.1;
-    replace ihψ := ihψ hl.2;
-    simp_all;
+    simp only [Formula.letterless] at hl
+    replace ihφ := ihφ hl.1
+    replace ihψ := ihψ hl.2
+    simp_all
   | hor φ ψ ihφ ihψ =>
-    simp only [Formula.letterless] at hl;
-    replace ihφ := ihφ hl.1;
-    replace ihψ := ihψ hl.2;
-    simp_all;
+    simp only [Formula.letterless] at hl
+    replace ihφ := ihφ hl.1
+    replace ihψ := ihψ hl.2
+    simp_all
 
 end Formula.ClassicalSemantics
 
@@ -113,49 +113,49 @@ variable {v : ClassicalSemantics.Valuation α} {φ ψ : Formula α}
 abbrev Formula.isTautology (φ : Formula α) := Valid (ClassicalSemantics.Valuation α) φ
 
 lemma isTautology_subst_of_isTautology (h : φ.isTautology) : ∀ s, (φ⟦s⟧).isTautology := by
-  intro s v;
-  apply Formula.ClassicalSemantics.iff_subst_self s |>.mp;
-  apply h;
+  intro s v
+  apply Formula.ClassicalSemantics.iff_subst_self s |>.mp
+  apply h
 
 lemma iff_isTautology_and : (φ.isTautology) ∧ (ψ.isTautology) ↔ (φ ⋏ ψ).isTautology := by
-  constructor;
-  . rintro ⟨hφ, hψ⟩ v;
-    have := hφ v;
-    have := hψ v;
-    tauto;
-  . intro h;
-    constructor;
-    . intro v; exact h v |>.1;
-    . intro v; exact h v |>.2;
+  constructor
+  . rintro ⟨hφ, hψ⟩ v
+    have := hφ v
+    have := hψ v
+    tauto
+  . intro h
+    constructor
+    . intro v; exact h v |>.1
+    . intro v; exact h v |>.2
 
 lemma of_isTautology_or : φ.isTautology ∨ ψ.isTautology → (φ ⋎ ψ).isTautology := by
-  rintro (hφ | hψ) v;
-  . left; exact hφ v;
-  . right; exact hψ v;
+  rintro (hφ | hψ) v
+  . left; exact hφ v
+  . right; exact hψ v
 
 lemma of_isTautology_imp₂ : (ψ.isTautology) → (φ ➝ ψ).isTautology := by
-  intro hψ v h;
-  apply hψ;
+  intro hψ v h
+  apply hψ
 
 @[simp]
 lemma isTautology_bot : ¬((⊥ : Formula α).isTautology) := by
-  intro h;
-  have := @h (λ _ => True);
-  simp at this;
+  intro h
+  have := @h (λ _ => True)
+  simp at this
 
 @[simp]
-lemma isTautology_top : (⊤ : Formula α).isTautology := by intro v; simp;
+lemma isTautology_top : (⊤ : Formula α).isTautology := by intro v; simp
 
 lemma isTautology_of_not_neg_isTautology_of_letterless (hl : φ.letterless) : ¬((∼φ).isTautology) → φ.isTautology := by
-  intro h v;
-  obtain ⟨w, hw⟩ : ∃ x : Valuation _, x ⊧ φ := by simpa [Formula.isTautology, Valid] using h;
-  have H := Formula.ClassicalSemantics.equiv_of_letterless hl;
-  apply H w v |>.mp;
-  assumption;
+  intro h v
+  obtain ⟨w, hw⟩ : ∃ x : Valuation _, x ⊧ φ := by simpa [Formula.isTautology, Valid] using h
+  have H := Formula.ClassicalSemantics.equiv_of_letterless hl
+  apply H w v |>.mp
+  assumption
 
 lemma neg_isTautology_of_not_isTautology_of_letterless (hl : φ.letterless) : ¬φ.isTautology → (∼φ).isTautology := by
-  contrapose!;
-  apply isTautology_of_not_neg_isTautology_of_letterless hl;
+  contrapose!
+  apply isTautology_of_not_neg_isTautology_of_letterless hl
 
 end
 

--- a/Foundation/Propositional/ClassicalSemantics/Hilbert.lean
+++ b/Foundation/Propositional/ClassicalSemantics/Hilbert.lean
@@ -11,18 +11,18 @@ open Formula.ClassicalSemantics
 namespace Hilbert.Cl
 
 theorem soundness (h : Hilbert.Cl ⊢! φ) : φ.isTautology := by
-  intro v;
+  intro v
   induction h with
-  | axm _ h => rcases h with (rfl | rfl) <;> tauto;
-  | mdp ihφψ ihφ => exact ihφψ ihφ;
-  | andElimL => simp [Semantics.Realize, val]; tauto;
-  | andElimR => simp [Semantics.Realize, val];
-  | orElim => simp [Semantics.Realize, val]; tauto;
-  | _ => tauto;
+  | axm _ h => rcases h with (rfl | rfl) <;> tauto
+  | mdp ihφψ ihφ => exact ihφψ ihφ
+  | andElimL => simp [Semantics.Realize, val]; tauto
+  | andElimR => simp [Semantics.Realize, val]
+  | orElim => simp [Semantics.Realize, val]; tauto
+  | _ => tauto
 
 lemma not_provable_of_exists_valuation : (∃ v : Valuation _, ¬(v ⊧ φ)) → Hilbert.Cl ⊬ φ := by
-  contrapose!;
-  simpa using soundness;
+  contrapose!
+  simpa using soundness
 
 section Completeness
 
@@ -34,72 +34,72 @@ def canonicalVal (T : SaturatedConsistentTableau Hilbert.Cl) : Valuation ℕ := 
 
 lemma truthlemma {T : SaturatedConsistentTableau Hilbert.Cl} : (canonicalVal T) ⊧ φ ↔ φ ∈ T.1.1 := by
   induction φ with
-  | hatom => simp [canonicalVal];
-  | hfalsum => simp [canonicalVal];
+  | hatom => simp [canonicalVal]
+  | hfalsum => simp [canonicalVal]
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro hφψ;
-      rcases imp_iff_not_or.mp hφψ with hφ | hψ;
-      . apply iff_mem₁_imp.mpr;
-        left;
-        exact iff_not_mem₁_mem₂.mp $ ihφ.not.mp $ hφ;
-      . apply iff_mem₁_imp.mpr;
-        right;
-        exact ihψ.mp hψ;
-    . rintro hφψ hφ;
-      apply ihψ.mpr;
-      rcases iff_mem₁_imp.mp hφψ with hφ | hψ;
-      . have := ihφ.not.mpr $ iff_not_mem₁_mem₂.mpr hφ; contradiction;
-      . exact hψ;
+    constructor
+    . intro hφψ
+      rcases imp_iff_not_or.mp hφψ with hφ | hψ
+      . apply iff_mem₁_imp.mpr
+        left
+        exact iff_not_mem₁_mem₂.mp $ ihφ.not.mp $ hφ
+      . apply iff_mem₁_imp.mpr
+        right
+        exact ihψ.mp hψ
+    . rintro hφψ hφ
+      apply ihψ.mpr
+      rcases iff_mem₁_imp.mp hφψ with hφ | hψ
+      . have := ihφ.not.mpr $ iff_not_mem₁_mem₂.mpr hφ; contradiction
+      . exact hψ
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      apply iff_mem₁_and.mpr;
-      constructor;
-      . apply ihφ.mp hφ;
-      . apply ihψ.mp hψ;
-    . rintro hφψ;
-      rcases iff_mem₁_and.mp hφψ with ⟨hφ, hψ⟩;
-      constructor;
-      . apply ihφ.mpr hφ;
-      . apply ihψ.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      apply iff_mem₁_and.mpr
+      constructor
+      . apply ihφ.mp hφ
+      . apply ihψ.mp hψ
+    . rintro hφψ
+      rcases iff_mem₁_and.mp hφψ with ⟨hφ, hψ⟩
+      constructor
+      . apply ihφ.mpr hφ
+      . apply ihψ.mpr hψ
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . apply iff_mem₁_or.mpr;
-        left;
-        apply ihφ.mp hφ;
-      . apply iff_mem₁_or.mpr;
-        right;
-        apply ihψ.mp hψ;
-    . rintro hφψ;
-      rcases iff_mem₁_or.mp hφψ with hφ | hψ;
-      . left; apply ihφ.mpr hφ;
-      . right; apply ihψ.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . apply iff_mem₁_or.mpr
+        left
+        apply ihφ.mp hφ
+      . apply iff_mem₁_or.mpr
+        right
+        apply ihψ.mp hψ
+    . rintro hφψ
+      rcases iff_mem₁_or.mp hφψ with hφ | hψ
+      . left; apply ihφ.mpr hφ
+      . right; apply ihψ.mpr hψ
 
 theorem completeness : (φ.isTautology) → (Hilbert.Cl ⊢! φ) := by
-  contrapose;
-  intro h;
+  contrapose
+  intro h
   obtain ⟨T, hT⟩ := lindenbaum (𝓢 := Hilbert.Cl) (t₀ := (∅, {φ})) $ by
-    intro Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h;
-    replace hΓ : Γ = ∅ := by simpa using hΓ;
-    subst hΓ;
-    rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
-    . simp only [Finset.coe_eq_empty] at hΔ;
-      subst hΔ;
-      exact of_O! $ (by simpa using hC) ⨀ verum!;
-    . simp only [Finset.coe_eq_singleton] at hΔ;
-      subst hΔ;
-      exact (by simpa using hC) ⨀ verum!;
-  unfold Formula.isTautology Semantics.Valid;
-  push_neg;
-  use (canonicalVal T);
-  apply truthlemma.not.mpr;
-  apply iff_not_mem₁_mem₂.mpr;
-  apply hT.2;
-  tauto;
+    intro Γ Δ hΓ hΔ
+    by_contra hC
+    apply h
+    replace hΓ : Γ = ∅ := by simpa using hΓ
+    subst hΓ
+    rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ)
+    . simp only [Finset.coe_eq_empty] at hΔ
+      subst hΔ
+      exact of_O! $ (by simpa using hC) ⨀ verum!
+    . simp only [Finset.coe_eq_singleton] at hΔ
+      subst hΔ
+      exact (by simpa using hC) ⨀ verum!
+  unfold Formula.isTautology Semantics.Valid
+  push_neg
+  use (canonicalVal T)
+  apply truthlemma.not.mpr
+  apply iff_not_mem₁_mem₂.mpr
+  apply hT.2
+  tauto
 
 theorem iff_isTautology_provable : φ.isTautology ↔ Hilbert.Cl ⊢! φ := ⟨
   completeness,
@@ -107,8 +107,8 @@ theorem iff_isTautology_provable : φ.isTautology ↔ Hilbert.Cl ⊢! φ := ⟨
 ⟩
 
 lemma exists_valuation_of_not_provable : ¬(Hilbert.Cl ⊢! φ) → ∃ v : Valuation _, ¬(v ⊧ φ) := by
-  contrapose!;
-  simpa using completeness;
+  contrapose!
+  simpa using completeness
 
 end Completeness
 
@@ -120,14 +120,14 @@ namespace Logic.Cl
 variable {φ : Formula ℕ}
 
 theorem tautologies : 𝐂𝐥 = { φ | φ.isTautology } := by
-  ext φ;
-  simp [Hilbert.Cl.iff_isTautology_provable, Entailment.theory];
+  ext φ
+  simp [Hilbert.Cl.iff_isTautology_provable, Entailment.theory]
 
 lemma exists_valuation_of_not (h : 𝐂𝐥 ⊬ φ) : ∃ v : Valuation _, ¬(v ⊧ φ) := by
-  apply Hilbert.Cl.exists_valuation_of_not_provable;
-  tauto;
+  apply Hilbert.Cl.exists_valuation_of_not_provable
+  tauto
 
-lemma iff_isTautology : 𝐂𝐥 ⊢! φ ↔ φ.isTautology := by simp [tautologies];
+lemma iff_isTautology : 𝐂𝐥 ⊢! φ ↔ φ.isTautology := by simp [tautologies]
 
 end Logic.Cl
 

--- a/Foundation/Propositional/ClassicalSemantics/ZeroSubst.lean
+++ b/Foundation/Propositional/ClassicalSemantics/ZeroSubst.lean
@@ -12,93 +12,93 @@ open Formula.ClassicalSemantics
 open Classical in
 noncomputable def vfSubst (v : Valuation α) : ZeroSubstitution α := ⟨
     λ a => if v a then ⊤ else ⊥,
-    by intro a; simp [Formula.subst.subst_atom]; split <;> tauto;
+    by intro a; simp [Formula.subst.subst_atom]; split <;> tauto
 ⟩
 
 theorem exists_neg_zeroSubst_of_not_isTautology (h : ¬φ.isTautology)
   : ∃ s : ZeroSubstitution α, Formula.isTautology (∼(φ⟦s.1⟧)) := by
-  unfold Formula.isTautology Valid at h;
-  push_neg at h;
-  obtain ⟨v, hv⟩ := h;
-  use vfSubst v;
-  intro u;
-  apply iff_subst_self _ |>.not.mp;
+  unfold Formula.isTautology Valid at h
+  push_neg at h
+  obtain ⟨v, hv⟩ := h
+  use vfSubst v
+  intro u
+  apply iff_subst_self _ |>.not.mp
   apply eq_fml_of_eq_atom (v := v) ?_ |>.not.mp
-  . exact hv;
-  . intro a;
-    simp [vfSubst];
-    split <;> tauto;
+  . exact hv
+  . intro a
+    simp [vfSubst]
+    split <;> tauto
 
 lemma isTautology_of_forall_zeroSubst : (∀ s : ZeroSubstitution α, ¬(∼(φ⟦s.1⟧)).isTautology) → φ.isTautology := by
-  contrapose!;
-  apply exists_neg_zeroSubst_of_not_isTautology;
+  contrapose!
+  apply exists_neg_zeroSubst_of_not_isTautology
 
 set_option push_neg.use_distrib true in
 lemma isTautology_vfSubst : v ⊧ φ ↔ (φ⟦(vfSubst v).1⟧.isTautology) := by
-  simp only [Formula.isTautology, Valid, Formula.subst.subst_atom];
+  simp only [Formula.isTautology, Valid, Formula.subst.subst_atom]
   induction φ with
   | hatom a =>
-    dsimp [vfSubst];
-    constructor;
-    . intro h w;
-      split;
-      . tauto;
-      . contradiction;
-    . intro h;
-      have := h v;
-      split at this;
-      . assumption;
-      . tauto;
-  | hfalsum => simp;
+    dsimp [vfSubst]
+    constructor
+    . intro h w
+      split
+      . tauto
+      . contradiction
+    . intro h
+      have := h v
+      split at this
+      . assumption
+      . tauto
+  | hfalsum => simp
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro h w hφ;
-      apply ihψ.mp;
-      apply h;
-      apply ihφ.mpr;
-      intro u;
-      apply equiv_of_letterless ?_ u w |>.mpr hφ;
-      exact φ.letterless_zeroSubst;
-    . intro h hφ;
-      apply ihψ.mpr;
-      intro w;
-      apply equiv_of_letterless ?_ v w |>.mp;
-      . apply h;
-        apply ihφ.mp hφ;
-      exact ψ.letterless_zeroSubst;
+    constructor
+    . intro h w hφ
+      apply ihψ.mp
+      apply h
+      apply ihφ.mpr
+      intro u
+      apply equiv_of_letterless ?_ u w |>.mpr hφ
+      exact φ.letterless_zeroSubst
+    . intro h hφ
+      apply ihψ.mpr
+      intro w
+      apply equiv_of_letterless ?_ v w |>.mp
+      . apply h
+        apply ihφ.mp hφ
+      exact ψ.letterless_zeroSubst
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (h | h) w;
-      . left; apply ihφ.mp; assumption;
-      . right; apply ihψ.mp; assumption;
-    . intro h;
-      rcases h v with hφ | hψ;
-      . left;
-        apply ihφ.mpr;
-        intro w;
-        apply equiv_of_letterless ?_ v w |>.mp hφ;
-        exact φ.letterless_zeroSubst;
-      . right;
-        apply ihψ.mpr;
-        intro w;
-        apply equiv_of_letterless ?_ v w |>.mp hψ;
-        exact ψ.letterless_zeroSubst;
+    constructor
+    . rintro (h | h) w
+      . left; apply ihφ.mp; assumption
+      . right; apply ihψ.mp; assumption
+    . intro h
+      rcases h v with hφ | hψ
+      . left
+        apply ihφ.mpr
+        intro w
+        apply equiv_of_letterless ?_ v w |>.mp hφ
+        exact φ.letterless_zeroSubst
+      . right
+        apply ihψ.mpr
+        intro w
+        apply equiv_of_letterless ?_ v w |>.mp hψ
+        exact ψ.letterless_zeroSubst
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩ w;
-      constructor;
-      . apply ihφ.mp hφ;
-      . apply ihψ.mp hψ;
-    . intro h;
-      have := h v;
-      constructor;
-      . apply ihφ.mpr;
-        intro w;
-        apply equiv_of_letterless ?_ v w |>.mp $ h v |>.1;
-        exact φ.letterless_zeroSubst;
-      . apply ihψ.mpr;
-        intro w;
-        apply equiv_of_letterless ?_ v w |>.mp $ h v |>.2;
-        exact ψ.letterless_zeroSubst;
+    constructor
+    . rintro ⟨hφ, hψ⟩ w
+      constructor
+      . apply ihφ.mp hφ
+      . apply ihψ.mp hψ
+    . intro h
+      have := h v
+      constructor
+      . apply ihφ.mpr
+        intro w
+        apply equiv_of_letterless ?_ v w |>.mp $ h v |>.1
+        exact φ.letterless_zeroSubst
+      . apply ihψ.mpr
+        intro w
+        apply equiv_of_letterless ?_ v w |>.mp $ h v |>.2
+        exact ψ.letterless_zeroSubst
 
 end LO.Propositional.ClassicalSemantics

--- a/Foundation/Propositional/ConsistentTableau.lean
+++ b/Foundation/Propositional/ConsistentTableau.lean
@@ -28,97 +28,97 @@ instance : HasSubset (Tableau α) := ⟨λ t₁ t₂ => t₁.1 ⊆ t₂.1 ∧ t�
 @[simp] lemma subset_def {t₁ t₂ : Tableau α} : t₁ ⊆ t₂ ↔ t₁.1 ⊆ t₂.1 ∧ t₁.2 ⊆ t₂.2 := by rfl
 
 @[simp] lemma equality_def {t₁ t₂ : Tableau α} : t₁ = t₂ ↔ t₁.1 = t₂.1 ∧ t₁.2 = t₂.2 := by
-  constructor;
-  . intro h; cases h; simp;
-  . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all;
+  constructor
+  . intro h; cases h; simp
+  . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all
 
 lemma not_mem₂ (hCon : t.Consistent 𝓢) {Γ : Finset (Formula α)} (hΓ : ∀ φ ∈ Γ, φ ∈ t.1) (h : 𝓢 ⊢! Γ.conj ➝ ψ) : ψ ∉ t.2 := by
-  by_contra hC;
-  have : 𝓢 ⊢! Γ.conj ➝ (Finset.disj {ψ}) := by simpa;
-  have : 𝓢 ⊬ Γ.conj ➝ (Finset.disj {ψ}) := hCon (by aesop) (by aesop);
-  contradiction;
+  by_contra hC
+  have : 𝓢 ⊢! Γ.conj ➝ (Finset.disj {ψ}) := by simpa
+  have : 𝓢 ⊬ Γ.conj ➝ (Finset.disj {ψ}) := hCon (by aesop) (by aesop)
+  contradiction
 
 section
 
 variable [Entailment.Int 𝓢]
 
 lemma disjoint_of_consistent (hCon : t.Consistent 𝓢) : Disjoint t.1 t.2 := by
-  by_contra h;
-  obtain ⟨T, hp₁, hp₂, hp⟩ := by simpa [Disjoint] using h;
-  obtain ⟨φ, hp⟩ := Set.nonempty_def.mp $ Set.nonempty_iff_ne_empty.mpr hp;
+  by_contra h
+  obtain ⟨T, hp₁, hp₂, hp⟩ := by simpa [Disjoint] using h
+  obtain ⟨φ, hp⟩ := Set.nonempty_def.mp $ Set.nonempty_iff_ne_empty.mpr hp
   have : 𝓢 ⊬ (Finset.conj {φ}) ➝ (Finset.disj {φ}) := hCon
     (by simp_all only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hp₁; assumption)
-    (by simp_all only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hp₂; assumption);
-  replace this : 𝓢 ⊬ φ ➝ φ := by simpa using this;
-  have : 𝓢 ⊢! φ ➝ φ := C!_id;
-  contradiction;
+    (by simp_all only [Finset.coe_singleton, Set.singleton_subset_iff]; apply hp₂; assumption)
+  replace this : 𝓢 ⊬ φ ➝ φ := by simpa using this
+  have : 𝓢 ⊢! φ ➝ φ := C!_id
+  contradiction
 
 variable [DecidableEq α]
 
 lemma iff_consistent_insert₁
   : Tableau.Consistent 𝓢 ((insert φ T), U) ↔ ∀ {Γ Δ : Finset (Formula α)}, (↑Γ ⊆ T) → (↑Δ ⊆ U) → 𝓢 ⊬ φ ⋏ Γ.conj ➝ Δ.disj := by
-  constructor;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := insert φ Γ) (Δ := Δ) ?_ hΔ;
-    . exact C!_trans (by simp) hC;
-    . simp only [Finset.coe_insert];
-      apply Set.insert_subset_insert;
-      exact hΓ;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    simp_all only;
-    apply h (Γ := Γ.erase φ) (Δ := Δ) (by simpa) hΔ;
-    refine C!_trans ?_ hC;
+  constructor
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := insert φ Γ) (Δ := Δ) ?_ hΔ
+    . exact C!_trans (by simp) hC
+    . simp only [Finset.coe_insert]
+      apply Set.insert_subset_insert
+      exact hΓ
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    simp_all only
+    apply h (Γ := Γ.erase φ) (Δ := Δ) (by simpa) hΔ
+    refine C!_trans ?_ hC
     . exact C!_trans CKFConjinsertFConj! $ CFConj_FConj!_of_subset $ Finset.insert_erase_subset φ Γ
 
 lemma iff_not_consistent_insert₁ : ¬Tableau.Consistent 𝓢 ((insert φ T), U) ↔ ∃ Γ Δ : Finset (Formula α), (↑Γ ⊆ T) ∧ (↑Δ ⊆ U) ∧ 𝓢 ⊢! φ ⋏ Γ.conj ➝ Δ.disj := by
-  constructor;
-  . contrapose!; apply iff_consistent_insert₁.mpr;
-  . contrapose!; apply iff_consistent_insert₁.mp;
+  constructor
+  . contrapose!; apply iff_consistent_insert₁.mpr
+  . contrapose!; apply iff_consistent_insert₁.mp
 
 lemma iff_consistent_insert₂ : Tableau.Consistent 𝓢 (T, (insert φ U)) ↔ ∀ {Γ Δ : Finset (Formula α)}, (↑Γ ⊆ T) → (↑Δ ⊆ U) → 𝓢 ⊬ Γ.conj ➝ φ ⋎ Δ.disj := by
-  constructor;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := Γ) (Δ := insert φ Δ) hΓ ?_;
-    . exact C!_trans hC $ by simp;
-    . simp only [Finset.coe_insert];
-      apply Set.insert_subset_insert;
-      exact hΔ;
-  . intro h Γ Δ hΓ hΔ;
-    by_contra hC;
-    apply h (Γ := Γ) (Δ := Δ.erase φ) hΓ (by simpa);
+  constructor
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := Γ) (Δ := insert φ Δ) hΓ ?_
+    . exact C!_trans hC $ by simp
+    . simp only [Finset.coe_insert]
+      apply Set.insert_subset_insert
+      exact hΔ
+  . intro h Γ Δ hΓ hΔ
+    by_contra hC
+    apply h (Γ := Γ) (Δ := Δ.erase φ) hΓ (by simpa)
     exact C!_trans hC $ by
-      refine C!_trans ?_ $ CinsertFDisjAFDisj! (𝓢 := 𝓢) (Γ := Δ.erase φ);
-      apply CDisj₂Disj₂_of_subset;
-      simp only [Finset.mem_toList, Finset.mem_insert, Finset.mem_erase, ne_eq];
-      tauto;
+      refine C!_trans ?_ $ CinsertFDisjAFDisj! (𝓢 := 𝓢) (Γ := Δ.erase φ)
+      apply CDisj₂Disj₂_of_subset
+      simp only [Finset.mem_toList, Finset.mem_insert, Finset.mem_erase, ne_eq]
+      tauto
 
 lemma iff_not_consistent_insert₂ : ¬Tableau.Consistent 𝓢 (T, (insert φ U)) ↔ ∃ Γ Δ : Finset (Formula α), (↑Γ ⊆ T) ∧ (↑Δ ⊆ U) ∧ 𝓢 ⊢! Γ.conj ➝ φ ⋎ Δ.disj := by
-  constructor;
-  . contrapose!; apply iff_consistent_insert₂.mpr;
-  . contrapose!; apply iff_consistent_insert₂.mp;
+  constructor
+  . contrapose!; apply iff_consistent_insert₂.mpr
+  . contrapose!; apply iff_consistent_insert₂.mp
 
 section Consistent
 
 variable {t : Tableau α}
 
 lemma consistent_either (hCon : t.Consistent 𝓢) (φ : Formula α) : Tableau.Consistent 𝓢 ((insert φ t.1), t.2) ∨ Tableau.Consistent 𝓢 (t.1, (insert φ t.2)) := by
-  by_contra hC;
-  push_neg at hC;
-  have ⟨hC₁, hC₂⟩ := hC;
+  by_contra hC
+  push_neg at hC
+  have ⟨hC₁, hC₂⟩ := hC
 
-  obtain ⟨Γ₁, Δ₁, hΓ₁, hΔ₁, h₁⟩ := iff_not_consistent_insert₁.mp hC₁;
-  replace h₁ := left_K!_symm h₁;
+  obtain ⟨Γ₁, Δ₁, hΓ₁, hΔ₁, h₁⟩ := iff_not_consistent_insert₁.mp hC₁
+  replace h₁ := left_K!_symm h₁
 
-  obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_consistent_insert₂.mp hC₂;
-  apply @hCon (Γ := Γ₁ ∪ Γ₂) (Δ := Δ₁ ∪ Δ₂) ?_ ?_;
-  . exact C!_trans (C!_trans (by simp) (cut! h₁ h₂)) (by simp);
-  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto;
-  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto;
+  obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_consistent_insert₂.mp hC₂
+  apply @hCon (Γ := Γ₁ ∪ Γ₂) (Δ := Δ₁ ∪ Δ₂) ?_ ?_
+  . exact C!_trans (C!_trans (by simp) (cut! h₁ h₂)) (by simp)
+  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto
+  . simp only [Finset.coe_union, Set.union_subset_iff]; tauto
 
-  -- have : 𝓢 ⊢! ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) $ C!_trans (cut! h₁ h₂) (K!_right EDisj₂AppendADisj₂Disj₂!);
+  -- have : 𝓢 ⊢! ⋀(Γ₁ ++ Γ₂) ➝ ⋁(Δ₁ ++ Δ₂) := C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) $ C!_trans (cut! h₁ h₂) (K!_right EDisj₂AppendADisj₂Disj₂!)
 
 end Consistent
 
@@ -133,62 +133,62 @@ variable [Entailment.Int 𝓢]
 variable {t : Tableau α}
 
 lemma mem₂_of_not_mem₁ (hMat : Saturated t) : φ ∉ t.1 → φ ∈ t.2 := by
-  intro h;
+  intro h
   cases (hMat φ) with
-  | inl h' => exact absurd h' h;
-  | inr _ => assumption;
+  | inl h' => exact absurd h' h
+  | inr _ => assumption
 
 lemma mem₁_of_not_mem₂ (hMat : Saturated t) : φ ∉ t.2 → φ ∈ t.1 := by
-  intro h;
+  intro h
   cases (hMat φ) with
-  | inl _ => assumption;
-  | inr h' => exact absurd h' h;
+  | inl _ => assumption
+  | inr h' => exact absurd h' h
 
 
 lemma not_mem₁_iff_mem₂ (hCon : t.Consistent 𝓢) (hMat : Saturated t) : φ ∉ t.1 ↔ φ ∈ t.2 := by
-  constructor;
-  . apply mem₂_of_not_mem₁ hMat;
-  . apply Set.disjoint_right.mp $ disjoint_of_consistent hCon;
+  constructor
+  . apply mem₂_of_not_mem₁ hMat
+  . apply Set.disjoint_right.mp $ disjoint_of_consistent hCon
 
 lemma not_mem₂_iff_mem₁ (hCon : t.Consistent 𝓢) (hMat : Saturated t) : φ ∉ t.2 ↔ φ ∈ t.1 := by
-  constructor;
-  . apply mem₁_of_not_mem₂ hMat;
-  . apply Set.disjoint_left.mp $ disjoint_of_consistent hCon;
+  constructor
+  . apply mem₁_of_not_mem₂ hMat
+  . apply Set.disjoint_left.mp $ disjoint_of_consistent hCon
 
 lemma saturated_duality
   {t₁ t₂ : Tableau α}
   (ct₁ : t₁.Consistent 𝓢) (ct₂ : t₂.Consistent 𝓢)
   (st₁ : Saturated t₁) (st₂ : Saturated t₂)
   : t₁.1 = t₂.1 ↔ t₁.2 = t₂.2 := by
-  constructor;
-  . intro h;
-    apply Set.eq_of_subset_of_subset;
-    . intro φ hp;
-      apply not_mem₁_iff_mem₂ ct₂ st₂ |>.mp; rw [←h];
-      apply not_mem₁_iff_mem₂ ct₁ st₁ |>.mpr hp;
-    . intro φ hp;
-      apply not_mem₁_iff_mem₂ ct₁ st₁ |>.mp; rw [h];
-      apply not_mem₁_iff_mem₂ ct₂ st₂ |>.mpr hp;
-  . intro h;
-    apply Set.eq_of_subset_of_subset;
-    . intro φ hp;
-      apply not_mem₂_iff_mem₁ ct₂ st₂ |>.mp; rw [←h];
-      apply not_mem₂_iff_mem₁ ct₁ st₁ |>.mpr hp;
-    . intro φ hp;
-      apply not_mem₂_iff_mem₁ ct₁ st₁ |>.mp; rw [h];
-      apply not_mem₂_iff_mem₁ ct₂ st₂ |>.mpr hp;
+  constructor
+  . intro h
+    apply Set.eq_of_subset_of_subset
+    . intro φ hp
+      apply not_mem₁_iff_mem₂ ct₂ st₂ |>.mp; rw [←h]
+      apply not_mem₁_iff_mem₂ ct₁ st₁ |>.mpr hp
+    . intro φ hp
+      apply not_mem₁_iff_mem₂ ct₁ st₁ |>.mp; rw [h]
+      apply not_mem₁_iff_mem₂ ct₂ st₂ |>.mpr hp
+  . intro h
+    apply Set.eq_of_subset_of_subset
+    . intro φ hp
+      apply not_mem₂_iff_mem₁ ct₂ st₂ |>.mp; rw [←h]
+      apply not_mem₂_iff_mem₁ ct₁ st₁ |>.mpr hp
+    . intro φ hp
+      apply not_mem₂_iff_mem₁ ct₁ st₁ |>.mp; rw [h]
+      apply not_mem₂_iff_mem₁ ct₂ st₂ |>.mpr hp
 
 end Saturated
 
 lemma emptyset_consistent [Entailment.Int 𝓢] [DecidableEq α] [H_consis : Entailment.Consistent 𝓢] : Consistent 𝓢 ⟨∅, ∅⟩ := by
-  intro Γ Δ hΓ hΔ;
-  by_contra hC;
-  obtain ⟨ψ, hψ⟩ := H_consis.exists_unprovable;
-  apply hψ;
-  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ;
-  subst hΓ hΔ;
-  simp only [Finset.conj_empty, Finset.disj_empty] at hC;
-  exact of_O! (hC ⨀ C!_id);
+  intro Γ Δ hΓ hΔ
+  by_contra hC
+  obtain ⟨ψ, hψ⟩ := H_consis.exists_unprovable
+  apply hψ
+  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ
+  subst hΓ hΔ
+  simp only [Finset.conj_empty, Finset.disj_empty] at hC
+  exact of_O! (hC ⨀ C!_id)
 
 section lindenbaum
 
@@ -217,120 +217,120 @@ local notation:max t"∞" => lindenbaum_maximal 𝓢 t
 variable {𝓢}
 
 lemma next_parametericConsistent [Entailment.Int 𝓢] (consistent : t.Consistent 𝓢) (φ : Formula α) : (t.lindenbaum_next 𝓢 φ).Consistent 𝓢 := by
-  dsimp [lindenbaum_next];
-  split;
-  . simpa;
-  . rcases (consistent_either consistent φ) with (h | h);
-    . contradiction;
-    . assumption;
+  dsimp [lindenbaum_next]
+  split
+  . simpa
+  . rcases (consistent_either consistent φ) with (h | h)
+    . contradiction
+    . assumption
 
 variable [Encodable α]
 
 lemma lindenbaum_next_indexed_parametricConsistent_succ [Entailment.Int 𝓢] {i : ℕ} : Consistent 𝓢 t[i] → Consistent 𝓢 t[i + 1] := by
-  dsimp [lindenbaum_next_indexed];
-  split;
-  . intro h;
-    apply next_parametericConsistent (𝓢 := 𝓢);
-    assumption;
-  . tauto;
+  dsimp [lindenbaum_next_indexed]
+  split
+  . intro h
+    apply next_parametericConsistent (𝓢 := 𝓢)
+    assumption
+  . tauto
 
 lemma mem_lindenbaum_next_indexed (t) (φ : Formula α) : φ ∈ t[(encode φ) + 1].1 ∨ φ ∈ t[(encode φ) + 1].2 := by
-  simp only [lindenbaum_next_indexed, encodek, lindenbaum_next];
-  split;
-  . left; tauto;
-  . right; tauto;
+  simp only [lindenbaum_next_indexed, encodek, lindenbaum_next]
+  split
+  . left; tauto
+  . right; tauto
 
 lemma lindenbaum_next_indexed_parametricConsistent [Entailment.Int 𝓢] (consistent : t.Consistent 𝓢) (i : ℕ) : t[i].Consistent 𝓢 := by
   induction i with
-  | zero => simpa;
-  | succ i ih => apply lindenbaum_next_indexed_parametricConsistent_succ; assumption;
+  | zero => simpa
+  | succ i ih => apply lindenbaum_next_indexed_parametricConsistent_succ; assumption
 
 variable {m n : ℕ}
 
 lemma lindenbaum_next_indexed_subset₁_of_lt (h : m ≤ n) : t[m].1 ⊆ t[n].1 := by
   induction h with
-  | refl => simp;
+  | refl => simp
   | step h ih =>
-    simp [lindenbaum_next_indexed, lindenbaum_next];
-    split;
-    . split <;> tauto;
-    . tauto;
+    simp [lindenbaum_next_indexed, lindenbaum_next]
+    split
+    . split <;> tauto
+    . tauto
 
 lemma lindenbaum_next_indexed_subset₂_of_lt (h : m ≤ n) : t[m].2 ⊆ t[n].2 := by
   induction h with
-  | refl => simp;
+  | refl => simp
   | step h ih =>
-    simp [lindenbaum_next_indexed, lindenbaum_next];
-    split;
-    . split <;> tauto;
-    . tauto;
+    simp [lindenbaum_next_indexed, lindenbaum_next]
+    split
+    . split <;> tauto
+    . tauto
 
 lemma exists_list_lindenbaum_index₁ {Γ : List _} (hΓ : ↑Γ.toFinset ⊆ ⋃ i, t[i].1): ∃ m, ∀ φ ∈ Γ, φ ∈ t[m].1 := by
   induction Γ with
-  | nil => simp;
+  | nil => simp
   | cons φ Γ ih =>
-    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp];
-    replace hΓ := Set.insert_subset_iff.mp hΓ;
-    obtain ⟨_, ⟨i, _⟩, _⟩ := hΓ.1;
-    obtain ⟨m, hm⟩ := ih hΓ.2;
-    use (i + m);
-    constructor;
-    . apply lindenbaum_next_indexed_subset₁_of_lt (m := i);
-      . omega;
-      . simp_all;
-    . intro ψ hq;
-      exact lindenbaum_next_indexed_subset₁_of_lt (by simp) $ hm ψ hq;
+    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp]
+    replace hΓ := Set.insert_subset_iff.mp hΓ
+    obtain ⟨_, ⟨i, _⟩, _⟩ := hΓ.1
+    obtain ⟨m, hm⟩ := ih hΓ.2
+    use (i + m)
+    constructor
+    . apply lindenbaum_next_indexed_subset₁_of_lt (m := i)
+      . omega
+      . simp_all
+    . intro ψ hq
+      exact lindenbaum_next_indexed_subset₁_of_lt (by simp) $ hm ψ hq
 
 lemma exists_finset_lindenbaum_index₁ {Γ : Finset _} (hΓ : ↑Γ ⊆ ⋃ i, t[i].1): ∃ m, ∀ φ ∈ Γ, φ ∈ t[m].1 := by
-  obtain ⟨m, hΓ⟩ := exists_list_lindenbaum_index₁ (Γ := Γ.toList) (t := t) (by simpa);
-  use m;
-  intro φ hφ;
-  apply hΓ;
-  simpa;
+  obtain ⟨m, hΓ⟩ := exists_list_lindenbaum_index₁ (Γ := Γ.toList) (t := t) (by simpa)
+  use m
+  intro φ hφ
+  apply hΓ
+  simpa
 
 lemma exists_list_lindenbaum_index₂ {Δ : List _} (hΔ : ↑Δ.toFinset ⊆ ⋃ i, t[i].2) : ∃ n, ∀ φ ∈ Δ, φ ∈ t[n].2 := by
   induction Δ with
-  | nil => simp;
+  | nil => simp
   | cons φ Δ ih =>
-    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp];
-    replace hΔ := Set.insert_subset_iff.mp hΔ;
-    obtain ⟨_, ⟨i, _⟩, _⟩ := hΔ.1;
-    obtain ⟨n, hn⟩ := ih hΔ.2;
-    use (i + n);
-    constructor;
-    . apply lindenbaum_next_indexed_subset₂_of_lt (m := i);
-      . omega;
+    simp_all only [List.coe_toFinset, List.toFinset_cons, Finset.coe_insert, List.mem_cons, forall_eq_or_imp]
+    replace hΔ := Set.insert_subset_iff.mp hΔ
+    obtain ⟨_, ⟨i, _⟩, _⟩ := hΔ.1
+    obtain ⟨n, hn⟩ := ih hΔ.2
+    use (i + n)
+    constructor
+    . apply lindenbaum_next_indexed_subset₂_of_lt (m := i)
+      . omega
       . simp_all
-    . intro ψ hq;
-      exact lindenbaum_next_indexed_subset₂_of_lt (by simp) $ hn ψ hq;
+    . intro ψ hq
+      exact lindenbaum_next_indexed_subset₂_of_lt (by simp) $ hn ψ hq
 
 lemma exists_finset_lindenbaum_index₂ {Δ : Finset _} (hΓ : ↑Δ ⊆ ⋃ i, t[i].2) : ∃ n, ∀ φ ∈ Δ, φ ∈ t[n].2 := by
-  obtain ⟨m, hΔ⟩ := exists_list_lindenbaum_index₂ (Δ := Δ.toList) (𝓢 := 𝓢) (t := t) (by simpa);
-  use m;
-  intro φ hφ;
-  apply hΔ;
-  simpa;
+  obtain ⟨m, hΔ⟩ := exists_list_lindenbaum_index₂ (Δ := Δ.toList) (𝓢 := 𝓢) (t := t) (by simpa)
+  use m
+  intro φ hφ
+  apply hΔ
+  simpa
 
 lemma exists_parametricConsistent_saturated_tableau [Entailment.Int 𝓢] (hCon : t.Consistent 𝓢) : ∃ u, t ⊆ u ∧ (Tableau.Consistent 𝓢 u) ∧ (Saturated u) := by
-  use t∞;
-  refine ⟨?subset, ?consistent, ?saturated⟩;
-  case subset => constructor <;> apply Set.subset_iUnion_of_subset 0 (by simp);
+  use t∞
+  refine ⟨?subset, ?consistent, ?saturated⟩
+  case subset => constructor <;> apply Set.subset_iUnion_of_subset 0 (by simp)
   case saturated =>
-    intro φ;
-    simp only [lindenbaum_maximal, Set.mem_iUnion];
-    rcases mem_lindenbaum_next_indexed (𝓢 := 𝓢) t φ with (h | h);
-    . left; use (encode φ + 1);
-    . right; use (encode φ + 1);
+    intro φ
+    simp only [lindenbaum_maximal, Set.mem_iUnion]
+    rcases mem_lindenbaum_next_indexed (𝓢 := 𝓢) t φ with (h | h)
+    . left; use (encode φ + 1)
+    . right; use (encode φ + 1)
   case consistent =>
-    intro Γ Δ hΓ hΔ;
-    simp_all only [lindenbaum_maximal];
-    obtain ⟨m, hΓ⟩ := exists_finset_lindenbaum_index₁ hΓ;
-    obtain ⟨n, hΔ⟩ := exists_finset_lindenbaum_index₂ hΔ;
-    rcases (lt_trichotomy m n) with hm | hmn | hn;
-    . exact lindenbaum_next_indexed_parametricConsistent hCon n (by intro φ hp; exact lindenbaum_next_indexed_subset₁_of_lt hm.le $ hΓ φ (by simpa)) hΔ;
-    . subst hmn;
-      exact lindenbaum_next_indexed_parametricConsistent hCon m hΓ hΔ;
-    . exact lindenbaum_next_indexed_parametricConsistent hCon m hΓ (by intro φ hp; exact lindenbaum_next_indexed_subset₂_of_lt hn.le $ hΔ φ hp);
+    intro Γ Δ hΓ hΔ
+    simp_all only [lindenbaum_maximal]
+    obtain ⟨m, hΓ⟩ := exists_finset_lindenbaum_index₁ hΓ
+    obtain ⟨n, hΔ⟩ := exists_finset_lindenbaum_index₂ hΔ
+    rcases (lt_trichotomy m n) with hm | hmn | hn
+    . exact lindenbaum_next_indexed_parametricConsistent hCon n (by intro φ hp; exact lindenbaum_next_indexed_subset₁_of_lt hm.le $ hΓ φ (by simpa)) hΔ
+    . subst hmn
+      exact lindenbaum_next_indexed_parametricConsistent hCon m hΓ hΔ
+    . exact lindenbaum_next_indexed_parametricConsistent hCon m hΓ (by intro φ hp; exact lindenbaum_next_indexed_subset₂_of_lt hn.le $ hΔ φ hp)
 
 protected alias lindenbaum := exists_parametricConsistent_saturated_tableau
 
@@ -353,8 +353,8 @@ lemma saturated (t : SaturatedConsistentTableau 𝓢) : Saturated t.1 := t.2.1
 variable {t₀ : Tableau α} {φ ψ : Formula α}
 
 lemma lindenbaum [Entailment.Int 𝓢] [Encodable α] (hCon : t₀.Consistent 𝓢) : ∃ (t : SaturatedConsistentTableau 𝓢), t₀ ⊆ t.1 := by
-  obtain ⟨t, ht, hCon, hMax⟩ := Tableau.lindenbaum hCon;
-  exact ⟨⟨t, hMax, hCon⟩, ht⟩;
+  obtain ⟨t, ht, hCon, hMax⟩ := Tableau.lindenbaum hCon
+  exact ⟨⟨t, hMax, hCon⟩, ht⟩
 
 instance [Entailment.Consistent 𝓢] [Entailment.Int 𝓢] [DecidableEq α] [Encodable α] : Nonempty (SaturatedConsistentTableau 𝓢) := ⟨lindenbaum Tableau.emptyset_consistent |>.choose⟩
 
@@ -373,11 +373,11 @@ lemma iff_not_mem₂_mem₁ : φ ∉ t.1.2 ↔ φ ∈ t.1.1 := Tableau.not_mem�
 lemma saturated_duality: t₁.1.1 = t₂.1.1 ↔ t₁.1.2 = t₂.1.2 := Tableau.saturated_duality t₁.consistent t₂.consistent t₁.saturated t₂.saturated
 
 lemma equality_of₁ (e₁ : t₁.1.1 = t₂.1.1) : t₁ = t₂ := by
-  have e := Tableau.equality_def.mpr ⟨e₁, (saturated_duality.mp e₁)⟩;
+  have e := Tableau.equality_def.mpr ⟨e₁, (saturated_duality.mp e₁)⟩
   calc
-    t₁ = ⟨t₁.1, t₁.saturated, t₁.consistent⟩ := by rfl;
-    _  = ⟨t₂.1, t₂.saturated, t₂.consistent⟩ := by simp [e];
-    _  = t₂                                  := by rfl;
+    t₁ = ⟨t₁.1, t₁.saturated, t₁.consistent⟩ := by rfl
+    _  = ⟨t₂.1, t₂.saturated, t₂.consistent⟩ := by simp [e]
+    _  = t₂                                  := by rfl
 
 lemma equality_of₂ (e₂ : t₁.1.2 = t₂.1.2) : t₁ = t₂ := equality_of₁ $ saturated_duality.mpr e₂
 
@@ -387,49 +387,49 @@ section
 variable [DecidableEq α] [Encodable α]
 
 lemma iff_provable_include₁ : T *⊢[𝓢]! φ ↔ ∀ t : SaturatedConsistentTableau 𝓢, (T ⊆ t.1.1) → φ ∈ t.1.1 := by
-  constructor;
-  . intro h t hT;
-    by_contra hφ;
-    replace hφ := iff_not_mem₁_mem₂.mp hφ;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply t.consistent (Γ := Γ.toFinset) (Δ := {φ}) ?_ ?_;
-    . apply FConj_DT.mpr;
-      simpa using iff_FiniteContext_Context.mp hΓ₂;
-    . intro ψ hψ;
-      apply hT;
-      apply hΓ₁;
-      simpa using hψ;
-    . simpa;
-  . intro h;
-    by_contra! hC;
+  constructor
+  . intro h t hT
+    by_contra hφ
+    replace hφ := iff_not_mem₁_mem₂.mp hφ
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h
+    apply t.consistent (Γ := Γ.toFinset) (Δ := {φ}) ?_ ?_
+    . apply FConj_DT.mpr
+      simpa using iff_FiniteContext_Context.mp hΓ₂
+    . intro ψ hψ
+      apply hT
+      apply hΓ₁
+      simpa using hψ
+    . simpa
+  . intro h
+    by_contra! hC
     obtain ⟨t, ht⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨T, {φ}⟩) $ by
-      intro Γ Δ hΓ hΔ;
-      revert hC;
-      contrapose;
-      simp only [not_not];
-      intro h;
-      replace h : T *⊢[𝓢]! Δ.disj := Context.weakening! (by simpa using hΓ) $ FConj_DT.mp h;
-      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
-      . simp only [Finset.coe_eq_empty] at hΔ;
-        subst hΔ;
-        exact of_O! $ by simpa using h;
-      . simp only [Finset.coe_eq_singleton] at hΔ;
-        subst hΔ;
-        simpa using h;
-    apply iff_not_mem₂_mem₁.mpr $ h t ht.1;
-    apply ht.2;
-    simp;
+      intro Γ Δ hΓ hΔ
+      revert hC
+      contrapose
+      simp only [not_not]
+      intro h
+      replace h : T *⊢[𝓢]! Δ.disj := Context.weakening! (by simpa using hΓ) $ FConj_DT.mp h
+      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ)
+      . simp only [Finset.coe_eq_empty] at hΔ
+        subst hΔ
+        exact of_O! $ by simpa using h
+      . simp only [Finset.coe_eq_singleton] at hΔ
+        subst hΔ
+        simpa using h
+    apply iff_not_mem₂_mem₁.mpr $ h t ht.1
+    apply ht.2
+    simp
 
 lemma iff_provable_include₁_finset {Γ : Finset (Formula α)} : ↑Γ *⊢[𝓢]! φ ↔ ∀ t : SaturatedConsistentTableau 𝓢, (↑Γ ⊆ t.1.1) → φ ∈ t.1.1 := iff_provable_include₁
 
 lemma iff_provable_mem₁ : 𝓢 ⊢! φ ↔ ∀ t : SaturatedConsistentTableau 𝓢, φ ∈ t.1.1 := by
-  constructor;
-  . intro h t;
-    apply iff_provable_include₁ (T := ∅) |>.mp;
-    . exact Context.of! h;
-    . simp;
-  . intro h;
-    exact Context.emptyPrf! $ iff_provable_include₁.mpr $ by tauto;
+  constructor
+  . intro h t
+    apply iff_provable_include₁ (T := ∅) |>.mp
+    . exact Context.of! h
+    . simp
+  . intro h
+    exact Context.emptyPrf! $ iff_provable_include₁.mpr $ by tauto
 
 end
 
@@ -440,215 +440,215 @@ end
 section Saturated
 
 lemma mdp_mem₁_provable (h : 𝓢 ⊢! φ ➝ ψ) (hp₁ : φ ∈ t.1.1) : ψ ∈ t.1.1 := by
-  apply iff_not_mem₂_mem₁.mp;
-  by_contra hq₂;
-  apply by simpa using t.consistent (Γ := {φ}) (Δ := {ψ}) (by simpa) (by simpa);
-  exact h;
+  apply iff_not_mem₂_mem₁.mp
+  by_contra hq₂
+  apply by simpa using t.consistent (Γ := {φ}) (Δ := {ψ}) (by simpa) (by simpa)
+  exact h
 
 lemma mdp_mem₂_provable (h : 𝓢 ⊢! φ ➝ ψ) (hp₁ : ψ ∈ t.1.2) : φ ∈ t.1.2 := by
-  by_contra hq₂;
-  have := iff_not_mem₂_mem₁.mpr $ mdp_mem₁_provable h $ iff_not_mem₂_mem₁.mp hq₂;
-  contradiction;
+  by_contra hq₂
+  have := iff_not_mem₂_mem₁.mpr $ mdp_mem₁_provable h $ iff_not_mem₂_mem₁.mp hq₂
+  contradiction
 
 @[simp] lemma mem₁_verum : ⊤ ∈ t.1.1 := by
-  apply iff_not_mem₂_mem₁.mp;
-  by_contra hC;
-  apply by simpa using t.consistent (Γ := ∅) (Δ := {⊤}) (by simp) (by simpa);
-  simp;
+  apply iff_not_mem₂_mem₁.mp
+  by_contra hC
+  apply by simpa using t.consistent (Γ := ∅) (Δ := {⊤}) (by simp) (by simpa)
+  simp
 
 @[simp] lemma not_mem₁_falsum : ⊥ ∉ t.1.1 := by
-  by_contra hC;
-  have : 𝓢 ⊬ ⊥ ➝ ⊥ := by simpa using t.consistent (Γ := {⊥}) (Δ := ∅) (by simpa) (by simp);
-  apply this;
-  simp;
+  by_contra hC
+  have : 𝓢 ⊬ ⊥ ➝ ⊥ := by simpa using t.consistent (Γ := {⊥}) (Δ := ∅) (by simpa) (by simp)
+  apply this
+  simp
 
 @[simp] lemma mem₂_falsum : ⊥ ∈ t.1.2 := iff_not_mem₁_mem₂.mp not_mem₁_falsum
 
 lemma mem₁_of_provable : 𝓢 ⊢! φ → φ ∈ t.1.1 := by
-  intro h;
-  exact mdp_mem₁_provable (C!_of_conseq! h) mem₁_verum;
+  intro h
+  exact mdp_mem₁_provable (C!_of_conseq! h) mem₁_verum
 
 lemma mdp_mem₁ [DecidableEq α] (h : φ ➝ ψ ∈ t.1.1) (hp : φ ∈ t.1.1) : ψ ∈ t.1.1 := by
-  apply iff_not_mem₂_mem₁.mp;
-  by_contra hC;
-  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ (by simpa);
-  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    tauto;
+  apply iff_not_mem₂_mem₁.mp
+  by_contra hC
+  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ (by simpa)
+  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    tauto
 
 lemma iff_mem₁_and [DecidableEq α] : φ ⋏ ψ ∈ t.1.1 ↔ φ ∈ t.1.1 ∧ ψ ∈ t.1.1 := by
-  constructor;
+  constructor
   . intro h; constructor <;> exact mdp_mem₁_provable (by simp) h
-  . rintro ⟨hp, hq⟩;
-    apply iff_not_mem₂_mem₁.mp;
-    by_contra hC;
-    apply t.consistent (Γ := {φ, ψ}) (Δ := {φ ⋏ ψ}) ?_ (by simp_all);
-    . apply CFConj_CDisj!_of_K_intro (φ := φ) (ψ := ψ) <;> simp;
-    . simp only [Finset.coe_insert, Finset.coe_singleton];
-      apply Set.doubleton_subset.mpr;
-      tauto;
+  . rintro ⟨hp, hq⟩
+    apply iff_not_mem₂_mem₁.mp
+    by_contra hC
+    apply t.consistent (Γ := {φ, ψ}) (Δ := {φ ⋏ ψ}) ?_ (by simp_all)
+    . apply CFConj_CDisj!_of_K_intro (φ := φ) (ψ := ψ) <;> simp
+    . simp only [Finset.coe_insert, Finset.coe_singleton]
+      apply Set.doubleton_subset.mpr
+      tauto
 
 lemma iff_mem₁_conj₂ [DecidableEq α] {Γ : List (Formula α)} : ⋀Γ ∈ t.1.1 ↔ ∀ φ ∈ Γ, φ ∈ t.1.1 := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ Γ_nil ih =>
-    simp only [(List.conj₂_cons_nonempty Γ_nil), List.mem_cons];
-    constructor;
-    . rintro h φ (rfl | hp);
-      . exact iff_mem₁_and.mp h |>.1;
-      . exact ih.mp (iff_mem₁_and.mp h |>.2) _ hp;
-    . intro h;
-      apply iff_mem₁_and.mpr;
-      simp_all;
-  | _ => simp;
+    simp only [(List.conj₂_cons_nonempty Γ_nil), List.mem_cons]
+    constructor
+    . rintro h φ (rfl | hp)
+      . exact iff_mem₁_and.mp h |>.1
+      . exact ih.mp (iff_mem₁_and.mp h |>.2) _ hp
+    . intro h
+      apply iff_mem₁_and.mpr
+      simp_all
+  | _ => simp
 
 lemma iff_mem₁_fconj [DecidableEq α] {Γ : Finset (Formula α)} : Γ.conj ∈ t.1.1 ↔ ↑Γ ⊆ t.1.1 := by
-  constructor;
-  . intro h φ hφ;
-    apply iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mp;
-    . apply mdp_mem₁_provable ?_ h; simp;
-    . simpa;
-  . intro h;
+  constructor
+  . intro h φ hφ
+    apply iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mp
+    . apply mdp_mem₁_provable ?_ h; simp
+    . simpa
+  . intro h
     apply mdp_mem₁_provable ?_ $ iff_mem₁_conj₂ (Γ := Γ.toList) (t := t) |>.mpr $ by
-      intro φ hφ;
-      apply h;
-      simp_all;
-    simp;
+      intro φ hφ
+      apply h
+      simp_all
+    simp
 
 private lemma of_mem₁_or [DecidableEq α] : φ ⋎ ψ ∈ t.1.1 → (φ ∈ t.1.1 ∨ ψ ∈ t.1.1) := by
-  intro h;
-  by_contra hC; push_neg at hC;
-  apply t.consistent (Γ := {φ ⋎ ψ}) (Δ := {φ, ψ}) (by simp_all) ?_;
-  . apply CFConj_CDisj!_of_A (φ := φ) (ψ := ψ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    constructor;
-    . exact iff_not_mem₁_mem₂.mp hC.1;
-    . exact iff_not_mem₁_mem₂.mp hC.2;
+  intro h
+  by_contra hC; push_neg at hC
+  apply t.consistent (Γ := {φ ⋎ ψ}) (Δ := {φ, ψ}) (by simp_all) ?_
+  . apply CFConj_CDisj!_of_A (φ := φ) (ψ := ψ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    constructor
+    . exact iff_not_mem₁_mem₂.mp hC.1
+    . exact iff_not_mem₁_mem₂.mp hC.2
 
 private lemma of_mem₂_or : φ ⋎ ψ ∈ t.1.2 → φ ∈ t.1.2 ∧ ψ ∈ t.1.2 := by
-  contrapose;
-  suffices (φ ∉ t.1.2 ∨ ψ ∉ t.1.2) → φ ⋎ ψ ∉ t.1.2 by tauto;
-  rintro (hφ | hψ);
-  . apply iff_not_mem₂_mem₁.mpr;
-    exact mdp_mem₁_provable or₁! $ iff_not_mem₂_mem₁.mp hφ;
-  . apply iff_not_mem₂_mem₁.mpr;
-    exact mdp_mem₁_provable or₂! $ iff_not_mem₂_mem₁.mp hψ;
+  contrapose
+  suffices (φ ∉ t.1.2 ∨ ψ ∉ t.1.2) → φ ⋎ ψ ∉ t.1.2 by tauto
+  rintro (hφ | hψ)
+  . apply iff_not_mem₂_mem₁.mpr
+    exact mdp_mem₁_provable or₁! $ iff_not_mem₂_mem₁.mp hφ
+  . apply iff_not_mem₂_mem₁.mpr
+    exact mdp_mem₁_provable or₂! $ iff_not_mem₂_mem₁.mp hψ
 
 lemma iff_mem₁_or [DecidableEq α] : φ ⋎ ψ ∈ t.1.1 ↔ φ ∈ t.1.1 ∨ ψ ∈ t.1.1 := by
-  constructor;
-  . apply of_mem₁_or;
-  . intro h;
+  constructor
+  . apply of_mem₁_or
+  . intro h
     cases h with
-    | inl h => exact mdp_mem₁_provable or₁! h;
-    | inr h => exact mdp_mem₁_provable or₂! h;
+    | inl h => exact mdp_mem₁_provable or₁! h
+    | inr h => exact mdp_mem₁_provable or₂! h
 
 lemma iff_mem₂_or [DecidableEq α] : φ ⋎ ψ ∈ t.1.2 ↔ φ ∈ t.1.2 ∧ ψ ∈ t.1.2 := by
-  constructor;
-  . apply of_mem₂_or;
-  . contrapose;
-    push_neg;
-    intro hφψ hφ;
-    rcases iff_mem₁_or.mp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ);
-    . have := iff_not_mem₂_mem₁.mpr hφ; contradiction;
-    . exact iff_not_mem₂_mem₁.mpr hψ;
+  constructor
+  . apply of_mem₂_or
+  . contrapose
+    push_neg
+    intro hφψ hφ
+    rcases iff_mem₁_or.mp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ)
+    . have := iff_not_mem₂_mem₁.mpr hφ; contradiction
+    . exact iff_not_mem₂_mem₁.mpr hψ
 
 lemma iff_mem₂_disj [DecidableEq α] {Γ : List (Formula α)} : ⋁Γ ∈ t.1.2 ↔ ∀ φ ∈ Γ, φ ∈ t.1.2 := by
   induction Γ using List.induction_with_singleton with
   | hcons φ Γ Γ_nil ih =>
-    simp only [(List.disj₂_cons_nonempty Γ_nil), List.mem_cons];
-    constructor;
-    . rintro h φ (rfl | hp);
-      . exact iff_mem₂_or.mp h |>.1;
-      . exact ih.mp (iff_mem₂_or.mp h |>.2) _ hp;
-    . intro h;
-      apply iff_mem₂_or.mpr;
-      simp_all;
-  | _ => simp;
+    simp only [(List.disj₂_cons_nonempty Γ_nil), List.mem_cons]
+    constructor
+    . rintro h φ (rfl | hp)
+      . exact iff_mem₂_or.mp h |>.1
+      . exact ih.mp (iff_mem₂_or.mp h |>.2) _ hp
+    . intro h
+      apply iff_mem₂_or.mpr
+      simp_all
+  | _ => simp
 
 lemma iff_mem₂_fdisj [DecidableEq α] {Γ : Finset (Formula α)} : Γ.disj ∈ t.1.2 ↔ ↑Γ ⊆ t.1.2 := by
-  apply Iff.trans $ show Γ.disj ∈ t.1.2 ↔ ⋁Γ.toList ∈ t.1.2 by constructor <;> apply mdp_mem₂_provable $ by simp;
-  apply Iff.trans iff_mem₂_disj;
-  simp_all only [Finset.mem_toList];
-  rfl;
+  apply Iff.trans $ show Γ.disj ∈ t.1.2 ↔ ⋁Γ.toList ∈ t.1.2 by constructor <;> apply mdp_mem₂_provable $ by simp
+  apply Iff.trans iff_mem₂_disj
+  simp_all only [Finset.mem_toList]
+  rfl
 
 lemma of_mem₁_imp [DecidableEq α] : φ ➝ ψ ∈ t.1.1 → (φ ∈ t.1.2 ∨ ψ ∈ t.1.1) := by
-  intro h;
-  by_contra hC;
-  push_neg at hC;
+  intro h
+  by_contra hC
+  push_neg at hC
   exact hC.2 $ mdp_mem₁ h $ iff_not_mem₂_mem₁.mp hC.1
 
 lemma of_mem₁_imp' [DecidableEq α] : φ ➝ ψ ∈ t.1.1 → (φ ∈ t.1.1 → ψ ∈ t.1.1) := by
-  intro h h₁;
-  apply or_iff_not_imp_left.mp $ of_mem₁_imp h;
-  apply iff_not_mem₂_mem₁.mpr h₁;
+  intro h h₁
+  apply or_iff_not_imp_left.mp $ of_mem₁_imp h
+  apply iff_not_mem₂_mem₁.mpr h₁
 
 lemma of_mem₁_neg [DecidableEq α] (h : ∼φ ∈ t.1.1) : φ ∈ t.1.2 := by
-  rcases of_mem₁_imp h with (hC | hC);
-  . assumption;
-  . exfalso;
-    exact SaturatedConsistentTableau.not_mem₁_falsum hC;
+  rcases of_mem₁_imp h with (hC | hC)
+  . assumption
+  . exfalso
+    exact SaturatedConsistentTableau.not_mem₁_falsum hC
 
 lemma of_mem₁_neg' [DecidableEq α] (h : ∼φ ∈ t.1.1) : φ ∉ t.1.1 := by
-  apply iff_not_mem₁_mem₂.mpr;
-  apply of_mem₁_neg h;
+  apply iff_not_mem₁_mem₂.mpr
+  apply of_mem₁_neg h
 
 private lemma of_mem₂_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ ➝ ψ ∈ t.1.2 → (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
-  intro h;
-  by_contra hC;
-  replace hC := not_and_or.mp hC;
-  rcases hC with (hφ | hψ);
-  . have : φ ⋎ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp (A!_replace_right lem! CNC!) t;
-    rcases iff_mem₁_or.mp this with (_ | _);
-    . contradiction;
-    . have := iff_not_mem₁_mem₂.mpr h;
-      contradiction;
-  . have : ψ ➝ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp imply₁! t;
-    have : φ ➝ ψ ∉ t.1.2 := iff_not_mem₂_mem₁.mpr $ mdp_mem₁ this (iff_not_mem₂_mem₁.mp hψ);
-    contradiction;
+  intro h
+  by_contra hC
+  replace hC := not_and_or.mp hC
+  rcases hC with (hφ | hψ)
+  . have : φ ⋎ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp (A!_replace_right lem! CNC!) t
+    rcases iff_mem₁_or.mp this with (_ | _)
+    . contradiction
+    . have := iff_not_mem₁_mem₂.mpr h
+      contradiction
+  . have : ψ ➝ (φ ➝ ψ) ∈ t.1.1 := iff_provable_mem₁.mp imply₁! t
+    have : φ ➝ ψ ∉ t.1.2 := iff_not_mem₂_mem₁.mpr $ mdp_mem₁ this (iff_not_mem₂_mem₁.mp hψ)
+    contradiction
 
 lemma iff_mem₁_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ ➝ ψ ∈ t.1.1 ↔ (φ ∈ t.1.2 ∨ ψ ∈ t.1.1) := by
-  constructor;
-  . apply of_mem₁_imp;
-  . contrapose;
-    push_neg;
-    intro hφψ;
-    rcases of_mem₂_imp $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩;
-    constructor;
-    . exact iff_not_mem₂_mem₁.mpr hφ;
-    . exact iff_not_mem₁_mem₂.mpr hψ;
+  constructor
+  . apply of_mem₁_imp
+  . contrapose
+    push_neg
+    intro hφψ
+    rcases of_mem₂_imp $ iff_not_mem₁_mem₂.mp hφψ with ⟨hφ, hψ⟩
+    constructor
+    . exact iff_not_mem₂_mem₁.mpr hφ
+    . exact iff_not_mem₁_mem₂.mpr hψ
 
 
 lemma iff_mem₂_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ ➝ ψ ∈ t.1.2 ↔ (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
-  constructor;
-  . apply of_mem₂_imp;
-  . contrapose;
-    push_neg;
-    intro hφψ hφ;
-    rcases of_mem₁_imp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ);
-    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction;
-    . exact iff_not_mem₂_mem₁.mpr hψ;
+  constructor
+  . apply of_mem₂_imp
+  . contrapose
+    push_neg
+    intro hφψ hφ
+    rcases of_mem₁_imp $ iff_not_mem₂_mem₁.mp hφψ with (hφ | hψ)
+    . have := iff_not_mem₁_mem₂.mpr hφ; contradiction
+    . exact iff_not_mem₂_mem₁.mpr hψ
 
 lemma not_mem₁_neg_of_mem₁ [DecidableEq α] : φ ∈ t.1.1 → ∼φ ∉ t.1.1 := by
-  intro hp;
-  by_contra hnp;
-  have := iff_mem₁_and.mpr ⟨hp, hnp⟩;
-  have : ⊥ ∈ t.1.1 := mdp_mem₁_provable CKNO! this;
+  intro hp
+  by_contra hnp
+  have := iff_mem₁_and.mpr ⟨hp, hnp⟩
+  have : ⊥ ∈ t.1.1 := mdp_mem₁_provable CKNO! this
   have : ⊥ ∉ t.1.1 := not_mem₁_falsum
-  contradiction;
+  contradiction
 
 lemma mem₂_neg_of_mem₁ [DecidableEq α] : φ ∈ t.1.1 → ∼φ ∈ t.1.2 := by
-  intro h;
-  exact iff_not_mem₁_mem₂ (φ := ∼φ) (t := t) |>.mp $ not_mem₁_neg_of_mem₁ h;
+  intro h
+  exact iff_not_mem₁_mem₂ (φ := ∼φ) (t := t) |>.mp $ not_mem₁_neg_of_mem₁ h
 
 lemma mdp₁_mem [DecidableEq α] (hp : φ ∈ t.1.1) (h : φ ➝ ψ ∈ t.1.1) : ψ ∈ t.1.1 := by
-  apply iff_not_mem₂_mem₁.mp;
-  by_contra hC;
-  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ (by simpa);
-  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp;
-  . simp only [Finset.coe_insert, Finset.coe_singleton];
-    apply Set.doubleton_subset.mpr;
-    constructor <;> assumption;
+  apply iff_not_mem₂_mem₁.mp
+  by_contra hC
+  apply t.consistent (Γ := {φ, φ ➝ ψ}) (Δ := {ψ}) ?_ (by simpa)
+  . apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp
+  . simp only [Finset.coe_insert, Finset.coe_singleton]
+    apply Set.doubleton_subset.mpr
+    constructor <;> assumption
 
 end Saturated
 

--- a/Foundation/Propositional/Dialectica/Basic.lean
+++ b/Foundation/Propositional/Dialectica/Basic.lean
@@ -76,7 +76,7 @@ lemma not_valid_iff_notValid {φ : Formula α} : (¬⊩ φ) ↔ (⊮ φ) := by
 @[simp] lemma interpret_imply {φ ψ : Formula α} {V f π} :
     ⟦f | π⟧⊩[V] φ ➝ ψ ↔ (⟦π.1 | f.2 π.1 π.2⟧⊩[V] φ → ⟦f.1 π.1 | π.2⟧⊩[V] ψ) := Eq.to_iff rfl
 
-@[simp] lemma interpret_verum {w c V} : ⟦w | c⟧⊩[V] (⊤ : Formula α) := by simp;
+@[simp] lemma interpret_verum {w c V} : ⟦w | c⟧⊩[V] (⊤ : Formula α) := by simp
 
 @[simp] lemma interpret_not {φ : Formula α} {V θ f} : ⟦f | θ⟧⊩[V] ∼φ ↔ ¬⟦θ | f θ⟧⊩[V] φ := Eq.to_iff rfl
 

--- a/Foundation/Propositional/Entailment/Cl.lean
+++ b/Foundation/Propositional/Entailment/Cl.lean
@@ -9,20 +9,20 @@ variable {𝓢 : S} [Entailment.Cl 𝓢]
 
 noncomputable instance : HasAxiomDummett 𝓢 where
   dummett φ ψ := by
-    have d₁ : 𝓢 ⊢ φ ➝ ((φ ➝ ψ) ⋎ (ψ ➝ φ)) := C_trans imply₁ or₂;
-    have d₂ : 𝓢 ⊢ ∼φ ➝ ((φ ➝ ψ) ⋎ (ψ ➝ φ)) := C_trans CNC or₁;
-    exact of_C_of_C_of_A d₁ d₂ lem;
+    have d₁ : 𝓢 ⊢ φ ➝ ((φ ➝ ψ) ⋎ (ψ ➝ φ)) := C_trans imply₁ or₂
+    have d₂ : 𝓢 ⊢ ∼φ ➝ ((φ ➝ ψ) ⋎ (ψ ➝ φ)) := C_trans CNC or₁
+    exact of_C_of_C_of_A d₁ d₂ lem
 
 noncomputable instance : Entailment.LC 𝓢 where
 
 
 noncomputable instance : HasAxiomPeirce 𝓢 where
   peirce φ ψ := by
-    refine of_C_of_C_of_A imply₁ ?_ lem;
-    apply deduct';
-    apply deduct;
-    refine (FiniteContext.byAxm (φ := (φ ➝ ψ) ➝ φ)) ⨀ ?_;
-    apply deduct;
+    refine of_C_of_C_of_A imply₁ ?_ lem
+    apply deduct'
+    apply deduct
+    refine (FiniteContext.byAxm (φ := (φ ➝ ψ) ➝ φ)) ⨀ ?_
+    apply deduct
     apply efq_of_mem_either (by aesop) (by aesop)
 
 end LO.Entailment

--- a/Foundation/Propositional/Entailment/LC.lean
+++ b/Foundation/Propositional/Entailment/LC.lean
@@ -9,26 +9,26 @@ variable {𝓢 : S} [Entailment.LC 𝓢]
 
 instance : HasAxiomWeakLEM 𝓢 where
   wlem φ := by
-    haveI : 𝓢 ⊢ (φ ➝ ∼φ) ⋎ (∼φ ➝ φ) := dummett;
+    haveI : 𝓢 ⊢ (φ ➝ ∼φ) ⋎ (∼φ ➝ φ) := dummett
     exact of_C_of_C_of_A (by
-      apply deduct';
-      apply A_intro_left;
-      apply N_of_CO;
-      apply deduct;
-      haveI d₁ : [φ, φ ➝ ∼φ] ⊢[𝓢] φ := FiniteContext.byAxm;
-      haveI d₂ : [φ, φ ➝ ∼φ] ⊢[𝓢] φ ➝ ∼φ := FiniteContext.byAxm;
-      have := CO_of_N $ d₂ ⨀ d₁;
-      exact this ⨀ d₁;
+      apply deduct'
+      apply A_intro_left
+      apply N_of_CO
+      apply deduct
+      haveI d₁ : [φ, φ ➝ ∼φ] ⊢[𝓢] φ := FiniteContext.byAxm
+      haveI d₂ : [φ, φ ➝ ∼φ] ⊢[𝓢] φ ➝ ∼φ := FiniteContext.byAxm
+      have := CO_of_N $ d₂ ⨀ d₁
+      exact this ⨀ d₁
     ) (by
-      apply deduct';
-      apply A_intro_right;
-      apply N_of_CO;
-      apply deduct;
-      haveI d₁ : [∼φ, ∼φ ➝ φ] ⊢[𝓢] ∼φ := FiniteContext.byAxm;
-      haveI d₂ : [∼φ, ∼φ ➝ φ] ⊢[𝓢] ∼φ ➝ φ := FiniteContext.byAxm;
-      haveI := d₂ ⨀ d₁;
-      exact (CO_of_N d₁) ⨀ this;
-    ) this;
+      apply deduct'
+      apply A_intro_right
+      apply N_of_CO
+      apply deduct
+      haveI d₁ : [∼φ, ∼φ ➝ φ] ⊢[𝓢] ∼φ := FiniteContext.byAxm
+      haveI d₂ : [∼φ, ∼φ ➝ φ] ⊢[𝓢] ∼φ ➝ φ := FiniteContext.byAxm
+      haveI := d₂ ⨀ d₁
+      exact (CO_of_N d₁) ⨀ this
+    ) this
 
 instance : Entailment.KC 𝓢 where
 

--- a/Foundation/Propositional/Formula.lean
+++ b/Foundation/Propositional/Formula.lean
@@ -29,7 +29,7 @@ instance : LogicalConnective (Formula α) where
   top := verum
   bot := falsum
 
-instance : LO.NegAbbrev (Formula α) := by tauto;
+instance : LO.NegAbbrev (Formula α) := by tauto
 
 section ToString
 
@@ -200,7 +200,7 @@ def ofNat : ℕ → Option (Formula α)
     | _ => none
 
 lemma ofNat_toNat : ∀ (φ : Formula α), ofNat (toNat φ) = some φ
-  | atom a  => by simp [toNat, ofNat, Nat.unpair_pair, encodek];
+  | atom a  => by simp [toNat, ofNat, Nat.unpair_pair, encodek]
   | ⊥       => by simp [toNat, ofNat]
   | φ ➝ ψ   => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
   | φ ⋏ ψ   => by simp [toNat, ofNat, ofNat_toNat φ, ofNat_toNat ψ]
@@ -265,52 +265,52 @@ namespace Formula.subformulas
 
 variable {φ ψ χ : Formula α}
 
-@[simp, grind] lemma mem_self : φ ∈ φ.subformulas := by induction φ <;> simp [subformulas];
+@[simp, grind] lemma mem_self : φ ∈ φ.subformulas := by induction φ <;> simp [subformulas]
 
 @[grind ⇒]
 protected lemma mem_imp (h : (ψ ➝ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
   induction φ with
   | himp =>
-    simp_all only [subformulas, Finset.mem_insert, imp_inj, Finset.mem_union];
-    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all;
-  | hor => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
-  | hand => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
-  | _ => simp_all [subformulas];
+    simp_all only [subformulas, Finset.mem_insert, imp_inj, Finset.mem_union]
+    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all
+  | hor => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
+  | hand => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
+  | _ => simp_all [subformulas]
 
 @[grind ⇒]
 protected lemma mem_and (h : (ψ ⋏ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
   induction φ with
-  | himp => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
-  | hor => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
+  | himp => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
+  | hor => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
   | hand =>
-    simp_all only [subformulas, Finset.mem_insert, Finset.mem_union];
-    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all;
-  | _ => simp_all [subformulas];
+    simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]
+    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all
+  | _ => simp_all [subformulas]
 
 @[grind ⇒]
 protected lemma mem_or (h : (ψ ⋎ χ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ χ ∈ φ.subformulas := by
   induction φ with
-  | himp => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
+  | himp => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
   | hor =>
-    simp_all only [subformulas, Finset.mem_insert, Finset.mem_union];
-    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all;
-  | hand => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto;
-  | _ => simp_all [subformulas];
+    simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]
+    rcases h with ⟨_⟩ | ⟨⟨_⟩ | ⟨_⟩⟩ <;> simp_all
+  | hand => simp_all only [subformulas, Finset.mem_insert, Finset.mem_union]; tauto
+  | _ => simp_all [subformulas]
 
 @[grind ⇒]
 protected lemma mem_neg (h : (∼ψ) ∈ φ.subformulas) : ψ ∈ φ.subformulas ∧ ⊥ ∈ φ.subformulas := by
-  rw [neg_def] at h;
-  grind;
+  rw [neg_def] at h
+  grind
 
-example {_ : φ ∈ φ.subformulas} : φ ∈ φ.subformulas := by grind;
+example {_ : φ ∈ φ.subformulas} : φ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
-example {_ : ∼ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind;
-example {_ : ∼ψ ∈ φ.subformulas} : ⊥ ∈ φ.subformulas := by grind;
+example {_ : ∼ψ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
+example {_ : ∼ψ ∈ φ.subformulas} : ⊥ ∈ φ.subformulas := by grind
 example {_ : ψ ⋏ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ⋎ χ ∈ φ.subformulas} : ψ ∈ φ.subformulas := by grind
 example {_ : ψ ➝ χ ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
-example {_ : ψ ⋏ (ψ ⋎ (χ ➝ ξ)) ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind;
+example {_ : ψ ⋏ (ψ ⋎ (χ ➝ ξ)) ∈ φ.subformulas} : χ ∈ φ.subformulas := by grind
 
 end Formula.subformulas
 
@@ -322,47 +322,47 @@ namespace FormulaFinset.SubformulaClosed
 
 variable {φ ψ χ : Formula α} {Γ : FormulaFinset α} [Γ.SubformulaClosed]
 
-@[grind ⇒] lemma mem_and₁ (h : φ ⋏ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
-@[grind ⇒] lemma mem_and₂ (h : φ ⋏ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
-@[grind ⇒] lemma mem_or₁ (h : φ ⋎ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
-@[grind ⇒] lemma mem_or₂ (h : φ ⋎ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
-@[grind ⇒] lemma mem_imp₁ (h : φ ➝ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
-@[grind ⇒] lemma mem_imp₂ (h : φ ➝ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
+@[grind ⇒] lemma mem_and₁ (h : φ ⋏ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
+@[grind ⇒] lemma mem_and₂ (h : φ ⋏ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
+@[grind ⇒] lemma mem_or₁ (h : φ ⋎ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
+@[grind ⇒] lemma mem_or₂ (h : φ ⋎ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
+@[grind ⇒] lemma mem_imp₁ (h : φ ➝ ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
+@[grind ⇒] lemma mem_imp₂ (h : φ ➝ ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas]
 
 instance subformulaClosed_subformulas [DecidableEq α] {φ : Formula α} : SubformulaClosed (φ.subformulas) := ⟨by
   induction φ with
-  | hatom => simp [Formula.subformulas];
-  | hfalsum => simp [Formula.subformulas];
+  | hatom => simp [Formula.subformulas]
+  | hfalsum => simp [Formula.subformulas]
   | himp φ ψ ihφ ihψ =>
-    rintro ξ hξ;
-    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ);
-    . tauto;
-    . trans φ.subformulas;
-      . exact ihφ _ hξ;
-      . intro; simp_all [Formula.subformulas];
-    . trans ψ.subformulas;
-      . exact ihψ _ hξ;
-      . intro; simp_all [Formula.subformulas];
+    rintro ξ hξ
+    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ)
+    . tauto
+    . trans φ.subformulas
+      . exact ihφ _ hξ
+      . intro; simp_all [Formula.subformulas]
+    . trans ψ.subformulas
+      . exact ihψ _ hξ
+      . intro; simp_all [Formula.subformulas]
   | hand φ ψ ihφ ihψ =>
-    rintro ξ hξ;
-    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ);
-    . tauto;
-    . trans φ.subformulas;
-      . exact ihφ _ hξ;
-      . intro; simp_all [Formula.subformulas];
-    . trans ψ.subformulas;
-      . exact ihψ _ hξ;
-      . intro; simp_all [Formula.subformulas];
+    rintro ξ hξ
+    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ)
+    . tauto
+    . trans φ.subformulas
+      . exact ihφ _ hξ
+      . intro; simp_all [Formula.subformulas]
+    . trans ψ.subformulas
+      . exact ihψ _ hξ
+      . intro; simp_all [Formula.subformulas]
   | hor φ ψ ihφ ihψ =>
-    rintro ξ hξ;
-    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ);
-    . tauto;
-    . trans φ.subformulas;
-      . exact ihφ _ hξ;
-      . intro; simp_all [Formula.subformulas];
-    . trans ψ.subformulas;
-      . exact ihψ _ hξ;
-      . intro; simp_all [Formula.subformulas];
+    rintro ξ hξ
+    rcases (by simpa [Formula.subformulas] using hξ) with (rfl | hξ | hξ)
+    . tauto
+    . trans φ.subformulas
+      . exact ihφ _ hξ
+      . intro; simp_all [Formula.subformulas]
+    . trans ψ.subformulas
+      . exact ihψ _ hξ
+      . intro; simp_all [Formula.subformulas]
 ⟩
 
 end FormulaFinset.SubformulaClosed
@@ -376,16 +376,16 @@ namespace FormulaSet.SubformulaClosed
 
 variable {φ ψ χ : Formula α} {T : FormulaSet α} [T.SubformulaClosed]
 
-@[grind ⇒] protected lemma mem_and₁ (h : φ ⋏ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas];
-@[grind ⇒] protected lemma mem_and₂ (h : φ ⋏ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas];
-@[grind ⇒] protected lemma mem_or₁ (h : φ ⋎ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas];
-@[grind ⇒] protected lemma mem_or₂ (h : φ ⋎ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas];
-@[grind ⇒] protected lemma mem_imp₁ (h : φ ➝ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas];
-@[grind ⇒] protected lemma mem_imp₂ (h : φ ➝ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas];
+@[grind ⇒] protected lemma mem_and₁ (h : φ ⋏ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas]
+@[grind ⇒] protected lemma mem_and₂ (h : φ ⋏ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas]
+@[grind ⇒] protected lemma mem_or₁ (h : φ ⋎ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas]
+@[grind ⇒] protected lemma mem_or₂ (h : φ ⋎ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas]
+@[grind ⇒] protected lemma mem_imp₁ (h : φ ➝ ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas]
+@[grind ⇒] protected lemma mem_imp₂ (h : φ ➝ ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas]
 
 
 instance [DecidableEq α] {φ : Formula α} : SubformulaClosed φ.subformulas.toSet := ⟨by
-  simpa using FormulaFinset.SubformulaClosed.subformulaClosed_subformulas (φ := φ) |>.closed;
+  simpa using FormulaFinset.SubformulaClosed.subformulaClosed_subformulas (φ := φ) |>.closed
 ⟩
 
 example {_ : φ ⋏ ψ ∈ T} : φ ∈ T := by grind
@@ -442,20 +442,20 @@ end subst
 end Formula
 
 @[simp]
-lemma Formula.subst_id {φ : Formula α} : φ⟦.id⟧ = φ := by induction φ <;> simp_all;
+lemma Formula.subst_id {φ : Formula α} : φ⟦.id⟧ = φ := by induction φ <;> simp_all
 
 def Substitution.comp (s₁ s₂ : Substitution α) : Substitution α := λ a => (s₁ a)⟦s₂⟧
 infixr:80 " ∘ " => Substitution.comp
 
 @[simp]
 lemma Formula.subst_comp {s₁ s₂ : Substitution α} {φ : Formula α} : φ⟦s₁ ∘ s₂⟧ = φ⟦s₁⟧⟦s₂⟧ := by
-  induction φ <;> simp_all [Substitution.comp];
+  induction φ <;> simp_all [Substitution.comp]
 
 def ZeroSubstitution (α) := { s : Substitution α // ∀ {a : α}, ((.atom a)⟦s⟧).letterless }
 
 lemma Formula.letterless_zeroSubst {φ : Formula α} {s : ZeroSubstitution α} : (φ⟦s.1⟧).letterless := by
-  induction φ <;> simp [Formula.letterless, *];
-  case hatom => exact s.2;
+  induction φ <;> simp [Formula.letterless, *]
+  case hatom => exact s.2
 
 
 class SubstitutionClosed (S : Set (Formula α)) where

--- a/Foundation/Propositional/Heyting/Semantics.lean
+++ b/Foundation/Propositional/Heyting/Semantics.lean
@@ -27,9 +27,9 @@ variable {ℍ : Type*} [HeytingAlgebra ℍ] (v : α → ℍ)
 
 @[simp] lemma hVal_imp (φ ψ : Formula α) : (φ ➝ ψ).hVal v = φ.hVal v ⇨ ψ.hVal v := rfl
 
-@[simp] lemma hVal_verum : (⊤ : Formula α).hVal v = ⊤ := by simp [Formula.top_def];
+@[simp] lemma hVal_verum : (⊤ : Formula α).hVal v = ⊤ := by simp [Formula.top_def]
 
-@[simp] lemma hVal_neg (φ : Formula α) : (∼φ).hVal v = (φ.hVal v)ᶜ := by simp [Formula.neg_def];
+@[simp] lemma hVal_neg (φ : Formula α) : (∼φ).hVal v = (φ.hVal v)ᶜ := by simp [Formula.neg_def]
 
 end Formula
 
@@ -63,9 +63,9 @@ scoped [LO.Propositional] infix:45 " ⊧ₕ " => LO.Propositional.HeytingSemanti
 
 @[simp] lemma hVal_iff (φ ψ : Formula α) : (ℍ ⊧ₕ φ ⭤ ψ) = bihimp (ℍ ⊧ₕ φ) (ℍ ⊧ₕ ψ) := by simp [LogicalConnective.iff, bihimp, inf_comm]
 
-@[simp] lemma hVal_verum : (ℍ ⊧ₕ ⊤) = ⊤ := by simp [Formula.top_def];
+@[simp] lemma hVal_verum : (ℍ ⊧ₕ ⊤) = ⊤ := by simp [Formula.top_def]
 
-@[simp] lemma hVal_not (φ : Formula α) : (ℍ ⊧ₕ ∼φ) = (ℍ ⊧ₕ φ)ᶜ := by simp [Formula.neg_def];
+@[simp] lemma hVal_not (φ : Formula α) : (ℍ ⊧ₕ ∼φ) = (ℍ ⊧ₕ φ)ᶜ := by simp [Formula.neg_def]
 
 instance : Semantics (Formula α) (HeytingSemantics α) := ⟨fun ℍ φ ↦ (ℍ ⊧ₕ φ) = ⊤⟩
 
@@ -86,8 +86,8 @@ instance : Semantics.And (HeytingSemantics α) := ⟨fun {ℍ φ ψ} ↦ by simp
   simp [LogicalConnective.iff, antisymm_iff]
 
 lemma val_not (φ : Formula α) : ℍ ⊧ ∼φ ↔ (ℍ ⊧ₕ φ) = ⊥ := by
-  simp only [val_def, Formula.hVal_neg];
-  rw [←HeytingAlgebra.himp_bot, himp_eq_top_iff, le_bot_iff];
+  simp only [val_def, Formula.hVal_neg]
+  rw [←HeytingAlgebra.himp_bot, himp_eq_top_iff, le_bot_iff]
   rfl
 
 @[simp] lemma val_or (φ ψ : Formula α) : ℍ ⊧ φ ⋎ ψ ↔ (ℍ ⊧ₕ φ) ⊔ (ℍ ⊧ₕ ψ) = ⊤ := by
@@ -102,13 +102,13 @@ lemma mod_models_iff {φ : Formula α} :
   simp [mod, Semantics.models, Semantics.set_models_iff]
 
 lemma sound {φ : Formula α} (d : H ⊢! φ) : mod H ⊧ φ := by
-  apply mod_models_iff.mpr;
-  intro ℍ hℍ;
+  apply mod_models_iff.mpr
+  intro ℍ hℍ
   induction d with
   | @axm φ s hφ =>
-    apply hℍ.RealizeSet;
-    use φ;
-    simpa;
+    apply hℍ.RealizeSet
+    use φ
+    simpa
   | @mdp φ ψ _ _ ihpq ihp =>
     have : (ℍ ⊧ₕ φ) ≤ (ℍ ⊧ₕ ψ) := by simpa using ihpq
     simpa [val_def'.mp ihp] using this
@@ -129,9 +129,9 @@ def lindenbaum : HeytingSemantics α where
 
 lemma lindenbaum_val_eq : (lindenbaum H ⊧ₕ φ) = ⟦φ⟧ := by
   induction φ with
-  | hand φ ψ ihp ihq => simp only [hVal_and, ihp, ihq]; rw [inf_def];
-  | hor _ _ ihp ihq => simp only [hVal_or, ihp, ihq]; rw [sup_def];
-  | himp _ _ ihp ihq => simp only [hVal_imply, ihp, ihq]; rw [himp_def];
+  | hand φ ψ ihp ihq => simp only [hVal_and, ihp, ihq]; rw [inf_def]
+  | hor _ _ ihp ihq => simp only [hVal_or, ihp, ihq]; rw [sup_def]
+  | himp _ _ ihp ihq => simp only [hVal_imply, ihp, ihq]; rw [himp_def]
   | _ => rfl
 
 variable {H}

--- a/Foundation/Propositional/Hilbert/Basic.lean
+++ b/Foundation/Propositional/Hilbert/Basic.lean
@@ -19,11 +19,11 @@ variable {H H₁ H₂ : Hilbert α}
 abbrev axiomInstances (H : Hilbert α) : Set (Formula α) := { φ⟦s⟧ | (φ ∈ H.axioms) (s : Substitution α) }
 
 lemma mem_axiomInstances_of_mem_axioms {φ} (h : φ ∈ H.axioms) : φ ∈ H.axiomInstances := by
-  use φ;
-  constructor;
-  . assumption;
-  . use Substitution.id;
-    simp;
+  use φ
+  constructor
+  . assumption
+  . use Substitution.id
+    simp
 
 variable {H : Hilbert α}
 
@@ -42,7 +42,7 @@ inductive Deduction (H : Hilbert α) : Formula α → Type u
 
 def Deduction.axm' {H : Hilbert α} {φ} (h : φ ∈ H.axioms) : Deduction H φ := by
   rw [(show φ = φ⟦.id⟧ by simp)]
-  apply Deduction.axm _ h;
+  apply Deduction.axm _ h
 
 instance : Entailment (Formula α) (Hilbert α) := ⟨Deduction⟩
 
@@ -51,12 +51,12 @@ instance : Entailment.HasAxiomImply₁ H := ⟨.implyS⟩
 instance : Entailment.HasAxiomImply₂ H := ⟨.implyK⟩
 instance : Entailment.HasAxiomAndInst H := ⟨.K_intro⟩
 instance : Entailment.Minimal H where
-  verum := .verum;
-  and₁  := .andElimL;
-  and₂  := .andElimR;
-  or₁   := .orIntroL;
-  or₂   := .orIntroR;
-  or₃   := .orElim;
+  verum := .verum
+  and₁  := .andElimL
+  and₂  := .andElimR
+  or₁   := .orIntroL
+  or₂   := .orIntroR
+  or₃   := .orElim
 
 @[induction_eliminator]
 protected lemma rec!
@@ -73,92 +73,92 @@ protected lemma rec!
   (orIntroR : ∀ {φ ψ},   motive (ψ ➝ φ ⋎ ψ) $ by simp)
   (orElim   : ∀ {φ ψ χ}, motive ((φ ➝ χ) ➝ (ψ ➝ χ) ➝ φ ⋎ ψ ➝ χ) $ by simp)
   : ∀ {φ}, (d : H ⊢! φ) → motive φ d := by
-  rintro φ ⟨d⟩;
+  rintro φ ⟨d⟩
   induction d with
-  | axm s h => apply axm s h;
+  | axm s h => apply axm s h
   | mdp hφψ hφ ihφψ ihφ =>
-    apply mdp;
-    . apply ihφψ;
-    . apply ihφ;
-  | verum => simpa;
-  | implyS => apply implyS;
-  | implyK => apply implyK;
-  | andElimL => apply andElimL;
-  | andElimR => apply andElimR;
-  | K_intro => apply K_intro;
-  | orIntroL => apply orIntroL;
-  | orIntroR => apply orIntroR;
-  | orElim => apply orElim;
+    apply mdp
+    . apply ihφψ
+    . apply ihφ
+  | verum => simpa
+  | implyS => apply implyS
+  | implyK => apply implyK
+  | andElimL => apply andElimL
+  | andElimR => apply andElimR
+  | K_intro => apply K_intro
+  | orIntroL => apply orIntroL
+  | orIntroR => apply orIntroR
+  | orElim => apply orElim
 
 lemma axm! {φ} (s) (h : φ ∈ H.axioms) : H ⊢! (φ⟦s⟧) := ⟨.axm s h⟩
 
 lemma axm'! {φ} (h : φ ∈ H.axioms) : H ⊢! φ := by simpa using axm! Substitution.id h
 
 lemma axm_instances! {φ} (h : φ ∈ H.axiomInstances) : H ⊢! φ := by
-  obtain ⟨ψ, hψ, s, rfl⟩ := h;
-  apply axm! s hψ;
+  obtain ⟨ψ, hψ, s, rfl⟩ := h
+  apply axm! s hψ
 
 lemma subst! {φ} (s) (h : H ⊢! φ) : H ⊢! (φ⟦s⟧) := by
   induction h with
-  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ;
-  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h;
-  | _ => simp;
+  | mdp ihφψ ihφ => apply ihφψ ⨀ ihφ
+  | @axm φ s' h => rw [(show φ⟦s'⟧⟦s⟧ = φ⟦s' ∘ s⟧ by simp)]; apply axm!; exact h
+  | _ => simp
 
 lemma weakerThan_of_provable_axioms (hs : H₂ ⊢!* H₁.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_iff.mpr;
-  intro φ h;
+  apply weakerThan_iff.mpr
+  intro φ h
   induction h with
-  | @axm φ s h => apply subst!; apply @hs φ h;
+  | @axm φ s h => apply subst!; apply @hs φ h
   | mdp ih₁ ih₂ => exact ih₁ ⨀ ih₂
-  | _ => simp;
+  | _ => simp
 
 lemma weakerThan_of_subset_axioms (hs : H₁.axioms ⊆ H₂.axioms) : H₁ ⪯ H₂ := by
-  apply weakerThan_of_provable_axioms;
-  intro φ h;
-  apply axm'!;
-  exact hs h;
+  apply weakerThan_of_provable_axioms
+  intro φ h
+  apply axm'!
+  exact hs h
 
 
 protected abbrev logic (H : Hilbert α) : Logic α := Entailment.theory H
 
 instance [H₁ ⪯ H₂] : H₁.logic ⪯ H₂.logic := by
-  apply weakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply WeakerThan.wk;
-  infer_instance;
+  apply weakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply WeakerThan.wk
+  infer_instance
 
 instance [H₁ ⪱ H₂] : H₁.logic ⪱ H₂.logic := by
-  apply strictlyWeakerThan_iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable];
-  apply strictlyWeakerThan_iff.mp;
-  infer_instance;
+  apply strictlyWeakerThan_iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq, Logic.iff_unprovable]
+  apply strictlyWeakerThan_iff.mp
+  infer_instance
 
 instance [H₁ ≊ H₂] : H₁.logic ≊ H₂.logic := by
-  apply Equiv.iff.mpr;
-  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq];
-  apply Equiv.iff.mp;
-  infer_instance;
+  apply Equiv.iff.mpr
+  simp only [theory, Logic.iff_provable, Set.mem_setOf_eq]
+  apply Equiv.iff.mp
+  infer_instance
 
-lemma iff_provable : H ⊢! φ ↔ H.logic ⊢! φ := by simp [theory];
-lemma iff_not_provable : H ⊬ φ ↔ H.logic ⊬ φ := by simp [theory];
+lemma iff_provable : H ⊢! φ ↔ H.logic ⊢! φ := by simp [theory]
+lemma iff_not_provable : H ⊬ φ ↔ H.logic ⊬ φ := by simp [theory]
 
 instance : Entailment.Minimal H.logic where
-  and₁ _ _     := by constructor; simp [theory];
-  and₂ _ _     := by constructor; simp [theory];
-  and₃ _ _     := by constructor; simp [theory];
-  or₁ _ _      := by constructor; simp [theory];
-  or₂ _ _      := by constructor; simp [theory];
-  or₃ _ _ _    := by constructor; simp [theory];
-  verum        := by constructor; simp [theory];
-  negEquiv _   := by constructor; simp [theory];
-  imply₁ _ _   := by constructor; simp [theory];
-  imply₂ _ _ _ := by constructor; simp [theory];
+  and₁ _ _     := by constructor; simp [theory]
+  and₂ _ _     := by constructor; simp [theory]
+  and₃ _ _     := by constructor; simp [theory]
+  or₁ _ _      := by constructor; simp [theory]
+  or₂ _ _      := by constructor; simp [theory]
+  or₃ _ _ _    := by constructor; simp [theory]
+  verum        := by constructor; simp [theory]
+  negEquiv _   := by constructor; simp [theory]
+  imply₁ _ _   := by constructor; simp [theory]
+  imply₂ _ _ _ := by constructor; simp [theory]
   mdp hφψ hφ := by
-    constructor;
-    replace hφψ := hφψ.1;
-    replace hφ := hφ.1;
-    simp only [theory, Set.mem_setOf_eq] at hφψ hφ ⊢;
-    exact hφψ ⨀ hφ;
+    constructor
+    replace hφψ := hφψ.1
+    replace hφ := hφ.1
+    simp only [theory, Set.mem_setOf_eq] at hφψ hφ ⊢
+    exact hφψ ⨀ hφ
 
 
 end Hilbert

--- a/Foundation/Propositional/Hilbert/Glivenko.lean
+++ b/Foundation/Propositional/Hilbert/Glivenko.lean
@@ -10,38 +10,38 @@ open Formula (atom)
 variable [DecidableEq α]
 
 theorem iff_provable_dn_efq_dne_provable : Hilbert.Int ⊢! ∼∼φ ↔ Hilbert.Cl ⊢! φ := by
-  constructor;
-  . intro d; exact of_NN! $ Int_weakerThan_Cl.subset d;
-  . intro d;
+  constructor
+  . intro d; exact of_NN! $ Int_weakerThan_Cl.subset d
+  . intro d
     induction d with
     | axm s hp =>
-      rcases hp with (rfl | rfl);
-      . apply dni'!;
-        exact efq!;
-      . simp only [Formula.subst.subst_or, Formula.subst.subst_atom, Formula.subst.subst_neg];
-        generalize (s 0) = ψ;
-        apply N!_iff_CO!.mpr;
-        apply FiniteContext.deduct'!;
-        have : [∼(ψ ⋎ ∼ψ)] ⊢[Hilbert.Int]! ∼ψ ⋏ ∼(ψ ➝ ⊥) := KNN!_of_NA! $ FiniteContext.id!;
-        exact (N!_iff_CO!.mp $ K!_right this) ⨀ (N!_iff_CO!.mp $ K!_left this);
-    | mdp ihφψ ihφ => exact CNNNN!_of_NNC! ihφψ ⨀ ihφ;
-    | _ => apply dni'!; simp;
+      rcases hp with (rfl | rfl)
+      . apply dni'!
+        exact efq!
+      . simp only [Formula.subst.subst_or, Formula.subst.subst_atom, Formula.subst.subst_neg]
+        generalize (s 0) = ψ
+        apply N!_iff_CO!.mpr
+        apply FiniteContext.deduct'!
+        have : [∼(ψ ⋎ ∼ψ)] ⊢[Hilbert.Int]! ∼ψ ⋏ ∼(ψ ➝ ⊥) := KNN!_of_NA! $ FiniteContext.id!
+        exact (N!_iff_CO!.mp $ K!_right this) ⨀ (N!_iff_CO!.mp $ K!_left this)
+    | mdp ihφψ ihφ => exact CNNNN!_of_NNC! ihφψ ⨀ ihφ
+    | _ => apply dni'!; simp
 
 alias glivenko := iff_provable_dn_efq_dne_provable
 
 theorem iff_provable_neg_efq_provable_neg_efq : Hilbert.Int ⊢! ∼φ ↔ Hilbert.Cl ⊢! ∼φ := by
-  constructor;
-  . intro d;
-    exact glivenko.mp $ dni'! d;
-  . intro d;
-    exact tne'! $ glivenko.mpr d;
+  constructor
+  . intro d
+    exact glivenko.mp $ dni'! d
+  . intro d
+    exact tne'! $ glivenko.mpr d
 
 end Hilbert
 
 lemma iff_negneg_Int_Cl : 𝐈𝐧𝐭 ⊢! ∼∼φ ↔ 𝐂𝐥 ⊢! φ := by
-  simpa [Entailment.theory] using Hilbert.iff_provable_dn_efq_dne_provable;
+  simpa [Entailment.theory] using Hilbert.iff_provable_dn_efq_dne_provable
 
 lemma iff_neg_Int_neg_Cl : 𝐈𝐧𝐭 ⊢! ∼φ ↔ 𝐂𝐥 ⊢! ∼φ := by
-  simpa [Entailment.theory] using Hilbert.iff_provable_neg_efq_provable_neg_efq;
+  simpa [Entailment.theory] using Hilbert.iff_provable_neg_efq_provable_neg_efq
 
 end LO.Propositional

--- a/Foundation/Propositional/Hilbert/WellKnown.lean
+++ b/Foundation/Propositional/Hilbert/WellKnown.lean
@@ -13,58 +13,58 @@ section
 
 class HasEFQ (H : Hilbert α) where
   p : α
-  mem_efq : (⊥ ➝ (.atom p)) ∈ H.axioms := by tauto;
+  mem_efq : (⊥ ➝ (.atom p)) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasEFQ] : Entailment.HasAxiomEFQ H where
   efq φ := by
     simpa using Deduction.axm
       (φ := Axioms.EFQ (.atom (HasEFQ.p H)))
       (s := λ b => if (HasEFQ.p H) = b then φ else (.atom b))
-      HasEFQ.mem_efq;
+      HasEFQ.mem_efq
 instance [DecidableEq α] [H.HasEFQ] : Entailment.Int H where
 
 
 class HasLEM (H : Hilbert α) where
   p : α
-  mem_lem : (.atom p ⋎ ∼(.atom p)) ∈ H.axioms := by tauto;
+  mem_lem : (.atom p ⋎ ∼(.atom p)) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasLEM] : Entailment.HasAxiomLEM H where
   lem φ := by
     simpa using Deduction.axm
       (φ := Axioms.LEM (.atom (HasLEM.p H)))
       (s := λ b => if (HasLEM.p H) = b then φ else (.atom b))
-      HasLEM.mem_lem;
+      HasLEM.mem_lem
 
 
 class HasDNE (H : Hilbert α) where
   p : α
-  mem_dne : (∼∼(.atom p) ➝ (.atom p)) ∈ H.axioms := by tauto;
+  mem_dne : (∼∼(.atom p) ➝ (.atom p)) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasDNE] : Entailment.HasAxiomDNE H where
   dne φ := by
     simpa using Deduction.axm
       (φ := Axioms.DNE (.atom (HasDNE.p H)))
       (s := λ b => if (HasDNE.p H) = b then φ else (.atom b))
-      HasDNE.mem_dne;
+      HasDNE.mem_dne
 
 
 class HasWeakLEM (H : Hilbert α) where
   p : α
-  mem_wlem : (∼(.atom p) ⋎ ∼∼(.atom p)) ∈ H.axioms := by tauto;
+  mem_wlem : (∼(.atom p) ⋎ ∼∼(.atom p)) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasWeakLEM] : Entailment.HasAxiomWeakLEM H where
   wlem φ := by
     simpa using Deduction.axm
       (φ := Axioms.WeakLEM (.atom (HasWeakLEM.p H)))
       (s := λ b => if (HasWeakLEM.p H) = b then φ else (.atom b))
-      HasWeakLEM.mem_wlem;
+      HasWeakLEM.mem_wlem
 
 
 class HasDummett (H : Hilbert α) where
   p : α
   q : α
-  ne_pq : p ≠ q := by tauto;
-  mem_dummet : ((.atom p) ➝ (.atom q)) ⋎ ((.atom q) ➝ (.atom p)) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by tauto
+  mem_dummet : ((.atom p) ➝ (.atom q)) ⋎ ((.atom q) ➝ (.atom p)) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasDummett] : Entailment.HasAxiomDummett H where
   dummett φ ψ := by
@@ -74,17 +74,17 @@ instance [DecidableEq α] [H.HasDummett] : Entailment.HasAxiomDummett H where
         if (HasDummett.p H) = b then φ
         else if (HasDummett.q H) = b then ψ
         else (.atom b))
-      HasDummett.mem_dummet;
+      HasDummett.mem_dummet
 
 
 class HasKrieselPutnam (H : Hilbert α) where
   p : α
   q : α
   r : α
-  ne_pq : p ≠ q := by tauto;
-  ne_qr : q ≠ r := by tauto;
-  ne_rp : r ≠ p := by tauto;
-  mem_kp : Axioms.KrieselPutnam (.atom p) (.atom q) (.atom r) ∈ H.axioms := by tauto;
+  ne_pq : p ≠ q := by tauto
+  ne_qr : q ≠ r := by tauto
+  ne_rp : r ≠ p := by tauto
+  mem_kp : Axioms.KrieselPutnam (.atom p) (.atom q) (.atom r) ∈ H.axioms := by tauto
 
 instance [DecidableEq α] [H.HasKrieselPutnam] : Entailment.HasAxiomKrieselPutnam H where
   krieselputnam φ ψ χ := by
@@ -95,7 +95,7 @@ instance [DecidableEq α] [H.HasKrieselPutnam] : Entailment.HasAxiomKrieselPutna
         else if (HasKrieselPutnam.q H) = b then ψ
         else if (HasKrieselPutnam.r H) = b then χ
         else (.atom b))
-      HasKrieselPutnam.mem_kp;
+      HasKrieselPutnam.mem_kp
 
 
 end
@@ -106,40 +106,40 @@ end Hilbert
 protected abbrev Hilbert.Int : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0)}⟩
 protected abbrev Int := Hilbert.Int.logic
 notation "𝐈𝐧𝐭" => Propositional.Int
-instance : Hilbert.Int.HasEFQ where p := 0;
+instance : Hilbert.Int.HasEFQ where p := 0
 instance : Entailment.Int (Hilbert.Int) where
 
 protected abbrev Hilbert.Cl : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.LEM (.atom 0)}⟩
 protected abbrev Cl := Hilbert.Cl.logic
 notation "𝐂𝐥" => Propositional.Cl
-instance : Hilbert.Cl.HasEFQ where p := 0;
-instance : Hilbert.Cl.HasLEM where p := 0;
+instance : Hilbert.Cl.HasEFQ where p := 0
+instance : Hilbert.Cl.HasLEM where p := 0
 instance : Entailment.Cl (Hilbert.Cl) where
 
-lemma Hilbert.Int_weakerThan_Cl : (Hilbert.Int) ⪯ (Hilbert.Cl) := by apply weakerThan_of_subset_axioms; tauto;
+lemma Hilbert.Int_weakerThan_Cl : (Hilbert.Int) ⪯ (Hilbert.Cl) := by apply weakerThan_of_subset_axioms; tauto
 
 
 protected abbrev Hilbert.KC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.WeakLEM (.atom 0)}⟩
 protected abbrev KC := Hilbert.KC.logic
 notation "𝐊𝐂" => Propositional.KC
-instance : Hilbert.KC.HasEFQ where p := 0;
-instance : Hilbert.KC.HasWeakLEM where p := 0;
+instance : Hilbert.KC.HasEFQ where p := 0
+instance : Hilbert.KC.HasWeakLEM where p := 0
 instance : Entailment.KC (Hilbert.KC) where
 
 
 protected abbrev Hilbert.LC : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.Dummett (.atom 0) (.atom 1)}⟩
 protected abbrev LC := Hilbert.LC.logic
 notation "𝐋𝐂" => Propositional.LC
-instance : Hilbert.LC.HasEFQ where p := 0;
-instance : Hilbert.LC.HasDummett where p := 0; q := 1;
+instance : Hilbert.LC.HasEFQ where p := 0
+instance : Hilbert.LC.HasDummett where p := 0; q := 1
 instance : Entailment.LC (Hilbert.LC) where
 
 
 protected abbrev Hilbert.KrieselPutnam : Hilbert ℕ := ⟨{Axioms.EFQ (.atom 0), Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2)}⟩
 protected abbrev KrieselPutnam := Hilbert.KrieselPutnam.logic
 notation "𝐊𝐏" => Propositional.KrieselPutnam
-instance : Hilbert.KrieselPutnam.HasEFQ where p := 0;
-instance : Hilbert.KrieselPutnam.HasKrieselPutnam where p := 0; q := 1; r := 2;
+instance : Hilbert.KrieselPutnam.HasEFQ where p := 0
+instance : Hilbert.KrieselPutnam.HasKrieselPutnam where p := 0; q := 1; r := 2
 instance : Entailment.KrieselPutnam (Hilbert.KrieselPutnam) where
 
 end LO.Propositional

--- a/Foundation/Propositional/Kripke/AxiomDummett.lean
+++ b/Foundation/Propositional/Kripke/AxiomDummett.lean
@@ -19,50 +19,50 @@ section definability
 variable {F : Kripke.Frame}
 
 lemma validate_axiomDummett_of_isPiecewiseStronglyConnected [F.IsPiecewiseStronglyConnected] : F ⊧ (Axioms.Dummett (.atom 0) (.atom 1)) := by
-  have := F.ps_connected;
-  revert this;
-  contrapose!;
-  intro h;
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h;
-  unfold Satisfies at h;
-  push_neg at h;
+  have := F.ps_connected
+  revert this
+  contrapose!
+  intro h
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h
+  unfold Satisfies at h
+  push_neg at h
 
-  rcases h with ⟨h₁, h₂⟩;
+  rcases h with ⟨h₁, h₂⟩
 
-  replace h₁ := Satisfies.imp_def.not.mp h₁;
-  push_neg at h₁;
-  obtain ⟨y, Rxy, ⟨hy0, nhy1⟩⟩ := h₁;
+  replace h₁ := Satisfies.imp_def.not.mp h₁
+  push_neg at h₁
+  obtain ⟨y, Rxy, ⟨hy0, nhy1⟩⟩ := h₁
 
-  replace h₂ := Satisfies.imp_def.not.mp h₂;
-  push_neg at h₂;
-  obtain ⟨z, Rxz, ⟨hz1, nhz0⟩⟩ := h₂;
+  replace h₂ := Satisfies.imp_def.not.mp h₂
+  push_neg at h₂
+  obtain ⟨z, Rxz, ⟨hz1, nhz0⟩⟩ := h₂
 
-  use x, y, z;
-  refine ⟨Rxy, Rxz, ?_⟩;
-  . by_contra hC;
-    replace hC := not_and_or.mp hC;
-    push_neg at hC;
-    rcases hC with (Ryz | Rzy);
-    . exact nhz0 $ Satisfies.formula_hereditary Ryz hy0;
-    . exact nhy1 $ Satisfies.formula_hereditary Rzy hz1;
+  use x, y, z
+  refine ⟨Rxy, Rxz, ?_⟩
+  . by_contra hC
+    replace hC := not_and_or.mp hC
+    push_neg at hC
+    rcases hC with (Ryz | Rzy)
+    . exact nhz0 $ Satisfies.formula_hereditary Ryz hy0
+    . exact nhy1 $ Satisfies.formula_hereditary Rzy hz1
 
 lemma isPiecewiseStronglyConnected_of_validate_axiomDummett (h : F ⊧ (Axioms.Dummett (.atom 0) (.atom 1))) : F.IsPiecewiseStronglyConnected := ⟨by
-  rintro x y z Rxy Ryz;
+  rintro x y z Rxy Ryz
   let V : Kripke.Valuation F := ⟨λ {v a} => match a with | 0 => y ≺ v | 1 => z ≺ v | _ => True, by
-    intro w v Rwv a ha;
-    split at ha;
+    intro w v Rwv a ha
+    split at ha
     . apply F.trans ha Rwv
     . apply F.trans ha Rwv
-    . tauto;
-  ⟩;
-  replace h : F ⊧ (Axioms.Dummett (.atom 0) (.atom 1)) := by simpa using h;
-  rcases Formula.Kripke.Satisfies.or_def.mp $ @h V x with (hi | hi);
-  . right;
-    apply hi Rxy;
-    apply F.refl;
-  . left;
-    apply hi Ryz;
-    apply F.refl;
+    . tauto
+  ⟩
+  replace h : F ⊧ (Axioms.Dummett (.atom 0) (.atom 1)) := by simpa using h
+  rcases Formula.Kripke.Satisfies.or_def.mp $ @h V x with (hi | hi)
+  . right
+    apply hi Rxy
+    apply F.refl
+  . left
+    apply hi Ryz
+    apply F.refl
 ⟩
 
 end definability
@@ -81,21 +81,21 @@ open SaturatedConsistentTableau
 open Classical
 
 instance [Entailment.HasAxiomDummett 𝓢] : (canonicalFrame 𝓢).IsPiecewiseStronglyConnected := ⟨by
-  rintro x y z Rxy Ryz;
-  apply or_iff_not_imp_left.mpr;
-  intro nRyz;
-  obtain ⟨φ, hyp, nhzp⟩ := Set.not_subset.mp nRyz;
-  intro ψ hqz;
+  rintro x y z Rxy Ryz
+  apply or_iff_not_imp_left.mpr
+  intro nRyz
+  obtain ⟨φ, hyp, nhzp⟩ := Set.not_subset.mp nRyz
+  intro ψ hqz
   have : ψ ➝ φ ∉ x.1.1 := by
-    by_contra hqpx;
-    have hqpz : ψ ➝ φ ∈ z.1.1 := by aesop;
-    have : φ ∈ z.1.1 := mdp₁_mem hqz hqpz;
-    contradiction;
-  have := iff_mem₁_or.mp $ mem₁_of_provable (t := x) (φ := (φ ➝ ψ) ⋎ (ψ ➝ φ)) dummett!;
-  have hpqx : φ ➝ ψ ∈ x.1.1 := by aesop;
-  have hpqy : φ ➝ ψ ∈ y.1.1 := Rxy hpqx;
-  have : ψ ∈ y.1.1 := mdp₁_mem hyp hpqy;
-  exact this;
+    by_contra hqpx
+    have hqpz : ψ ➝ φ ∈ z.1.1 := by aesop
+    have : φ ∈ z.1.1 := mdp₁_mem hqz hqpz
+    contradiction
+  have := iff_mem₁_or.mp $ mem₁_of_provable (t := x) (φ := (φ ➝ ψ) ⋎ (ψ ➝ φ)) dummett!
+  have hpqx : φ ➝ ψ ∈ x.1.1 := by aesop
+  have hpqy : φ ➝ ψ ∈ y.1.1 := Rxy hpqx
+  have : ψ ∈ y.1.1 := mdp₁_mem hyp hpqy
+  exact this
 ⟩
 
 end canonicality

--- a/Foundation/Propositional/Kripke/AxiomKrieselPutnam.lean
+++ b/Foundation/Propositional/Kripke/AxiomKrieselPutnam.lean
@@ -32,45 +32,45 @@ variable {F : Kripke.Frame}
 open Formula (atom)
 
 lemma validate_axiomKrieselPutnam_of_satisfiesKrieselPutnamCondition [F.SatisfiesKriselPutnamCondition ] : F ⊧ (Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2)) := by
-  intro V x y Rxy h₁;
-  by_contra hC;
-  replace hC := Satisfies.or_def.not.mp hC;
-  push_neg at hC;
-  obtain ⟨h₂, h₃⟩ := hC;
+  intro V x y Rxy h₁
+  by_contra hC
+  replace hC := Satisfies.or_def.not.mp hC
+  push_neg at hC
+  obtain ⟨h₂, h₃⟩ := hC
 
-  replace h₂ := Satisfies.imp_def.not.mp h₂;
-  push_neg at h₂;
-  obtain ⟨z₁, Ryz₁, ⟨hz₁₁, hz₁₂⟩⟩ := h₂;
+  replace h₂ := Satisfies.imp_def.not.mp h₂
+  push_neg at h₂
+  obtain ⟨z₁, Ryz₁, ⟨hz₁₁, hz₁₂⟩⟩ := h₂
 
-  replace h₃ := Satisfies.imp_def.not.mp h₃;
-  push_neg at h₃;
-  obtain ⟨z₂, Ryz₂, ⟨hz₂₁, hz₂₂⟩⟩ := h₃;
+  replace h₃ := Satisfies.imp_def.not.mp h₃
+  push_neg at h₃
+  obtain ⟨z₂, Ryz₂, ⟨hz₂₁, hz₂₂⟩⟩ := h₃
 
   obtain ⟨u, Ryu, ⟨Ruz₁, Ruz₂, h⟩⟩ := F.kriesel_putnam y z₁ z₂ ⟨
     Ryz₁, Ryz₂,
     by
-      rcases Satisfies.or_def.mp $ h₁ Ryz₁ hz₁₁ with (h | h);
-      . exfalso; exact hz₁₂ h;
-      . by_contra hC; exact hz₂₂ $ Satisfies.formula_hereditary hC h;
+      rcases Satisfies.or_def.mp $ h₁ Ryz₁ hz₁₁ with (h | h)
+      . exfalso; exact hz₁₂ h
+      . by_contra hC; exact hz₂₂ $ Satisfies.formula_hereditary hC h
     ,
     by
-      rcases Satisfies.or_def.mp $ h₁ Ryz₂ hz₂₁ with (h | h);
-      . by_contra hC; exact hz₁₂ $ Satisfies.formula_hereditary hC h;
-      . exfalso; exact hz₂₂ h;
-  ⟩;
+      rcases Satisfies.or_def.mp $ h₁ Ryz₂ hz₂₁ with (h | h)
+      . by_contra hC; exact hz₁₂ $ Satisfies.formula_hereditary hC h
+      . exfalso; exact hz₂₂ h
+  ⟩
 
   have : ¬Satisfies ⟨F, V⟩ u (∼(.atom 0)) := by
-    by_contra hC;
-    rcases Satisfies.or_def.mp $ h₁ Ryu hC with (h | h);
-    . apply hz₁₂; exact Satisfies.formula_hereditary Ruz₁ h;
-    . apply hz₂₂; exact Satisfies.formula_hereditary Ruz₂ h;
-  replace this := Satisfies.neg_def.not.mp this;
-  push_neg at this;
-  obtain ⟨v, Ruv, hv⟩ := this;
+    by_contra hC
+    rcases Satisfies.or_def.mp $ h₁ Ryu hC with (h | h)
+    . apply hz₁₂; exact Satisfies.formula_hereditary Ruz₁ h
+    . apply hz₂₂; exact Satisfies.formula_hereditary Ruz₂ h
+  replace this := Satisfies.neg_def.not.mp this
+  push_neg at this
+  obtain ⟨v, Ruv, hv⟩ := this
 
-  obtain ⟨w, Rvw, (Rz₁w | Rz₂w)⟩ := h v Ruv;
-  . exact Satisfies.not_of_neg (Satisfies.formula_hereditary (φ := (∼(.atom 0))) Rz₁w hz₁₁) $ Satisfies.formula_hereditary Rvw hv;
-  . exact Satisfies.not_of_neg (Satisfies.formula_hereditary (φ := (∼(.atom 0))) Rz₂w hz₂₁) $ Satisfies.formula_hereditary Rvw hv;
+  obtain ⟨w, Rvw, (Rz₁w | Rz₂w)⟩ := h v Ruv
+  . exact Satisfies.not_of_neg (Satisfies.formula_hereditary (φ := (∼(.atom 0))) Rz₁w hz₁₁) $ Satisfies.formula_hereditary Rvw hv
+  . exact Satisfies.not_of_neg (Satisfies.formula_hereditary (φ := (∼(.atom 0))) Rz₂w hz₂₁) $ Satisfies.formula_hereditary Rvw hv
 
 end definability
 
@@ -90,154 +90,154 @@ open Classical
 namespace Canonical
 
 instance [Entailment.HasAxiomKrieselPutnam 𝓢] : (canonicalFrame 𝓢).SatisfiesKriselPutnamCondition := ⟨by
-  rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩;
-  let ΓNyz := { φ | ∼φ ∈ (y.1.1 ∩ z.1.1)}.image (∼·);
+  rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩
+  let ΓNyz := { φ | ∼φ ∈ (y.1.1 ∩ z.1.1)}.image (∼·)
   obtain ⟨u, hu₁, hu₂⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := ⟨x.1.1 ∪ ΓNyz, y.1.2 ∪ z.1.2⟩) $ by
-    rintro Γ Δ hΓ hΔ;
-    by_contra hC;
-    let Γx := { φ ∈ Γ | φ ∈ x.1.1};
-    let Γ₁ := { φ ∈ Γ | φ ∈ ΓNyz };
-    let Γ₂ := Γ₁.preimage (∼·) $ by simp [Set.InjOn];
-    let Δy := { φ ∈ Δ | φ ∈ y.1.2};
-    let Δz := { φ ∈ Δ | φ ∈ z.1.2};
-    replace hC : 𝓢 ⊢! (Γx ∪ Γ₁).conj ➝ (Δy ∪ Δz).disj := C!_replace ?_ ?_ hC;
-    . replace hC : 𝓢 ⊢! Γx.conj ⋏ Γ₁.conj ➝ Δy.disj ⋎ Δz.disj := C!_replace CKFconjFconjUnion! CFdisjUnionAFdisj hC;
-      generalize eδy : Δy.disj = δy at hC;
-      generalize eδz : Δz.disj = δz at hC;
-      replace hC : ↑Γx *⊢[𝓢]! ∼(Γ₂.disj) ➝ δy ⋎ δz := C!_trans ?_ $ FConj_DT.mp $ CK!_iff_CC!.mp hC;
-      . generalize eγ : Γ₂.disj = γ at hC;
-        replace hC : ↑Γx *⊢[𝓢]! (∼γ ➝ δy) ⋎ (∼γ ➝ δz) := krieselputnam'! hC;
-        replace hC : ∼γ ➝ δy ∈ x.1.1 ∨ ∼γ ➝ δz ∈ x.1.1 := iff_mem₁_or.mp $ iff_provable_include₁.mp hC x ?_;
-        . rcases hC with h | h;
+    rintro Γ Δ hΓ hΔ
+    by_contra hC
+    let Γx := { φ ∈ Γ | φ ∈ x.1.1}
+    let Γ₁ := { φ ∈ Γ | φ ∈ ΓNyz }
+    let Γ₂ := Γ₁.preimage (∼·) $ by simp [Set.InjOn]
+    let Δy := { φ ∈ Δ | φ ∈ y.1.2}
+    let Δz := { φ ∈ Δ | φ ∈ z.1.2}
+    replace hC : 𝓢 ⊢! (Γx ∪ Γ₁).conj ➝ (Δy ∪ Δz).disj := C!_replace ?_ ?_ hC
+    . replace hC : 𝓢 ⊢! Γx.conj ⋏ Γ₁.conj ➝ Δy.disj ⋎ Δz.disj := C!_replace CKFconjFconjUnion! CFdisjUnionAFdisj hC
+      generalize eδy : Δy.disj = δy at hC
+      generalize eδz : Δz.disj = δz at hC
+      replace hC : ↑Γx *⊢[𝓢]! ∼(Γ₂.disj) ➝ δy ⋎ δz := C!_trans ?_ $ FConj_DT.mp $ CK!_iff_CC!.mp hC
+      . generalize eγ : Γ₂.disj = γ at hC
+        replace hC : ↑Γx *⊢[𝓢]! (∼γ ➝ δy) ⋎ (∼γ ➝ δz) := krieselputnam'! hC
+        replace hC : ∼γ ➝ δy ∈ x.1.1 ∨ ∼γ ➝ δz ∈ x.1.1 := iff_mem₁_or.mp $ iff_provable_include₁.mp hC x ?_
+        . rcases hC with h | h
           . apply iff_not_mem₂_mem₁.mpr $ of_mem₁_imp' (Rxy h) ?_
-            . subst eδy;
-              apply iff_mem₂_fdisj.mpr;
-              intro φ hφ;
-              simp only [Finset.coe_filter, Set.mem_setOf_eq, Δy] at hφ;
-              exact hφ.2;
-            . subst eγ;
-              apply mdp_mem₁_provable (φ := Γ₁.conj) ?_ ?_;
-              . apply C!_trans ?_ CFconjNNFconj!;
-                apply CFConj_FConj!_of_subset;
-                intro φ;
-                simp only [Finset.mem_image, Finset.mem_preimage, Finset.mem_filter, forall_exists_index, and_imp, Γ₁, Γ₂];
-                rintro _ _ _ rfl;
-                tauto;
-              . apply iff_mem₁_fconj.mpr;
-                intro φ;
-                simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.coe_filter, and_imp, forall_exists_index, Γ₁, ΓNyz];
-                rintro _ _ _ _ rfl;
-                assumption;
+            . subst eδy
+              apply iff_mem₂_fdisj.mpr
+              intro φ hφ
+              simp only [Finset.coe_filter, Set.mem_setOf_eq, Δy] at hφ
+              exact hφ.2
+            . subst eγ
+              apply mdp_mem₁_provable (φ := Γ₁.conj) ?_ ?_
+              . apply C!_trans ?_ CFconjNNFconj!
+                apply CFConj_FConj!_of_subset
+                intro φ
+                simp only [Finset.mem_image, Finset.mem_preimage, Finset.mem_filter, forall_exists_index, and_imp, Γ₁, Γ₂]
+                rintro _ _ _ rfl
+                tauto
+              . apply iff_mem₁_fconj.mpr
+                intro φ
+                simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.coe_filter, and_imp, forall_exists_index, Γ₁, ΓNyz]
+                rintro _ _ _ _ rfl
+                assumption
           . apply iff_not_mem₂_mem₁.mpr $ of_mem₁_imp' (Rxz h) ?_
-            . subst eδz;
-              apply iff_mem₂_fdisj.mpr;
-              intro φ hφ;
-              simp only [Finset.coe_filter, Set.mem_setOf_eq, Δz] at hφ;
-              exact hφ.2;
-            . subst eγ;
-              apply mdp_mem₁_provable (φ := Γ₁.conj) ?_ ?_;
-              . apply C!_trans ?_ CFconjNNFconj!;
-                apply CFConj_FConj!_of_subset;
-                intro φ;
-                simp only [Finset.mem_image, Finset.mem_preimage, Finset.mem_filter, forall_exists_index, and_imp, Γ₁, Γ₂];
-                rintro _ _ _ rfl;
-                tauto;
-              . apply iff_mem₁_fconj.mpr;
-                intro φ;
-                simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.coe_filter, and_imp, forall_exists_index, Γ₁, ΓNyz];
-                rintro _ _ _ _ rfl;
-                assumption;
-        . intro φ hφ;
-          simp only [Finset.coe_filter, Set.mem_setOf_eq, Γx] at hφ;
-          exact hφ.2;
-      . apply Context.of!;
-        apply right_Fconj!_intro;
-        simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.mem_filter, and_imp, forall_exists_index, Γ₁, Γ₂, ΓNyz];
-        rintro _ hψ ψ hψ₁ hψ₂ rfl;
-        apply C!_trans CNFdisjFconj!;
-        apply left_Fconj!_intro;
-        suffices ∼ψ ∈ Γ ∧ ∼ψ ∈ y.1.1 ∧ ∼ψ ∈ z.1.1 by simpa [Γ₁, Γ₂] using this;
-        tauto;
-    . apply CFConj_FConj!_of_subset;
-      intro φ hφ;
-      simp only [Finset.mem_union, Finset.mem_filter, Γx, Γ₁];
-      rcases hΓ hφ with h | h <;> tauto;
-    . apply CFDisjFDisj_of_subset;
-      intro φ hφ;
-      simp only [Finset.mem_union, Finset.mem_filter, Δy, Δz];
-      rcases hΔ hφ with h | h <;> tauto;
-  replace hu₁ := Set.union_subset_iff.mp hu₁;
-  replace hu₂ := Set.union_subset_iff.mp hu₂;
-  use u;
-  refine ⟨?_, ?_, ?_, ?_⟩;
-  . exact hu₁.1;
-  . apply Kripke.canonicalFrame.rel₂.mpr; exact hu₂ |>.1;
-  . apply Kripke.canonicalFrame.rel₂.mpr; exact hu₂ |>.2;
-  . intro v Ruv;
-    by_contra! hC;
+            . subst eδz
+              apply iff_mem₂_fdisj.mpr
+              intro φ hφ
+              simp only [Finset.coe_filter, Set.mem_setOf_eq, Δz] at hφ
+              exact hφ.2
+            . subst eγ
+              apply mdp_mem₁_provable (φ := Γ₁.conj) ?_ ?_
+              . apply C!_trans ?_ CFconjNNFconj!
+                apply CFConj_FConj!_of_subset
+                intro φ
+                simp only [Finset.mem_image, Finset.mem_preimage, Finset.mem_filter, forall_exists_index, and_imp, Γ₁, Γ₂]
+                rintro _ _ _ rfl
+                tauto
+              . apply iff_mem₁_fconj.mpr
+                intro φ
+                simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.coe_filter, and_imp, forall_exists_index, Γ₁, ΓNyz]
+                rintro _ _ _ _ rfl
+                assumption
+        . intro φ hφ
+          simp only [Finset.coe_filter, Set.mem_setOf_eq, Γx] at hφ
+          exact hφ.2
+      . apply Context.of!
+        apply right_Fconj!_intro
+        simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Finset.mem_filter, and_imp, forall_exists_index, Γ₁, Γ₂, ΓNyz]
+        rintro _ hψ ψ hψ₁ hψ₂ rfl
+        apply C!_trans CNFdisjFconj!
+        apply left_Fconj!_intro
+        suffices ∼ψ ∈ Γ ∧ ∼ψ ∈ y.1.1 ∧ ∼ψ ∈ z.1.1 by simpa [Γ₁, Γ₂] using this
+        tauto
+    . apply CFConj_FConj!_of_subset
+      intro φ hφ
+      simp only [Finset.mem_union, Finset.mem_filter, Γx, Γ₁]
+      rcases hΓ hφ with h | h <;> tauto
+    . apply CFDisjFDisj_of_subset
+      intro φ hφ
+      simp only [Finset.mem_union, Finset.mem_filter, Δy, Δz]
+      rcases hΔ hφ with h | h <;> tauto
+  replace hu₁ := Set.union_subset_iff.mp hu₁
+  replace hu₂ := Set.union_subset_iff.mp hu₂
+  use u
+  refine ⟨?_, ?_, ?_, ?_⟩
+  . exact hu₁.1
+  . apply Kripke.canonicalFrame.rel₂.mpr; exact hu₂ |>.1
+  . apply Kripke.canonicalFrame.rel₂.mpr; exact hu₂ |>.2
+  . intro v Ruv
+    by_contra! hC
     obtain ⟨γ₁, hγ₁₁, hγ₁₂⟩ : ∃ γ₁ ∈ v.1.1, ∼γ₁ ∈ y.1.1 := by
       have : Tableau.Inconsistent 𝓢 ⟨y.1.1 ∪ v.1.1, ∅⟩ := by
-        by_contra hconsis;
-        obtain ⟨t, ht⟩ := lindenbaum hconsis;
-        apply hC t ?_ |>.1;
-        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.1;
-        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.2;
-      dsimp [Tableau.Inconsistent, Tableau.Consistent] at this;
-      push_neg at this;
-      obtain ⟨Γ, Δ, hΓ, hΔ, hΓΔ⟩ := this;
-      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ;
-      subst hΔ;
-      simp only [Finset.disj_empty, Decidable.not_not] at hΓΔ;
-      use ({ φ ∈ Γ | φ ∈ v.1.1}).conj;
-      constructor;
-      . apply iff_mem₁_fconj.mpr;
-        intro;
-        simp;
-      . apply iff_provable_include₁_finset (Γ := {x ∈ Γ | x ∈ y.1.1}) |>.mp ?_ y ?_;
-        . apply N!_iff_CO!.mpr;
-          apply FConj_DT'.mpr;
-          apply Context.weakening! ?_ (FConj_DT.mp hΓΔ);
-          intro φ hφ;
-          simp only [Finset.coe_union, Finset.coe_filter, Set.mem_union, Set.mem_setOf_eq];
-          rcases hΓ hφ with _ | _ <;> tauto;
-        . intro;
-          simp;
+        by_contra hconsis
+        obtain ⟨t, ht⟩ := lindenbaum hconsis
+        apply hC t ?_ |>.1
+        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.1
+        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.2
+      dsimp [Tableau.Inconsistent, Tableau.Consistent] at this
+      push_neg at this
+      obtain ⟨Γ, Δ, hΓ, hΔ, hΓΔ⟩ := this
+      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ
+      subst hΔ
+      simp only [Finset.disj_empty, Decidable.not_not] at hΓΔ
+      use ({ φ ∈ Γ | φ ∈ v.1.1}).conj
+      constructor
+      . apply iff_mem₁_fconj.mpr
+        intro
+        simp
+      . apply iff_provable_include₁_finset (Γ := {x ∈ Γ | x ∈ y.1.1}) |>.mp ?_ y ?_
+        . apply N!_iff_CO!.mpr
+          apply FConj_DT'.mpr
+          apply Context.weakening! ?_ (FConj_DT.mp hΓΔ)
+          intro φ hφ
+          simp only [Finset.coe_union, Finset.coe_filter, Set.mem_union, Set.mem_setOf_eq]
+          rcases hΓ hφ with _ | _ <;> tauto
+        . intro
+          simp
     obtain ⟨γ₂, hγ₂₁, hγ₂₂⟩ : ∃ γ₂ ∈ v.1.1, ∼γ₂ ∈ z.1.1 := by
       have : Tableau.Inconsistent 𝓢 ⟨z.1.1 ∪ v.1.1, ∅⟩ := by
-        by_contra hconsis;
-        obtain ⟨t, ht⟩ := lindenbaum hconsis;
-        apply hC t ?_ |>.2;
-        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.1;
-        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.2;
-      dsimp [Tableau.Inconsistent, Tableau.Consistent] at this;
-      push_neg at this;
-      obtain ⟨Γ, Δ, hΓ, hΔ, hΓΔ⟩ := this;
-      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ;
-      subst hΔ;
-      simp only [Finset.disj_empty, Decidable.not_not] at hΓΔ;
-      use ({ φ ∈ Γ | φ ∈ v.1.1}).conj;
-      constructor;
-      . apply iff_mem₁_fconj.mpr;
-        intro;
-        simp;
-      . apply iff_provable_include₁_finset (Γ := {x ∈ Γ | x ∈ z.1.1}) |>.mp ?_ z ?_;
-        . apply N!_iff_CO!.mpr;
-          apply FConj_DT'.mpr;
-          apply Context.weakening! ?_ (FConj_DT.mp hΓΔ);
-          intro φ hφ;
-          simp only [Finset.coe_union, Finset.coe_filter, Set.mem_union, Set.mem_setOf_eq];
-          rcases hΓ hφ with _ | _ <;> tauto;
-        . intro;
-          simp;
+        by_contra hconsis
+        obtain ⟨t, ht⟩ := lindenbaum hconsis
+        apply hC t ?_ |>.2
+        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.1
+        . exact Set.union_subset_iff.mp (Tableau.subset_def.mp ht |>.1) |>.2
+      dsimp [Tableau.Inconsistent, Tableau.Consistent] at this
+      push_neg at this
+      obtain ⟨Γ, Δ, hΓ, hΔ, hΓΔ⟩ := this
+      simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΔ
+      subst hΔ
+      simp only [Finset.disj_empty, Decidable.not_not] at hΓΔ
+      use ({ φ ∈ Γ | φ ∈ v.1.1}).conj
+      constructor
+      . apply iff_mem₁_fconj.mpr
+        intro
+        simp
+      . apply iff_provable_include₁_finset (Γ := {x ∈ Γ | x ∈ z.1.1}) |>.mp ?_ z ?_
+        . apply N!_iff_CO!.mpr
+          apply FConj_DT'.mpr
+          apply Context.weakening! ?_ (FConj_DT.mp hΓΔ)
+          intro φ hφ
+          simp only [Finset.coe_union, Finset.coe_filter, Set.mem_union, Set.mem_setOf_eq]
+          rcases hΓ hφ with _ | _ <;> tauto
+        . intro
+          simp
     have : ∼(γ₁ ⋏ γ₂) ∈ v.1.1 := Ruv $ hu₁.2 $ by
-      simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Formula.neg_inj, exists_eq_right, ΓNyz];
+      simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, Formula.neg_inj, exists_eq_right, ΓNyz]
       constructor <;>
-      . apply mdp_mem₁_provable CANNNK!;
-        apply iff_mem₁_or.mpr;
-        tauto;
-    apply of_mem₁_neg' this;
-    apply iff_mem₁_and.mpr;
-    tauto;
+      . apply mdp_mem₁_provable CANNNK!
+        apply iff_mem₁_or.mpr
+        tauto
+    apply of_mem₁_neg' this
+    apply iff_mem₁_and.mpr
+    tauto
 ⟩
 
 end Canonical

--- a/Foundation/Propositional/Kripke/AxiomLEM.lean
+++ b/Foundation/Propositional/Kripke/AxiomLEM.lean
@@ -21,40 +21,40 @@ section definability
 variable {F : Kripke.Frame}
 
 lemma validate_axiomLEM_of_isSymmetric [F.IsSymmetric] : F ⊧ (Axioms.LEM (.atom 0)) := by
-  have := F.symm;
-  revert this;
-  contrapose!;
-  intro h;
+  have := F.symm
+  revert this
+  contrapose!
+  intro h
 
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h;
-  unfold Satisfies at h;
-  push_neg at h;
-  rcases h with ⟨h₁, h₂⟩;
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h
+  unfold Satisfies at h
+  push_neg at h
+  rcases h with ⟨h₁, h₂⟩
 
-  replace h₂ := Satisfies.neg_def.not.mp h₂;
-  push_neg at h₂;
-  obtain ⟨y, Rxy, hy⟩ := h₂;
+  replace h₂ := Satisfies.neg_def.not.mp h₂
+  push_neg at h₂
+  obtain ⟨y, Rxy, hy⟩ := h₂
 
-  use x, y;
-  constructor;
-  . assumption;
-  . by_contra Ryx;
-    exact h₁ $ Satisfies.formula_hereditary Ryx hy;
+  use x, y
+  constructor
+  . assumption
+  . by_contra Ryx
+    exact h₁ $ Satisfies.formula_hereditary Ryx hy
 
 lemma validate_axiomLEM_of_isEuclidean [F.IsEuclidean] : F ⊧ (Axioms.LEM (.atom 0)) := validate_axiomLEM_of_isSymmetric
 
 lemma isEuclidean_of_validate_axiomLEM (h : F ⊧ (Axioms.LEM (.atom 0))) : F.IsEuclidean := ⟨by
-  rintro x y z Rxy Rxz;
+  rintro x y z Rxy Rxz
   let V : Kripke.Valuation F := ⟨λ {v a} => y ≺ v, by
-    intro w v Rwv a Rzw;
-    exact F.trans Rzw Rwv;
-  ⟩;
-  suffices Satisfies ⟨F, V⟩ z (.atom 0) by simpa [Satisfies] using this;
-  apply V.hereditary Rxz;
-  have : ∀ (w : F.World), x ≺ w → y ≺ w → y ≺ x := by simpa [Semantics.Realize, Satisfies, V, or_iff_not_imp_right] using h V x;
-  apply this y;
-  . exact Rxy;
-  . apply F.refl;
+    intro w v Rwv a Rzw
+    exact F.trans Rzw Rwv
+  ⟩
+  suffices Satisfies ⟨F, V⟩ z (.atom 0) by simpa [Satisfies] using this
+  apply V.hereditary Rxz
+  have : ∀ (w : F.World), x ≺ w → y ≺ w → y ≺ x := by simpa [Semantics.Realize, Satisfies, V, or_iff_not_imp_right] using h V x
+  apply this y
+  . exact Rxy
+  . apply F.refl
 ⟩
 
 end definability
@@ -74,21 +74,21 @@ open Classical
 
 instance [Entailment.HasAxiomLEM 𝓢] : (canonicalFrame 𝓢).IsEuclidean := ⟨by
   suffices ∀ x y z : (canonicalFrame 𝓢), x ≺ y → x ≺ z → z ≺ y by
-    intro x y z Rxy Rxz;
-    exact this x z y Rxz Rxy;
+    intro x y z Rxy Rxz
+    exact this x z y Rxz Rxy
 
-  rintro x y z;
-  intro Rxy;
-  contrapose!;
-  intro nRzy;
-  obtain ⟨φ, hzφ, nhyφ⟩ := Set.not_subset.mp nRzy;
-  apply Set.not_subset.mpr;
-  use ∼φ;
-  constructor;
-  . by_contra hnφ;
-    have : φ ∈ y.1.1 := Rxy $ (or_iff_not_imp_right.mp $ iff_mem₁_or.mp $ mem₁_of_provable (by simp)) hnφ;
-    contradiction;
-  . exact not_mem₁_neg_of_mem₁ hzφ;
+  rintro x y z
+  intro Rxy
+  contrapose!
+  intro nRzy
+  obtain ⟨φ, hzφ, nhyφ⟩ := Set.not_subset.mp nRzy
+  apply Set.not_subset.mpr
+  use ∼φ
+  constructor
+  . by_contra hnφ
+    have : φ ∈ y.1.1 := Rxy $ (or_iff_not_imp_right.mp $ iff_mem₁_or.mp $ mem₁_of_provable (by simp)) hnφ
+    contradiction
+  . exact not_mem₁_neg_of_mem₁ hzφ
 ⟩
 
 end canonicality

--- a/Foundation/Propositional/Kripke/AxiomWeakLEM.lean
+++ b/Foundation/Propositional/Kripke/AxiomWeakLEM.lean
@@ -22,48 +22,48 @@ section definability
 variable {F : Kripke.Frame}
 
 lemma validate_axiomWeakLEM_of_isPiecewiseStronglyConvergent [F.IsPiecewiseStronglyConvergent] : F ⊧ (Axioms.WeakLEM (.atom 0)) := by
-  have := F.ps_convergent;
-  revert this;
-  contrapose!;
-  intro h;
-  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h;
-  unfold Satisfies at h;
-  push_neg at h;
-  rcases h with ⟨h₁, h₂⟩;
+  have := F.ps_convergent
+  revert this
+  contrapose!
+  intro h
+  obtain ⟨V, x, h⟩ := ValidOnFrame.exists_valuation_world_of_not h
+  unfold Satisfies at h
+  push_neg at h
+  rcases h with ⟨h₁, h₂⟩
 
-  replace h₁ := Satisfies.neg_def.not.mp h₁;
-  push_neg at h₁;
-  obtain ⟨y, Rxy, hy⟩ := h₁;
+  replace h₁ := Satisfies.neg_def.not.mp h₁
+  push_neg at h₁
+  obtain ⟨y, Rxy, hy⟩ := h₁
 
-  replace h₂ := Satisfies.neg_def.not.mp h₂;
-  push_neg at h₂;
-  obtain ⟨z, Rxz, hz⟩ := h₂;
+  replace h₂ := Satisfies.neg_def.not.mp h₂
+  push_neg at h₂
+  obtain ⟨z, Rxz, hz⟩ := h₂
 
-  use x, y, z;
-  refine ⟨Rxy, Rxz, ?_⟩;
-  . intro u Ryu;
-    by_contra Rzu;
-    exact (Satisfies.neg_def.mp hz) Rzu $ Satisfies.formula_hereditary Ryu hy;
+  use x, y, z
+  refine ⟨Rxy, Rxz, ?_⟩
+  . intro u Ryu
+    by_contra Rzu
+    exact (Satisfies.neg_def.mp hz) Rzu $ Satisfies.formula_hereditary Ryu hy
 
 
 lemma isPiecewiseStronglyConvergent_of_validate_axiomWeakLEM (h : F ⊧ (Axioms.WeakLEM (.atom 0))) : F.IsPiecewiseStronglyConvergent := ⟨by
-  rintro x y z Rxy Ryz;
+  rintro x y z Rxy Ryz
   let V : Kripke.Valuation F := ⟨λ {v a} => y ≺ v, by
-    intro w v Rwv a Ryw;
-    apply F.trans Ryw Rwv;
-  ⟩;
-  replace h : F ⊧ (Axioms.WeakLEM (.atom 0)) := by simpa using h;
+    intro w v Rwv a Ryw
+    apply F.trans Ryw Rwv
+  ⟩
+  replace h : F ⊧ (Axioms.WeakLEM (.atom 0)) := by simpa using h
   have : ¬Satisfies ⟨F, V⟩ x (∼(.atom 0)) := by
-    suffices ∃ y, x ≺ y ∧ V y 0 by simpa [Satisfies];
-    use y;
-    constructor;
-    . exact Rxy;
-    . simp [V];
+    suffices ∃ y, x ≺ y ∧ V y 0 by simpa [Satisfies]
+    use y
+    constructor
+    . exact Rxy
+    . simp [V]
   have : Satisfies ⟨F, V⟩ x (∼∼(.atom 0)) := by
-    apply or_iff_not_imp_left.mp $ Satisfies.or_def.mp $ @h V x;
-    assumption;
-  obtain ⟨w, Rzw, hw⟩ := by simpa [Satisfies] using @this z Ryz;
-  use w;
+    apply or_iff_not_imp_left.mp $ Satisfies.or_def.mp $ @h V x
+    assumption
+  obtain ⟨w, Rzw, hw⟩ := by simpa [Satisfies] using @this z Ryz
+  use w
 ⟩
 
 end definability
@@ -82,17 +82,17 @@ open SaturatedConsistentTableau
 open Classical
 
 instance [Entailment.HasAxiomWeakLEM 𝓢] : (canonicalFrame 𝓢).IsPiecewiseStronglyConvergent := ⟨by
-  rintro x y z Rxy Rxz;
+  rintro x y z Rxy Rxz
   suffices Tableau.Consistent 𝓢 (y.1.1 ∪ z.1.1, ∅) by
-    obtain ⟨w, hw⟩ := lindenbaum (𝓢 := 𝓢) this;
-    use w;
-    simpa using hw;
+    obtain ⟨w, hw⟩ := lindenbaum (𝓢 := 𝓢) this
+    use w
+    simpa using hw
 
-  intro Γ Δ;
-  intro hΓ hΔ h;
-  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ;
-  subst hΔ;
-  simp only [Finset.disj_empty] at h;
+  intro Γ Δ
+  intro hΓ hΔ h
+  simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ
+  subst hΔ
+  simp only [Finset.disj_empty] at h
 
   let Θx := { φ ∈ Γ | (φ ∈ y.1.1 ∧ φ ∈ x.1.1) ∨ (φ ∈ z.1.1 ∧ φ ∈ x.1.1) }
   let Θy := { φ ∈ Γ | φ ∈ y.1.1 ∧ φ ∉ x.1.1 }
@@ -100,52 +100,52 @@ instance [Entailment.HasAxiomWeakLEM 𝓢] : (canonicalFrame 𝓢).IsPiecewiseSt
 
   suffices ∼Θy.conj ∈ x.1.1 by
     apply not_mem₁_neg_of_mem₁ (φ := Θy.conj) (t := y) $ iff_mem₁_fconj.mpr $ by
-      intro φ;
-      simp only [Finset.coe_filter, Set.mem_setOf_eq, Θy];
-      tauto;
-    exact Rxy this;
+      intro φ
+      simp only [Finset.coe_filter, Set.mem_setOf_eq, Θy]
+      tauto
+    exact Rxy this
 
   have : 𝓢 ⊢! (Θx.conj ⋏ Θy.conj ⋏ Θz.conj) ➝ ⊥ := by
-    apply C!_trans ?_ h;
-    apply CK!_iff_CC!.mpr;
-    apply FConj_DT.mpr;
-    apply CK!_iff_CC!.mpr;
-    apply FConj_DT'.mpr;
-    apply FConj_DT'.mpr;
-    apply FConj_DT.mp;
-    apply CFConj_FConj!_of_subset;
-    intro φ hφ;
-    rcases hΓ hφ with h | h;
+    apply C!_trans ?_ h
+    apply CK!_iff_CC!.mpr
+    apply FConj_DT.mpr
+    apply CK!_iff_CC!.mpr
+    apply FConj_DT'.mpr
+    apply FConj_DT'.mpr
+    apply FConj_DT.mp
+    apply CFConj_FConj!_of_subset
+    intro φ hφ
+    rcases hΓ hφ with h | h
     . suffices φ ∈ Θx ∪ Θy by
-        apply Finset.mem_union.mpr;
-        tauto;
-      simp [Θx, Θy, Θz];
-      tauto;
+        apply Finset.mem_union.mpr
+        tauto
+      simp [Θx, Θy, Θz]
+      tauto
     . suffices φ ∈ Θx ∪ Θz by
         rw [(show Θx ∪ Θy ∪ Θz = Θx ∪ Θz ∪ Θy by rw [Finset.union_assoc, Finset.union_comm Θy, ←Finset.union_assoc])]
-        apply Finset.mem_union.mpr;
-        tauto;
-      simp [Θx, Θy, Θz];
-      tauto;
+        apply Finset.mem_union.mpr
+        tauto
+      simp [Θx, Θy, Θz]
+      tauto
   have : 𝓢 ⊢! Θx.conj ➝ Θy.conj ➝ ∼Θz.conj := CK!_iff_CC!.mp $
-    (C!_trans (CK!_iff_CC!.mp $ C!_trans (K!_left K!_assoc) this) (K!_right $ neg_equiv!));
-  replace : [Θx.conj] ⊢[𝓢]! Θy.conj ➝ ∼Θz.conj := FiniteContext.deductInv'! this;
-  replace : [Θx.conj] ⊢[𝓢]! ∼∼Θz.conj ➝ ∼Θy.conj := contra! this;
+    (C!_trans (CK!_iff_CC!.mp $ C!_trans (K!_left K!_assoc) this) (K!_right $ neg_equiv!))
+  replace : [Θx.conj] ⊢[𝓢]! Θy.conj ➝ ∼Θz.conj := FiniteContext.deductInv'! this
+  replace : [Θx.conj] ⊢[𝓢]! ∼∼Θz.conj ➝ ∼Θy.conj := contra! this
 
   have mem_Θx_x : Θx.conj ∈ x.1.1 := iff_mem₁_fconj.mpr $ by
-    intro φ;
-    simp only [Finset.coe_filter, Set.mem_setOf_eq, Θx, Θy, Θz];
-    tauto;
+    intro φ
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Θx, Θy, Θz]
+    tauto
   have mem_Θz_z : Θz.conj ∈ z.1.1 := iff_mem₁_fconj.mpr $ by
-    intro φ;
-    simp only [Finset.coe_filter, Set.mem_setOf_eq, Θz, Θy, Θx];
-    tauto;
+    intro φ
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Θz, Θy, Θx]
+    tauto
 
-  have nmem_nΘz_z : ∼Θz.conj ∉ z.1.1 := not_mem₁_neg_of_mem₁ mem_Θz_z;
-  have nmem_nΘz_x : ∼Θz.conj ∉ x.1.1 := Set.not_mem_subset Rxz nmem_nΘz_z;
-  have mem_nnΘz_x : ∼∼Θz.conj ∈ x.1.1 := or_iff_not_imp_left.mp (iff_mem₁_or.mp $ mem₁_of_provable $ wlem!) nmem_nΘz_x;
+  have nmem_nΘz_z : ∼Θz.conj ∉ z.1.1 := not_mem₁_neg_of_mem₁ mem_Θz_z
+  have nmem_nΘz_x : ∼Θz.conj ∉ x.1.1 := Set.not_mem_subset Rxz nmem_nΘz_z
+  have mem_nnΘz_x : ∼∼Θz.conj ∈ x.1.1 := or_iff_not_imp_left.mp (iff_mem₁_or.mp $ mem₁_of_provable $ wlem!) nmem_nΘz_x
 
-  exact mdp₁_mem mem_nnΘz_x $ mdp_mem₁_provable this mem_Θx_x;
+  exact mdp₁_mem mem_nnΘz_x $ mdp_mem₁_provable this mem_Θx_x
 ⟩
 
 end canonicality

--- a/Foundation/Propositional/Kripke/Basic.lean
+++ b/Foundation/Propositional/Kripke/Basic.lean
@@ -87,89 +87,89 @@ variable {M : Kripke.Model} {w w' : M.World} {a : ℕ} {φ ψ χ : Formula ℕ}
 
 @[simp] protected lemma iff_models : w ⊧ φ ↔ Formula.Kripke.Satisfies M w φ := iff_of_eq rfl
 
-@[simp] lemma atom_def : w ⊧ atom a ↔ M w a := by simp [Satisfies];
+@[simp] lemma atom_def : w ⊧ atom a ↔ M w a := by simp [Satisfies]
 
-@[simp] lemma top_def  : w ⊧ ⊤ ↔ True := by simp [Satisfies];
+@[simp] lemma top_def  : w ⊧ ⊤ ↔ True := by simp [Satisfies]
 
-@[simp] lemma bot_def  : w ⊧ ⊥ ↔ False := by simp [Satisfies];
+@[simp] lemma bot_def  : w ⊧ ⊥ ↔ False := by simp [Satisfies]
 
-@[simp] lemma and_def  : w ⊧ φ ⋏ ψ ↔ w ⊧ φ ∧ w ⊧ ψ := by simp [Satisfies];
+@[simp] lemma and_def  : w ⊧ φ ⋏ ψ ↔ w ⊧ φ ∧ w ⊧ ψ := by simp [Satisfies]
 
-@[simp] lemma or_def   : w ⊧ φ ⋎ ψ ↔ w ⊧ φ ∨ w ⊧ ψ := by simp [Satisfies];
+@[simp] lemma or_def   : w ⊧ φ ⋎ ψ ↔ w ⊧ φ ∨ w ⊧ ψ := by simp [Satisfies]
 
-@[simp] lemma imp_def  : w ⊧ φ ➝ ψ ↔ ∀ {w' : M.World}, (w ≺ w') → (w' ⊧ φ → w' ⊧ ψ) := by simp [Satisfies, imp_iff_not_or];
+@[simp] lemma imp_def  : w ⊧ φ ➝ ψ ↔ ∀ {w' : M.World}, (w ≺ w') → (w' ⊧ φ → w' ⊧ ψ) := by simp [Satisfies, imp_iff_not_or]
 
-@[simp] lemma neg_def  : w ⊧ ∼φ ↔ ∀ {w' : M.World}, (w ≺ w') → ¬(w' ⊧ φ) := by simp [Satisfies];
+@[simp] lemma neg_def  : w ⊧ ∼φ ↔ ∀ {w' : M.World}, (w ≺ w') → ¬(w' ⊧ φ) := by simp [Satisfies]
 
 lemma not_of_neg : w ⊧ ∼φ → ¬w ⊧ φ := fun h hC ↦ h (refl w) hC
 
 instance : Semantics.Top M.World where
-  realize_top := by simp [Satisfies];
+  realize_top := by simp [Satisfies]
 
 instance : Semantics.Bot M.World where
-  realize_bot := by simp [Satisfies];
+  realize_bot := by simp [Satisfies]
 
 instance : Semantics.And M.World where
-  realize_and := by simp [Satisfies];
+  realize_and := by simp [Satisfies]
 
 instance : Semantics.Or M.World where
-  realize_or := by simp [Satisfies];
+  realize_or := by simp [Satisfies]
 
 lemma formula_hereditary
   (hw : w ≺ w') : w ⊧ φ → w' ⊧ φ := by
   induction φ with
-  | hatom => apply M.Val.hereditary hw;
+  | hatom => apply M.Val.hereditary hw
   | himp =>
-    intro hpq v hv;
-    exact hpq $ M.trans hw hv;
-  | hor => simp_all; tauto;
-  | _ => simp_all;
+    intro hpq v hv
+    exact hpq $ M.trans hw hv
+  | hor => simp_all; tauto
+  | _ => simp_all
 
 lemma formula_hereditary_not (hw : w ≺ w') : ¬w' ⊧ φ → ¬w ⊧ φ := by
-  contrapose;
-  push_neg;
-  exact formula_hereditary hw;
+  contrapose
+  push_neg
+  exact formula_hereditary hw
 
-lemma negEquiv : w ⊧ ∼φ ↔ w ⊧ φ ➝ ⊥ := by simp_all [Satisfies];
+lemma negEquiv : w ⊧ ∼φ ↔ w ⊧ φ ➝ ⊥ := by simp_all [Satisfies]
 
 lemma iff_subst_self {F : Frame} {V : Valuation F} {x : F.World} (s) :
   letI U : Kripke.Valuation F := ⟨
     λ w a => Satisfies ⟨F, V⟩ w ((.atom a)⟦s⟧),
     fun {_ _} Rwv {_} => formula_hereditary Rwv
-  ⟩;
+  ⟩
   Satisfies ⟨F, U⟩ x φ ↔ Satisfies ⟨F, V⟩ x (φ⟦s⟧) := by
   induction φ generalizing x with
-  | hatom a => simp [Satisfies];
-  | hfalsum => simp [Satisfies];
+  | hatom a => simp [Satisfies]
+  | hfalsum => simp [Satisfies]
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . intro hφψ y Rxy hφs;
-      apply ihψ.mp;
-      apply hφψ Rxy;
-      apply ihφ.mpr hφs;
-    . intro hφψs y Rxy hφ;
-      apply ihψ.mpr;
-      apply hφψs Rxy;
-      apply ihφ.mp hφ;
+    constructor
+    . intro hφψ y Rxy hφs
+      apply ihψ.mp
+      apply hφψ Rxy
+      apply ihφ.mpr hφs
+    . intro hφψs y Rxy hφ
+      apply ihψ.mpr
+      apply hφψs Rxy
+      apply ihφ.mp hφ
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . apply ihφ.mp hφ;
-      . apply ihψ.mp hψ;
-    . rintro ⟨hφ, hψ⟩;
-      apply Satisfies.and_def.mpr;
-      constructor;
-      . apply ihφ.mpr hφ;
-      . apply ihψ.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . apply ihφ.mp hφ
+      . apply ihψ.mp hψ
+    . rintro ⟨hφ, hψ⟩
+      apply Satisfies.and_def.mpr
+      constructor
+      . apply ihφ.mpr hφ
+      . apply ihψ.mpr hψ
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . left; apply ihφ.mp hφ;
-      . right; apply ihψ.mp hψ;
-    . rintro (hφ | hψ);
-      . left; apply ihφ.mpr hφ;
-      . right; apply ihψ.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . left; apply ihφ.mp hφ
+      . right; apply ihψ.mp hψ
+    . rintro (hφ | hψ)
+      . left; apply ihφ.mpr hφ
+      . right; apply ihψ.mpr hψ
 
 end Satisfies
 
@@ -187,57 +187,57 @@ variable {M : Model} {φ ψ χ : Formula ℕ}
 @[simp] protected lemma iff_models : M ⊧ φ ↔ Formula.Kripke.ValidOnModel M φ := iff_of_eq rfl
 
 
-protected lemma verum : M ⊧ ⊤ := by simp [ValidOnModel];
+protected lemma verum : M ⊧ ⊤ := by simp [ValidOnModel]
 
 instance : Semantics.Top (Model) := ⟨λ _ => ValidOnModel.verum⟩
 
 
-protected lemma bot : ¬M ⊧ ⊥ := by simp [ValidOnModel];
+protected lemma bot : ¬M ⊧ ⊥ := by simp [ValidOnModel]
 
 instance : Semantics.Bot (Model) := ⟨λ _ => ValidOnModel.bot⟩
 
 
 lemma iff_not_exists_world {M : Kripke.Model} : (¬M ⊧ φ) ↔ (∃ x : M.World, ¬x ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 
 alias ⟨exists_world_of_not, not_of_exists_world⟩ := iff_not_exists_world
 
-protected lemma andElim₁ : M ⊧ φ ⋏ ψ ➝ φ := by simp_all [ValidOnModel, Satisfies];
+protected lemma andElim₁ : M ⊧ φ ⋏ ψ ➝ φ := by simp_all [ValidOnModel, Satisfies]
 
-protected lemma andElim₂ : M ⊧ φ ⋏ ψ ➝ ψ := by simp_all [ValidOnModel, Satisfies];
+protected lemma andElim₂ : M ⊧ φ ⋏ ψ ➝ ψ := by simp_all [ValidOnModel, Satisfies]
 
 protected lemma andInst₃ : M ⊧ φ ➝ ψ ➝ φ ⋏ ψ := by
-  intro x y _ hp z Ryz hq;
-  replace hp : Satisfies M z φ := formula_hereditary Ryz hp;
-  exact ⟨hp, hq⟩;
+  intro x y _ hp z Ryz hq
+  replace hp : Satisfies M z φ := formula_hereditary Ryz hp
+  exact ⟨hp, hq⟩
 
-protected lemma orInst₁ : M ⊧ φ ➝ φ ⋎ ψ := by simp_all [ValidOnModel, Satisfies];
+protected lemma orInst₁ : M ⊧ φ ➝ φ ⋎ ψ := by simp_all [ValidOnModel, Satisfies]
 
-protected lemma orInst₂ : M ⊧ ψ ➝ φ ⋎ ψ := by simp_all [ValidOnModel, Satisfies];
+protected lemma orInst₂ : M ⊧ ψ ➝ φ ⋎ ψ := by simp_all [ValidOnModel, Satisfies]
 
 protected lemma orElim : M ⊧ (φ ➝ χ) ➝ (ψ ➝ χ) ➝ (φ ⋎ ψ ➝ χ) := by
-  intro w₁ w₂ _ hpr w₃ hw₂₃ hqr w₄ hw₃₄ hpq;
+  intro w₁ w₂ _ hpr w₃ hw₂₃ hqr w₄ hw₃₄ hpq
   cases hpq with
-  | inl hp => exact hpr (M.trans hw₂₃ hw₃₄) hp;
-  | inr hq => exact hqr hw₃₄ hq;
+  | inl hp => exact hpr (M.trans hw₂₃ hw₃₄) hp
+  | inr hq => exact hqr hw₃₄ hq
 
 protected lemma imply₁ : M ⊧ φ ➝ ψ ➝ φ := by
-  intro x y _ hp z Ryz _;
-  exact formula_hereditary Ryz hp;
+  intro x y _ hp z Ryz _
+  exact formula_hereditary Ryz hp
 
 protected lemma imply₂ : M ⊧ (φ ➝ ψ ➝ χ) ➝ (φ ➝ ψ) ➝ φ ➝ χ := by
-  intro x y _ hpqr z Ryz hpq w Rzw hp;
-  have Ryw : y ≺ w := M.trans Ryz Rzw;
-  have Rww : w ≺ w := M.refl;
-  exact hpqr Ryw hp Rww (hpq Rzw hp);
+  intro x y _ hpqr z Ryz hpq w Rzw hp
+  have Ryw : y ≺ w := M.trans Ryz Rzw
+  have Rww : w ≺ w := M.refl
+  exact hpqr Ryw hp Rww (hpq Rzw hp)
 
 protected lemma mdp (hpq : M ⊧ φ ➝ ψ) (hp : M ⊧ φ) : M ⊧ ψ := by
-  intro w;
-  exact hpq w M.refl $ hp w;
+  intro w
+  exact hpq w M.refl $ hp w
 
-protected lemma efq : M ⊧ Axioms.EFQ φ := by simp [ValidOnModel, Satisfies];
+protected lemma efq : M ⊧ Axioms.EFQ φ := by simp [ValidOnModel, Satisfies]
 
 end ValidOnModel
 
@@ -253,44 +253,44 @@ variable {F : Frame} {φ ψ χ : Formula ℕ}
 
 @[simp] protected lemma models_iff : F ⊧ φ ↔ ValidOnFrame F φ := iff_of_eq rfl
 
-protected lemma top : F ⊧ ⊤ := by tauto;
+protected lemma top : F ⊧ ⊤ := by tauto
 instance : Semantics.Top (Frame) := ⟨λ _ => ValidOnFrame.top⟩
 
 protected lemma bot : ¬F ⊧ ⊥ := by
-  simp [ValidOnFrame.models_iff, ValidOnFrame];
-  exact ⟨(λ _ _ => True), by tauto⟩;
+  simp [ValidOnFrame.models_iff, ValidOnFrame]
+  exact ⟨(λ _ _ => True), by tauto⟩
 instance : Semantics.Bot (Frame) := ⟨λ _ => ValidOnFrame.bot⟩
 
 
 lemma iff_not_exists_valuation : (¬F ⊧ φ) ↔ (∃ V : Kripke.Valuation F, ¬(⟨F, V⟩ : Kripke.Model) ⊧ φ) := by
-  simp [ValidOnFrame];
+  simp [ValidOnFrame]
 
 alias ⟨exists_valuation_of_not, not_of_exists_valuation⟩ := iff_not_exists_valuation
 
 
 lemma iff_not_exists_valuation_world : (¬F ⊧ φ) ↔ (∃ V : Kripke.Valuation F, ∃ x : (⟨F, V⟩ : Kripke.Model).World, ¬Satisfies _ x φ) := by
-  simp [ValidOnFrame, ValidOnModel, Semantics.Realize];
+  simp [ValidOnFrame, ValidOnModel, Semantics.Realize]
 
 alias ⟨exists_valuation_world_of_not, not_of_exists_valuation_world⟩ := iff_not_exists_valuation_world
 
 
 lemma iff_not_exists_model_world :  (¬F ⊧ φ) ↔ (∃ M : Kripke.Model, ∃ x : M.World, M.toFrame = F ∧ ¬(x ⊧ φ)) := by
-  constructor;
-  . intro h;
-    obtain ⟨V, x, h⟩ := iff_not_exists_valuation_world.mp h;
-    use ⟨F, V⟩, x;
-    tauto;
-  . rintro ⟨M, x, rfl, h⟩;
-    exact iff_not_exists_valuation_world.mpr ⟨M.Val, x, h⟩;
+  constructor
+  . intro h
+    obtain ⟨V, x, h⟩ := iff_not_exists_valuation_world.mp h
+    use ⟨F, V⟩, x
+    tauto
+  . rintro ⟨M, x, rfl, h⟩
+    exact iff_not_exists_valuation_world.mpr ⟨M.Val, x, h⟩
 
 alias ⟨exists_model_world_of_not, not_of_exists_model_world⟩ := iff_not_exists_model_world
 
 
 protected lemma subst (h : F ⊧ φ) : F ⊧ φ⟦s⟧ := by
-  by_contra hC;
-  obtain ⟨V, ⟨x, hx⟩⟩ := exists_valuation_world_of_not hC;
-  apply Satisfies.iff_subst_self s |>.not.mpr hx;
-  apply h;
+  by_contra hC
+  obtain ⟨V, ⟨x, hx⟩⟩ := exists_valuation_world_of_not hC
+  apply Satisfies.iff_subst_self s |>.not.mpr hx
+  apply h
 
 protected lemma andElim₁ : F ⊧ φ ⋏ ψ ➝ φ := fun _ => ValidOnModel.andElim₁
 
@@ -325,21 +325,21 @@ section
 variable {C : Kripke.FrameClass} {φ ψ χ : Formula ℕ}
 
 lemma iff_not_validOnFrameClass_exists_frame : (¬C ⊧ φ) ↔ (∃ F ∈ C, ¬F ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_frame_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_frame⟩ := iff_not_validOnFrameClass_exists_frame
 
 lemma iff_not_validOnFrameClass_exists_model : (¬C ⊧ φ) ↔ (∃ M : Kripke.Model, M.toFrame ∈ C ∧ ¬M ⊧ φ) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_model_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_model⟩ := iff_not_validOnFrameClass_exists_model
 
 lemma iff_not_validOnFrameClass_exists_model_world : (¬C ⊧ φ) ↔ (∃ M : Kripke.Model, ∃ x : M.World, M.toFrame ∈ C ∧ ¬(x ⊧ φ)) := by
-  apply not_iff_not.mp;
-  push_neg;
-  tauto;
+  apply not_iff_not.mp
+  push_neg
+  tauto
 alias ⟨exists_model_world_of_not_validOnFrameClass, not_validOnFrameClass_of_exists_model_world⟩ := iff_not_validOnFrameClass_exists_model_world
 
 end
@@ -359,10 +359,10 @@ abbrev ValidatesFormula (C : FrameClass) (φ : Formula ℕ) := Validates C {φ}
 variable {C C₁ C₂ : FrameClass} {Γ Γ₁ Γ₂ : FormulaSet ℕ} {φ φ₁ φ₂ : Formula ℕ}
 
 lemma Validates.inter_of (h₁ : C₁.Validates Γ₁) (h₂ : C₂.Validates Γ₂) : (C₁ ∩ C₂).Validates (Γ₁ ∪ Γ₂) := by
-  rintro F;
-  rintro ⟨hF₁, hF₂⟩ φ (hφ₁ | hφ₂);
-  . exact h₁ F hF₁ _ hφ₁;
-  . exact h₂ F hF₂ _ hφ₂;
+  rintro F
+  rintro ⟨hF₁, hF₂⟩ φ (hφ₁ | hφ₂)
+  . exact h₁ F hF₁ _ hφ₁
+  . exact h₂ F hF₂ _ hφ₂
 
 lemma ValidatesFormula.inter_of (h₁ : C₁.ValidatesFormula φ₁) (h₂ : C₂.ValidatesFormula φ₂) : (C₁ ∩ C₂).Validates {φ₁, φ₂}
   := Validates.inter_of h₁ h₂
@@ -371,26 +371,26 @@ lemma ValidatesFormula.inter_of (h₁ : C₁.ValidatesFormula φ₁) (h₂ : C�
 protected abbrev all : FrameClass := Set.univ
 
 @[simp]
-lemma all.IsNonempty : FrameClass.all.Nonempty := by use whitepoint; tauto;
+lemma all.IsNonempty : FrameClass.all.Nonempty := by use whitepoint; tauto
 
 lemma all.validates_AxiomEFQ : FrameClass.all.ValidatesFormula (Axioms.EFQ (.atom 0)) := by
-  suffices ∀ (F : Frame), Formula.Kripke.ValidOnFrame F (Axioms.EFQ (.atom 0)) by simpa [Validates];
-  intro F;
-  exact Formula.Kripke.ValidOnFrame.efq;
+  suffices ∀ (F : Frame), Formula.Kripke.ValidOnFrame F (Axioms.EFQ (.atom 0)) by simpa [Validates]
+  intro F
+  exact Formula.Kripke.ValidOnFrame.efq
 
 lemma Validates.withAxiomEFQ (hV : C.Validates Γ) : C.Validates (insert (Axioms.EFQ (.atom 0)) Γ) := by
-  convert Validates.inter_of all.validates_AxiomEFQ hV;
-  tauto_set;
+  convert Validates.inter_of all.validates_AxiomEFQ hV
+  tauto_set
 
 protected abbrev finite_all : FrameClass := { F | F.IsFinite }
 
 @[simp]
-lemma finite_all.nonempty : FrameClass.finite_all.Nonempty := by use whitepoint; tauto;
+lemma finite_all.nonempty : FrameClass.finite_all.Nonempty := by use whitepoint; tauto
 
 lemma finite_all.validates_AxiomEFQ : FrameClass.finite_all.ValidatesFormula (Axioms.EFQ (.atom 0)) := by
-  suffices ∀ (F : Frame), F.IsFinite → Formula.Kripke.ValidOnFrame F (Axioms.EFQ (.atom 0)) by simpa [Validates];
-  intro F _;
-  exact Formula.Kripke.ValidOnFrame.efq;
+  suffices ∀ (F : Frame), F.IsFinite → Formula.Kripke.ValidOnFrame F (Axioms.EFQ (.atom 0)) by simpa [Validates]
+  intro F _
+  exact Formula.Kripke.ValidOnFrame.efq
 
 end FrameClass
 

--- a/Foundation/Propositional/Kripke/Completeness.lean
+++ b/Foundation/Propositional/Kripke/Completeness.lean
@@ -21,29 +21,29 @@ def canonicalFrame (𝓢 : S) [Entailment.Consistent 𝓢] [Entailment.Int 𝓢]
   rel_partial_order := {
     refl := by tauto_set
     trans := by tauto_set
-    antisymm := fun x y Sxy Syx => equality_of₁ $ by tauto_set;
+    antisymm := fun x y Sxy Syx => equality_of₁ $ by tauto_set
   }
 
 namespace canonicalFrame
 
 variable {x y : canonicalFrame 𝓢}
 
-lemma rel₁ : x ≺ y ↔ x.1.1 ⊆ y.1.1 := by simp [Frame.Rel', canonicalFrame];
+lemma rel₁ : x ≺ y ↔ x.1.1 ⊆ y.1.1 := by simp [Frame.Rel', canonicalFrame]
 
 lemma rel₂ : x ≺ y ↔ y.1.2 ⊆ x.1.2 := by
-  constructor;
-  . intro h φ;
-    contrapose;
-    intro hφ;
-    apply iff_not_mem₂_mem₁.mpr;
-    apply h;
-    exact iff_not_mem₂_mem₁.mp hφ;
-  . intro h φ;
-    contrapose;
-    intro hφ;
-    apply iff_not_mem₁_mem₂.mpr;
-    apply h;
-    exact iff_not_mem₁_mem₂.mp hφ;
+  constructor
+  . intro h φ
+    contrapose
+    intro hφ
+    apply iff_not_mem₂_mem₁.mpr
+    apply h
+    exact iff_not_mem₂_mem₁.mp hφ
+  . intro h φ
+    contrapose
+    intro hφ
+    apply iff_not_mem₁_mem₂.mpr
+    apply h
+    exact iff_not_mem₁_mem₂.mp hφ
 
 end canonicalFrame
 
@@ -69,87 +69,87 @@ private lemma truthlemma.himp
   (ihp : ∀ {t : (Kripke.canonicalModel 𝓢).World}, t ⊧ φ ↔ φ ∈ t.1.1)
   (ihq : ∀ {t : (Kripke.canonicalModel 𝓢).World}, t ⊧ ψ ↔ ψ ∈ t.1.1)
   : t ⊧ φ ➝ ψ ↔ φ ➝ ψ ∈ t.1.1 := by
-  constructor;
-  . contrapose;
-    intro h;
-    replace h := iff_not_mem₁_mem₂.mp h;
+  constructor
+  . contrapose
+    intro h
+    replace h := iff_not_mem₁_mem₂.mp h
     obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (𝓢 := 𝓢) (t₀ := (insert φ t.1.1, {ψ})) $ by
-      intro Γ Δ hΓ hΔ;
-      by_contra hC;
-      apply t.consistent (Γ := Γ.erase φ) (Δ := {φ ➝ ψ}) ?_ ?_;
-      . simp only [Finset.disj_singleton];
-        apply FConj_DT.mpr;
+      intro Γ Δ hΓ hΔ
+      by_contra hC
+      apply t.consistent (Γ := Γ.erase φ) (Δ := {φ ➝ ψ}) ?_ ?_
+      . simp only [Finset.disj_singleton]
+        apply FConj_DT.mpr
         apply Context.deduct!
-        replace hC := Context.weakening! (Δ := insert φ Γ.toSet) (by simp) $ FConj_DT.mp hC;
-        rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
-        . simp only [Finset.coe_eq_empty] at hΔ;
-          subst hΔ;
-          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_diff_singleton] at hC ⊢;
-          exact of_O! hC;
-        . simp only [Finset.coe_eq_singleton] at hΔ;
-          subst hΔ;
-          simpa using hC;
-      . simpa using Set.iff_subset_insert_subset_diff.mp hΓ;
-      . simpa;
-    have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
-    apply Satisfies.imp_def.not.mpr;
-    push_neg;
-    use t';
-    constructor;
-    . assumption;
-    . constructor;
-      . apply ihp.mpr;
-        assumption;
-      . apply ihq.not.mpr;
-        apply iff_not_mem₁_mem₂.mpr;
-        simp_all only [Set.singleton_subset_iff];
-  . intro h t' htt' hp;
-    replace hp := ihp.mp hp;
-    have hpq := htt' h;
-    apply ihq.mpr;
-    apply iff_not_mem₂_mem₁.mp;
-    apply not_mem₂ (Γ := {φ, φ ➝ ψ});
-    . simp only [Finset.coe_insert, Finset.coe_singleton];
-      apply Set.doubleton_subset.mpr;
-      tauto;
-    . suffices 𝓢 ⊢! Finset.conj {φ, φ ➝ ψ} ➝ Finset.disj {ψ} by simpa;
-      apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp;
+        replace hC := Context.weakening! (Δ := insert φ Γ.toSet) (by simp) $ FConj_DT.mp hC
+        rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ)
+        . simp only [Finset.coe_eq_empty] at hΔ
+          subst hΔ
+          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_diff_singleton] at hC ⊢
+          exact of_O! hC
+        . simp only [Finset.coe_eq_singleton] at hΔ
+          subst hΔ
+          simpa using hC
+      . simpa using Set.iff_subset_insert_subset_diff.mp hΓ
+      . simpa
+    have ⟨_, _⟩ := Set.insert_subset_iff.mp h
+    apply Satisfies.imp_def.not.mpr
+    push_neg
+    use t'
+    constructor
+    . assumption
+    . constructor
+      . apply ihp.mpr
+        assumption
+      . apply ihq.not.mpr
+        apply iff_not_mem₁_mem₂.mpr
+        simp_all only [Set.singleton_subset_iff]
+  . intro h t' htt' hp
+    replace hp := ihp.mp hp
+    have hpq := htt' h
+    apply ihq.mpr
+    apply iff_not_mem₂_mem₁.mp
+    apply not_mem₂ (Γ := {φ, φ ➝ ψ})
+    . simp only [Finset.coe_insert, Finset.coe_singleton]
+      apply Set.doubleton_subset.mpr
+      tauto
+    . suffices 𝓢 ⊢! Finset.conj {φ, φ ➝ ψ} ➝ Finset.disj {ψ} by simpa
+      apply CFConj_CDisj!_of_innerMDP (φ := φ) (ψ := ψ) <;> simp
 
 lemma truthlemma : t ⊧ φ ↔ φ ∈ t.1.1 := by
   induction φ generalizing t with
-  | hatom => tauto;
-  | hfalsum => simp only [Semantics.Bot.realize_bot, not_mem₁_falsum];
-  | himp φ ψ ihp ihq => exact truthlemma.himp ihp ihq;
-  | hand φ ψ ihp ihq => simp [SaturatedConsistentTableau.iff_mem₁_and, *];
-  | hor φ ψ ihp ihq => simp [SaturatedConsistentTableau.iff_mem₁_or, *];
+  | hatom => tauto
+  | hfalsum => simp only [Semantics.Bot.realize_bot, not_mem₁_falsum]
+  | himp φ ψ ihp ihq => exact truthlemma.himp ihp ihq
+  | hand φ ψ ihp ihq => simp [SaturatedConsistentTableau.iff_mem₁_and, *]
+  | hor φ ψ ihp ihq => simp [SaturatedConsistentTableau.iff_mem₁_or, *]
 
 lemma iff_valid_on_canonicalModel_deducible : (Kripke.canonicalModel 𝓢) ⊧ φ ↔ 𝓢 ⊢! φ := by
-  constructor;
-  . contrapose;
-    intro h;
+  constructor
+  . contrapose
+    intro h
     have : Tableau.Consistent 𝓢 (∅, {φ}) := by
-      simp only [Tableau.Consistent];
-      rintro Γ Δ hΓ hΔ;
-      by_contra hC;
-      apply h;
-      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
-      . simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ;
-        subst hΓ hΔ;
-        simp only [Finset.conj_empty, Finset.disj_empty] at hC;
-        exact of_O! $ hC ⨀ verum!;
-      . simp only [Set.subset_empty_iff, Finset.coe_eq_empty, Finset.coe_eq_singleton] at hΓ hΔ;
-        subst hΓ hΔ;
-        simp only [Finset.conj_empty, Finset.disj_singleton] at hC;
-        exact hC ⨀ verum!;
-    obtain ⟨t', ht'⟩ := lindenbaum this;
+      simp only [Tableau.Consistent]
+      rintro Γ Δ hΓ hΔ
+      by_contra hC
+      apply h
+      rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ)
+      . simp only [Set.subset_empty_iff, Finset.coe_eq_empty] at hΓ hΔ
+        subst hΓ hΔ
+        simp only [Finset.conj_empty, Finset.disj_empty] at hC
+        exact of_O! $ hC ⨀ verum!
+      . simp only [Set.subset_empty_iff, Finset.coe_eq_empty, Finset.coe_eq_singleton] at hΓ hΔ
+        subst hΓ hΔ
+        simp only [Finset.conj_empty, Finset.disj_singleton] at hC
+        exact hC ⨀ verum!
+    obtain ⟨t', ht'⟩ := lindenbaum this
     simp only [ValidOnModel.iff_models, ValidOnModel, Satisfies.iff_models, not_forall]
-    existsi t';
-    apply truthlemma.not.mpr;
-    apply iff_not_mem₁_mem₂.mpr;
-    simp_all;
-  . intro h t;
-    suffices φ ∈ t.1.1 by exact truthlemma.mpr this;
-    exact mem₁_of_provable h;
+    existsi t'
+    apply truthlemma.not.mpr
+    apply iff_not_mem₁_mem₂.mpr
+    simp_all
+  . intro h t
+    suffices φ ∈ t.1.1 by exact truthlemma.mpr this
+    exact mem₁_of_provable h
 
 end truthlemma
 
@@ -158,10 +158,10 @@ class Canonical (𝓢 : S) [Entailment.Consistent 𝓢] [Entailment.Int 𝓢] (C
   canonical : (Kripke.canonicalFrame 𝓢) ∈ C
 
 instance instCompleteOfCanonical [Canonical 𝓢 C] : Complete 𝓢 C := ⟨by
-  intro φ h;
-  apply iff_valid_on_canonicalModel_deducible.mp;
-  apply h;
-  exact Canonical.canonical;
+  intro φ h
+  apply iff_valid_on_canonicalModel_deducible.mp
+  apply h
+  exact Canonical.canonical
 ⟩
 
 end Kripke

--- a/Foundation/Propositional/Kripke/Filtration.lean
+++ b/Foundation/Propositional/Kripke/Filtration.lean
@@ -15,11 +15,11 @@ def filterEquiv (M : Kripke.Model) (T : FormulaSet ℕ) [T.SubformulaClosed] (x 
 variable (M : Kripke.Model) (T : FormulaSet ℕ) [T.SubformulaClosed]
 
 lemma filterEquiv.equivalence : Equivalence (filterEquiv M T) where
-  refl := by intro x φ _; rfl;
-  symm := by intro x y h φ hp; exact h _ hp |>.symm;
+  refl := by intro x φ _; rfl
+  symm := by intro x y h φ hp; exact h _ hp |>.symm
   trans := by
-    intro x y z exy eyz;
-    intro φ hp;
+    intro x y z exy eyz
+    intro φ hp
     exact Iff.trans (exy φ hp) (eyz φ hp)
 
 def FilterEqvSetoid : Setoid (M.World) := ⟨filterEquiv M T, filterEquiv.equivalence M T⟩
@@ -34,34 +34,34 @@ lemma finite (T_finite : T.Finite) : Finite (FilterEqvQuotient M T) := by
   have : Finite (𝒫 T) := Set.Finite.powerset T_finite
   let f : FilterEqvQuotient M T → 𝒫 T :=
     λ (X : FilterEqvQuotient M T) => Quotient.lift (λ x => ⟨{ φ ∈ T | x ⊧ φ }, (by simp_all)⟩) (by
-      intro x y hxy;
-      suffices {φ | φ ∈ T ∧ Satisfies M x φ} = {φ | φ ∈ T ∧ Satisfies M y φ} by simpa;
-      apply Set.eq_of_subset_of_subset;
-      . rintro φ ⟨hp, hx⟩; exact ⟨hp, (hxy φ hp).mp hx⟩;
-      . rintro φ ⟨hp, hy⟩; exact ⟨hp, (hxy φ hp).mpr hy⟩;
+      intro x y hxy
+      suffices {φ | φ ∈ T ∧ Satisfies M x φ} = {φ | φ ∈ T ∧ Satisfies M y φ} by simpa
+      apply Set.eq_of_subset_of_subset
+      . rintro φ ⟨hp, hx⟩; exact ⟨hp, (hxy φ hp).mp hx⟩
+      . rintro φ ⟨hp, hy⟩; exact ⟨hp, (hxy φ hp).mpr hy⟩
     ) X
   have hf : Function.Injective f := by
-    intro X Y h;
-    obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-    obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-    simp [f] at h;
-    apply Quotient.eq''.mpr;
-    intro φ hp;
-    constructor;
-    . intro hpx;
-      have : ∀ a ∈ T, x ⊧ a → a ∈ T ∧ y ⊧ a := by simpa using h.subset;
-      exact this φ hp hpx |>.2;
-    . intro hpy;
-      have := h.symm.subset;
-      simp only [Set.setOf_subset_setOf, and_imp] at this;
-      exact this φ hp hpy |>.2;
+    intro X Y h
+    obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+    obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+    simp [f] at h
+    apply Quotient.eq''.mpr
+    intro φ hp
+    constructor
+    . intro hpx
+      have : ∀ a ∈ T, x ⊧ a → a ∈ T ∧ y ⊧ a := by simpa using h.subset
+      exact this φ hp hpx |>.2
+    . intro hpy
+      have := h.symm.subset
+      simp only [Set.setOf_subset_setOf, and_imp] at this
+      exact this φ hp hpy |>.2
   exact Finite.of_injective f hf
 
 instance : Nonempty (FilterEqvQuotient M T) := ⟨⟦M.toFrame.world_nonempty.some⟧⟩
 
 lemma iff_of_eq (h : (⟦x⟧ : FilterEqvQuotient M T) = ⟦y⟧) : ∀ φ ∈ T, x ⊧ φ ↔ y ⊧ φ := by
-  simp [FilterEqvSetoid, filterEquiv] at h;
-  tauto;
+  simp [FilterEqvSetoid, filterEquiv] at h
+  tauto
 
 end FilterEqvQuotient
 
@@ -72,11 +72,11 @@ class FilterOf (FM : Model) (M : Model) (T : FormulaSet ℕ) [T.SubformulaClosed
   def_rel_back : ∀ {x y : M.World}, (cast def_world.symm ⟦x⟧) ≺ (cast def_world.symm ⟦y⟧) → ∀ φ ∈ T, (x ⊧ φ → y ⊧ φ)
   def_valuation X a : (ha : (atom a) ∈ T := by grind) →
     FM X a ↔ Quotient.lift (λ x => M x a) (by
-      intro x y h;
-      apply eq_iff_iff.mpr;
-      constructor;
-      . intro hx; exact h (.atom a) ha |>.mp hx;
-      . intro hy; exact h (.atom a) ha |>.mpr hy;
+      intro x y h
+      apply eq_iff_iff.mpr
+      constructor
+      . intro hx; exact h (.atom a) ha |>.mp hx
+      . intro hy; exact h (.atom a) ha |>.mpr hy
     ) (cast def_world X)
 
 attribute [simp] FilterOf.def_world
@@ -88,12 +88,12 @@ variable {M T}
 
 /-
 lemma serial_filterOf_of_serial (h_filter : FilterOf FM M T) (hSerial : Serial M.toFrame) : Serial FM.Rel := by
-  intro X;
-  obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (h_filter.def_world) X);
-  obtain ⟨y, Rxy⟩ := hSerial x;
-  use (cast (h_filter.def_world.symm) ⟦y⟧);
-  convert h_filter.def_rel_forth $ Rxy;
-  simp_all;
+  intro X
+  obtain ⟨x, hx⟩ := Quotient.exists_rep (cast (h_filter.def_world) X)
+  obtain ⟨y, Rxy⟩ := hSerial x
+  use (cast (h_filter.def_world.symm) ⟦y⟧)
+  convert h_filter.def_rel_forth $ Rxy
+  simp_all
 -/
 
 end
@@ -108,94 +108,94 @@ variable {M : Model} {T : FormulaSet ℕ} [T.SubformulaClosed]
 theorem filtration {x : M.World} {φ : Formula ℕ} (hs : φ ∈ T := by grind) : x ⊧ φ ↔ (cast (filterOf.def_world.symm) ⟦x⟧) ⊧ φ := by
   induction φ generalizing x with
   | hatom a =>
-    have := filterOf.def_valuation (cast filterOf.def_world.symm ⟦x⟧) a;
-    simp_all [Satisfies];
+    have := filterOf.def_valuation (cast filterOf.def_world.symm ⟦x⟧) a
+    simp_all [Satisfies]
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . refine ihφ (by grind) |>.mp hφ;
-      . refine ihψ (by grind) |>.mp hψ;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . refine ihφ (by grind) |>.mpr hφ;
-      . refine ihψ (by grind) |>.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . refine ihφ (by grind) |>.mp hφ
+      . refine ihψ (by grind) |>.mp hψ
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . refine ihφ (by grind) |>.mpr hφ
+      . refine ihψ (by grind) |>.mpr hψ
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . left; exact ihφ (by grind) |>.mp hφ;
-      . right; exact ihψ (by grind) |>.mp hψ;
-    . rintro (hφ | hψ);
-      . left; exact ihφ (by grind) |>.mpr hφ;
-      . right; exact ihψ (by grind) |>.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . left; exact ihφ (by grind) |>.mp hφ
+      . right; exact ihψ (by grind) |>.mp hψ
+    . rintro (hφ | hψ)
+      . left; exact ihφ (by grind) |>.mpr hφ
+      . right; exact ihψ (by grind) |>.mpr hψ
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . rintro hφψ Y RXY hφ;
-      obtain ⟨y, ey⟩ := Quotient.exists_rep (cast (filterOf.def_world) Y);
-      have : y ⊧ ψ → Y ⊧ ψ := by simpa [ey] using ihψ (x := y) |>.mp;
-      apply this;
-      apply filterOf.def_rel_back ?_ (φ := φ ➝ ψ) hs hφψ;
-      . apply _root_.refl;
-      . apply ihφ (by grind) |>.mpr;
-        simpa [ey] using hφ;
-      . simpa [ey] using RXY;
-    . rintro hφψ y Rxy hφ;
-      apply ihψ (by grind) |>.mpr;
-      apply hφψ;
-      . apply filterOf.def_rel_forth Rxy;
-      . apply ihφ (by grind) |>.mp hφ;
+    constructor
+    . rintro hφψ Y RXY hφ
+      obtain ⟨y, ey⟩ := Quotient.exists_rep (cast (filterOf.def_world) Y)
+      have : y ⊧ ψ → Y ⊧ ψ := by simpa [ey] using ihψ (x := y) |>.mp
+      apply this
+      apply filterOf.def_rel_back ?_ (φ := φ ➝ ψ) hs hφψ
+      . apply _root_.refl
+      . apply ihφ (by grind) |>.mpr
+        simpa [ey] using hφ
+      . simpa [ey] using RXY
+    . rintro hφψ y Rxy hφ
+      apply ihψ (by grind) |>.mpr
+      apply hφψ
+      . apply filterOf.def_rel_forth Rxy
+      . apply ihφ (by grind) |>.mp hφ
   | _ => tauto
 
 end
 
 abbrev standardFiltrationValuation (X : FilterEqvQuotient M T) (a : ℕ) := (ha : (atom a) ∈ T) → Quotient.lift (λ x => M.Val x a) (by
-  intro x y h;
-  apply eq_iff_iff.mpr;
-  constructor;
-  . intro hx; exact h (.atom a) ha |>.mp hx;
-  . intro hy; exact h (.atom a) ha |>.mpr hy;
+  intro x y h
+  apply eq_iff_iff.mpr
+  constructor
+  . intro hx; exact h (.atom a) ha |>.mp hx
+  . intro hy; exact h (.atom a) ha |>.mpr hy
 ) X
 
 
 abbrev coarsestFiltrationFrame (M : Model) (T : FormulaSet ℕ) [T.SubformulaClosed] : Kripke.Frame where
   World := FilterEqvQuotient M T
   Rel := Quotient.lift₂ (λ x y => ∀ φ ∈ T, (x ⊧ φ → y ⊧ φ)) (by
-    intro x₁ y₁ x₂ y₂ hx hy;
-    apply eq_iff_iff.mpr;
-    constructor;
-    . intro h φ hφ hφ_x₂;
-      apply hy φ |>.mp;
-      apply h;
+    intro x₁ y₁ x₂ y₂ hx hy
+    apply eq_iff_iff.mpr
+    constructor
+    . intro h φ hφ hφ_x₂
+      apply hy φ |>.mp
+      apply h
       . exact hφ
-      . apply hx φ |>.mpr hφ_x₂;
-    . intro h φ hφ hφ_y₁;
-      apply hy φ |>.mpr;
-      apply h;
+      . apply hx φ |>.mpr hφ_x₂
+    . intro h φ hφ hφ_y₁
+      apply hy φ |>.mpr
+      apply h
       . exact hφ
-      . apply hx φ |>.mp hφ_y₁;
+      . apply hx φ |>.mp hφ_y₁
   )
   rel_partial_order := {
     refl := by
-      rintro X;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      simp;
+      rintro X
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      simp
     trans := by
-      rintro X Y Z RXY RYZ;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-      obtain ⟨z, rfl⟩ := Quotient.exists_rep Z;
-      simp_all;
+      rintro X Y Z RXY RYZ
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+      obtain ⟨z, rfl⟩ := Quotient.exists_rep Z
+      simp_all
     antisymm := by
-      rintro X Y RXY RYX;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-      simp only [Quotient.eq];
-      intro φ hφ₁;
-      constructor;
-      . intro hφ₂;
-        exact RXY φ hφ₁ hφ₂;
-      . intro hφ₂;
-        exact RYX φ hφ₁ hφ₂;
+      rintro X Y RXY RYX
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+      simp only [Quotient.eq]
+      intro φ hφ₁
+      constructor
+      . intro hφ₂
+        exact RXY φ hφ₁ hφ₂
+      . intro hφ₂
+        exact RYX φ hφ₁ hφ₂
   }
 
 abbrev coarsestFiltrationModel (M : Model) (T : FormulaSet ℕ) [T.SubformulaClosed] : Kripke.Model where
@@ -203,20 +203,20 @@ abbrev coarsestFiltrationModel (M : Model) (T : FormulaSet ℕ) [T.SubformulaClo
   Val := ⟨
     standardFiltrationValuation M T,
     by
-      intro X Y RXY a hX ha;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-      apply RXY (.atom a) ha;
-      tauto;
+      intro X Y RXY a hX ha
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+      apply RXY (.atom a) ha
+      tauto
   ⟩
 
 instance coarsestFiltrationModel.filterOf {M} {T : FormulaSet ℕ} [T.SubformulaClosed] : FilterOf (coarsestFiltrationModel M T) M T where
   def_valuation := by tauto
   def_rel_forth := by
-    intro x y Rxy;
-    intro φ hφ;
-    apply Formula.Kripke.Satisfies.formula_hereditary Rxy;
-  def_rel_back := by tauto;
+    intro x y Rxy
+    intro φ hφ
+    apply Formula.Kripke.Satisfies.formula_hereditary Rxy
+  def_rel_back := by tauto
 
 
 section
@@ -231,53 +231,53 @@ abbrev finestFiltrationTransitiveClosureFrame (M : Model) (T : FormulaSet ℕ) [
   Rel := TransGen (λ X Y => ∃ x y, X = ⟦x⟧ ∧ Y = ⟦y⟧ ∧ x ≺ y)
   rel_partial_order := {
     refl := by
-      rintro X;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      apply TransGen.single;
-      use x, x;
+      rintro X
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      apply TransGen.single
+      use x, x
       exact ⟨rfl, rfl, M.refl⟩
-    trans := by apply TransGen.trans;
+    trans := by apply TransGen.trans
     antisymm := by
-      rintro x y Rxy Ryx;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep x;
-      obtain ⟨y, rfl⟩ := Quotient.exists_rep y;
-      simp only [Quotient.eq, FilterEqvSetoid, filterEquiv];
-      intro φ hφ;
-      constructor;
-      . obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp Rxy;
-        clear Rxy Ryx;
+      rintro x y Rxy Ryx
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep x
+      obtain ⟨y, rfl⟩ := Quotient.exists_rep y
+      simp only [Quotient.eq, FilterEqvSetoid, filterEquiv]
+      intro φ hφ
+      constructor
+      . obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp Rxy
+        clear Rxy Ryx
         induction n using PNat.recOn generalizing x with
         | one =>
-          simp [FilterEqvSetoid, filterEquiv] at hn;
-          obtain ⟨u, Rxu, v, Ryv, Ruv⟩ := hn;
-          intro hx;
-          have : u ⊧ φ := Rxu φ hφ |>.mp hx;
-          have : v ⊧ φ := formula_hereditary Ruv this;
-          exact Ryv φ hφ |>.mpr this;
+          simp [FilterEqvSetoid, filterEquiv] at hn
+          obtain ⟨u, Rxu, v, Ryv, Ruv⟩ := hn
+          intro hx
+          have : u ⊧ φ := Rxu φ hφ |>.mp hx
+          have : v ⊧ φ := formula_hereditary Ruv this
+          exact Ryv φ hφ |>.mpr this
         | succ n ih =>
-          obtain ⟨⟨u⟩, ⟨x', u', exx', euu', Rx'u'⟩, RUY⟩ := hn;
-          intro hx;
-          have : x' ⊧ φ := FilterEqvQuotient.iff_of_eq exx' φ hφ |>.mp hx;
-          have : u' ⊧ φ := formula_hereditary Rx'u' this;
-          have : u ⊧ φ := FilterEqvQuotient.iff_of_eq euu' φ hφ |>.mpr this;
-          exact ih u RUY this;
-      . obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp Ryx;
-        clear Rxy Ryx;
+          obtain ⟨⟨u⟩, ⟨x', u', exx', euu', Rx'u'⟩, RUY⟩ := hn
+          intro hx
+          have : x' ⊧ φ := FilterEqvQuotient.iff_of_eq exx' φ hφ |>.mp hx
+          have : u' ⊧ φ := formula_hereditary Rx'u' this
+          have : u ⊧ φ := FilterEqvQuotient.iff_of_eq euu' φ hφ |>.mpr this
+          exact ih u RUY this
+      . obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp Ryx
+        clear Rxy Ryx
         induction n using PNat.recOn generalizing y with
         | one =>
-          simp [FilterEqvSetoid, filterEquiv] at hn;
-          obtain ⟨u, Rxu, v, Ryv, Ruv⟩ := hn;
-          intro hy;
-          have : u ⊧ φ := Rxu φ hφ |>.mp hy;
-          have : v ⊧ φ := formula_hereditary Ruv this;
-          exact Ryv φ hφ |>.mpr this;
+          simp [FilterEqvSetoid, filterEquiv] at hn
+          obtain ⟨u, Rxu, v, Ryv, Ruv⟩ := hn
+          intro hy
+          have : u ⊧ φ := Rxu φ hφ |>.mp hy
+          have : v ⊧ φ := formula_hereditary Ruv this
+          exact Ryv φ hφ |>.mpr this
         | succ n ih =>
-          obtain ⟨⟨u⟩, ⟨y', u', eyy', euu', Ry'u'⟩, RUY⟩ := hn;
-          intro hy;
-          have : y' ⊧ φ := FilterEqvQuotient.iff_of_eq eyy' φ hφ |>.mp hy;
-          have : u' ⊧ φ := formula_hereditary Ry'u' this;
-          have : u ⊧ φ := FilterEqvQuotient.iff_of_eq euu' φ hφ |>.mpr this;
-          exact ih u RUY this;
+          obtain ⟨⟨u⟩, ⟨y', u', eyy', euu', Ry'u'⟩, RUY⟩ := hn
+          intro hy
+          have : y' ⊧ φ := FilterEqvQuotient.iff_of_eq eyy' φ hφ |>.mp hy
+          have : u' ⊧ φ := formula_hereditary Ry'u' this
+          have : u ⊧ φ := FilterEqvQuotient.iff_of_eq euu' φ hφ |>.mpr this
+          exact ih u RUY this
   }
 
 abbrev finestFiltrationTransitiveClosureModel (M : Model) (T : FormulaSet ℕ) [T.SubformulaClosed] : Kripke.Model where
@@ -285,54 +285,54 @@ abbrev finestFiltrationTransitiveClosureModel (M : Model) (T : FormulaSet ℕ) [
   Val := ⟨
     standardFiltrationValuation M T,
     by
-      intro X Y RXY a hX ha;
-      obtain ⟨x, rfl⟩ := Quotient.exists_rep X;
-      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y;
-      obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp RXY;
-      clear RXY;
+      intro X Y RXY a hX ha
+      obtain ⟨x, rfl⟩ := Quotient.exists_rep X
+      obtain ⟨y, rfl⟩ := Quotient.exists_rep Y
+      obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp RXY
+      clear RXY
       induction n using PNat.recOn generalizing x with
       | one =>
-        obtain ⟨u, v, exu, eyv, Ruv⟩ : ∃ u v : M.World, (⟦x⟧ : FilterEqvQuotient M T) = ⟦u⟧ ∧ (⟦y⟧ : FilterEqvQuotient M T) = ⟦v⟧ ∧ u ≺ v := by simpa using hn;
-        have := FilterEqvQuotient.iff_of_eq (h := exu) (.atom a) ha |>.mp $ hX ha;
-        have := formula_hereditary Ruv this;
-        exact FilterEqvQuotient.iff_of_eq eyv (.atom a) ha |>.mpr this;
+        obtain ⟨u, v, exu, eyv, Ruv⟩ : ∃ u v : M.World, (⟦x⟧ : FilterEqvQuotient M T) = ⟦u⟧ ∧ (⟦y⟧ : FilterEqvQuotient M T) = ⟦v⟧ ∧ u ≺ v := by simpa using hn
+        have := FilterEqvQuotient.iff_of_eq (h := exu) (.atom a) ha |>.mp $ hX ha
+        have := formula_hereditary Ruv this
+        exact FilterEqvQuotient.iff_of_eq eyv (.atom a) ha |>.mpr this
       | succ n ih =>
-        obtain ⟨_, ⟨x', u', exx', rfl, Rx'u'⟩, RUY⟩ := hn;
-        refine ih u' ?_ RUY;
-        intro ha;
-        apply M.Val.hereditary Rx'u';
-        apply FilterEqvQuotient.iff_of_eq exx' _ ha |>.mp;
-        tauto;
+        obtain ⟨_, ⟨x', u', exx', rfl, Rx'u'⟩, RUY⟩ := hn
+        refine ih u' ?_ RUY
+        intro ha
+        apply M.Val.hereditary Rx'u'
+        apply FilterEqvQuotient.iff_of_eq exx' _ ha |>.mp
+        tauto
   ⟩
 
 
 instance finestFiltrationTransitiveClosureModel.filterOf : FilterOf (finestFiltrationTransitiveClosureModel M T) M T where
   def_valuation := by tauto
   def_rel_forth := by
-    intro x y Rxy;
-    apply TransGen.single;
-    use x, y;
-    tauto;
+    intro x y Rxy
+    apply TransGen.single
+    use x, y
+    tauto
   def_rel_back := by
-    rintro x y RXY;
-    obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp RXY;
-    clear RXY;
+    rintro x y RXY
+    obtain ⟨n, hn⟩ := HRel.TransGen.exists_iterate.mp RXY
+    clear RXY
     induction n using PNat.recOn generalizing x with
     | one =>
-      obtain ⟨u, v, exu, eyv, Ruv⟩ : ∃ u v : M.World, (⟦x⟧ : FilterEqvQuotient M T) = ⟦u⟧ ∧ (⟦y⟧ : FilterEqvQuotient M T) = ⟦v⟧ ∧ u ≺ v := by simpa using hn;
-      intro φ hφ hx;
-      have : u ⊧ φ := FilterEqvQuotient.iff_of_eq exu _ hφ |>.mp hx;
-      have : v ⊧ φ := formula_hereditary Ruv this;
-      exact FilterEqvQuotient.iff_of_eq eyv _ hφ |>.mpr this;
+      obtain ⟨u, v, exu, eyv, Ruv⟩ : ∃ u v : M.World, (⟦x⟧ : FilterEqvQuotient M T) = ⟦u⟧ ∧ (⟦y⟧ : FilterEqvQuotient M T) = ⟦v⟧ ∧ u ≺ v := by simpa using hn
+      intro φ hφ hx
+      have : u ⊧ φ := FilterEqvQuotient.iff_of_eq exu _ hφ |>.mp hx
+      have : v ⊧ φ := formula_hereditary Ruv this
+      exact FilterEqvQuotient.iff_of_eq eyv _ hφ |>.mpr this
     | succ n ih =>
-      obtain ⟨U, ⟨v, w, exv, euw, Rvw⟩, RUY⟩ := hn;
-      obtain ⟨u, rfl⟩ := Quotient.exists_rep U;
-      intro φ hφ hx;
-      refine @ih u ?_ φ hφ ?_;
-      . simpa using RUY;
-      . have : v ⊧ φ := FilterEqvQuotient.iff_of_eq exv _ hφ |>.mp hx;
-        have : w ⊧ φ := formula_hereditary Rvw this;
-        exact FilterEqvQuotient.iff_of_eq euw _ hφ |>.mpr this;
+      obtain ⟨U, ⟨v, w, exv, euw, Rvw⟩, RUY⟩ := hn
+      obtain ⟨u, rfl⟩ := Quotient.exists_rep U
+      intro φ hφ hx
+      refine @ih u ?_ φ hφ ?_
+      . simpa using RUY
+      . have : v ⊧ φ := FilterEqvQuotient.iff_of_eq exv _ hφ |>.mp hx
+        have : w ⊧ φ := formula_hereditary Rvw this
+        exact FilterEqvQuotient.iff_of_eq euw _ hφ |>.mpr this
 
 end
 

--- a/Foundation/Propositional/Kripke/Hilbert.lean
+++ b/Foundation/Propositional/Kripke/Hilbert.lean
@@ -16,66 +16,66 @@ section FrameClass
 variable {C C₁ C₂ : Kripke.FrameClass}
 
 lemma soundness_of_validates_axioms (hV : C.Validates H.axioms) : H ⊢! φ → C ⊧ φ := by
-  intro hφ F hF;
+  intro hφ F hF
   induction hφ with
-  | verum => apply ValidOnFrame.top;
-  | implyS => apply ValidOnFrame.imply₁;
-  | implyK => apply ValidOnFrame.imply₂;
-  | andElimL => apply ValidOnFrame.andElim₁;
-  | andElimR => apply ValidOnFrame.andElim₂;
-  | K_intro => apply ValidOnFrame.andInst₃;
-  | orIntroL => apply ValidOnFrame.orInst₁;
-  | orIntroR => apply ValidOnFrame.orInst₂;
-  | orElim => apply ValidOnFrame.orElim;
-  | mdp => exact ValidOnFrame.mdp (by assumption) (by assumption);
+  | verum => apply ValidOnFrame.top
+  | implyS => apply ValidOnFrame.imply₁
+  | implyK => apply ValidOnFrame.imply₂
+  | andElimL => apply ValidOnFrame.andElim₁
+  | andElimR => apply ValidOnFrame.andElim₂
+  | K_intro => apply ValidOnFrame.andInst₃
+  | orIntroL => apply ValidOnFrame.orInst₁
+  | orIntroR => apply ValidOnFrame.orInst₂
+  | orElim => apply ValidOnFrame.orElim
+  | mdp => exact ValidOnFrame.mdp (by assumption) (by assumption)
   | axm s hi =>
-    apply ValidOnFrame.subst;
-    apply hV F hF _ hi;
+    apply ValidOnFrame.subst
+    apply hV F hF _ hi
 
 lemma instSound_of_validates_axioms (hV : C.Validates H.axioms) : Sound H C := ⟨fun {_} => soundness_of_validates_axioms hV⟩
 
 lemma consistent_of_sound_frameclass (C : FrameClass) (hC : Set.Nonempty C) [sound : Sound H C] : Entailment.Consistent H := by
-  apply Entailment.Consistent.of_unprovable (f := ⊥);
-  apply not_imp_not.mpr sound.sound;
-  apply Semantics.set_models_iff.not.mpr;
-  push_neg;
-  obtain ⟨F, hF⟩ := hC;
-  use F;
-  constructor;
-  . assumption;
-  . simp;
+  apply Entailment.Consistent.of_unprovable (f := ⊥)
+  apply not_imp_not.mpr sound.sound
+  apply Semantics.set_models_iff.not.mpr
+  push_neg
+  obtain ⟨F, hF⟩ := hC
+  use F
+  constructor
+  . assumption
+  . simp
 
 lemma finite_sound_of_sound (sound : Sound H.logic C) : Sound H.logic ({ F | F ∈ C ∧ Finite F }) := ⟨by
-  rintro φ hφ F ⟨hF₁, _⟩;
-  exact sound.sound hφ hF₁;
+  rintro φ hφ F ⟨hF₁, _⟩
+  exact sound.sound hφ hF₁
 ⟩
 
 lemma weakerThan_of_subset_frameClass (C₁ C₂ : FrameClass) (hC : C₂ ⊆ C₁) [Sound H₁ C₁] [Complete H₂ C₂] : H₁ ⪯ H₂ := by
-  apply Entailment.weakerThan_iff.mpr;
-  intro φ hφ;
-  apply Complete.complete (𝓜 := C₂);
-  intro F hF;
-  apply Sound.sound (𝓢 := H₁) (𝓜 := C₁) hφ;
-  apply hC hF;
+  apply Entailment.weakerThan_iff.mpr
+  intro φ hφ
+  apply Complete.complete (𝓜 := C₂)
+  intro F hF
+  apply Sound.sound (𝓢 := H₁) (𝓜 := C₁) hφ
+  apply hC hF
 
 lemma eq_Hilbert_Logic_KripkeFrameClass_Logic [sound : Sound H C] [complete : Complete H C] : H.logic = C.logic := by
-  ext φ;
-  constructor;
-  . intro h;
-    apply sound.sound;
-    simpa;
-  . intro h;
-    simpa using complete.complete h;
+  ext φ
+  constructor
+  . intro h
+    apply sound.sound
+    simpa
+  . intro h
+    simpa using complete.complete h
 
 instance [Sound H C] : Sound H.logic C := by
-  constructor;
-  intro φ hφ;
-  apply Sound.sound $ by simpa using hφ;
+  constructor
+  intro φ hφ
+  apply Sound.sound $ by simpa using hφ
 
 instance [Complete H C] : Complete H.logic C := by
-  constructor;
-  intro φ hφ;
-  simpa using Complete.complete hφ;
+  constructor
+  intro φ hφ
+  simpa using Complete.complete hφ
 
 
 section

--- a/Foundation/Propositional/Kripke/Logic/Cl.lean
+++ b/Foundation/Propositional/Kripke/Logic/Cl.lean
@@ -22,10 +22,10 @@ protected abbrev FrameClass.Cl : FrameClass := { F | F.IsCl }
 protected abbrev FrameClass.finite_Cl : FrameClass := { F | F.IsFiniteCl }
 
 instance [F.IsCl] : F.IsKrieselPutnam := ⟨by
-  rintro x y z ⟨Rxy, Rxz, Ryz, _⟩;
-  exfalso;
-  apply Ryz;
-  exact F.eucl Rxy Rxz;
+  rintro x y z ⟨Rxy, Rxz, Ryz, _⟩
+  exfalso
+  apply Ryz
+  exact F.eucl Rxy Rxz
 ⟩
 
 end Kripke
@@ -38,25 +38,25 @@ namespace Cl.Kripke
 
 instance : Sound Hilbert.Cl FrameClass.Cl :=
   instSound_of_validates_axioms $ by
-    apply FrameClass.Validates.withAxiomEFQ;
-    rintro F hF _ rfl;
-    replace hF := Set.mem_setOf_eq.mp hF;
-    apply validate_axiomLEM_of_isEuclidean;
+    apply FrameClass.Validates.withAxiomEFQ
+    rintro F hF _ rfl
+    replace hF := Set.mem_setOf_eq.mp hF
+    apply validate_axiomLEM_of_isEuclidean
 
 instance : Sound Hilbert.Cl FrameClass.finite_Cl :=
   instSound_of_validates_axioms $ by
-    apply FrameClass.Validates.withAxiomEFQ;
-    rintro F ⟨_, hF⟩ _ rfl;
-    apply validate_axiomLEM_of_isEuclidean;
+    apply FrameClass.Validates.withAxiomEFQ
+    rintro F ⟨_, hF⟩ _ rfl
+    apply validate_axiomLEM_of_isEuclidean
 
 instance : Entailment.Consistent Hilbert.Cl := consistent_of_sound_frameclass FrameClass.Cl $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
   infer_instance
 
 instance : Canonical Hilbert.Cl FrameClass.Cl :=  ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.Cl FrameClass.Cl := inferInstance
@@ -69,79 +69,79 @@ open
 
 instance : Complete Hilbert.Cl FrameClass.finite_Cl := by
   suffices Complete Hilbert.Cl { F : Frame | F.IsFinite ∧ F.IsSymmetric } by
-    convert this;
-    constructor;
-    . rintro ⟨_, hF⟩; exact ⟨by tauto, inferInstance⟩;
+    convert this
+    constructor
+    . rintro ⟨_, hF⟩; exact ⟨by tauto, inferInstance⟩
     . rintro ⟨_, hF⟩; exact {}
 
-  constructor;
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.Cl);
-  rintro F F_con V r;
-  replace F_con := Set.mem_setOf_eq.mp F_con;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let RM := M↾r;
+  constructor
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.Cl)
+  rintro F F_con V r
+  replace F_con := Set.mem_setOf_eq.mp F_con
+  let M : Kripke.Model := ⟨F, V⟩
+  let RM := M↾r
 
-  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp;
+  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp
 
-  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas);
-  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr;
-  apply hφ;
+  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas)
+  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr
+  apply hφ
 
-  refine ⟨?_, ?_⟩;
+  refine ⟨?_, ?_⟩
   . exact {
       world_finite := by
-        apply FilterEqvQuotient.finite;
-        simp;
-    };
-  . constructor;
-    rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ RXY;
-    . simp_all;
-    . apply TransGen.single;
-      use ⟨y, by tauto⟩, ⟨x, by tauto⟩;
-      refine ⟨by tauto, by tauto, ?_⟩;
-      . have : y ≺ x := IsSymm.symm _ _ Rry;
-        tauto;
-    . apply TransGen.single;
-      use ⟨y, by tauto⟩, ⟨x, by tauto⟩;
-      refine ⟨by tauto, by tauto, ?_⟩;
-      . have : x ≺ y := IsSymm.symm _ _ Rrx;
-        tauto;
-    . apply Relation.TransGen.single;
-      use ⟨y, by tauto⟩, ⟨x, by tauto⟩;
-      refine ⟨by tauto, by tauto, ?_⟩;
-      . simpa using F.eucl' Rrx Rry;
+        apply FilterEqvQuotient.finite
+        simp
+    }
+  . constructor
+    rintro ⟨x, (rfl | Rrx)⟩ ⟨y, (rfl | Rry)⟩ RXY
+    . simp_all
+    . apply TransGen.single
+      use ⟨y, by tauto⟩, ⟨x, by tauto⟩
+      refine ⟨by tauto, by tauto, ?_⟩
+      . have : y ≺ x := IsSymm.symm _ _ Rry
+        tauto
+    . apply TransGen.single
+      use ⟨y, by tauto⟩, ⟨x, by tauto⟩
+      refine ⟨by tauto, by tauto, ?_⟩
+      . have : x ≺ y := IsSymm.symm _ _ Rrx
+        tauto
+    . apply Relation.TransGen.single
+      use ⟨y, by tauto⟩, ⟨x, by tauto⟩
+      refine ⟨by tauto, by tauto, ?_⟩
+      . simpa using F.eucl' Rrx Rry
 
 end FFP
 
 end Cl.Kripke
 
 instance : Hilbert.LC ⪱ Hilbert.Cl := by
-  constructor;
-  . apply Hilbert.weakerThan_of_provable_axioms;
-    rintro φ (rfl | rfl) <;> simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.LEM (.atom 0);
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.weakerThan_of_provable_axioms
+    rintro φ (rfl | rfl) <;> simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.LEM (.atom 0)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.LC)
-      apply not_validOnFrameClass_of_exists_frame;
+      apply not_validOnFrameClass_of_exists_frame
       let F : Frame := {
         World := Fin 2,
         Rel := λ x y => x ≤ y
         rel_partial_order := {
-          refl := by omega;
-          trans := by omega;
-          antisymm := by omega;
+          refl := by omega
+          trans := by omega
+          antisymm := by omega
         }
-      };
-      use F;
-      constructor;
+      }
+      use F
+      constructor
       . refine { ps_connected := by intro x y z; omega; }
-      . apply not_imp_not.mpr $ Kripke.isEuclidean_of_validate_axiomLEM;
-        by_contra hC;
-        have := @F.eucl _ 0 1 0;
-        omega;
+      . apply not_imp_not.mpr $ Kripke.isEuclidean_of_validate_axiomLEM
+        by_contra hC
+        have := @F.eucl _ 0 1 0
+        omega
 
 instance : Hilbert.Int ⪱ Hilbert.Cl := calc
   Hilbert.Int ⪱ Hilbert.KC := inferInstance

--- a/Foundation/Propositional/Kripke/Logic/Int.lean
+++ b/Foundation/Propositional/Kripke/Logic/Int.lean
@@ -22,25 +22,25 @@ instance : Entailment.Consistent Hilbert.Int := consistent_of_sound_frameclass F
 
 instance : Sound Hilbert.Int FrameClass.finite_Int := instSound_of_validates_axioms FrameClass.finite_all.validates_AxiomEFQ
 
-instance : Canonical Hilbert.Int FrameClass.Int := by tauto;
+instance : Canonical Hilbert.Int FrameClass.Int := by tauto
 
 instance : Complete Hilbert.Int FrameClass.Int := inferInstance
 
 section FFP
 
 instance : Complete Hilbert.Int FrameClass.finite_Int := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.Int);
-  intro F _ V x;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let FM := coarsestFiltrationModel M ↑φ.subformulas;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.Int)
+  intro F _ V x
+  let M : Kripke.Model := ⟨F, V⟩
+  let FM := coarsestFiltrationModel M ↑φ.subformulas
 
-  apply filtration FM (coarsestFiltrationModel.filterOf) (by simp) |>.mpr;
-  apply hφ;
+  apply filtration FM (coarsestFiltrationModel.filterOf) (by simp) |>.mpr
+  apply hφ
 
-  apply Frame.isFinite_iff _ |>.mpr;
-  apply FilterEqvQuotient.finite;
-  simp;
+  apply Frame.isFinite_iff _ |>.mpr
+  apply FilterEqvQuotient.finite
+  simp
 ⟩
 
 end FFP
@@ -50,7 +50,7 @@ section DP
 variable {M₁ : Kripke.Model} {M₂ : Kripke.Model}
 
 abbrev counterexampleDPFrame (F₁ : Kripke.Frame) (F₂ : Kripke.Frame) (w₁ : F₁.World) (w₂ : F₂.World) : Kripke.Frame where
-  World := Unit ⊕ F₁.World ⊕ F₂.World;
+  World := Unit ⊕ F₁.World ⊕ F₂.World
   Rel x y :=
     match x, y with
     | (Sum.inl _), (Sum.inl _) => True
@@ -60,25 +60,25 @@ abbrev counterexampleDPFrame (F₁ : Kripke.Frame) (F₂ : Kripke.Frame) (w₁ :
     | (Sum.inr $ Sum.inr x), (Sum.inr $ Sum.inr y) => F₂.Rel x y
     | _, _ => False
   rel_partial_order := {
-    refl := by simp;
+    refl := by simp
     trans := by
-      simp only [Sum.forall, true_implies, imp_self, implies_true, true_and, false_implies, and_true, and_self, forall_const, imp_false];
-      constructor;
-      . constructor;
-        . intro _ _; apply F₁.trans;
-        . intro _ _; apply F₂.trans;
-      . constructor;
-        . intro _ _ _; apply F₁.trans;
-        . intro _ _ _; apply F₂.trans;
+      simp only [Sum.forall, true_implies, imp_self, implies_true, true_and, false_implies, and_true, and_self, forall_const, imp_false]
+      constructor
+      . constructor
+        . intro _ _; apply F₁.trans
+        . intro _ _; apply F₂.trans
+      . constructor
+        . intro _ _ _; apply F₁.trans
+        . intro _ _ _; apply F₂.trans
     antisymm := by
-      simp only [Sum.forall, imp_self, implies_true, reduceCtorEq, and_self, imp_false, false_implies, Sum.inr.injEq, true_and, Sum.inl.injEq, and_true];
-      constructor;
-      . intro _ _; apply F₁.antisymm;
-      . intro _ _; apply F₂.antisymm;
+      simp only [Sum.forall, imp_self, implies_true, reduceCtorEq, and_self, imp_false, false_implies, Sum.inr.injEq, true_and, Sum.inl.injEq, and_true]
+      constructor
+      . intro _ _; apply F₁.antisymm
+      . intro _ _; apply F₂.antisymm
   }
 
 abbrev counterexampleDPModel (M₁ : Kripke.Model) (M₂ : Kripke.Model) (w₁ : M₁.World) (w₂ : M₂.World) : Model where
-  toFrame := counterexampleDPFrame M₁.toFrame M₂.toFrame w₁ w₂;
+  toFrame := counterexampleDPFrame M₁.toFrame M₂.toFrame w₁ w₂
   Val := ⟨
     λ w a =>
       match w with
@@ -86,70 +86,70 @@ abbrev counterexampleDPModel (M₁ : Kripke.Model) (M₂ : Kripke.Model) (w₁ :
       | Sum.inr $ Sum.inr w => M₂ w a
       | _ => False,
     by
-      simp only [counterexampleDPFrame, Sum.forall, imp_false, not_false_eq_true, implies_true, imp_self, IsEmpty.forall_iff, and_self, and_true, true_and];
-      constructor;
-      . intro _ _;
-        apply M₁.Val.hereditary;
-      . intro _ _;
-        apply M₂.Val.hereditary;
+      simp only [counterexampleDPFrame, Sum.forall, imp_false, not_false_eq_true, implies_true, imp_self, IsEmpty.forall_iff, and_self, and_true, true_and]
+      constructor
+      . intro _ _
+        apply M₁.Val.hereditary
+      . intro _ _
+        apply M₂.Val.hereditary
   ⟩
 
 lemma satisfies_left_on_counterexampleDPModel :
   w ⊧ φ ↔ (Satisfies (counterexampleDPModel M₁ M₂ w₁ w₂) (Sum.inr $ Sum.inl w) φ) := by
   induction φ generalizing w with
   | himp φ ψ ihp ihq =>
-    constructor;
-    . intro hpq X hWX hp;
+    constructor
+    . intro hpq X hWX hp
       obtain ⟨x, hx, ex⟩ : ∃ x, (M₁.Rel w x) ∧ (Sum.inr $ Sum.inl x) = X := by
-        replace hWX : (counterexampleDPModel M₁ M₂ w₁ w₂).Rel _ X := hWX;
-        simp only [counterexampleDPModel, counterexampleDPFrame] at hWX;
-        split at hWX;
-        all_goals simp_all;
-      subst ex;
-      exact ihq.mp $ hpq hx $ ihp.mpr hp;
-    . intro h v Rwv hp;
-      apply @ihq v |>.mpr $ h (by simpa) $ ihp.mp hp;
-  | _ => simp_all [counterexampleDPModel, Satisfies.iff_models, Satisfies];
+        replace hWX : (counterexampleDPModel M₁ M₂ w₁ w₂).Rel _ X := hWX
+        simp only [counterexampleDPModel, counterexampleDPFrame] at hWX
+        split at hWX
+        all_goals simp_all
+      subst ex
+      exact ihq.mp $ hpq hx $ ihp.mpr hp
+    . intro h v Rwv hp
+      apply @ihq v |>.mpr $ h (by simpa) $ ihp.mp hp
+  | _ => simp_all [counterexampleDPModel, Satisfies.iff_models, Satisfies]
 
 lemma satisfies_right_on_counterexampleDPModel :
   w ⊧ φ ↔ (Satisfies (counterexampleDPModel M₁ M₂ w₁ w₂) (Sum.inr $ Sum.inr w) φ) := by
   induction φ generalizing w with
   | himp φ ψ ihp ihq =>
-    constructor;
-    . intro h X hWX hp;
+    constructor
+    . intro h X hWX hp
       obtain ⟨x, hx, ex⟩ : ∃ x, (M₂.Rel w x) ∧ (Sum.inr $ Sum.inr x) = X := by
-        replace hWX : (counterexampleDPModel M₁ M₂ w₁ w₂).Rel _ X := hWX;
-        simp only [counterexampleDPModel, counterexampleDPFrame] at hWX;
-        split at hWX;
-        all_goals simp_all;
-      subst ex;
-      exact ihq.mp $ h hx $ ihp.mpr hp;
-    . intro h v Rwv hp;
-      exact ihq.mpr $ h (by simpa) $ ihp.mp hp;
-  | _ => simp_all [counterexampleDPModel, Satisfies.iff_models, Satisfies];
+        replace hWX : (counterexampleDPModel M₁ M₂ w₁ w₂).Rel _ X := hWX
+        simp only [counterexampleDPModel, counterexampleDPFrame] at hWX
+        split at hWX
+        all_goals simp_all
+      subst ex
+      exact ihq.mp $ h hx $ ihp.mpr hp
+    . intro h v Rwv hp
+      exact ihq.mpr $ h (by simpa) $ ihp.mp hp
+  | _ => simp_all [counterexampleDPModel, Satisfies.iff_models, Satisfies]
 
 theorem disjunctive : Hilbert.Int ⊢! φ ⋎ ψ → Hilbert.Int ⊢! φ ∨ Hilbert.Int ⊢! ψ := by
-  contrapose!;
-  rintro ⟨hnφ, hnψ⟩;
+  contrapose!
+  rintro ⟨hnφ, hnψ⟩
 
-  obtain ⟨M₁, w₁, hM₁, hφ⟩ := iff_not_validOnFrameClass_exists_model_world.mp $ Complete.exists_countermodel_of_not_provable (𝓜 := FrameClass.Int) hnφ;
-  obtain ⟨M₂, w₂, hM₂, hψ⟩ := iff_not_validOnFrameClass_exists_model_world.mp $ Complete.exists_countermodel_of_not_provable (𝓜 := FrameClass.Int) hnψ;
+  obtain ⟨M₁, w₁, hM₁, hφ⟩ := iff_not_validOnFrameClass_exists_model_world.mp $ Complete.exists_countermodel_of_not_provable (𝓜 := FrameClass.Int) hnφ
+  obtain ⟨M₂, w₂, hM₂, hψ⟩ := iff_not_validOnFrameClass_exists_model_world.mp $ Complete.exists_countermodel_of_not_provable (𝓜 := FrameClass.Int) hnψ
 
-  apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.Int);
-  apply not_validOnFrameClass_of_exists_model_world;
-  let M := counterexampleDPModel M₁ M₂ w₁ w₂;
-  use M, (Sum.inl ());
-  constructor;
-  . tauto;
-  . apply Formula.Kripke.Satisfies.or_def.not.mpr;
-    push_neg;
-    constructor;
-    . apply not_imp_not.mpr $ @Satisfies.formula_hereditary (M := M) (w := Sum.inl ()) (w' := Sum.inr $ Sum.inl w₁) φ ?_;
-      . exact satisfies_left_on_counterexampleDPModel.not.mp hφ;
-      . apply M₁.refl;
-    . apply not_imp_not.mpr $ @Satisfies.formula_hereditary (M := M) (w := Sum.inl ()) (w' := Sum.inr $ Sum.inr w₂) ψ ?_;
-      . exact satisfies_right_on_counterexampleDPModel.not.mp hψ;
-      . apply M₂.refl;
+  apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.Int)
+  apply not_validOnFrameClass_of_exists_model_world
+  let M := counterexampleDPModel M₁ M₂ w₁ w₂
+  use M, (Sum.inl ())
+  constructor
+  . tauto
+  . apply Formula.Kripke.Satisfies.or_def.not.mpr
+    push_neg
+    constructor
+    . apply not_imp_not.mpr $ @Satisfies.formula_hereditary (M := M) (w := Sum.inl ()) (w' := Sum.inr $ Sum.inl w₁) φ ?_
+      . exact satisfies_left_on_counterexampleDPModel.not.mp hφ
+      . apply M₁.refl
+    . apply not_imp_not.mpr $ @Satisfies.formula_hereditary (M := M) (w := Sum.inl ()) (w' := Sum.inr $ Sum.inr w₂) ψ ?_
+      . exact satisfies_right_on_counterexampleDPModel.not.mp hψ
+      . apply M₂.refl
 
 instance : Entailment.Disjunctive Hilbert.Int := ⟨disjunctive⟩
 

--- a/Foundation/Propositional/Kripke/Logic/KC.lean
+++ b/Foundation/Propositional/Kripke/Logic/KC.lean
@@ -22,13 +22,13 @@ protected abbrev FrameClass.KC : FrameClass := { F | F.IsPiecewiseStronglyConver
 protected abbrev FrameClass.finite_KC : FrameClass := { F | F.IsFiniteKC }
 
 instance [F.IsKC] : F.IsKrieselPutnam := ⟨by
-  rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩;
-  use x;
-  refine ⟨F.refl, Rxy, Rxz, ?_⟩;
-  intro v Rxv;
-  obtain ⟨u, Ryu, Rvu⟩ := F.ps_convergent Rxy Rxv;
-  use u;
-  tauto;
+  rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩
+  use x
+  refine ⟨F.refl, Rxy, Rxz, ?_⟩
+  intro v Rxv
+  obtain ⟨u, Ryu, Rvu⟩ := F.ps_convergent Rxy Rxv
+  use u
+  tauto
 ⟩
 
 end Kripke
@@ -40,26 +40,26 @@ namespace KC.Kripke
 
 instance : Sound Hilbert.KC FrameClass.KC :=
   instSound_of_validates_axioms $ by
-    apply FrameClass.Validates.withAxiomEFQ;
-    rintro F hF _ rfl;
-    replace hF := Set.mem_setOf_eq.mp hF;
+    apply FrameClass.Validates.withAxiomEFQ
+    rintro F hF _ rfl
+    replace hF := Set.mem_setOf_eq.mp hF
     apply validate_axiomWeakLEM_of_isPiecewiseStronglyConvergent
 
 instance : Sound Hilbert.KC FrameClass.finite_KC :=
   instSound_of_validates_axioms $ by
-    apply FrameClass.Validates.withAxiomEFQ;
-    rintro F hF _ rfl;
-    replace hF := Set.mem_setOf_eq.mp hF;
+    apply FrameClass.Validates.withAxiomEFQ
+    rintro F hF _ rfl
+    replace hF := Set.mem_setOf_eq.mp hF
     apply validate_axiomWeakLEM_of_isPiecewiseStronglyConvergent
 
 instance : Entailment.Consistent Hilbert.KC := consistent_of_sound_frameclass FrameClass.KC $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 
 instance : Canonical Hilbert.KC FrameClass.KC := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.KC FrameClass.KC := inferInstance
@@ -71,62 +71,62 @@ open
   Relation
 
 instance : Complete (Hilbert.KC) FrameClass.finite_KC := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.KC);
-  rintro F F_con V r;
-  replace F_con := Set.mem_setOf_eq.mp F_con;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let RM := M↾r;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.KC)
+  rintro F F_con V r
+  replace F_con := Set.mem_setOf_eq.mp F_con
+  let M : Kripke.Model := ⟨F, V⟩
+  let RM := M↾r
 
-  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp;
+  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp
 
-  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas);
-  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr;
-  apply hφ;
+  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas)
+  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr
+  apply hφ
   exact {
-    world_finite := by apply FilterEqvQuotient.finite; simp;
+    world_finite := by apply FilterEqvQuotient.finite; simp
     ps_convergent := by
-      rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ;
-      . simp only [exists_and_left, and_self];
-        let Z : RM.World := ⟨z, by tauto⟩;
-        use ⟦Z⟧;
-        apply Relation.TransGen.single;
-        use Z;
-        constructor;
-        . tauto;
-        . use Z;
-          constructor;
-          . tauto;
-          . apply F.refl;
-      . let Y : RM.World := ⟨y, by tauto⟩;
-        let Z : RM.World := ⟨z, by tauto⟩;
-        use ⟦Z⟧;
-        constructor;
-        . apply TransGen.single;
-          use Y, Z;
-          tauto;
-        . apply Frame.refl;
-      . let Y : RM.World := ⟨y, by tauto⟩;
-        let Z : RM.World := ⟨z, by tauto⟩;
-        use ⟦Y⟧;
-        constructor;
-        . apply Frame.refl;
-        . apply TransGen.single;
-          use Z, Y;
-          tauto;
-      . obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rry Rrz;
-        have : r ≺ u := F.trans Rry Ryu;
-        let Y : RM.World := ⟨y, by tauto⟩;
-        let Z : RM.World := ⟨z, by tauto⟩;
-        let U : RM.World := ⟨u, by tauto⟩;
-        use ⟦U⟧;
-        constructor;
-        . apply TransGen.single;
-          use Y, U;
-          tauto;
-        . apply TransGen.single;
-          use Z, U;
-          tauto;
+      rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ
+      . simp only [exists_and_left, and_self]
+        let Z : RM.World := ⟨z, by tauto⟩
+        use ⟦Z⟧
+        apply Relation.TransGen.single
+        use Z
+        constructor
+        . tauto
+        . use Z
+          constructor
+          . tauto
+          . apply F.refl
+      . let Y : RM.World := ⟨y, by tauto⟩
+        let Z : RM.World := ⟨z, by tauto⟩
+        use ⟦Z⟧
+        constructor
+        . apply TransGen.single
+          use Y, Z
+          tauto
+        . apply Frame.refl
+      . let Y : RM.World := ⟨y, by tauto⟩
+        let Z : RM.World := ⟨z, by tauto⟩
+        use ⟦Y⟧
+        constructor
+        . apply Frame.refl
+        . apply TransGen.single
+          use Z, Y
+          tauto
+      . obtain ⟨u, Ryu, Rzu⟩ := F.ps_convergent Rry Rrz
+        have : r ≺ u := F.trans Rry Ryu
+        let Y : RM.World := ⟨y, by tauto⟩
+        let Z : RM.World := ⟨z, by tauto⟩
+        let U : RM.World := ⟨u, by tauto⟩
+        use ⟦U⟧
+        constructor
+        . apply TransGen.single
+          use Y, U
+          tauto
+        . apply TransGen.single
+          use Z, U
+          tauto
   }
 ⟩
 
@@ -135,54 +135,54 @@ end FFP
 end KC.Kripke
 
 instance : Hilbert.KrieselPutnam ⪱ Hilbert.KC := by
-  constructor;
-  . apply weakerThan_of_subset_frameClass FrameClass.KrieselPutnam FrameClass.KC;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
+  constructor
+  . apply weakerThan_of_subset_frameClass FrameClass.KrieselPutnam FrameClass.KC
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
     infer_instance
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.WeakLEM (.atom 0);
-    constructor;
-    . simp;
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.WeakLEM (.atom 0)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KrieselPutnam)
-      apply not_validOnFrameClass_of_exists_frame;
+      apply not_validOnFrameClass_of_exists_frame
       let F : Frame := {
         World := Fin 3,
         Rel := λ x y => x = 0 ∨ x = y
         rel_partial_order := {
-          refl := by omega;
-          trans := by omega;
-          antisymm := by omega;
+          refl := by omega
+          trans := by omega
+          antisymm := by omega
         }
-      };
-      use F;
-      constructor;
+      }
+      use F
+      constructor
       . refine {
           kriesel_putnam := by
-            rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩;
+            rintro x y z ⟨Rxy, Rxz, nRyz, nRzy⟩
             match x, y, z with
             | _, 0, 0
             | _, 1, 1
-            | _, 2, 2 => simp_all;
+            | _, 2, 2 => simp_all
             | 1, _, 2
             | 2, _, 1
             | 0, 0, _
             | 0, 1, 0
-            | 0, 2, 0 => omega;
+            | 0, 2, 0 => omega
             | 0, 1, 2
             | 0, 2, 1 =>
-              use 0;
-              refine ⟨by tauto, by tauto, by tauto, ?_⟩;
-              intro u hu;
+              use 0
+              refine ⟨by tauto, by tauto, by tauto, ?_⟩
+              intro u hu
               match u with
-              | 0 => use 1; tauto;
-              | 1 => use 1; tauto;
-              | 2 => use 2; tauto;
+              | 0 => use 1; tauto
+              | 1 => use 1; tauto
+              | 2 => use 2; tauto
         }
-      . apply not_imp_not.mpr $ Kripke.isPiecewiseStronglyConvergent_of_validate_axiomWeakLEM;
-        by_contra hC;
-        have := @F.ps_convergent _ 0 1 2;
-        omega;
+      . apply not_imp_not.mpr $ Kripke.isPiecewiseStronglyConvergent_of_validate_axiomWeakLEM
+        by_contra hC
+        have := @F.ps_convergent _ 0 1 2
+        omega
 
 instance : Hilbert.Int ⪱ Hilbert.KC := calc
   Hilbert.Int ⪱ Hilbert.KrieselPutnam := inferInstance

--- a/Foundation/Propositional/Kripke/Logic/KrieselPutnam.lean
+++ b/Foundation/Propositional/Kripke/Logic/KrieselPutnam.lean
@@ -14,19 +14,19 @@ protected abbrev Kripke.FrameClass.KrieselPutnam : FrameClass := { F | F.Satisfi
 namespace Hilbert.KrieselPutnam.Kripke
 
 instance : Sound Hilbert.KrieselPutnam FrameClass.KrieselPutnam := instSound_of_validates_axioms $ by
-    apply FrameClass.Validates.withAxiomEFQ;
-    rintro F hF _ rfl;
-    replace hF := Set.mem_setOf_eq.mp hF;
+    apply FrameClass.Validates.withAxiomEFQ
+    rintro F hF _ rfl
+    replace hF := Set.mem_setOf_eq.mp hF
     apply validate_axiomKrieselPutnam_of_satisfiesKrieselPutnamCondition
 
 instance : Entailment.Consistent Hilbert.KrieselPutnam := consistent_of_sound_frameclass FrameClass.KrieselPutnam $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
   infer_instance
 
 instance : Canonical Hilbert.KrieselPutnam FrameClass.KrieselPutnam := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.KrieselPutnam FrameClass.KrieselPutnam := inferInstance
@@ -34,21 +34,21 @@ instance : Complete Hilbert.KrieselPutnam FrameClass.KrieselPutnam := inferInsta
 end KrieselPutnam.Kripke
 
 instance : Hilbert.Int ⪱ Hilbert.KrieselPutnam := by
-  constructor;
-  . apply Hilbert.weakerThan_of_subset_axioms $ by simp;
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2);
-    constructor;
-    . simp;
+  constructor
+  . apply Hilbert.weakerThan_of_subset_axioms $ by simp
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.KrieselPutnam (.atom 0) (.atom 1) (.atom 2)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.all)
-      apply not_validOnFrameClass_of_exists_model_world;
+      apply not_validOnFrameClass_of_exists_model_world
       let M : Kripke.Model := {
         World := Fin 5
         Rel x y := x = y ∨ x = 0 ∨ (x ≤ 1 ∧ y = 2) ∨ (x ≤ 1 ∧ y = 3) ∨ (x ≤ 1 ∧ y = 4)
         rel_partial_order := {
-          refl := by tauto;
-          trans := by omega;
-          antisymm := by omega;
+          refl := by tauto
+          trans := by omega
+          antisymm := by omega
         }
         Val := ⟨λ w a =>
           match a with
@@ -57,52 +57,52 @@ instance : Hilbert.Int ⪱ Hilbert.KrieselPutnam := by
           | 2 => w = 4
           | _ => False,
           by
-            intro x y Rxy a ha;
-            split at ha;
-            . subst ha; simp [Frame.Rel'] at Rxy; tauto;
-            . subst ha; simp [Frame.Rel'] at Rxy; tauto;
-            . subst ha; simp [Frame.Rel'] at Rxy; tauto;
-            . tauto;
+            intro x y Rxy a ha
+            split at ha
+            . subst ha; simp [Frame.Rel'] at Rxy; tauto
+            . subst ha; simp [Frame.Rel'] at Rxy; tauto
+            . subst ha; simp [Frame.Rel'] at Rxy; tauto
+            . tauto
         ⟩
       }
-      use M, 0;
-      constructor;
-      . tauto;
-      . apply Satisfies.imp_def.not.mpr;
-        push_neg;
-        use 1;
-        constructor;
-        . tauto;
-        . constructor;
-          . intro x R1x;
+      use M, 0
+      constructor
+      . tauto
+      . apply Satisfies.imp_def.not.mpr
+        push_neg
+        use 1
+        constructor
+        . tauto
+        . constructor
+          . intro x R1x
             match x with
-            | 0 => omega;
+            | 0 => omega
             | 1 =>
               suffices ¬Satisfies M 1 (∼.atom 0) by tauto
-              apply Satisfies.neg_def.not.mpr;
-              push_neg;
-              use 2;
-              constructor;
-              . tauto;
-              . simp [Semantics.Realize, Satisfies, M];
-            | 2 => tauto;
-            | 3 => tauto;
-            | 4 => tauto;
-          . apply Satisfies.or_def.not.mpr;
-            push_neg;
-            constructor;
-            . apply Satisfies.imp_def.not.mpr;
-              push_neg;
-              use 4;
-              constructor;
-              . tauto;
-              . simp [Semantics.Realize, Satisfies, M, Frame.Rel'];
-            . apply Satisfies.imp_def.not.mpr;
-              push_neg;
-              use 3;
-              constructor;
-              . tauto;
-              . simp [Semantics.Realize, Satisfies, M, Frame.Rel'];
+              apply Satisfies.neg_def.not.mpr
+              push_neg
+              use 2
+              constructor
+              . tauto
+              . simp [Semantics.Realize, Satisfies, M]
+            | 2 => tauto
+            | 3 => tauto
+            | 4 => tauto
+          . apply Satisfies.or_def.not.mpr
+            push_neg
+            constructor
+            . apply Satisfies.imp_def.not.mpr
+              push_neg
+              use 4
+              constructor
+              . tauto
+              . simp [Semantics.Realize, Satisfies, M, Frame.Rel']
+            . apply Satisfies.imp_def.not.mpr
+              push_neg
+              use 3
+              constructor
+              . tauto
+              . simp [Semantics.Realize, Satisfies, M, Frame.Rel']
 
 end Hilbert
 

--- a/Foundation/Propositional/Kripke/Logic/LC.lean
+++ b/Foundation/Propositional/Kripke/Logic/LC.lean
@@ -25,113 +25,113 @@ namespace Hilbert
 namespace LC.Kripke
 
 instance : Sound Hilbert.LC FrameClass.LC := instSound_of_validates_axioms $ by
-  apply FrameClass.Validates.withAxiomEFQ;
-  rintro F hF _ rfl;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply validate_axiomDummett_of_isPiecewiseStronglyConnected;
+  apply FrameClass.Validates.withAxiomEFQ
+  rintro F hF _ rfl
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply validate_axiomDummett_of_isPiecewiseStronglyConnected
 
 instance : Sound Hilbert.LC FrameClass.finite_LC := instSound_of_validates_axioms $ by
-  apply FrameClass.Validates.withAxiomEFQ;
-  rintro F hF _ rfl;
-  replace hF := Set.mem_setOf_eq.mp hF;
-  apply validate_axiomDummett_of_isPiecewiseStronglyConnected;
+  apply FrameClass.Validates.withAxiomEFQ
+  rintro F hF _ rfl
+  replace hF := Set.mem_setOf_eq.mp hF
+  apply validate_axiomDummett_of_isPiecewiseStronglyConnected
 
 instance : Entailment.Consistent Hilbert.LC := consistent_of_sound_frameclass FrameClass.LC $ by
-  use whitepoint;
-  apply Set.mem_setOf_eq.mpr;
+  use whitepoint
+  apply Set.mem_setOf_eq.mpr
   infer_instance
 
 instance : Canonical Hilbert.LC FrameClass.LC := ⟨by
-  apply Set.mem_setOf_eq.mpr;
-  infer_instance;
+  apply Set.mem_setOf_eq.mpr
+  infer_instance
 ⟩
 
 instance : Complete Hilbert.LC FrameClass.LC := inferInstance
 
 open finestFiltrationTransitiveClosureModel Relation in
 instance : Complete Hilbert.LC FrameClass.finite_LC := ⟨by
-  intro φ hφ;
-  apply Complete.complete (𝓜 := FrameClass.LC);
-  rintro F F_conn V r;
-  replace F_conn := Set.mem_setOf_eq.mp F_conn;
-  let M : Kripke.Model := ⟨F, V⟩;
-  let RM := M↾r;
+  intro φ hφ
+  apply Complete.complete (𝓜 := FrameClass.LC)
+  rintro F F_conn V r
+  replace F_conn := Set.mem_setOf_eq.mp F_conn
+  let M : Kripke.Model := ⟨F, V⟩
+  let RM := M↾r
 
-  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp;
+  apply Model.pointGenerate.modal_equivalent_at_root (M := M) (r := r) |>.mp
 
-  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas);
-  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr;
-  apply hφ;
+  let FRM := finestFiltrationTransitiveClosureModel RM (φ.subformulas)
+  apply filtration FRM finestFiltrationTransitiveClosureModel.filterOf (by simp) |>.mpr
+  apply hφ
   exact {
     world_finite := by
-      apply FilterEqvQuotient.finite;
-      simp;
+      apply FilterEqvQuotient.finite
+      simp
     ps_connected := by
-      rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ;
-      . simp only [exists_and_left, or_self];
+      rintro X ⟨y, (rfl | Rry)⟩ ⟨z, (rfl | Rrz)⟩ RXY RXZ
+      . simp only [exists_and_left, or_self]
         apply Relation.TransGen.single
-        use ⟨z, by tauto⟩;
-        constructor;
+        use ⟨z, by tauto⟩
+        constructor
         . tauto
-        . use ⟨z, by tauto⟩;
-          constructor;
-          . tauto;
-          . exact F.refl;
-      . left;
-        apply Relation.TransGen.single;
-        use ⟨y, by tauto⟩, ⟨z, by tauto⟩;
-        tauto;
-      . right;
-        apply Relation.TransGen.single;
-        use ⟨z, by tauto⟩, ⟨y, by tauto⟩;
-        tauto;
-      . let Y : RM.World := ⟨y, by tauto⟩;
-        let Z : RM.World := ⟨z, by tauto⟩;
-        rcases F.ps_connected Rry Rrz with (Ryz | Rrw);
-        . left;
-          apply Relation.TransGen.single;
-          use Y, Z;
-          tauto;
-        . right;
-          apply Relation.TransGen.single;
-          use Z, Y;
-          tauto;
+        . use ⟨z, by tauto⟩
+          constructor
+          . tauto
+          . exact F.refl
+      . left
+        apply Relation.TransGen.single
+        use ⟨y, by tauto⟩, ⟨z, by tauto⟩
+        tauto
+      . right
+        apply Relation.TransGen.single
+        use ⟨z, by tauto⟩, ⟨y, by tauto⟩
+        tauto
+      . let Y : RM.World := ⟨y, by tauto⟩
+        let Z : RM.World := ⟨z, by tauto⟩
+        rcases F.ps_connected Rry Rrz with (Ryz | Rrw)
+        . left
+          apply Relation.TransGen.single
+          use Y, Z
+          tauto
+        . right
+          apply Relation.TransGen.single
+          use Z, Y
+          tauto
   }
 ⟩
 
 end LC.Kripke
 
 instance : Hilbert.KC ⪱ Hilbert.LC := by
-  constructor;
-  . apply weakerThan_of_subset_frameClass FrameClass.KC FrameClass.LC;
-    intro F hF;
-    simp_all only [Set.mem_setOf_eq];
+  constructor
+  . apply weakerThan_of_subset_frameClass FrameClass.KC FrameClass.LC
+    intro F hF
+    simp_all only [Set.mem_setOf_eq]
     infer_instance
-  . apply Entailment.not_weakerThan_iff.mpr;
-    use Axioms.Dummett (.atom 0) (.atom 1);
-    constructor;
-    . simp;
+  . apply Entailment.not_weakerThan_iff.mpr
+    use Axioms.Dummett (.atom 0) (.atom 1)
+    constructor
+    . simp
     . apply Sound.not_provable_of_countermodel (𝓜 := FrameClass.KC)
-      apply not_validOnFrameClass_of_exists_frame;
+      apply not_validOnFrameClass_of_exists_frame
       use {
         World := Fin 4
         Rel := λ x y => ¬(x = 1 ∧ y = 2) ∧ ¬(x = 2 ∧ y = 1) ∧ (x ≤ y)
         rel_partial_order := {
-          refl := by omega;
-          trans := by omega;
-          antisymm := by omega;
+          refl := by omega
+          trans := by omega
+          antisymm := by omega
         }
-      };
-      constructor;
+      }
+      constructor
       . refine {
           ps_convergent := by
-            intros x y z Rxy Ryz;
-            use 3;
-            omega;
+            intros x y z Rxy Ryz
+            use 3
+            omega
         }
-      . apply not_imp_not.mpr $ isPiecewiseStronglyConnected_of_validate_axiomDummett;
-        by_contra hC;
-        simpa using @hC.ps_connected 0 1 2;
+      . apply not_imp_not.mpr $ isPiecewiseStronglyConnected_of_validate_axiomDummett
+        by_contra hC
+        simpa using @hC.ps_connected 0 1 2
 
 end Hilbert
 

--- a/Foundation/Propositional/Kripke/Preservation.lean
+++ b/Foundation/Propositional/Kripke/Preservation.lean
@@ -21,16 +21,16 @@ instance : CoeFun (Model.Bisimulation M₁ M₂) (λ _ => M₁.World → M₂.Wo
 def Model.Bisimulation.symm (bi : M₁ ⇄ M₂) : M₂ ⇄ M₁ := {
   toRel := λ a b => bi.toRel b a
   atomic := by
-    intro x₂ x₁ a h;
-    exact (bi.atomic h).symm;
+    intro x₂ x₁ a h
+    exact (bi.atomic h).symm
   forth := by
-    intro x₂ y₂ x₁ hxy h;
-    obtain ⟨y₁, ⟨hy₁, hxy⟩⟩ := bi.back hxy h;
-    use y₁;
+    intro x₂ y₂ x₁ hxy h
+    obtain ⟨y₁, ⟨hy₁, hxy⟩⟩ := bi.back hxy h
+    use y₁
   back := by
-    intro x₁ x₂ y₁ hxy h;
-    obtain ⟨y₂, ⟨hy₂, hxy⟩⟩ := bi.forth hxy h;
-    use y₂;
+    intro x₁ x₂ y₁ hxy h
+    obtain ⟨y₂, ⟨hy₂, hxy⟩⟩ := bi.forth hxy h
+    use y₂
 }
 
 end Bisimulation
@@ -42,36 +42,36 @@ def ModalEquivalent {M₁ M₂ : Model} (w₁ : M₁.World) (w₂ : M₂.World) 
 infix:50 " ↭ " => ModalEquivalent
 
 lemma modal_equivalent_of_bisimilar (Bi : M₁ ⇄ M₂) (bisx : Bi x₁ x₂) : x₁ ↭ x₂ := by
-  intro φ;
+  intro φ
   induction φ generalizing x₁ x₂ with
-  | hatom a => exact Bi.atomic bisx;
+  | hatom a => exact Bi.atomic bisx
   | hand φ ψ ihφ ihψ =>
-    constructor;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . exact ihφ bisx |>.mp hφ;
-      . exact ihψ bisx |>.mp hψ;
-    . rintro ⟨hφ, hψ⟩;
-      constructor;
-      . exact ihφ bisx |>.mpr hφ;
-      . exact ihψ bisx |>.mpr hψ;
+    constructor
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . exact ihφ bisx |>.mp hφ
+      . exact ihψ bisx |>.mp hψ
+    . rintro ⟨hφ, hψ⟩
+      constructor
+      . exact ihφ bisx |>.mpr hφ
+      . exact ihψ bisx |>.mpr hψ
   | hor φ ψ ihφ ihψ =>
-    constructor;
-    . rintro (hφ | hψ);
-      . left;  exact ihφ bisx |>.mp hφ;
-      . right; exact ihψ bisx |>.mp hψ;
-    . rintro (hφ | hψ);
-      . left;  exact ihφ bisx |>.mpr hφ;
-      . right; exact ihψ bisx |>.mpr hψ;
+    constructor
+    . rintro (hφ | hψ)
+      . left;  exact ihφ bisx |>.mp hφ
+      . right; exact ihψ bisx |>.mp hψ
+    . rintro (hφ | hψ)
+      . left;  exact ihφ bisx |>.mpr hφ
+      . right; exact ihψ bisx |>.mpr hψ
   | himp φ ψ ihφ ihψ =>
-    constructor;
-    . rintro hφψ y₂ Rx₂y₂ hφ;
-      obtain ⟨y₁, ⟨bisy, Rx₁y₁⟩⟩ := Bi.back bisx Rx₂y₂;
-      exact ihψ bisy |>.mp $ hφψ Rx₁y₁ ((ihφ bisy).mpr hφ);
-    . rintro hφψ y₁ Rx₁y₁ hφ;
-      obtain ⟨y₂, ⟨bisy, Rx₂y₂⟩⟩ := Bi.forth bisx Rx₁y₁;
-      exact ihψ bisy |>.mpr $ hφψ Rx₂y₂ ((ihφ bisy).mp hφ);
-  | _ => simp_all;
+    constructor
+    . rintro hφψ y₂ Rx₂y₂ hφ
+      obtain ⟨y₁, ⟨bisy, Rx₁y₁⟩⟩ := Bi.back bisx Rx₂y₂
+      exact ihψ bisy |>.mp $ hφψ Rx₁y₁ ((ihφ bisy).mpr hφ)
+    . rintro hφψ y₁ Rx₁y₁ hφ
+      obtain ⟨y₂, ⟨bisy, Rx₂y₂⟩⟩ := Bi.forth bisx Rx₁y₁
+      exact ihψ bisy |>.mpr $ hφψ Rx₂y₂ ((ihφ bisy).mp hφ)
+  | _ => simp_all
 
 def ModalEquivalent.symm {M₁ M₂ : Model} {w₁ : M₁.World} {w₂ : M₂.World} (h : w₁ ↭ w₂) : w₂ ↭ w₁ := fun {_} => Iff.symm h
 
@@ -95,22 +95,22 @@ variable {F F₁ F₂ F₃ : Kripke.Frame}
 
 def id : F →ₚ F where
   toFun := _root_.id
-  forth := by simp;
-  back := by simp;
+  forth := by simp
+  back := by simp
 
 def comp (f : F₁ →ₚ F₂) (g : F₂ →ₚ F₃) : F₁ →ₚ F₃ where
   toFun := g ∘ f
   forth := by
-    intro x y hxy;
-    exact g.forth $ f.forth hxy;
+    intro x y hxy
+    exact g.forth $ f.forth hxy
   back := by
-    intro x w hxw;
-    obtain ⟨y, ⟨rfl, hxy⟩⟩ := g.back hxw;
-    obtain ⟨u, ⟨rfl, hfu⟩⟩ := f.back hxy;
-    use u;
-    constructor;
-    . simp_all;
-    . assumption;
+    intro x w hxw
+    obtain ⟨y, ⟨rfl, hxy⟩⟩ := g.back hxw
+    obtain ⟨u, ⟨rfl, hfu⟩⟩ := f.back hxy
+    use u
+    constructor
+    . simp_all
+    . assumption
 
 end Frame.PseudoEpimorphism
 
@@ -134,41 +134,41 @@ def ofAtomic (f : M₁.toFrame →ₚ M₂.toFrame) (atomic : ∀ {w a}, (M₁ w
 
 def id : M →ₚ M where
   toFun := _root_.id
-  forth := by simp;
-  back := by simp;
-  atomic := by simp;
+  forth := by simp
+  back := by simp
+  atomic := by simp
 
 def comp (f : M₁ →ₚ M₂) (g : M₂ →ₚ M₃) : M₁ →ₚ M₃ := ofAtomic (f.toPseudoEpimorphism.comp (g.toPseudoEpimorphism)) $ by
-  intro x φ;
-  constructor;
-  . intro h;
-    apply g.atomic.mp;
-    apply f.atomic.mp;
-    assumption;
-  . intro h;
-    apply f.atomic.mpr;
-    apply g.atomic.mpr;
-    assumption;
+  intro x φ
+  constructor
+  . intro h
+    apply g.atomic.mp
+    apply f.atomic.mp
+    assumption
+  . intro h
+    apply f.atomic.mpr
+    apply g.atomic.mpr
+    assumption
 
 def bisimulation (f : M₁ →ₚ M₂) : M₁ ⇄ M₂ where
   toRel x y := y = f x
   atomic := by
-    rintro x₁ x₂ a rfl;
-    constructor;
-    . apply f.atomic.mp;
-    . apply f.atomic.mpr;
+    rintro x₁ x₂ a rfl
+    constructor
+    . apply f.atomic.mp
+    . apply f.atomic.mpr
   forth := by
-    simp only [exists_eq_left, forall_eq];
-    intro x₁ y₁ rx₁y₁;
-    exact f.forth rx₁y₁;
+    simp only [exists_eq_left, forall_eq]
+    intro x₁ y₁ rx₁y₁
+    exact f.forth rx₁y₁
   back := by
-    rintro x₁ x₂ y₂ rfl rx₂y₂;
-    obtain ⟨y₁, ⟨rfl, _⟩⟩ := f.back rx₂y₂;
-    use y₁;
+    rintro x₁ x₂ y₂ rfl rx₂y₂
+    obtain ⟨y₁, ⟨rfl, _⟩⟩ := f.back rx₂y₂
+    use y₁
 
 lemma modal_equivalence (f : M₁ →ₚ M₂) (w : M₁.World) : w ↭ (f w) := by
-  apply modal_equivalent_of_bisimilar $ Model.PseudoEpimorphism.bisimulation f;
-  simp [Model.PseudoEpimorphism.bisimulation];
+  apply modal_equivalent_of_bisimilar $ Model.PseudoEpimorphism.bisimulation f
+  simp [Model.PseudoEpimorphism.bisimulation]
 
 end Model.PseudoEpimorphism
 

--- a/Foundation/Propositional/Kripke/Rooted.lean
+++ b/Foundation/Propositional/Kripke/Rooted.lean
@@ -17,21 +17,21 @@ abbrev pointGenerate (F : Kripke.Frame) (r : F.World) : Kripke.Frame where
   Rel x y := x.1 ≺ y.1
   world_nonempty := ⟨r, by tauto⟩
   rel_partial_order := {
-    refl := by rintro ⟨x, (rfl | hx)⟩ <;> exact F.refl;
+    refl := by rintro ⟨x, (rfl | hx)⟩ <;> exact F.refl
     trans := by
-      rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ ⟨z, (rfl | hz)⟩ Rxy Ryz;
-      any_goals assumption;
-      any_goals apply F.refl;
-      any_goals apply F.trans Rxy Ryz;
+      rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ ⟨z, (rfl | hz)⟩ Rxy Ryz
+      any_goals assumption
+      any_goals apply F.refl
+      any_goals apply F.trans Rxy Ryz
     antisymm := by
-      rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ Rxy Ryx;
-      . simp;
-      . simp_all only [Subtype.mk.injEq];
-        apply F.rel_partial_order.antisymm <;> assumption;
-      . simp_all only [Subtype.mk.injEq];
-        apply F.rel_partial_order.antisymm <;> assumption;
-      . simp_all only [Subtype.mk.injEq];
-        apply F.rel_partial_order.antisymm <;> assumption;
+      rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ Rxy Ryx
+      . simp
+      . simp_all only [Subtype.mk.injEq]
+        apply F.rel_partial_order.antisymm <;> assumption
+      . simp_all only [Subtype.mk.injEq]
+        apply F.rel_partial_order.antisymm <;> assumption
+      . simp_all only [Subtype.mk.injEq]
+        apply F.rel_partial_order.antisymm <;> assumption
   }
 infix:100 "↾" => Frame.pointGenerate
 
@@ -42,7 +42,7 @@ variable {F : Frame} {r : F.World}
 protected abbrev root : (F↾r).World := ⟨r, by tauto⟩
 
 instance instIsRooted : (F↾r).IsRooted pointGenerate.root where
-  root_generates := by rintro ⟨w, (rfl | Rrw)⟩ hw <;> tauto;
+  root_generates := by rintro ⟨w, (rfl | Rrw)⟩ hw <;> tauto
 
 instance [Finite F.World] : Finite (F↾r).World := Subtype.finite
 
@@ -51,18 +51,18 @@ instance [Finite F] : (F↾r).IsFinite := (isFinite_iff _).mpr inferInstance
 instance [DecidableEq F.World] : DecidableEq (F↾r).World := Subtype.instDecidableEq
 
 lemma rel_irrefl (F_irrefl : Irreflexive F) : Irreflexive (F↾r).Rel := by
-  rintro ⟨x, (rfl | hx)⟩ h;
-  all_goals apply F_irrefl; exact h;
+  rintro ⟨x, (rfl | hx)⟩ h
+  all_goals apply F_irrefl; exact h
 
 def pMorphism : (F↾r) →ₚ F where
   toFun := λ ⟨x, _⟩ => x
   forth := by
-    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy;
-    repeat exact hxy;
+    rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ hxy
+    repeat exact hxy
   back := by
-    rintro ⟨x, (rfl | hx)⟩ y Rwv;
+    rintro ⟨x, (rfl | hx)⟩ y Rwv
     . simp at Rwv; use ⟨y, by tauto⟩
-    . use ⟨y, by right; exact F.trans hx Rwv⟩;
+    . use ⟨y, by right; exact F.trans hx Rwv⟩
 
 end pointGenerate
 
@@ -73,7 +73,7 @@ def Model.pointGenerate (M : Kripke.Model) (r : M.World) : Model where
   toFrame := M.toFrame↾r
   Val := ⟨
     λ w a => M.Val w.1 a,
-    by rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ r a hx; all_goals exact M.Val.hereditary (by tauto) hx;
+    by rintro ⟨x, (rfl | hx)⟩ ⟨y, (rfl | hy)⟩ r a hx; all_goals exact M.Val.hereditary (by tauto) hx
   ⟩
 infix:100 "↾" => Model.pointGenerate
 
@@ -84,9 +84,9 @@ variable {M : Kripke.Model} {r : M.World}
 protected abbrev root : (M↾r).World := ⟨r, by tauto⟩
 
 protected def pMorphism : (M↾r) →ₚ M := by
-  apply Model.PseudoEpimorphism.ofAtomic (Frame.pointGenerate.pMorphism (F := M.toFrame) (r := r));
-  simp only [pointGenerate, Frame.pointGenerate, Subtype.forall];
-  rintro p x (rfl | Rrx) <;> tauto;
+  apply Model.PseudoEpimorphism.ofAtomic (Frame.pointGenerate.pMorphism (F := M.toFrame) (r := r))
+  simp only [pointGenerate, Frame.pointGenerate, Subtype.forall]
+  rintro p x (rfl | Rrx) <;> tauto
 
 protected def bisimulation (r : M.World) : (M↾r) ⇄ M := Model.pointGenerate.pMorphism.bisimulation
 

--- a/Foundation/Propositional/Logic/Basic.lean
+++ b/Foundation/Propositional/Logic/Basic.lean
@@ -25,25 +25,25 @@ export Substitution (subst!)
 
 @[simp low]
 lemma iff_provable : L ⊢! φ ↔ φ ∈ L := by
-  constructor;
-  . intro h;
-    exact PLift.down h.some;
-  . intro h;
-    constructor;
-    constructor;
-    exact h;
+  constructor
+  . intro h
+    exact PLift.down h.some
+  . intro h
+    constructor
+    constructor
+    exact h
 
 @[simp low]
 lemma iff_unprovable : L ⊬ φ ↔ φ ∉ L := by
-  apply not_congr;
-  simp [iff_provable];
+  apply not_congr
+  simp [iff_provable]
 
 lemma iff_equal_provable_equiv : L₁ = L₂ ↔ L₁ ≊ L₂ := by
-  constructor;
-  . tauto;
-  . rintro h;
-    ext φ;
-    simpa using Equiv.iff.mp h φ;
+  constructor
+  . tauto
+  . rintro h
+    ext φ
+    simpa using Equiv.iff.mp h φ
 
 section
 
@@ -51,17 +51,17 @@ variable [L.IsSuperintuitionistic] [Consistent L]
 
 @[simp]
 lemma no_bot : L ⊬ ⊥ := by
-  obtain ⟨φ, hφ⟩ := Consistent.exists_unprovable (𝓢 := L) inferInstance;
-  by_contra! hC;
-  apply hφ;
-  apply of_O!;
-  exact hC;
+  obtain ⟨φ, hφ⟩ := Consistent.exists_unprovable (𝓢 := L) inferInstance
+  by_contra! hC
+  apply hφ
+  apply of_O!
+  exact hC
 
 -- TODO: more general place
 lemma not_neg_of! (hφ : L ⊢! φ) : L ⊬ ∼φ := by
-  by_contra! hC;
-  apply L.no_bot;
-  exact hC ⨀ hφ;
+  by_contra! hC
+  apply L.no_bot
+  exact hC ⨀ hφ
 
 end
 
@@ -76,21 +76,21 @@ variable {L : Logic α}
 instance : (∅ : Logic α) ⪯ L := ⟨by simp [Entailment.theory]⟩
 
 instance [HasAxiomVerum L] : (∅ : Logic α) ⪱ L := by
-  apply strictlyWeakerThan_iff.mpr;
-  constructor;
-  . simp;
-  . use ⊤; constructor <;> simp;
+  apply strictlyWeakerThan_iff.mpr
+  constructor
+  . simp
+  . use ⊤; constructor <;> simp
 
 instance : L ⪯ (Set.univ : Logic α) := ⟨by simp [Entailment.theory]⟩
 
 instance [Consistent L] : L ⪱ (Set.univ : Logic α) := by
-  apply strictlyWeakerThan_iff.mpr;
-  constructor;
-  . simp;
-  . obtain ⟨φ, hφ⟩ := consistent_iff_exists_unprovable (𝓢 := L) |>.mp (by assumption);
-    use φ;
-    constructor;
-    . assumption;
+  apply strictlyWeakerThan_iff.mpr
+  constructor
+  . simp
+  . obtain ⟨φ, hφ⟩ := consistent_iff_exists_unprovable (𝓢 := L) |>.mp (by assumption)
+    use φ
+    constructor
+    . assumption
     . simp
 
 end

--- a/Foundation/Propositional/Logic/Letterless_Int_Cl.lean
+++ b/Foundation/Propositional/Logic/Letterless_Int_Cl.lean
@@ -15,17 +15,17 @@ namespace Logic
 open LO.Entailment LO.Entailment.FiniteContext LO.Modal.Entailment
 
 theorem iff_letterless_Int_Cl {φ : Formula ℕ} (hφ : φ.letterless) : 𝐈𝐧𝐭 ⊢! φ ↔ 𝐂𝐥 ⊢! φ := by
-  constructor;
-  . apply WeakerThan.wk;
-    infer_instance;
-  . intro h;
-    have : Modal.Hilbert.S4 ⊢! ◇φᵍ := Modal.Logic.iff_provable_Cl_provable_dia_gS4.mp h;
-    have : Modal.Hilbert.Triv ⊢! ◇φᵍ := WeakerThan.pbl this;
-    have : Modal.Hilbert.Triv ⊢! φᵍ := diaT'! this;
-    have : (φᵍᵀ.toPropFormula _).isTautology := Modal.Logic.Triv.iff_isTautology.mp this;
-    have : Modal.KD ⊢! φᵍ := Modal.Logic.provable_KD_of_classical_tautology (Formula.goedelTranslate.letterless hφ) this;
-    have : Modal.S4 ⊢! φᵍ := WeakerThan.pbl this;
-    exact Modal.modalCompanion_Int_S4.companion.mpr this;
+  constructor
+  . apply WeakerThan.wk
+    infer_instance
+  . intro h
+    have : Modal.Hilbert.S4 ⊢! ◇φᵍ := Modal.Logic.iff_provable_Cl_provable_dia_gS4.mp h
+    have : Modal.Hilbert.Triv ⊢! ◇φᵍ := WeakerThan.pbl this
+    have : Modal.Hilbert.Triv ⊢! φᵍ := diaT'! this
+    have : (φᵍᵀ.toPropFormula _).isTautology := Modal.Logic.Triv.iff_isTautology.mp this
+    have : Modal.KD ⊢! φᵍ := Modal.Logic.provable_KD_of_classical_tautology (Formula.goedelTranslate.letterless hφ) this
+    have : Modal.S4 ⊢! φᵍ := WeakerThan.pbl this
+    exact Modal.modalCompanion_Int_S4.companion.mpr this
 
 end Logic
 

--- a/Foundation/Propositional/Logic/PostComplete.lean
+++ b/Foundation/Propositional/Logic/PostComplete.lean
@@ -4,12 +4,12 @@ import Foundation.Propositional.ClassicalSemantics.Hilbert
 import Foundation.Propositional.ClassicalSemantics.ZeroSubst
 
 lemma Set.ssubset_of_subset_ne {α : Type*} {s t : Set α} (h : s ⊆ t) (hne : s ≠ t) : s ⊂ t := by
-  constructor;
-  . assumption;
-  . revert hne;
-    contrapose!;
-    intro _;
-    apply Set.eq_of_subset_of_subset <;> assumption;
+  constructor
+  . assumption
+  . revert hne
+    contrapose!
+    intro _
+    apply Set.eq_of_subset_of_subset <;> assumption
 
 namespace LO.Propositional
 
@@ -23,18 +23,18 @@ open Propositional.Hilbert.Cl
 open ClassicalSemantics
 
 theorem Cl.post_complete : ¬∃ L : Logic _, Entailment.Consistent L ∧ Nonempty (L.IsSuperintuitionistic) ∧ 𝐂𝐥 ⪱ L := by
-  by_contra! hC;
-  obtain ⟨L, L_consis, ⟨L_ne⟩, L_Cl⟩ := hC;
-  apply Logic.no_bot (L := L);
-  obtain ⟨hL, φ, hφ₁, hφ₂⟩ := Entailment.strictlyWeakerThan_iff.mp L_Cl;
-  have ⟨v, hv⟩ := exists_valuation_of_not hφ₁;
+  by_contra! hC
+  obtain ⟨L, L_consis, ⟨L_ne⟩, L_Cl⟩ := hC
+  apply Logic.no_bot (L := L)
+  obtain ⟨hL, φ, hφ₁, hφ₂⟩ := Entailment.strictlyWeakerThan_iff.mp L_Cl
+  have ⟨v, hv⟩ := exists_valuation_of_not hφ₁
   have h₁ : L ⊢! ∼(φ⟦(vfSubst v).1⟧) := hL $ by
-    apply iff_isTautology.mpr;
-    apply neg_isTautology_of_not_isTautology_of_letterless;
-    . apply Formula.letterless_zeroSubst;
-    . apply isTautology_vfSubst.not.mp hv;
-  have h₂ : L ⊢! φ⟦(vfSubst v).1⟧ := L.subst! _ hφ₂;
-  exact h₁ ⨀ h₂;
+    apply iff_isTautology.mpr
+    apply neg_isTautology_of_not_isTautology_of_letterless
+    . apply Formula.letterless_zeroSubst
+    . apply isTautology_vfSubst.not.mp hv
+  have h₂ : L ⊢! φ⟦(vfSubst v).1⟧ := L.subst! _ hφ₂
+  exact h₁ ⨀ h₂
 
 end Logic
 

--- a/Foundation/ProvabilityLogic/GL/Soundness.lean
+++ b/Foundation/ProvabilityLogic/GL/Soundness.lean
@@ -16,17 +16,17 @@ variable {L : FirstOrder.Language} [L.ReferenceableBy L]
          {𝔅 : Provability T U} [𝔅.HBL]
 
 lemma GL.arithmetical_soundness (h : Modal.GL ⊢! A) {f : Realization 𝔅} : U ⊢!. f A := by
-  replace h := Normal.iff_logic_provable_provable.mp h;
+  replace h := Normal.iff_logic_provable_provable.mp h
   induction h using Hilbert.Normal.rec! with
   | axm _ hp =>
     rcases hp with (⟨_, rfl⟩ | ⟨_, rfl⟩)
-    . exact D2_shift;
-    . exact FLT_shift;
-  | nec ihp => exact D1_shift ihp;
-  | mdp ihpq ihp => exact ihpq ⨀ ihp;
-  | imply₁ => exact imply₁!;
-  | imply₂ => exact imply₂!;
-  | ec => exact CCCOCOC!;
+    . exact D2_shift
+    . exact FLT_shift
+  | nec ihp => exact D1_shift ihp
+  | mdp ihpq ihp => exact ihpq ⨀ ihp
+  | imply₁ => exact imply₁!
+  | imply₂ => exact imply₂!
+  | ec => exact CCCOCOC!
 
 open Classical
 

--- a/Foundation/ProvabilityLogic/GL/Unprovability.lean
+++ b/Foundation/ProvabilityLogic/GL/Unprovability.lean
@@ -18,28 +18,28 @@ def indep (𝔅 : Provability T₀ T) (σ : Sentence L) : Sentence L := ∼(𝔅
 
 lemma indep_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
     T ⊢!. 𝔅.indep σ ➝ 𝔅.indep π := by
-  apply CKK!_of_C!_of_C!;
-  . apply contra!;
-    apply WeakerThan.pbl (𝓢 := T₀.toAxiom);
-    apply 𝔅.prov_distribute_imply;
-    cl_prover [h];
-  . apply contra!;
-    apply WeakerThan.pbl (𝓢 := T₀.toAxiom);
-    apply 𝔅.prov_distribute_imply;
-    cl_prover [h];
+  apply CKK!_of_C!_of_C!
+  . apply contra!
+    apply WeakerThan.pbl (𝓢 := T₀.toAxiom)
+    apply 𝔅.prov_distribute_imply
+    cl_prover [h]
+  . apply contra!
+    apply WeakerThan.pbl (𝓢 := T₀.toAxiom)
+    apply 𝔅.prov_distribute_imply
+    cl_prover [h]
 
 lemma indep_iff_distribute_inside [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
     T ⊢!. 𝔅.indep σ ⭤ 𝔅.indep π := by
   apply K!_intro
-  . exact indep_distribute $ h;
-  . apply indep_distribute;
-    cl_prover [h];
+  . exact indep_distribute $ h
+  . apply indep_distribute
+    cl_prover [h]
 
 lemma indep_iff_distribute [𝔅.HBL2] (h : T ⊢!. σ ⭤ π) :
     T ⊢!. 𝔅.indep σ ↔ T ⊢!. 𝔅.indep π := by
-  constructor;
-  . intro H; exact K!_left (indep_iff_distribute_inside h) ⨀ H;
-  . intro H; exact K!_right (indep_iff_distribute_inside h) ⨀ H;
+  constructor
+  . intro H; exact K!_left (indep_iff_distribute_inside h) ⨀ H
+  . intro H; exact K!_right (indep_iff_distribute_inside h) ⨀ H
 
 end Provability
 
@@ -61,10 +61,10 @@ section Corollary
 
 /-- Gödel's Second Incompleteness Theorem -/
 example [𝐈𝚺₁ ⪯ T] (height : T.standardProvability.height = ⊤) : T ⊬. T.standardProvability.con := by
-  have h := GL.arithmetical_completeness_iff height (T := T) |>.not.mpr $ GL.unprovable_notbox (φ := ⊥);
-  push_neg at h;
-  obtain ⟨f, h⟩ := h;
-  exact Realization.iff_interpret_neg (L := ℒₒᵣ) |>.not.mp h;
+  have h := GL.arithmetical_completeness_iff height (T := T) |>.not.mpr $ GL.unprovable_notbox (φ := ⊥)
+  push_neg at h
+  obtain ⟨f, h⟩ := h
+  exact Realization.iff_interpret_neg (L := ℒₒᵣ) |>.not.mp h
 
 end Corollary
 
@@ -72,41 +72,41 @@ section Independency
 
 lemma iff_modalConsis_bewConsis_inside :
     T ⊢!. f (∼□⊥) ⭤ T.standardProvability.con := by
-  apply K!_intro;
-  . refine C!_trans (K!_left Realization.iff_interpret_neg_inside) ?_;
-    apply contra!;
-    simp [Realization.interpret];
+  apply K!_intro
+  . refine C!_trans (K!_left Realization.iff_interpret_neg_inside) ?_
+    apply contra!
+    simp [Realization.interpret]
   . refine C!_trans ?_ (K!_right Realization.iff_interpret_neg_inside)
-    apply contra!;
-    simp [Realization.interpret];
+    apply contra!
+    simp [Realization.interpret]
 
 variable [𝐈𝚺₁ ⪯ T]
 
 lemma iff_modalIndep_bewIndep_inside :
     T ⊢!. f (Modal.independency A) ⭤ T.standardProvability.indep (f A) := by
-  apply K!_intro;
-  . refine C!_trans (K!_left $ Realization.iff_interpret_and_inside) ?_;
-    apply CKK!_of_C!_of_C!;
-    . apply K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ);
-    . apply C!_trans (K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) (A := □(∼A))) ?_;
-      apply contra!;
-      apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply T.standardProvability.prov_distribute_imply;
-      apply K!_right $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) ;
-  . refine C!_trans ?_ (K!_right $ Realization.iff_interpret_and_inside);
-    apply CKK!_of_C!_of_C!;
-    . exact C!_trans (K!_right $ Realization.iff_interpret_neg_inside (A := □A)) C!_id;
-    . apply C!_trans ?_ (K!_right $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) (A := □(∼A)));
-      apply contra!;
-      apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
-      apply T.standardProvability.prov_distribute_imply;
-      apply K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ);
+  apply K!_intro
+  . refine C!_trans (K!_left $ Realization.iff_interpret_and_inside) ?_
+    apply CKK!_of_C!_of_C!
+    . apply K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ)
+    . apply C!_trans (K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) (A := □(∼A))) ?_
+      apply contra!
+      apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom)
+      apply T.standardProvability.prov_distribute_imply
+      apply K!_right $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) 
+  . refine C!_trans ?_ (K!_right $ Realization.iff_interpret_and_inside)
+    apply CKK!_of_C!_of_C!
+    . exact C!_trans (K!_right $ Realization.iff_interpret_neg_inside (A := □A)) C!_id
+    . apply C!_trans ?_ (K!_right $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ) (A := □(∼A)))
+      apply contra!
+      apply WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom)
+      apply T.standardProvability.prov_distribute_imply
+      apply K!_left $ Realization.iff_interpret_neg_inside (L := ℒₒᵣ)
 
 lemma iff_modalIndep_bewIndep :
     T ⊢!. f (Modal.independency A) ↔ T ⊢!. T.standardProvability.indep (f A) := by
-  constructor;
-  . intro h; exact (K!_left iff_modalIndep_bewIndep_inside) ⨀ h;
-  . intro h; exact (K!_right iff_modalIndep_bewIndep_inside) ⨀ h;
+  constructor
+  . intro h; exact (K!_left iff_modalIndep_bewIndep_inside) ⨀ h
+  . intro h; exact (K!_right iff_modalIndep_bewIndep_inside) ⨀ h
 
 lemma iff_not_modalIndep_not_bewIndep_inside :
     T ⊢!. ∼f (Modal.independency A) ⭤ ∼T.standardProvability.indep (f A) :=
@@ -114,56 +114,56 @@ lemma iff_not_modalIndep_not_bewIndep_inside :
 
 lemma iff_not_modalIndep_not_bewIndep :
     T ⊢!. ∼f (Modal.independency A) ↔ T ⊢!. ∼T.standardProvability.indep (f A) := by
-  constructor;
-  . intro h; exact (K!_left iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
-  . intro h; exact (K!_right iff_not_modalIndep_not_bewIndep_inside) ⨀ h;
+  constructor
+  . intro h; exact (K!_left iff_not_modalIndep_not_bewIndep_inside) ⨀ h
+  . intro h; exact (K!_right iff_not_modalIndep_not_bewIndep_inside) ⨀ h
 
 lemma unprovable_independency_of_consistency (height : T.standardProvability.height = ⊤) :
     T ⊬. T.standardProvability.indep (T.standardProvability.con) := by
   let g : T.PLRealization := ⟨λ _ => ⊥⟩
   suffices T ⊬. g (Modal.independency (∼□⊥)) by
-    have H₁ := iff_modalIndep_bewIndep (f := g) (T := T) (A := ∼□⊥);
+    have H₁ := iff_modalIndep_bewIndep (f := g) (T := T) (A := ∼□⊥)
     have H₂ := T.standardProvability.indep_iff_distribute (T := T)
       (σ := g (∼□⊥))
       (π := T.standardProvability.con)
-      iff_modalConsis_bewConsis_inside;
-    exact Iff.trans H₁ H₂ |>.not.mp this;
-  have h := GL.arithmetical_completeness_iff height |>.not.mpr $ GL.unprovable_independency (φ := ∼□⊥);
-  push_neg at h;
-  obtain ⟨f, h⟩ := h;
-  congr;
+      iff_modalConsis_bewConsis_inside
+    exact Iff.trans H₁ H₂ |>.not.mp this
+  have h := GL.arithmetical_completeness_iff height |>.not.mpr $ GL.unprovable_independency (φ := ∼□⊥)
+  push_neg at h
+  obtain ⟨f, h⟩ := h
+  congr
 
 lemma unrefutable_independency_of_consistency (height : T.standardProvability.height = ⊤):
     T ⊬. ∼T.standardProvability.indep (T.standardProvability.con) := by
   let g : T.PLRealization := ⟨λ _ => ⊥⟩
   suffices T ⊬. ∼g (Modal.independency (∼□⊥)) by
-    have H₁ := iff_not_modalIndep_not_bewIndep (f := g) (T := T) (A := ∼□⊥);
+    have H₁ := iff_not_modalIndep_not_bewIndep (f := g) (T := T) (A := ∼□⊥)
     have H₂ : T ⊢!.
       ∼T.standardProvability.indep (g (∼□⊥)) ⭤
       ∼T.standardProvability.indep T.standardProvability.con
       := ENN!_of_E! $ T.standardProvability.indep_iff_distribute_inside (T := T)
       (σ := g (∼□⊥))
       (π := T.standardProvability.con)
-      iff_modalConsis_bewConsis_inside;
+      iff_modalConsis_bewConsis_inside
     replace H₂ :
       T ⊢!. ∼T.standardProvability.indep (g (∼□⊥)) ↔
       T ⊢!. ∼T.standardProvability.indep T.standardProvability.con
       := by
-      constructor;
-      . intro H; exact K!_left H₂ ⨀ H;
-      . intro H; exact K!_right H₂ ⨀ H;
-    apply Iff.trans H₁ H₂ |>.not.mp this;
-  have h := GL.arithmetical_completeness_iff height |>.not.mpr $ GL.unprovable_not_independency_of_consistency;
-  push_neg at h;
-  obtain ⟨f, h⟩ := h;
-  replace h := Realization.iff_interpret_neg (L := ℒₒᵣ) |>.not.mp h;
-  congr;
+      constructor
+      . intro H; exact K!_left H₂ ⨀ H
+      . intro H; exact K!_right H₂ ⨀ H
+    apply Iff.trans H₁ H₂ |>.not.mp this
+  have h := GL.arithmetical_completeness_iff height |>.not.mpr $ GL.unprovable_not_independency_of_consistency
+  push_neg at h
+  obtain ⟨f, h⟩ := h
+  replace h := Realization.iff_interpret_neg (L := ℒₒᵣ) |>.not.mp h
+  congr
 
 theorem undecidable_independency_of_consistency (height : T.standardProvability.height = ⊤) :
     Independent T.toAxiom (T.standardProvability.indep T.standardProvability.con) := by
-  constructor;
-  . exact unprovable_independency_of_consistency height;
-  . exact unrefutable_independency_of_consistency height;
+  constructor
+  . exact unprovable_independency_of_consistency height
+  . exact unrefutable_independency_of_consistency height
 
 end Independency
 

--- a/Foundation/ProvabilityLogic/Grz/Completeness.lean
+++ b/Foundation/ProvabilityLogic/Grz/Completeness.lean
@@ -26,85 +26,85 @@ def strongInterpret (f : Realization 𝔅) : Formula ℕ → Sentence L
 lemma iff_interpret_boxdot_strongInterpret_inside [𝔅.HBL2] :
     T ⊢!. f (Aᵇ) ⭤ f.strongInterpret A := by
   induction A with
-  | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
-  | hfalsum => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
-  | himp A B ihA ihB => exact ECC!_of_E!_of_E! ihA ihB;
+  | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate]
+  | hfalsum => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate]
+  | himp A B ihA ihB => exact ECC!_of_E!_of_E! ihA ihB
   | hbox A ih =>
-    apply K!_intro;
-    . apply C!_trans CCCCOOK! ?_;
-      apply CKK!_of_C!_of_C!;
-      . exact K!_left ih;
-      . exact 𝔅.prov_distribute_imply'' $ K!_left ih;
-    . apply C!_trans ?_ CKCCCOO!;
-      apply CKK!_of_C!_of_C!;
-      . exact K!_right ih;
-      . exact 𝔅.prov_distribute_imply'' $ K!_right ih;
+    apply K!_intro
+    . apply C!_trans CCCCOOK! ?_
+      apply CKK!_of_C!_of_C!
+      . exact K!_left ih
+      . exact 𝔅.prov_distribute_imply'' $ K!_left ih
+    . apply C!_trans ?_ CKCCCOO!
+      apply CKK!_of_C!_of_C!
+      . exact K!_right ih
+      . exact 𝔅.prov_distribute_imply'' $ K!_right ih
 
 lemma iff_interpret_boxdot_strongInterpret [𝔅.HBL2] :
     T ⊢!. f (Aᵇ) ↔ T ⊢!. f.strongInterpret A := by
-  constructor;
-  . intro h; exact (K!_left iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
-  . intro h; exact (K!_right iff_interpret_boxdot_strongInterpret_inside) ⨀ h;
+  constructor
+  . intro h; exact (K!_left iff_interpret_boxdot_strongInterpret_inside) ⨀ h
+  . intro h; exact (K!_right iff_interpret_boxdot_strongInterpret_inside) ⨀ h
 
 lemma iff_models_interpret_boxdot_strongInterpret
     {M} [Nonempty M] [Structure L M] [M ⊧ₘ* T] [𝔅.HBL2] [𝔅.SoundOnModel M] :
     M ⊧ₘ₀ f (Aᵇ) ↔ M ⊧ₘ₀ f.strongInterpret A := by
   induction A with
-  | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
-  | hfalsum => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate];
+  | hatom φ => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate]
+  | hfalsum => simp [Realization.interpret, strongInterpret, Formula.boxdotTranslate]
   | himp A B ihA ihB =>
-    simp only [Formula.boxdotTranslate, interpret, models₀_imply_iff, strongInterpret];
-    constructor;
-    . intro hAB hA;
-      apply ihB.mp;
-      apply hAB;
-      apply ihA.mpr;
-      exact hA;
-    . intro hAB hA;
-      apply ihB.mpr;
-      apply hAB;
-      apply ihA.mp;
-      exact hA;
+    simp only [Formula.boxdotTranslate, interpret, models₀_imply_iff, strongInterpret]
+    constructor
+    . intro hAB hA
+      apply ihB.mp
+      apply hAB
+      apply ihA.mpr
+      exact hA
+    . intro hAB hA
+      apply ihB.mpr
+      apply hAB
+      apply ihA.mp
+      exact hA
   | hbox A ih =>
     suffices (M ⊧ₘ₀ f (Aᵇ)) ∧ (M ⊧ₘ₀ 𝔅 (f (Aᵇ))) ↔ M ⊧ₘ₀ f.strongInterpret A ∧ M ⊧ₘ₀ 𝔅 (f.strongInterpret A) by
-      simpa [Formula.boxdotTranslate, interpret, strongInterpret] using this;
-    constructor;
-    . rintro ⟨h₁, h₂⟩;
-      constructor;
-      . exact ih.mp h₁;
-      . apply Provability.SoundOnModel.sound.mpr;
-        exact iff_interpret_boxdot_strongInterpret.mp $ Provability.SoundOnModel.sound.mp h₂;
-    . rintro ⟨h₁, h₂⟩;
-      constructor;
-      . apply ih.mpr h₁;
-      . apply Provability.SoundOnModel.sound.mpr;
-        exact iff_interpret_boxdot_strongInterpret.mpr $ Provability.SoundOnModel.sound.mp h₂;
+      simpa [Formula.boxdotTranslate, interpret, strongInterpret] using this
+    constructor
+    . rintro ⟨h₁, h₂⟩
+      constructor
+      . exact ih.mp h₁
+      . apply Provability.SoundOnModel.sound.mpr
+        exact iff_interpret_boxdot_strongInterpret.mp $ Provability.SoundOnModel.sound.mp h₂
+    . rintro ⟨h₁, h₂⟩
+      constructor
+      . apply ih.mpr h₁
+      . apply Provability.SoundOnModel.sound.mpr
+        exact iff_interpret_boxdot_strongInterpret.mpr $ Provability.SoundOnModel.sound.mp h₂
 
 end Realization
 
 theorem Grz.arithmetical_completeness_iff
     {T : ArithmeticTheory} [T.Δ₁] [𝐈𝚺₁ ⪯ T] (height : T.standardProvability.height = ⊤) :
     (∀ f : T.PLRealization, T ⊢!. f.strongInterpret A) ↔ Modal.Grz ⊢! A := by
-  constructor;
-  . intro h;
-    suffices Modal.GL ⊢! Aᵇ by apply iff_boxdot_GL_Grz.mp this;
-    apply GL.arithmetical_completeness_iff height |>.mp;
-    intro f;
-    apply Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ).mpr;
-    apply h;
-  . intro h f;
-    replace h := iff_boxdot_GL_Grz.mpr h;
-    have : (∀ f : T.PLRealization, T ⊢!. f (Aᵇ)) := GL.arithmetical_completeness_iff height |>.mpr h;
-    exact Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ this f;
+  constructor
+  . intro h
+    suffices Modal.GL ⊢! Aᵇ by apply iff_boxdot_GL_Grz.mp this
+    apply GL.arithmetical_completeness_iff height |>.mp
+    intro f
+    apply Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ).mpr
+    apply h
+  . intro h f
+    replace h := iff_boxdot_GL_Grz.mpr h
+    have : (∀ f : T.PLRealization, T ⊢!. f (Aᵇ)) := GL.arithmetical_completeness_iff height |>.mpr h
+    exact Realization.iff_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ this f
 
 theorem Grz.arithmetical_completeness_model_iff
     {T : ArithmeticTheory} [T.Δ₁] [𝐈𝚺₁ ⪯ T] [ℕ ⊧ₘ* T] :
     (∀ f : T.PLRealization, ℕ ⊧ₘ₀ f.strongInterpret A) ↔ Modal.Grz ⊢! A := by
-  apply Iff.trans ?_ Modal.Logic.iff_provable_Grz_provable_boxdot_S;
-  apply Iff.trans ?_ (S.arithmetical_completeness_iff (T := T)).symm;
+  apply Iff.trans ?_ Modal.Logic.iff_provable_Grz_provable_boxdot_S
+  apply Iff.trans ?_ (S.arithmetical_completeness_iff (T := T)).symm
   have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
-  constructor;
-  . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mpr $ h f;
-  . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ h f;
+  constructor
+  . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mpr $ h f
+  . intro h f; exact Realization.iff_models_interpret_boxdot_strongInterpret (L := ℒₒᵣ) |>.mp $ h f
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/Incompleteness.lean
+++ b/Foundation/ProvabilityLogic/Incompleteness.lean
@@ -86,15 +86,15 @@ section irreflexsive_syntactic_language
 variable [L.ReferenceableBy L₀] {T₀ : Theory L₀} {T : Theory L} {𝔅 : Provability T₀ T}
 
 lemma D2' [𝔅.HBL2] (σ τ) : T₀ ⊢!. 𝔅 (σ ➝ τ) → T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := by
-  intro h;
-  exact 𝔅.D2 σ τ ⨀ h;
+  intro h
+  exact 𝔅.D2 σ τ ⨀ h
 
 lemma prov_distribute_imply [𝔅.HBL2] (h : T ⊢!. σ ➝ τ) : T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := 𝔅.D2' σ τ <| 𝔅.D1 h
 
 lemma prov_distribute_iff [𝔅.HBL2] (h : T ⊢!. σ ⭤ τ) : T₀ ⊢!. 𝔅 σ ⭤ 𝔅 τ := by
-  apply E!_intro;
-  . exact prov_distribute_imply $ K!_left h;
-  . exact prov_distribute_imply $ K!_right h;
+  apply E!_intro
+  . exact prov_distribute_imply $ K!_left h
+  . exact prov_distribute_imply $ K!_right h
 
 lemma dia_distribute_imply [L₀.DecidableEq] [L.DecidableEq] [𝔅.HBL2]
     (h : T ⊢!. σ ➝ τ) : T₀ ⊢!. 𝔅.dia σ ➝ 𝔅.dia τ := by
@@ -104,9 +104,9 @@ lemma dia_distribute_imply [L₀.DecidableEq] [L.DecidableEq] [𝔅.HBL2]
   cl_prover [this]
 
 lemma prov_distribute_and [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ ⋏ 𝔅 τ := by
-  have h₁ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ := 𝔅.D2' _ _ <| 𝔅.D1 and₁!;
-  have h₂ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 τ := 𝔅.D2' _ _ <| 𝔅.D1 and₂!;
-  exact right_K!_intro h₁ h₂;
+  have h₁ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 σ := 𝔅.D2' _ _ <| 𝔅.D1 and₁!
+  have h₂ : T₀ ⊢!. 𝔅 (σ ⋏ τ) ➝ 𝔅 τ := 𝔅.D2' _ _ <| 𝔅.D1 and₂!
+  exact right_K!_intro h₁ h₂
 
 lemma prov_distribute_and' [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢!. 𝔅 (σ ⋏ τ) → T₀ ⊢!. 𝔅 σ ⋏ 𝔅 τ := λ h => prov_distribute_and ⨀ h
 
@@ -122,21 +122,21 @@ section reflexive_syntactic_language
 variable [L.DecidableEq] [L.ReferenceableBy L] {T₀ T : Theory L} [T₀ ⪯ T] {𝔅 : Provability T₀ T}
 
 lemma D1_shift : T ⊢!. σ → T ⊢!. 𝔅 σ := by
-  intro h;
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D1 h;
+  intro h
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom)
+  apply 𝔅.D1 h
 
 lemma D2_shift [𝔅.HBL2] : T ⊢!. 𝔅 (σ ➝ τ) ➝ 𝔅 σ ➝ 𝔅 τ := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D2;
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom)
+  apply 𝔅.D2
 
 lemma D3_shift [𝔅.HBL3] : T ⊢!. 𝔅 σ ➝ 𝔅 (𝔅 σ) := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.D3;
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom)
+  apply 𝔅.D3
 
 lemma FLT_shift [𝔅.FormalizedLoeb] : T ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
-  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom);
-  apply 𝔅.FLT;
+  apply Entailment.WeakerThan.pbl (𝓢 := T₀.toAxiom)
+  apply 𝔅.FLT
 
 lemma prov_distribute_imply' [𝔅.HBL2] (h : T₀ ⊢!. σ ➝ τ) :
     T₀ ⊢!. 𝔅 σ ➝ 𝔅 τ := prov_distribute_imply $ WeakerThan.pbl h
@@ -164,9 +164,9 @@ local notation "𝗚" => 𝔅.goedel
 variable (𝔅)
 
 lemma goedel_spec : T₀ ⊢!. 𝗚 ⭤ ∼𝔅 𝗚 := by
-  convert (diag (T := T₀) “x. ¬!𝔅.prov x”);
-  simp [goedel];
-  rfl;
+  convert (diag (T := T₀) “x. ¬!𝔅.prov x”)
+  simp [goedel]
+  rfl
 
 variable {𝔅}
 
@@ -184,7 +184,7 @@ variable (𝔅 : Provability T₀ T)
 local notation "𝗚" => 𝔅.goedel
 
 theorem unprovable_goedel : T ⊬. 𝗚 := by
-  intro h;
+  intro h
   have h₁ : T ⊢!. 𝔅 𝗚 := D1_shift h
   have : T ⊢!. ⊥ := by cl_prover [h₁, 𝔅.goedel_spec, h]
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
@@ -192,12 +192,12 @@ theorem unprovable_goedel : T ⊬. 𝗚 := by
   contradiction
 
 theorem unrefutable_goedel [𝔅.GoedelSound] : T ⊬. ∼𝗚 := by
-  intro h₂;
+  intro h₂
   have h₁ : T ⊢!. 𝗚 := GoedelSound.goedel_sound <| by cl_prover [𝔅.goedel_spec, h₂]
-  have : T ⊢!. ⊥ := (N!_iff_CO!.mp h₂) ⨀ h₁;
+  have : T ⊢!. ⊥ := (N!_iff_CO!.mp h₂) ⨀ h₁
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <|
-    inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this);
-  contradiction;
+    inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this)
+  contradiction
 
 theorem goedel_independent [𝔅.GoedelSound] : Independent (T : Axiom L) 𝗚 := by
   constructor
@@ -268,9 +268,9 @@ local prefix:80 "𝗞" => 𝔅.kreisel
 variable (𝔅)
 
 lemma kreisel_spec (σ : Sentence L) : T₀ ⊢!. 𝗞 σ ⭤ (𝔅 (𝗞 σ) ➝ σ) := by
-  convert (diag (T := T₀) “x. !𝔅.prov x → !σ”);
-  simp [kreisel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs];
-  rfl;
+  convert (diag (T := T₀) “x. !𝔅.prov x → !σ”)
+  simp [kreisel, ← TransitiveRewriting.comp_app, Rew.substs_comp_substs]
+  rfl
 
 variable {𝔅}
 
@@ -289,17 +289,17 @@ variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] {𝔅 : Provability
 local notation "𝗞" => 𝔅.kreisel
 
 theorem loeb_theorm (H : T ⊢!. 𝔅 σ ➝ σ) : T ⊢!. σ := by
-  have d₁ : T ⊢!. 𝔅 (𝗞 σ) ➝ σ := C!_trans (WeakerThan.pbl (kreisel_specAux₁ σ)) H;
-  have d₂ : T ⊢!. 𝔅 (𝗞 σ)     := WeakerThan.pbl (𝓢 := T₀.toAxiom) (𝔅.D1 $ WeakerThan.pbl (kreisel_specAux₂ σ) ⨀ d₁);
-  exact d₁ ⨀ d₂;
+  have d₁ : T ⊢!. 𝔅 (𝗞 σ) ➝ σ := C!_trans (WeakerThan.pbl (kreisel_specAux₁ σ)) H
+  have d₂ : T ⊢!. 𝔅 (𝗞 σ)     := WeakerThan.pbl (𝓢 := T₀.toAxiom) (𝔅.D1 $ WeakerThan.pbl (kreisel_specAux₂ σ) ⨀ d₁)
+  exact d₁ ⨀ d₂
 
 instance : 𝔅.Loeb := ⟨loeb_theorm⟩
 
 theorem formalized_loeb_theorem (σ) : T₀ ⊢!. 𝔅 (𝔅 σ ➝ σ) ➝ 𝔅 σ := by
-  have hκ₁ : T₀ ⊢!. 𝔅 (𝗞 σ) ➝ 𝔅 σ := kreisel_specAux₁ σ;
-  have : T₀ ⊢!. (𝔅 σ ➝ σ) ➝ (𝔅 (𝗞 σ) ➝ σ) := CCC!_of_C!_left hκ₁;
-  have : T ⊢!. (𝔅 σ ➝ σ) ➝ 𝗞 σ := WeakerThan.pbl (𝓢 := T₀.toAxiom) $ C!_trans this (kreisel_specAux₂ σ);
-  exact C!_trans (𝔅.D2 _ _ ⨀ (𝔅.D1 this)) hκ₁;
+  have hκ₁ : T₀ ⊢!. 𝔅 (𝗞 σ) ➝ 𝔅 σ := kreisel_specAux₁ σ
+  have : T₀ ⊢!. (𝔅 σ ➝ σ) ➝ (𝔅 (𝗞 σ) ➝ σ) := CCC!_of_C!_left hκ₁
+  have : T ⊢!. (𝔅 σ ➝ σ) ➝ 𝗞 σ := WeakerThan.pbl (𝓢 := T₀.toAxiom) $ C!_trans this (kreisel_specAux₂ σ)
+  exact C!_trans (𝔅.D2 _ _ ⨀ (𝔅.D1 this)) hκ₁
 
 instance [L.DecidableEq] : 𝔅.FormalizedLoeb := ⟨formalized_loeb_theorem (T := T)⟩
 
@@ -308,8 +308,8 @@ end LoebTheorem
 variable  {𝔅 : Provability T₀ T} [Consistent T]
 
 lemma unprovable_con_via_loeb [L.DecidableEq] [𝔅.Loeb] : T ⊬. 𝔅.con := by
-  by_contra hC;
-  have : T ⊢!. ⊥ := Loeb.LT $ N!_iff_CO!.mp hC;
+  by_contra hC
+  have : T ⊢!. ⊥ := Loeb.LT $ N!_iff_CO!.mp hC
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr
     <| inconsistent_iff_provable_bot.mpr (by simpa [Axiom.provable_iff] using this)
   contradiction
@@ -318,18 +318,18 @@ variable [L.DecidableEq] [Diagonalization T₀] [T₀ ⪯ T] [𝔅.HBL] [𝔅.Go
 
 lemma formalized_unprovable_not_con :
     T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) := by
-  by_contra hC;
-  have : T ⊢!. ∼𝔅.con := Loeb.LT $ CN!_of_CN!_right hC;
-  have : T ⊬. ∼𝔅.con := con_unrefutable 𝔅;
-  contradiction;
+  by_contra hC
+  have : T ⊢!. ∼𝔅.con := Loeb.LT $ CN!_of_CN!_right hC
+  have : T ⊬. ∼𝔅.con := con_unrefutable 𝔅
+  contradiction
 
 lemma formalized_unrefutable_goedel : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.goedel) := by
-  by_contra hC;
-  have : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con)  := formalized_unprovable_not_con;
+  by_contra hC
+  have : T ⊬. 𝔅.con ➝ ∼𝔅 (∼𝔅.con)  := formalized_unprovable_not_con
   have : T ⊢!. 𝔅.con ➝ ∼𝔅 (∼𝔅.con) :=
     C!_trans hC $ WeakerThan.pbl <| K!_left <| ENN!_of_E!
-      <| prov_distribute_iff <| ENN!_of_E! <| WeakerThan.pbl (𝔅.goedel_iff_con);
-  contradiction;
+      <| prov_distribute_iff <| ENN!_of_E! <| WeakerThan.pbl (𝔅.goedel_iff_con)
+  contradiction
 
 end Loeb
 
@@ -342,10 +342,10 @@ local notation "𝗥" => 𝔅.goedel
 variable [𝔅.Rosser]
 
 theorem unrefutable_rosser : T ⊬. ∼𝗥 := by
-  intro hnρ;
-  have hρ : T ⊢!. 𝗥 := WeakerThan.pbl $ (K!_right 𝔅.goedel_spec) ⨀ (𝔅.Ro hnρ);
+  intro hnρ
+  have hρ : T ⊢!. 𝗥 := WeakerThan.pbl $ (K!_right 𝔅.goedel_spec) ⨀ (𝔅.Ro hnρ)
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr $ inconsistent_iff_provable_bot.mpr <|
-    by simpa [Axiom.provable_iff] using (N!_iff_CO!.mp hnρ) ⨀ hρ;
+    by simpa [Axiom.provable_iff] using (N!_iff_CO!.mp hnρ) ⨀ hρ
   contradiction
 
 theorem rosser_independent : Independent (T : Axiom L) 𝗥 := by
@@ -361,8 +361,8 @@ variable (𝔅)
 omit [Diagonalization T₀] [Consistent T] in
 /-- If `𝔅` satisfies Rosser provability condition, then `𝔅.con` is provable from `T`. -/
 theorem kriesel_remark : T ⊢!. 𝔅.con := by
-  have : T₀ ⊢!. ∼𝔅 ⊥ := 𝔅.Ro (N!_iff_CO!.mpr (by simp));
-  exact WeakerThan.pbl $ this;
+  have : T₀ ⊢!. ∼𝔅 ⊥ := 𝔅.Ro (N!_iff_CO!.mpr (by simp))
+  exact WeakerThan.pbl $ this
 
 end Rosser
 

--- a/Foundation/ProvabilityLogic/Interpretation.lean
+++ b/Foundation/ProvabilityLogic/Interpretation.lean
@@ -50,49 +50,49 @@ lemma interpret_boxItr_def (n : ℕ) : f (□^[n] A) = 𝔅^[n] (f A) := by
 variable [DecidableEq (Sentence L)]
 
 lemma iff_interpret_neg_inside : T ⊢!. f (∼A) ⭤ ∼(f A) := by
-  dsimp [Realization.interpret];
-  cl_prover;
+  dsimp [Realization.interpret]
+  cl_prover
 
 lemma iff_interpret_or_inside : T ⊢!. f (A ⋎ B) ⭤ (f A) ⋎ (f B) := by
-  dsimp [Realization.interpret];
-  cl_prover;
+  dsimp [Realization.interpret]
+  cl_prover
 
 lemma iff_interpret_and_inside : T ⊢!. f (A ⋏ B) ⭤ (f A) ⋏ (f B) := by
-  dsimp [Realization.interpret];
-  cl_prover;
+  dsimp [Realization.interpret]
+  cl_prover
 
 lemma iff_interpret_neg : T ⊢!. f (∼A) ↔ T ⊢!. ∼(f A) := by
-  dsimp [Realization.interpret];
-  constructor <;> . intro h; cl_prover [h];
+  dsimp [Realization.interpret]
+  constructor <;> . intro h; cl_prover [h]
 
 lemma iff_interpret_or : T ⊢!. f (A ⋎ B) ↔ T ⊢!. (f A) ⋎ (f B) := by
-  dsimp [Realization.interpret];
-  constructor <;> . intro h; cl_prover [h];
+  dsimp [Realization.interpret]
+  constructor <;> . intro h; cl_prover [h]
 
 lemma iff_interpret_and : T ⊢!. f (A ⋏ B) ↔ T ⊢!. (f A) ⋏ (f B) := by
-  dsimp [Realization.interpret];
-  constructor <;> . intro h; cl_prover [h];
+  dsimp [Realization.interpret]
+  constructor <;> . intro h; cl_prover [h]
 
 lemma iff_interpret_and' : T ⊢!. f (A ⋏ B) ↔ T ⊢!. (f A) ∧ T ⊢!. (f B) := by
-  dsimp [Realization.interpret];
-  constructor;
-  . intro h; constructor <;> cl_prover [h];
-  . rintro ⟨hA, hB⟩; cl_prover [hA, hB];
+  dsimp [Realization.interpret]
+  constructor
+  . intro h; constructor <;> cl_prover [h]
+  . rintro ⟨hA, hB⟩; cl_prover [hA, hB]
 
 end
 
 lemma letterless_interpret {𝔅 : Provability T₀ T}
     {f₁ f₂ : Realization 𝔅} (A_letterless : A.letterless) : f₁ A = f₂ A := by
   induction A with
-  | hatom a => simp at A_letterless;
-  | hfalsum => simp_all [Realization.interpret];
+  | hatom a => simp at A_letterless
+  | hfalsum => simp_all [Realization.interpret]
   | himp A B ihA ihB =>
-    replace ihA := ihA $ Modal.Formula.letterless.def_imp₁ A_letterless;
-    replace ihB := ihB $ Modal.Formula.letterless.def_imp₂ A_letterless;
-    simp_all [Realization.interpret];
+    replace ihA := ihA $ Modal.Formula.letterless.def_imp₁ A_letterless
+    replace ihB := ihB $ Modal.Formula.letterless.def_imp₂ A_letterless
+    simp_all [Realization.interpret]
   | hbox A ihA =>
-    replace ihA := ihA $ Modal.Formula.letterless.def_box A_letterless;
-    simp_all [Realization.interpret];
+    replace ihA := ihA $ Modal.Formula.letterless.def_box A_letterless
+    simp_all [Realization.interpret]
 
 
 end Realization

--- a/Foundation/ProvabilityLogic/N/Soundness.lean
+++ b/Foundation/ProvabilityLogic/N/Soundness.lean
@@ -15,11 +15,11 @@ variable {L : FirstOrder.Language} [L.ReferenceableBy L]
 
 lemma N.arithmetical_soundness (h : Hilbert.N ⊢! A) {f : Realization 𝔅} : U ⊢!. f A := by
   induction h using Hilbert.Normal.rec! with
-  | axm _ hp => simp at hp;
-  | nec ihp => exact D1_shift ihp;
-  | mdp ihpq ihp => exact ihpq ⨀ ihp;
-  | imply₁ => exact imply₁!;
-  | imply₂ => exact imply₂!;
-  | ec => exact CCCOCOC!;
+  | axm _ hp => simp at hp
+  | nec ihp => exact D1_shift ihp
+  | mdp ihpq ihp => exact ihpq ⨀ ihp
+  | imply₁ => exact imply₁!
+  | imply₂ => exact imply₂!
+  | ec => exact CCCOCOC!
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/S/Completeness.lean
+++ b/Foundation/ProvabilityLogic/S/Completeness.lean
@@ -36,120 +36,120 @@ lemma GL_S_TFAE :
       ∀ f : T.PLRealization, ℕ ⊧ₘ₀ (f A)
     ].TFAE := by
   tfae_have 1 → 2 := by
-    intro h;
-    have h : Modal.S ⊢! Finset.conj A.rflSubformula ➝ A := WeakerThan.pbl h;
-    apply h ⨀ ?_;
-    apply FConj!_iff_forall_provable.mpr;
-    simp [-Logic.iff_provable];
+    intro h
+    have h : Modal.S ⊢! Finset.conj A.rflSubformula ➝ A := WeakerThan.pbl h
+    apply h ⨀ ?_
+    apply FConj!_iff_forall_provable.mpr
+    simp [-Logic.iff_provable]
   tfae_have 2 → 3 := by
-    intro h f;
+    intro h f
     have : 𝐑₀ ⪯ T := WeakerThan.trans (inferInstanceAs (𝐑₀ ⪯ 𝐈𝚺₁)) inferInstance
-    apply S.arithmetical_soundness;
-    exact h;
+    apply S.arithmetical_soundness
+    exact h
   tfae_have 3 → 1 := by
-    contrapose;
-    push_neg;
-    intro hA;
-    replace hA := Hilbert.Normal.iff_logic_provable_provable.not.mp hA;
-    obtain ⟨M₁, r₁, _, hA⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp hA;
-    let M₀ := Model.extendRoot M₁ 1;
-    let r₀ : M₀.World := Model.extendRoot.root;
-    replace hA := Formula.Kripke.Satisfies.imp_def.not.mp hA;
-    push_neg at hA;
-    obtain ⟨hA₁, hA₂⟩ := hA;
+    contrapose
+    push_neg
+    intro hA
+    replace hA := Hilbert.Normal.iff_logic_provable_provable.not.mp hA
+    obtain ⟨M₁, r₁, _, hA⟩ := Logic.GL.Kripke.iff_unprovable_exists_unsatisfies_FiniteTransitiveTree.mp hA
+    let M₀ := Model.extendRoot M₁ 1
+    let r₀ : M₀.World := Model.extendRoot.root
+    replace hA := Formula.Kripke.Satisfies.imp_def.not.mp hA
+    push_neg at hA
+    obtain ⟨hA₁, hA₂⟩ := hA
     replace hA₁ : ∀ φ ∈ A.rflSubformula, r₁ ⊧ φ := by
-      intro φ hφ;
+      intro φ hφ
       apply Model.extendRoot.inr_satisfies_iff.mp
         $ (Satisfies.fconj_def.mp
-        $ Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr hA₁) φ hφ;
+        $ Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr hA₁) φ hφ
     have : Fintype M₀.World := Fintype.ofFinite _
     let σ : SolovaySentences T.standardProvability (M₀.toFrame) r₀ :=
       SolovaySentences.standard T M₀.toFrame
-    use σ.realization;
+    use σ.realization
     have H :
       ∀ B ∈ A.subformulas,
       (r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ (σ.realization B)) ∧
       (¬r₁ ⊧ B → 𝐈𝚺₁ ⊢!. (σ r₀) ➝ ∼(σ.realization B)) := by
-      intro B B_sub;
+      intro B B_sub
       induction B with
-      | hfalsum => simp [Realization.interpret];
+      | hfalsum => simp [Realization.interpret]
       | himp B C ihB ihC =>
-        dsimp [Realization.interpret];
-        constructor;
-        . intro h;
-          rcases Satisfies.imp_def₂.mp h with (hA | hB);
-          . exact C!_trans (ihB (by grind) |>.2 hA) CNC!;
-          . exact C!_trans (ihC (by grind) |>.1 hB) imply₁!;
-        . intro h;
-          have := Satisfies.imp_def.not.mp h;
-          push_neg at this;
-          obtain ⟨hA, hB⟩ := this;
-          apply deduct'!;
-          apply NC!_of_N!_of_!;
-          . exact deductInv'! $ ihB (by grind) |>.1 hA;
-          . exact deductInv'! $ ihC (by grind) |>.2 hB;
+        dsimp [Realization.interpret]
+        constructor
+        . intro h
+          rcases Satisfies.imp_def₂.mp h with (hA | hB)
+          . exact C!_trans (ihB (by grind) |>.2 hA) CNC!
+          . exact C!_trans (ihC (by grind) |>.1 hB) imply₁!
+        . intro h
+          have := Satisfies.imp_def.not.mp h
+          push_neg at this
+          obtain ⟨hA, hB⟩ := this
+          apply deduct'!
+          apply NC!_of_N!_of_!
+          . exact deductInv'! $ ihB (by grind) |>.1 hA
+          . exact deductInv'! $ ihC (by grind) |>.2 hB
       | hatom =>
-        constructor;
-        . intro h;
-          apply right_Fdisj'!_intro;
-          simpa;
-        . intro h;
-          apply CN!_of_CN!_right;
-          apply left_Fdisj'!_intro;
-          intro i hi;
-          apply σ.SC1;
-          by_contra hC; subst hC;
-          apply h;
-          simpa using hi;
+        constructor
+        . intro h
+          apply right_Fdisj'!_intro
+          simpa
+        . intro h
+          apply CN!_of_CN!_right
+          apply left_Fdisj'!_intro
+          intro i hi
+          apply σ.SC1
+          by_contra hC; subst hC
+          apply h
+          simpa using hi
       | hbox B ihB =>
-        simp only [Realization.interpret];
-        constructor;
-        . intro h;
-          apply C!_of_conseq!;
-          apply T.standardProvability.D1;
-          apply Entailment.WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom);
+        simp only [Realization.interpret]
+        constructor
+        . intro h
+          apply C!_of_conseq!
+          apply T.standardProvability.D1
+          apply Entailment.WeakerThan.pbl (𝓢 := 𝐈𝚺₁.toAxiom)
           have : 𝐈𝚺₁ ⊢!. ((⩖ j, σ j)) ➝ σ.realization B := by
-            apply left_Fdisj'!_intro;
+            apply left_Fdisj'!_intro
             have hrfl : r₁ ⊧ □B ➝ B := by
-              apply hA₁;
-              simpa [Formula.rflSubformula];
-            rintro (i | i) _;
+              apply hA₁
+              simpa [Formula.rflSubformula]
+            rintro (i | i) _
             . rw [(show (Sum.inl i) = r₀ by simp [r₀]; omega)]
-              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization B by convert this;
-              apply ihB (by grind) |>.1;
-              exact hrfl h;
-            . by_cases e : i = r₁;
-              . rw [e];
-                apply σ.mainlemma (i := r₁) (by trivial);
-                exact Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr $ hrfl h;
-              . apply σ.mainlemma (i := i) (by trivial);
-                apply Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr;
-                apply h;
-                apply Frame.root_genaretes'!;
+              suffices 𝐈𝚺₁ ⊢!. σ r₀ ➝ σ.realization B by convert this
+              apply ihB (by grind) |>.1
+              exact hrfl h
+            . by_cases e : i = r₁
+              . rw [e]
+                apply σ.mainlemma (i := r₁) (by trivial)
+                exact Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr $ hrfl h
+              . apply σ.mainlemma (i := i) (by trivial)
+                apply Model.extendRoot.inr_satisfies_iff (n := 1) |>.mpr
+                apply h
+                apply Frame.root_genaretes'!
                 assumption
           have b : 𝐈𝚺₁ ⊢!. ⩖ j, σ j := oRing_provable₀_of _ _ fun (V : Type) _ _ ↦ by
             simpa [models₀_iff, σ, SolovaySentences.standard_σ_def] using ISigma1.Metamath.SolovaySentences.disjunctive
           exact this ⨀ b
-        . intro h;
-          have := Satisfies.box_def.not.mp h;
-          push_neg at this;
-          obtain ⟨i, Rij, hA⟩ := this;
+        . intro h
+          have := Satisfies.box_def.not.mp h
+          push_neg at this
+          obtain ⟨i, Rij, hA⟩ := this
           have : 𝐈𝚺₁ ⊢!. σ.σ (Sum.inr i) ➝ ∼σ.realization B :=
             σ.mainlemma_neg (A := B) (i := i) (by trivial)
-            <| Model.extendRoot.inr_satisfies_iff (n := 1) |>.not.mpr hA;
+            <| Model.extendRoot.inr_satisfies_iff (n := 1) |>.not.mpr hA
           have : 𝐈𝚺₁ ⊢!. ∼T.standardProvability (∼σ (Sum.inr i)) ➝ ∼T.standardProvability (σ.realization B) :=
             contra!
             $ T.standardProvability.prov_distribute_imply'
-            $ CN!_of_CN!_right $ this;
-          refine C!_trans ?_ this;
-          apply σ.SC2;
-          tauto;
-    have : ℕ ⊧ₘ* 𝐈𝚺₁ := models_of_subtheory (U := 𝐈𝚺₁) (T := T) (M := ℕ) inferInstance;
-    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂;
-    simp only [models₀_imply_iff, models₀_not_iff] at this;
+            $ CN!_of_CN!_right $ this
+          refine C!_trans ?_ this
+          apply σ.SC2
+          tauto
+    have : ℕ ⊧ₘ* 𝐈𝚺₁ := models_of_subtheory (U := 𝐈𝚺₁) (T := T) (M := ℕ) inferInstance
+    have : ℕ ⊧ₘ₀ σ.σ r₀ ➝ ∼σ.realization A := models_of_provable₀ inferInstance $ H A (by simp) |>.2 hA₂
+    simp only [models₀_imply_iff, models₀_not_iff] at this
     exact this <| by
       simpa [models₀_iff, σ, SolovaySentences.standard_σ_def] using ISigma1.Metamath.SolovaySentences.solovay_root_sound
-  tfae_finish;
+  tfae_finish
 
 theorem S.arithmetical_completeness_iff : Modal.S ⊢! A ↔ ∀ f : T.PLRealization, ℕ ⊧ₘ₀ f A := GL_S_TFAE.out 1 2
 

--- a/Foundation/ProvabilityLogic/S/Soundness.lean
+++ b/Foundation/ProvabilityLogic/S/Soundness.lean
@@ -15,14 +15,14 @@ variable {T₀ T : FirstOrder.Theory ℒₒᵣ} [T₀ ⪯ T] [Diagonalization T�
 theorem S.arithmetical_soundness (h : Modal.S ⊢! A) (f : Realization 𝔅) : ℕ ⊧ₘ₀ f A := by
   induction h using S.rec' with
   | mem_GL h =>
-    exact models_of_provable₀ inferInstance (GL.arithmetical_soundness h);
+    exact models_of_provable₀ inferInstance (GL.arithmetical_soundness h)
   | axiomT =>
-    simp only [Realization.interpret, models₀_imply_iff];
-    intro h;
+    simp only [Realization.interpret, models₀_imply_iff]
+    intro h
     exact models_of_provable₀ inferInstance (Iff.mp SoundOnModel.sound h)
   | mdp ihAB ihA =>
-    simp only [Realization.interpret, models₀_imply_iff] at ihAB;
-    apply ihAB ihA;
+    simp only [Realization.interpret, models₀_imply_iff] at ihAB
+    apply ihAB ihA
 
 end ProvabilityLogic
 

--- a/Foundation/ProvabilityLogic/SolovaySentences.lean
+++ b/Foundation/ProvabilityLogic/SolovaySentences.lean
@@ -172,47 +172,47 @@ private lemma mainlemma_aux {i : M} (hri : r ≺ i) :
     (i ⊧ A → T₀ ⊢!. S i ➝ S.realization A) ∧
     (¬i ⊧ A → T₀ ⊢!. S i ➝ ∼S.realization A) := by
   induction A generalizing i with
-  | hfalsum => simp [Realization.interpret, Semantics.Realize, Satisfies];
+  | hfalsum => simp [Realization.interpret, Semantics.Realize, Satisfies]
   | hatom a =>
-    constructor;
-    . intro h;
-      apply right_Fdisj'!_intro;
-      simpa using h;
-    . intro h;
-      apply CN!_of_CN!_right;
-      apply left_Fdisj'!_intro;
-      intro i hi;
-      apply S.SC1;
-      by_contra hC; subst hC;
-      apply h;
-      simpa using hi;
+    constructor
+    . intro h
+      apply right_Fdisj'!_intro
+      simpa using h
+    . intro h
+      apply CN!_of_CN!_right
+      apply left_Fdisj'!_intro
+      intro i hi
+      apply S.SC1
+      by_contra hC; subst hC
+      apply h
+      simpa using hi
   | himp A B ihA ihB =>
-    simp only [Realization.interpret, Semantics.Imp.realize_imp, Classical.not_imp, and_imp];
-    constructor;
-    . intro h;
-      rcases Satisfies.imp_def₂.mp h with (hA | hB);
-      . exact C!_trans ((ihA hri).2 hA) CNC!;
-      . exact C!_trans ((ihB hri).1 hB) imply₁!;
-    . intro hA hB;
-      exact not_imply_prem''! ((ihA hri).1 hA) ((ihB hri).2 hB);
+    simp only [Realization.interpret, Semantics.Imp.realize_imp, Classical.not_imp, and_imp]
+    constructor
+    . intro h
+      rcases Satisfies.imp_def₂.mp h with (hA | hB)
+      . exact C!_trans ((ihA hri).2 hA) CNC!
+      . exact C!_trans ((ihB hri).1 hB) imply₁!
+    . intro hA hB
+      exact not_imply_prem''! ((ihA hri).1 hA) ((ihB hri).2 hB)
   | hbox A ihA =>
-    simp only [Realization.interpret];
-    constructor;
-    . intro h;
-      apply C!_trans $ S.SC3 i $ (by rintro rfl; exact IsIrrefl.irrefl _ hri);
-      apply 𝔅.prov_distribute_imply';
-      apply left_Fdisj'!_intro;
-      rintro j Rij;
+    simp only [Realization.interpret]
+    constructor
+    . intro h
+      apply C!_trans $ S.SC3 i $ (by rintro rfl; exact IsIrrefl.irrefl _ hri)
+      apply 𝔅.prov_distribute_imply'
+      apply left_Fdisj'!_intro
+      rintro j Rij
       replace Rij : i ≺ j := by simpa using Rij
       exact (ihA (IsTrans.trans _ _ _ hri Rij)).1 (h j Rij)
-    . intro h;
-      have := Satisfies.box_def.not.mp h;
-      push_neg at this;
-      obtain ⟨j, Rij, hA⟩ := this;
+    . intro h
+      have := Satisfies.box_def.not.mp h
+      push_neg at this
+      obtain ⟨j, Rij, hA⟩ := this
       have := CN!_of_CN!_right $ (ihA (IsTrans.trans _ _ _ hri Rij)).2 hA
       have : T₀ ⊢!. ∼𝔅 (∼S.σ j) ➝ ∼𝔅 (S.realization A) :=
-        contra! $ 𝔅.prov_distribute_imply' $ CN!_of_CN!_right $ (ihA (IsTrans.trans _ _ _ hri Rij)).2 hA;
-      exact C!_trans (S.SC2 i j Rij) this;
+        contra! $ 𝔅.prov_distribute_imply' $ CN!_of_CN!_right $ (ihA (IsTrans.trans _ _ _ hri Rij)).2 hA
+      exact C!_trans (S.SC2 i j Rij) this
 
 theorem mainlemma (S : SolovaySentences 𝔅 M.toFrame r) {i : M} (hri : r ≺ i) :
     i ⊧ A → T₀ ⊢!. S i ➝ S.realization A := (mainlemma_aux S hri).1

--- a/Foundation/Vorspiel/Chain.lean
+++ b/Foundation/Vorspiel/Chain.lean
@@ -11,19 +11,19 @@ variable {l l₁ l₂ : List α}
 variable {R : α → α → Prop}
 
 lemma Chain'.nodup_of_trans_irreflex [IsTrans _ R] [IsIrrefl _ R] (h_chain : l.Chain' R) : l.Nodup := by
-  by_contra hC;
-  replace ⟨d, hC⟩ := List.exists_duplicate_iff_not_nodup.mpr hC;
-  have := List.duplicate_iff_sublist.mp hC;
-  have := @List.Chain'.sublist α R [d, d] l ⟨IsTrans.trans⟩ h_chain this;
-  simp at this;
-  exact IsIrrefl.irrefl d this;
+  by_contra hC
+  replace ⟨d, hC⟩ := List.exists_duplicate_iff_not_nodup.mpr hC
+  have := List.duplicate_iff_sublist.mp hC
+  have := @List.Chain'.sublist α R [d, d] l ⟨IsTrans.trans⟩ h_chain this
+  simp at this
+  exact IsIrrefl.irrefl d this
 
 instance finiteNodupList [DecidableEq α] [Finite α] : Finite { l : List α // l.Nodup } := @fintypeNodupList α (Fintype.ofFinite α) |>.finite
 
 lemma chains_finite [DecidableEq α] [Finite α] [IsTrans _ R] [IsIrrefl _ R] : Finite { l : List α // l.Chain' R } := by
-  apply @Finite.of_injective { l : List α // l.Chain' R } { l : List α // l.Nodup } _ ?f;
-  case f => intro ⟨l, hl⟩; refine ⟨l, List.Chain'.nodup_of_trans_irreflex hl⟩;
-  simp [Function.Injective];
+  apply @Finite.of_injective { l : List α // l.Chain' R } { l : List α // l.Nodup } _ ?f
+  case f => intro ⟨l, hl⟩; refine ⟨l, List.Chain'.nodup_of_trans_irreflex hl⟩
+  simp [Function.Injective]
 
 end
 

--- a/Foundation/Vorspiel/Fin/Fin1.lean
+++ b/Foundation/Vorspiel/Fin/Fin1.lean
@@ -4,6 +4,6 @@ namespace Fin.Fin1
 
 variable {n : Fin 1}
 
-@[simp] lemma not_lt_zero : ¬0 < n := by simp;
+@[simp] lemma not_lt_zero : ¬0 < n := by simp
 
 end Fin.Fin1

--- a/Foundation/Vorspiel/Fin/Supplemental.lean
+++ b/Foundation/Vorspiel/Fin/Supplemental.lean
@@ -9,8 +9,8 @@ import Mathlib.Data.Fintype.Pigeonhole
 namespace Fin
 
 lemma isEmpty_embedding_lt (hn : n > m) : IsEmpty (Fin n ↪ Fin m) := by
-  apply Function.Embedding.isEmpty_of_card_lt;
-  simpa;
+  apply Function.Embedding.isEmpty_of_card_lt
+  simpa
 
 variable {n : ℕ} [NeZero n] {i : Fin n}
 
@@ -18,7 +18,7 @@ def last' : Fin n := ⟨n - 1, Nat.sub_one_lt'⟩
 
 @[simp]
 lemma lt_last' : i ≤ Fin.last' := by
-  apply Nat.le_sub_one_of_lt;
-  apply Fin.is_lt;
+  apply Nat.le_sub_one_of_lt
+  apply Fin.is_lt
 
 end Fin

--- a/Foundation/Vorspiel/Finset/Card.lean
+++ b/Foundation/Vorspiel/Finset/Card.lean
@@ -8,14 +8,14 @@ variable {α} {s t : Finset α}
 lemma ssubset_of_subset_lt_card
   (h_subset : s ⊆ t)
   (h_card_le : s.card < t.card) : s ⊂ t := by
-  constructor;
-  . assumption;
-  . by_contra hC;
-    have : t = s := Finset.eq_iff_card_le_of_subset hC |>.mp (by omega);
-    subst this;
-    simp at h_card_le;
+  constructor
+  . assumption
+  . by_contra hC
+    have : t = s := Finset.eq_iff_card_le_of_subset hC |>.mp (by omega)
+    subst this
+    simp at h_card_le
 
-lemma eq_card_of_eq (h : s = t) : s.card = t.card := by tauto;
+lemma eq_card_of_eq (h : s = t) : s.card = t.card := by tauto
 
 lemma sum_le_card
   {n} {f : α → ℕ}
@@ -23,6 +23,6 @@ lemma sum_le_card
   : (∑ a ∈ s, f a) ≤ s.card * n :=
   calc
     _ ≤ (∑ x ∈ s, n) := by apply Finset.sum_le_sum hf
-    _ = s.card * n   := by simp_all;
+    _ = s.card * n   := by simp_all
 
 end Finset

--- a/Foundation/Vorspiel/Finset/Supplemental.lean
+++ b/Foundation/Vorspiel/Finset/Supplemental.lean
@@ -5,14 +5,14 @@ namespace Finset
 variable {α : Type*} [DecidableEq α] {a b : α} {s : Finset α}
 
 lemma doubleton_subset : ({a, b} : Finset α) ⊆ s ↔ a ∈ s ∧ b ∈ s := by
-  constructor;
-  . intro h;
-    have ⟨ha, hb⟩ := Finset.insert_subset_iff.mp h;
-    tauto;
-  . rintro ⟨ha, hb⟩;
-    apply Finset.insert_subset_iff.mpr;
-    constructor;
-    . assumption;
-    . simpa;
+  constructor
+  . intro h
+    have ⟨ha, hb⟩ := Finset.insert_subset_iff.mp h
+    tauto
+  . rintro ⟨ha, hb⟩
+    apply Finset.insert_subset_iff.mpr
+    constructor
+    . assumption
+    . simpa
 
 end Finset

--- a/Foundation/Vorspiel/HRel/Basic.lean
+++ b/Foundation/Vorspiel/HRel/Basic.lean
@@ -31,66 +31,66 @@ lemma succ_left (Rxz : R x z) (Rzy : R.Iterate n z y) : R.Iterate (n + 1) x y :=
 @[simp]
 lemma eq : HRel.Iterate (α := α) (· = ·) n = (· = ·) := by
   induction n with
-  | zero => rfl;
+  | zero => rfl
   | succ n ih => simp [Iterate]; aesop
 
 lemma forward : (R.Iterate (n + 1) x y) ↔ ∃ z, R.Iterate n x z ∧ R z y := by
   induction n generalizing x y with
-  | zero => simp_all;
+  | zero => simp_all
   | succ n ih =>
-    constructor;
-    . rintro ⟨z, Rxz, Rzy⟩;
-      obtain ⟨w, Rzw, Rwy⟩ := ih.mp Rzy;
-      use w;
-      constructor;
-      . use z;
-      . assumption;
-    . rintro ⟨z, ⟨w, Rxw, Rwz⟩, Rzy⟩;
-      use w;
-      constructor;
-      . assumption;
-      . apply ih.mpr;
-        use z;
+    constructor
+    . rintro ⟨z, Rxz, Rzy⟩
+      obtain ⟨w, Rzw, Rwy⟩ := ih.mp Rzy
+      use w
+      constructor
+      . use z
+      . assumption
+    . rintro ⟨z, ⟨w, Rxw, Rwz⟩, Rzy⟩
+      use w
+      constructor
+      . assumption
+      . apply ih.mpr
+        use z
 
 lemma true_any (h : x = y) : HRel.Iterate (λ _ _ => True) n x y := by
   induction n with
-  | zero => simpa;
-  | succ n ih => use x;
+  | zero => simpa
+  | succ n ih => use x
 
 lemma congr (h : R.Iterate n x y) (he : n = m) : R.Iterate m x y := by
-  subst he;
-  exact h;
+  subst he
+  exact h
 
 lemma comp : (∃ z, R.Iterate n x z ∧ R.Iterate m z y) ↔ R.Iterate (n + m) x y := by
-  constructor;
-  . rintro ⟨z, hzx, hzy⟩;
+  constructor
+  . rintro ⟨z, hzx, hzy⟩
     induction n generalizing x with
-    | zero => simp_all;
+    | zero => simp_all
     | succ n ih =>
-      suffices R.Iterate (n + m + 1) x y by apply congr this (by omega);
-      obtain ⟨w, hxw, hwz⟩ := hzx;
-      use w;
-      constructor;
-      . exact hxw;
-      . exact @ih w hwz;
-  . rintro h;
+      suffices R.Iterate (n + m + 1) x y by apply congr this (by omega)
+      obtain ⟨w, hxw, hwz⟩ := hzx
+      use w
+      constructor
+      . exact hxw
+      . exact @ih w hwz
+  . rintro h
     induction n generalizing x with
-    | zero => simp_all;
+    | zero => simp_all
     | succ n ih =>
-      have rxy : R.Iterate (n + m + 1) x y := congr h (by omega);
-      obtain ⟨w, rxw, rwy⟩ := rxy;
-      obtain ⟨u, rwu, ruy⟩ := @ih w rwy;
-      use u;
-      constructor;
-      . use w;
-      . assumption;
+      have rxy : R.Iterate (n + m + 1) x y := congr h (by omega)
+      obtain ⟨w, rxw, rwy⟩ := rxy
+      obtain ⟨u, rwu, ruy⟩ := @ih w rwy
+      use u
+      constructor
+      . use w
+      . assumption
 
 lemma unwrap_of_trans {n : ℕ+} [IsTrans _ R] (Rxy : R.Iterate n x y) : R x y := by
   induction n using PNat.recOn generalizing x with
-  | one => simpa using Rxy;
+  | one => simpa using Rxy
   | succ n ih =>
-    obtain ⟨z, Rxz, Rzy⟩ := Rxy;
-    exact IsTrans.trans _ _ _ Rxz (ih Rzy);
+    obtain ⟨z, Rxz, Rzy⟩ := Rxy
+    exact IsTrans.trans _ _ _ Rxz (ih Rzy)
 
 lemma unwrap_of_trans_of_pos {n : ℕ} (h : 0 < n) [IsTrans _ R] (Rxy : R.Iterate n x y) : R x y := by
   have : ∃ m : ℕ+, n = m := ⟨⟨n, h⟩, by simp⟩
@@ -99,10 +99,10 @@ lemma unwrap_of_trans_of_pos {n : ℕ} (h : 0 < n) [IsTrans _ R] (Rxy : R.Iterat
 
 lemma unwrap_of_refl_trans {n : ℕ} [IsRefl _ R] [IsTrans _ R] (Rxy : R.Iterate n x y) : R x y := by
   induction n generalizing x with
-  | zero => subst Rxy; apply IsRefl.refl;
+  | zero => subst Rxy; apply IsRefl.refl
   | succ n ih =>
-    obtain ⟨z, Rxz, Rzy⟩ := Rxy;
-    exact IsTrans.trans _ _ _ Rxz (ih Rzy);
+    obtain ⟨z, Rxz, Rzy⟩ := Rxy
+    exact IsTrans.trans _ _ _ Rxz (ih Rzy)
 
 lemma constant_trans_of_pos {n : ℕ} (pos : 0 < n) [IsTrans _ R] (Rzx : R z x) (Rxy : R.Iterate n x y) : R.Iterate n z y := by
   rcases (pos_succ_iff pos).mp Rxy with ⟨w, Rxw, hwy⟩
@@ -123,25 +123,25 @@ namespace ReflGen
 instance : IsRefl α (R.ReflGen) := ⟨by apply Relation.ReflGen.refl⟩
 
 instance [IsTrans _ R] : IsTrans α (R.ReflGen) := ⟨by
-  rintro a b c (rfl | Rab) (rfl | Rbc);
-  . exact Relation.ReflGen.refl;
-  . exact Relation.ReflGen.single Rbc;
-  . exact Relation.ReflGen.single Rab;
-  . exact Relation.ReflGen.single $ IsTrans.trans a b c Rab Rbc;
+  rintro a b c (rfl | Rab) (rfl | Rbc)
+  . exact Relation.ReflGen.refl
+  . exact Relation.ReflGen.single Rbc
+  . exact Relation.ReflGen.single Rab
+  . exact Relation.ReflGen.single $ IsTrans.trans a b c Rab Rbc
 ⟩
 
 instance [IsSymm _ R] : IsSymm α (ReflGen R) := ⟨by
-  rintro a b (rfl | Rab);
-  . exact Relation.ReflGen.refl;
-  . exact Relation.ReflGen.single $ IsSymm.symm _ _ Rab;
+  rintro a b (rfl | Rab)
+  . exact Relation.ReflGen.refl
+  . exact Relation.ReflGen.single $ IsSymm.symm _ _ Rab
 ⟩
 
 instance [IsIrrefl _ R] [IsTrans _ R] : IsAntisymm α (ReflGen R) := ⟨by
-  rintro a b (rfl | Rab) (rfl | Rba);
-  . trivial;
-  . trivial;
-  . trivial;
-  . exfalso;
+  rintro a b (rfl | Rab) (rfl | Rba)
+  . trivial
+  . trivial
+  . trivial
+  . exfalso
     exact IsIrrefl.irrefl a $ IsTrans.trans a b a Rab Rba
 ⟩
 
@@ -167,33 +167,33 @@ lemma head (Rxy : x ≺ y) (Ryz : y ≺^+ z) : x ≺^+ z := Relation.TransGen.he
 lemma tail (Rxy : x ≺^+ y) (Ryz : y ≺ z) : x ≺^+ z := Relation.TransGen.tail Rxy Ryz
 
 lemma exists_iterate : TransGen R x y ↔ ∃ n : ℕ+, R.Iterate n x y := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h with
-    | single h => use 1; simpa;
+    | single h => use 1; simpa
     | tail Rxy Ryz ih =>
-      obtain ⟨⟨n, hn⟩, Rxy⟩ := ih;
-      use ⟨n + 1, by omega⟩;
-      apply HRel.Iterate.forward.mpr;
-      refine ⟨_, Rxy, Ryz⟩;
-  . rintro ⟨n, Rxy⟩;
+      obtain ⟨⟨n, hn⟩, Rxy⟩ := ih
+      use ⟨n + 1, by omega⟩
+      apply HRel.Iterate.forward.mpr
+      refine ⟨_, Rxy, Ryz⟩
+  . rintro ⟨n, Rxy⟩
     induction n using PNat.recOn generalizing x with
     | one =>
-      apply single;
-      simpa using Rxy;
+      apply single
+      simpa using Rxy
     | succ n ih =>
-      obtain ⟨z, Rxz, Rzy⟩ := Rxy;
-      apply head;
-      . exact Rxz;
-      . apply ih;
-        exact Rzy;
+      obtain ⟨z, Rxz, Rzy⟩ := Rxy
+      apply head
+      . exact Rxz
+      . apply ih
+        exact Rzy
 
 lemma remove_iterate {n : ℕ+} (Rxy : R.TransGen.Iterate n x y) : R.TransGen x y := by
-  apply unwrap_of_trans (n := n) Rxy;
+  apply unwrap_of_trans (n := n) Rxy
 
 lemma unwrap [IsTrans _ R] (Rxy : R.TransGen x y) : R x y := by
-  have ⟨n, Rxy⟩ := TransGen.exists_iterate.mp Rxy;
-  exact unwrap_of_trans (n := n) Rxy;
+  have ⟨n, Rxy⟩ := TransGen.exists_iterate.mp Rxy
+  exact unwrap_of_trans (n := n) Rxy
 
 @[simp] lemma unwrap_iff [IsTrans _ R] : R.TransGen x y ↔ R x y :=
   ⟨unwrap, single⟩
@@ -201,18 +201,18 @@ lemma unwrap [IsTrans _ R] (Rxy : R.TransGen x y) : R x y := by
 instance [IsRefl _ R] : IsRefl α R.TransGen := ⟨fun x ↦ Relation.TransGen.single (IsRefl.refl x)⟩
 
 instance [IsSymm _ R] : IsSymm α R.TransGen := ⟨by
-  rintro x y Rxy;
+  rintro x y Rxy
   induction Rxy with
   | single Rxy =>
-    apply single;
-    apply IsSymm.symm _ _ Rxy;
+    apply single
+    apply IsSymm.symm _ _ Rxy
   | tail _ hyz ih =>
     exact trans (Relation.TransGen.single $ (IsSymm.symm _ _) hyz) ih
 ⟩
 
 instance [IsTrans _ R] [IsAntisymm _ R] : IsAntisymm α R.TransGen := ⟨by
-  rintro x y Rxy Ryx;
-  exact IsAntisymm.antisymm _ _ Rxy.unwrap Ryx.unwrap;
+  rintro x y Rxy Ryx
+  exact IsAntisymm.antisymm _ _ Rxy.unwrap Ryx.unwrap
 ⟩
 
 end TransGen
@@ -225,37 +225,37 @@ instance : IsRefl _ (R.ReflTransGen) := ⟨by apply Relation.ReflTransGen.refl�
 instance : IsTrans _ (R.ReflTransGen) := ⟨by apply Relation.ReflTransGen.trans⟩
 
 lemma exists_iterate : R.ReflTransGen x y ↔ ∃ n : ℕ, R.Iterate n x y := by
-  constructor;
-  . intro h;
+  constructor
+  . intro h
     induction h with
-    | refl => use 0;  simp;
+    | refl => use 0;  simp
     | tail Rxy Ryz ih =>
-      obtain ⟨n, Rxy⟩ := ih;
-      use n + 1;
-      apply HRel.Iterate.forward.mpr;
-      exact ⟨_, Rxy, Ryz⟩;
-  . rintro ⟨n, h⟩;
+      obtain ⟨n, Rxy⟩ := ih
+      use n + 1
+      apply HRel.Iterate.forward.mpr
+      exact ⟨_, Rxy, Ryz⟩
+  . rintro ⟨n, h⟩
     induction n generalizing x y with
-    | zero => subst h; apply Relation.ReflTransGen.refl;
+    | zero => subst h; apply Relation.ReflTransGen.refl
     | succ n ih =>
-      obtain ⟨z, Rxz, Rzy⟩ := h;
-      apply Relation.ReflTransGen.head;
-      . exact Rxz;
-      . apply ih;
-        exact Rzy;
+      obtain ⟨z, Rxz, Rzy⟩ := h
+      apply Relation.ReflTransGen.head
+      . exact Rxz
+      . apply ih
+        exact Rzy
 
 lemma remove_iterate (Rxy : (ReflTransGen R).Iterate n x y) : (R.ReflTransGen) x y := by
-  apply unwrap_of_refl_trans (n := n) Rxy;
+  apply unwrap_of_refl_trans (n := n) Rxy
 
 lemma unwrap [IsRefl _ R] [IsTrans _ R] (Rxy : (R.ReflTransGen) x y) : R x y := by
-  obtain ⟨n, Rxy⟩ := ReflTransGen.exists_iterate.mp Rxy;
-  exact unwrap_of_refl_trans Rxy;
+  obtain ⟨n, Rxy⟩ := ReflTransGen.exists_iterate.mp Rxy
+  exact unwrap_of_refl_trans Rxy
 
 instance [IsSymm _ R] : IsSymm _ (R.ReflTransGen) := ⟨by
-  rintro x y Rxy;
+  rintro x y Rxy
   induction Rxy with
-  | refl => apply Relation.ReflTransGen.refl;
-  | @tail y z Rxy Ryz Ryx => exact Relation.ReflTransGen.head (IsSymm.symm _ _ Ryz) Ryx;
+  | refl => apply Relation.ReflTransGen.refl
+  | @tail y z Rxy Ryz Ryx => exact Relation.ReflTransGen.head (IsSymm.symm _ _ Ryz) Ryx
 ⟩
 
 end ReflTransGen
@@ -268,12 +268,12 @@ namespace IrreflGen
 instance : IsIrrefl α (R.IrreflGen) := ⟨by simp [IrreflGen]⟩
 
 instance [IsTrans _ R] [IsAntisymm _ R] : IsTrans _ (R.IrreflGen) := ⟨by
-  rintro a b c ⟨Rab, hne⟩ ⟨Rbc, _⟩;
-  constructor;
-  . exact IsTrans.trans a b c Rab Rbc;
-  . by_contra hC;
-    subst hC;
-    exact hne $ IsAntisymm.antisymm a b Rab Rbc;
+  rintro a b c ⟨Rab, hne⟩ ⟨Rbc, _⟩
+  constructor
+  . exact IsTrans.trans a b c Rab Rbc
+  . by_contra hC
+    subst hC
+    exact hne $ IsAntisymm.antisymm a b Rab Rbc
 ⟩
 
 instance [IsPartialOrder _ R] : IsStrictOrder _ (R.IrreflGen) where

--- a/Foundation/Vorspiel/HRel/CWF.lean
+++ b/Foundation/Vorspiel/HRel/CWF.lean
@@ -20,7 +20,7 @@ lemma ConverseWellFounded.iff_has_max : ConverseWellFounded R ↔ (∀ (s : Set 
   simp [ConverseWellFounded, WellFounded.wellFounded_iff_has_min, flip]
 
 lemma ConverseWellFounded.has_max (h : ConverseWellFounded R) : ∀ (s : Set α), Set.Nonempty s → ∃ m ∈ s, ∀ x ∈ s, ¬(R m x) := by
-  apply ConverseWellFounded.iff_has_max.mp h;
+  apply ConverseWellFounded.iff_has_max.mp h
 
 instance [Finite α] [IsTrans α R] [IsIrrefl α R] : IsConverseWellFounded _ R := ⟨by
   apply @Finite.wellFounded_of_trans_of_irrefl _ _ _

--- a/Foundation/Vorspiel/HRel/Connected.lean
+++ b/Foundation/Vorspiel/HRel/Connected.lean
@@ -9,15 +9,15 @@ class IsPiecewiseConnected (R : HRel α) where
   p_connected : PiecewiseConnected R
 
 lemma IsPiecewiseConnected.p_connected' {R : HRel α} [IsPiecewiseConnected R] {x y z : α} (Rxy : R x y) (Rxz : R x z) (hyz : y ≠ z) : R y z ∨ R z y := by
-  rcases IsPiecewiseConnected.p_connected Rxy Rxz with (Ryz | rfl | Rzy) <;> tauto;
+  rcases IsPiecewiseConnected.p_connected Rxy Rxz with (Ryz | rfl | Rzy) <;> tauto
 
 instance [IsTrichotomous _ R] : IsPiecewiseConnected R :=
   ⟨fun ⦃_ y z⦄ _ _ ↦ IsTrichotomous.trichotomous y z⟩
 
 instance [IsRightEuclidean R] : IsPiecewiseConnected R := ⟨by
-  intro x y z Rxy Rxz;
-  have : R y z := IsRightEuclidean.reucl Rxy Rxz;
-  tauto;
+  intro x y z Rxy Rxz
+  have : R y z := IsRightEuclidean.reucl Rxy Rxz
+  tauto
 ⟩
 
 def PiecewiseStronglyConnected (R : HRel α) := ∀ ⦃x y z⦄, R x y → R x z → (R y z ∨ R z y)
@@ -28,27 +28,27 @@ class IsPiecewiseStronglyConnected (R : HRel α) where
 instance [IsTotal _ R] : IsPiecewiseStronglyConnected R := ⟨fun ⦃_ y z⦄ _ _ ↦ IsTotal.total y z⟩
 
 instance [IsPiecewiseConnected R] [IsRefl _ R] : IsPiecewiseStronglyConnected R := ⟨by
-  intro x y z Rxy Rxz;
-  rcases IsPiecewiseConnected.p_connected Rxy Rxz with (Ryz | rfl | Rzy);
-  . tauto;
-  . left; apply refl;
-  . tauto;
+  intro x y z Rxy Rxz
+  rcases IsPiecewiseConnected.p_connected Rxy Rxz with (Ryz | rfl | Rzy)
+  . tauto
+  . left; apply refl
+  . tauto
 ⟩
 
 instance [IsPiecewiseStronglyConnected R] : IsPiecewiseConnected R := ⟨by
-  intro x y z Rxy Rxz;
-  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz <;> tauto;
+  intro x y z Rxy Rxz
+  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz <;> tauto
 ⟩
 
 instance [IsRefl _ R] [IsPiecewiseStronglyConnected R] : IsPiecewiseStronglyConvergent R := ⟨by
-  intro x y z Rxy Rxz;
-  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz with (Ryz | Rzy);
-  . use z;
-    constructor;
-    . assumption;
-    . apply IsRefl.refl;
-  . use y;
-    constructor;
-    . apply IsRefl.refl;
-    . assumption;
+  intro x y z Rxy Rxz
+  rcases IsPiecewiseStronglyConnected.ps_connected Rxy Rxz with (Ryz | Rzy)
+  . use z
+    constructor
+    . assumption
+    . apply IsRefl.refl
+  . use y
+    constructor
+    . apply IsRefl.refl
+    . assumption
 ⟩

--- a/Foundation/Vorspiel/HRel/Convergent.lean
+++ b/Foundation/Vorspiel/HRel/Convergent.lean
@@ -16,8 +16,8 @@ class IsStronglyConvergent (R : HRel α) where
   s_convergent : StronglyConvergent R
 
 instance [IsStronglyConvergent R] : IsConvergent R := ⟨by
-  rintro x y _;
-  apply IsStronglyConvergent.s_convergent;
+  rintro x y _
+  apply IsStronglyConvergent.s_convergent
 ⟩
 
 
@@ -33,6 +33,6 @@ class IsPiecewiseStronglyConvergent (R : HRel α) where
   ps_convergent : PiecewiseStronglyConvergent R
 
 instance [IsPiecewiseStronglyConvergent R] : IsPiecewiseConvergent R := ⟨by
-  rintro x y z Rxy Rxz _;
-  apply IsPiecewiseStronglyConvergent.ps_convergent Rxy Rxz;
+  rintro x y z Rxy Rxz _
+  apply IsPiecewiseStronglyConvergent.ps_convergent Rxy Rxz
 ⟩

--- a/Foundation/Vorspiel/HRel/Coreflexive.lean
+++ b/Foundation/Vorspiel/HRel/Coreflexive.lean
@@ -8,18 +8,18 @@ class IsCoreflexive (R : HRel α) where
   corefl : Coreflexive R
 
 instance [IsSymm _ R] [IsAntisymm _ R] : IsCoreflexive R := ⟨by
-  intro x y Rxy;
-  apply IsAntisymm.antisymm (r := R);
-  . assumption;
-  . exact IsSymm.symm _ _ Rxy;
+  intro x y Rxy
+  apply IsAntisymm.antisymm (r := R)
+  . assumption
+  . exact IsSymm.symm _ _ Rxy
 ⟩
 
 instance [IsCoreflexive R] : IsTrans _ R := ⟨by
-  rintro x y z Rxy Ryz;
-  rwa [IsCoreflexive.corefl Rxy, IsCoreflexive.corefl Ryz] at *;
+  rintro x y z Rxy Ryz
+  rwa [IsCoreflexive.corefl Rxy, IsCoreflexive.corefl Ryz] at *
 ⟩
 
 instance [IsCoreflexive R] : IsSymm _ R := ⟨by
-  intro x y Rxy;
-  rwa [IsCoreflexive.corefl Rxy] at *;
+  intro x y Rxy
+  rwa [IsCoreflexive.corefl Rxy] at *
 ⟩

--- a/Foundation/Vorspiel/HRel/Equality.lean
+++ b/Foundation/Vorspiel/HRel/Equality.lean
@@ -7,10 +7,10 @@ class IsEquality (R : HRel α) extends IsRefl α R, IsCoreflexive R
 
 @[simp]
 lemma equality [IsEquality R] : ∀ ⦃x y⦄, R x y ↔ x = y := by
-  intro x y;
-  constructor;
-  . apply IsCoreflexive.corefl;
-  . rintro rfl; apply IsRefl.refl;
+  intro x y
+  constructor
+  . apply IsCoreflexive.corefl
+  . rintro rfl; apply IsRefl.refl
 
 instance [IsEquality R] : IsSymm α R := ⟨by simp_all⟩
 

--- a/Foundation/Vorspiel/HRel/Euclidean.lean
+++ b/Foundation/Vorspiel/HRel/Euclidean.lean
@@ -10,36 +10,36 @@ class IsRightEuclidean (R : HRel α) where
 lemma IsRightEuclidean.reucl' [IsRightEuclidean R] {x y z : α} (Rxy : R x y) (Rxz : R x z) : R z y := reucl Rxz Rxy
 
 instance [IsSymm _ R] [IsTrans _ R] : IsRightEuclidean R := ⟨by
-  intro x y z Rxy Rxz;
-  apply IsSymm.symm;
-  apply IsTrans.trans;
-  . exact IsSymm.symm _ _ Rxz;
-  . assumption;
+  intro x y z Rxy Rxz
+  apply IsSymm.symm
+  apply IsTrans.trans
+  . exact IsSymm.symm _ _ Rxz
+  . assumption
 ⟩
 
 
 instance [IsRefl _ R] [IsRightEuclidean R] : IsSymm α R := ⟨by
-  intro x y Rxy;
-  apply IsRightEuclidean.reucl Rxy;
+  intro x y Rxy
+  apply IsRightEuclidean.reucl Rxy
   . apply IsRefl.refl
 ⟩
 
 instance [IsSymm _ R] [IsRightEuclidean R] : IsTrans α R := ⟨by
-  intro x y z Rxy Ryz;
-  apply IsSymm.symm;
-  apply IsRightEuclidean.reucl;
-  . exact Ryz;
-  . exact IsSymm.symm _ _ Rxy;
+  intro x y z Rxy Ryz
+  apply IsSymm.symm
+  apply IsRightEuclidean.reucl
+  . exact Ryz
+  . exact IsSymm.symm _ _ Rxy
 ⟩
 
 instance [IsRefl _ R] [IsRightEuclidean R] : IsTrans α R := inferInstance
 
 instance [IsSymm _ R] [IsTrans _ R] [IsSerial R] : IsRefl α R := ⟨by
-  rintro x;
-  obtain ⟨y, Rxy⟩ := IsSerial.serial (R := R) x;
-  apply IsTrans.trans;
-  . exact Rxy;
-  . apply IsSymm.symm; exact Rxy;
+  rintro x
+  obtain ⟨y, Rxy⟩ := IsSerial.serial (R := R) x
+  apply IsTrans.trans
+  . exact Rxy
+  . apply IsSymm.symm; exact Rxy
 ⟩
 
 

--- a/Foundation/Vorspiel/HRel/WCWF.lean
+++ b/Foundation/Vorspiel/HRel/WCWF.lean
@@ -17,76 +17,76 @@ variable {α : Type*} {rel : α → α → Prop}
 
 lemma dependent_choice (h : ∃ s : Set α, s.Nonempty ∧ ∀ a ∈ s, ∃ b ∈ s, rel a b)
   : ∃ f : ℕ → α, ∀ x, rel (f x) (f (x + 1)) := by
-  obtain ⟨s, ⟨x, hx⟩, h'⟩ := h;
-  choose! f hfs hR using h';
-  use fun n ↦ f^[n] x;
-  intro n;
-  simp only [Function.iterate_succ'];
-  refine hR (f^[n] x) ?a;
+  obtain ⟨s, ⟨x, hx⟩, h'⟩ := h
+  choose! f hfs hR using h'
+  use fun n ↦ f^[n] x
+  intro n
+  simp only [Function.iterate_succ']
+  refine hR (f^[n] x) ?a
   induction n with
-  | zero => simpa;
-  | succ n ih => simp only [Function.iterate_succ']; apply hfs _ ih;
+  | zero => simpa
+  | succ n ih => simp only [Function.iterate_succ']; apply hfs _ ih
 
 lemma Finite.exists_ne_map_eq_of_infinite_lt {α β} [LinearOrder α] [Infinite α] [Finite β] (f : α → β)
   : ∃ x y : α, (x < y) ∧ f x = f y
   := by
-    obtain ⟨i, j, hij, e⟩ := Finite.exists_ne_map_eq_of_infinite f;
-    rcases lt_trichotomy i j with (hij | _ | hij);
-    . use i, j;
-    . contradiction;
-    . use j, i; simp [hij, e];
+    obtain ⟨i, j, hij, e⟩ := Finite.exists_ne_map_eq_of_infinite f
+    rcases lt_trichotomy i j with (hij | _ | hij)
+    . use i, j
+    . contradiction
+    . use j, i; simp [hij, e]
 
 
 lemma antisymm_of_weaklyConverseWellFounded : WeaklyConverseWellFounded rel → AntiSymmetric rel := by
-  dsimp [AntiSymmetric];
-  contrapose!;
-  rintro ⟨x, y, Rxy, Ryz, hxy⟩;
-  apply ConverseWellFounded.iff_has_max.not.mpr;
-  push_neg;
-  use {x, y};
-  constructor;
-  . simp;
-  . intro z hz;
-    by_cases z = x;
-    . use y; simp_all [HRel.IrreflGen];
-    . use x; simp_all [HRel.IrreflGen];
+  dsimp [AntiSymmetric]
+  contrapose!
+  rintro ⟨x, y, Rxy, Ryz, hxy⟩
+  apply ConverseWellFounded.iff_has_max.not.mpr
+  push_neg
+  use {x, y}
+  constructor
+  . simp
+  . intro z hz
+    by_cases z = x
+    . use y; simp_all [HRel.IrreflGen]
+    . use x; simp_all [HRel.IrreflGen]
 
 instance [IsWeaklyConverseWellFounded _ rel] : IsAntisymm _ rel := ⟨by
-  apply antisymm_of_weaklyConverseWellFounded;
-  apply isWeaklyConverseWellFounded_iff _ _ |>.mp;
-  assumption;
+  apply antisymm_of_weaklyConverseWellFounded
+  apply isWeaklyConverseWellFounded_iff _ _ |>.mp
+  assumption
 ⟩
 
 
 lemma weaklyConverseWellFounded_of_finite_trans_antisymm (hFin : Finite α) (R_trans : Transitive rel)
   : AntiSymmetric rel → WeaklyConverseWellFounded rel := by
     dsimp [AntiSymmetric]
-    contrapose!;
-    intro hWCWF;
-    replace hWCWF := ConverseWellFounded.iff_has_max.not.mp hWCWF;
-    push_neg at hWCWF;
-    obtain ⟨f, hf⟩ := dependent_choice hWCWF; clear hWCWF;
-    dsimp [HRel.IrreflGen] at hf;
+    contrapose!
+    intro hWCWF
+    replace hWCWF := ConverseWellFounded.iff_has_max.not.mp hWCWF
+    push_neg at hWCWF
+    obtain ⟨f, hf⟩ := dependent_choice hWCWF; clear hWCWF
+    dsimp [HRel.IrreflGen] at hf
 
-    obtain ⟨i, j, hij, e⟩ := Finite.exists_ne_map_eq_of_infinite_lt f;
-    use (f i), (f (i + 1));
-    have ⟨hi₁, hi₂⟩ := hf i;
-    refine ⟨(by assumption), ?_, (by assumption)⟩;
+    obtain ⟨i, j, hij, e⟩ := Finite.exists_ne_map_eq_of_infinite_lt f
+    use (f i), (f (i + 1))
+    have ⟨hi₁, hi₂⟩ := hf i
+    refine ⟨(by assumption), ?_, (by assumption)⟩
 
-    have : i + 1 < j := lt_iff_le_and_ne.mpr ⟨by omega, by aesop⟩;
+    have : i + 1 < j := lt_iff_le_and_ne.mpr ⟨by omega, by aesop⟩
     have H : ∀ i j, i < j → rel (f i) (f j) := by
       intro i j hij
       induction hij with
-      | refl => exact hf i |>.1;
-      | step _ ih => exact R_trans ih $ hf _ |>.1;
-    have := H (i + 1) j this;
-    simpa [e];
+      | refl => exact hf i |>.1
+      | step _ ih => exact R_trans ih $ hf _ |>.1
+    have := H (i + 1) j this
+    simpa [e]
 
 instance [Finite α] [IsTrans _ rel] [IsAntisymm _ rel] : IsWeaklyConverseWellFounded α rel := ⟨by
-  apply weaklyConverseWellFounded_of_finite_trans_antisymm;
-  . assumption;
-  . exact IsTrans.trans;
-  . exact IsAntisymm.antisymm;
+  apply weaklyConverseWellFounded_of_finite_trans_antisymm
+  . assumption
+  . exact IsTrans.trans
+  . exact IsAntisymm.antisymm
 ⟩
 
 end

--- a/Foundation/Vorspiel/List/Chain.lean
+++ b/Foundation/Vorspiel/List/Chain.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.List.Nodup
 import Mathlib.Data.List.Range
 import Foundation.Vorspiel.Fin.Supplemental
 
-lemma Nat.zero_lt_of_not_zero {n : ℕ} (hn : n ≠ 0) : 0 < n := by omega;
+lemma Nat.zero_lt_of_not_zero {n : ℕ} (hn : n ≠ 0) : 0 < n := by omega
 
 
 namespace List
@@ -20,9 +20,9 @@ def finIdxOf (l : List α) (hx : x ∈ l) : Fin l.length := ⟨l.idxOf x, idxOf_
 @[simp] lemma get_finIdxOf {hx : x ∈ l} : l.get (l.finIdxOf hx) = x := by simp [finIdxOf]
 
 lemma neq_findIdxOf_of_neq {hx : x ∈ l} {hy : y ∈ l} (exy : x ≠ y) : l.finIdxOf hx ≠ l.finIdxOf hy := by
-  simp only [finIdxOf, ne_eq, Fin.mk.injEq];
-  apply List.idxOf_inj hx hy |>.not.mpr;
-  exact exy;
+  simp only [finIdxOf, ne_eq, Fin.mk.injEq]
+  apply List.idxOf_inj hx hy |>.not.mpr
+  exact exy
 
 end
 
@@ -30,38 +30,38 @@ end
 section
 
 lemma range.le_chain'_succ : List.Chain' (· < ·) (List.range (n + 1)) := by
-  apply List.chain'_range_succ (· < ·) n |>.mpr;
-  omega;
+  apply List.chain'_range_succ (· < ·) n |>.mpr
+  omega
 
 @[simp]
 lemma range.le_chain' : List.Chain' (· < ·) (List.range n) := by
   match n with
   | 0 => simp [List.range_zero]
-  | n + 1 => apply le_chain'_succ;
+  | n + 1 => apply le_chain'_succ
 
 lemma finRange.le_chain'_succ : List.Chain' (· < ·) (List.finRange (n + 1)) := by
-  rw [finRange_succ];
+  rw [finRange_succ]
   induction n with
   | zero => simp [finRange]
   | succ n ih =>
     rw [List.finRange_succ, List.map]
-    apply List.chain'_append_cons_cons (α := Fin (n + 2)) (l₁ := []) |>.mpr;
-    refine ⟨?_, ?_, ?_⟩;
-    . tauto;
-    . tauto;
+    apply List.chain'_append_cons_cons (α := Fin (n + 2)) (l₁ := []) |>.mpr
+    refine ⟨?_, ?_, ?_⟩
+    . tauto
+    . tauto
     . have := @List.chain'_map_of_chain'
         (α := Fin (n + 1)) (β := Fin (n + 2)) (R := (· < ·)) (S := (· < ·))
         (f := Fin.succ)
         (by simp)
         (l := 0 :: (map Fin.succ (finRange n)))
-      apply this;
-      exact ih;
+      apply this
+      exact ih
 
 @[simp]
 lemma finRange.le_chain' : List.Chain' (· < ·) (List.finRange n) := by
   match n with
   | 0 => simp [List.finRange_zero]
-  | n + 1 => apply finRange.le_chain'_succ;
+  | n + 1 => apply finRange.le_chain'_succ
 
 end
 
@@ -74,125 +74,125 @@ lemma of_lt (h : List.Chain' R l) (hij : i < j) : R (l.get i) (l.get j) :=
   List.pairwise_iff_get.mp (List.chain'_iff_pairwise.mp h) _ _ hij
 
 lemma connected_of_trans' (h : List.Chain' R l) (eij : i ≠ j) : R (l.get i) (l.get j) ∨ R (l.get j) (l.get i) := by
-  rcases Nat.lt_trichotomy i j with (_ | _ | _);
-  . left; exact of_lt h $ by omega;
-  . omega;
-  . right; exact of_lt h $ by omega;
+  rcases Nat.lt_trichotomy i j with (_ | _ | _)
+  . left; exact of_lt h $ by omega
+  . omega
+  . right; exact of_lt h $ by omega
 
 lemma connected_of_trans [DecidableEq α] (h : List.Chain' R l) (hx : x ∈ l) (hy : y ∈ l) (exy : x ≠ y) : R x y ∨ R y x := by
-  have : x = l.get (l.finIdxOf hx) := List.get_finIdxOf.symm;
-  have : y = l.get (l.finIdxOf hy) := List.get_finIdxOf.symm;
-  convert Chain'.connected_of_trans' (i := l.finIdxOf hx) (j := l.finIdxOf hy) h $ List.neq_findIdxOf_of_neq exy;
+  have : x = l.get (l.finIdxOf hx) := List.get_finIdxOf.symm
+  have : y = l.get (l.finIdxOf hy) := List.get_finIdxOf.symm
+  convert Chain'.connected_of_trans' (i := l.finIdxOf hx) (j := l.finIdxOf hy) h $ List.neq_findIdxOf_of_neq exy
 
 lemma noDup_of_irrefl_trans (h : List.Chain' R l) [IsIrrefl _ R] : l.Nodup := by
-  apply List.nodup_iff_getElem?_ne_getElem?.mpr;
-  intro i j hij hj;
-  let i' : Fin l.length := ⟨i, by omega⟩;
-  let j' : Fin l.length := ⟨j, by omega⟩;
-  by_contra hC;
+  apply List.nodup_iff_getElem?_ne_getElem?.mpr
+  intro i j hij hj
+  let i' : Fin l.length := ⟨i, by omega⟩
+  let j' : Fin l.length := ⟨j, by omega⟩
+  by_contra hC
   replace hC : l.get i' = l.get j' := by simpa [
     (show l[i]? = l.get i' by exact List.getElem?_eq_getElem (by omega)),
     (show l[j]? = l.get j' by exact List.getElem?_eq_getElem (by omega))
-  ] using hC;
-  have : R (l.get i') (l.get j') := of_lt h (by simpa);
-  rw [hC] at this;
-  exact IsIrrefl.irrefl _ this;
+  ] using hC
+  have : R (l.get i') (l.get j') := of_lt h (by simpa)
+  rw [hC] at this
+  exact IsIrrefl.irrefl _ this
 
 end Chain'
 
 
 lemma mem_head?_eq_head : a ∈ l.head? → ∃ h, a = l.head h := by
   match l with
-  | [] => simp;
+  | [] => simp
   | y::ys =>
-    simp [head?_cons, head_cons];
-    tauto;
+    simp [head?_cons, head_cons]
+    tauto
 
 lemma concat_head?_eq_head (lh : l ≠ []) : (l.concat a).head? = some (l.head lh) := by
   match l with
-  | [] => contradiction;
-  | _::_ => simp;
+  | [] => contradiction
+  | _::_ => simp
 
 lemma chain'_concat :  List.Chain' R (l.concat a) ↔ List.Chain' R l ∧ ∀ x ∈ l.getLast?, R x a := by
   rw [List.concat_eq_append]
-  constructor;
-  . intro h;
-    simpa using List.chain'_append.mp h;
-  . rintro ⟨h₁, h₂⟩;
-    apply List.chain'_append.mpr;
-    refine ⟨h₁, ?_, ?_⟩;
-    . simp;
-    . intro x hx;
-      have : R x a := h₂ x hx;
-      simpa;
+  constructor
+  . intro h
+    simpa using List.chain'_append.mp h
+  . rintro ⟨h₁, h₂⟩
+    apply List.chain'_append.mpr
+    refine ⟨h₁, ?_, ?_⟩
+    . simp
+    . intro x hx
+      have : R x a := h₂ x hx
+      simpa
 
 lemma chain'_concat_of_not_nil (hl : l ≠ []) : List.Chain' R (l.concat a) ↔ List.Chain' R l ∧ R (l.getLast hl) a := by
-  apply Iff.trans List.chain'_concat;
-  suffices (∀ x ∈ l.getLast?, R x a) ↔ R (l.getLast hl) a by tauto;
-  constructor;
-  . intro h;
-    apply h (l.getLast hl);
-    apply List.getLast_mem_getLast?;
-  . rintro h x hx;
-    convert h;
-    simp_all [Option.some.injEq, List.getLast?_eq_some_getLast hl];
+  apply Iff.trans List.chain'_concat
+  suffices (∀ x ∈ l.getLast?, R x a) ↔ R (l.getLast hl) a by tauto
+  constructor
+  . intro h
+    apply h (l.getLast hl)
+    apply List.getLast_mem_getLast?
+  . rintro h x hx
+    convert h
+    simp_all [Option.some.injEq, List.getLast?_eq_some_getLast hl]
 
 section
 
 variable [DecidableEq α]
 
 lemma rel_head_of_chain'_trans [IsTrans _ R] (h : List.Chain' R l) (lh : l ≠ []) : ∀ x ∈ l, x ≠ l.head lh → R (l.head lh) x := by
-  intro x hx₁ hx₂;
-  let i : Fin l.length := ⟨0, List.length_pos_of_ne_nil lh⟩;
-  let j : Fin l.length := List.finIdxOf _ hx₁;
-  convert List.Chain'.of_lt h (i := i) (j := j) ?_;
-  . apply List.head_eq_getElem_zero;
-  . apply List.get_finIdxOf.symm;
-  . apply lt_of_le_of_ne;
-    . apply Nat.zero_le;
-    . by_contra hC;
-      apply hx₂;
-      dsimp [i, j] at hC;
-      convert List.head_eq_getElem_zero lh |>.symm;
-      have := List.get_finIdxOf (hx := hx₁) |>.symm;
-      rwa [←hC] at this;
+  intro x hx₁ hx₂
+  let i : Fin l.length := ⟨0, List.length_pos_of_ne_nil lh⟩
+  let j : Fin l.length := List.finIdxOf _ hx₁
+  convert List.Chain'.of_lt h (i := i) (j := j) ?_
+  . apply List.head_eq_getElem_zero
+  . apply List.get_finIdxOf.symm
+  . apply lt_of_le_of_ne
+    . apply Nat.zero_le
+    . by_contra hC
+      apply hx₂
+      dsimp [i, j] at hC
+      convert List.head_eq_getElem_zero lh |>.symm
+      have := List.get_finIdxOf (hx := hx₁) |>.symm
+      rwa [←hC] at this
 
 lemma rel_head_of_chain'_preorder [IsPreorder _ R] (h : List.Chain' R l) (lh : l ≠ []) : ∀ x ∈ l, R (l.head lh) x := by
-  intro x hx;
-  by_cases e : x = l.head lh;
-  . subst e;
-    apply refl;
-  . apply rel_head_of_chain'_trans h lh <;> assumption;
+  intro x hx
+  by_cases e : x = l.head lh
+  . subst e
+    apply refl
+  . apply rel_head_of_chain'_trans h lh <;> assumption
 
 lemma rel_getLast_of_chain'_trans [IsTrans _ R] (h : List.Chain' R l) (lh : l ≠ []) : ∀ x ∈ l, x ≠ l.getLast lh → R x (l.getLast lh) := by
-  intro x hx₁ hx₂;
-  have : NeZero l.length := ⟨List.length_eq_zero_iff.not.mpr lh⟩;
-  let i : Fin l.length := List.finIdxOf l hx₁;
-  let j : Fin l.length := Fin.last';
-  convert List.Chain'.of_lt h (i := i) (j := j) ?_;
-  . apply List.get_finIdxOf.symm;
-  . apply List.getLast_eq_getElem;
-  . apply lt_of_le_of_ne;
-    . exact Fin.lt_last';
-    . by_contra hC;
-      apply hx₂;
-      dsimp [i, j] at hC;
-      convert List.getLast_eq_getElem lh |>.symm;
-      have := List.get_finIdxOf (hx := hx₁) |>.symm;
-      rwa [hC] at this;
+  intro x hx₁ hx₂
+  have : NeZero l.length := ⟨List.length_eq_zero_iff.not.mpr lh⟩
+  let i : Fin l.length := List.finIdxOf l hx₁
+  let j : Fin l.length := Fin.last'
+  convert List.Chain'.of_lt h (i := i) (j := j) ?_
+  . apply List.get_finIdxOf.symm
+  . apply List.getLast_eq_getElem
+  . apply lt_of_le_of_ne
+    . exact Fin.lt_last'
+    . by_contra hC
+      apply hx₂
+      dsimp [i, j] at hC
+      convert List.getLast_eq_getElem lh |>.symm
+      have := List.get_finIdxOf (hx := hx₁) |>.symm
+      rwa [hC] at this
 
 lemma rel_getLast_of_chain'_preorder [IsPreorder _ R] (h : List.Chain' R l) (lh : l ≠ []) : ∀ x ∈ l, R x (l.getLast lh) := by
-  intro x hx;
-  by_cases e : x = l.getLast lh;
-  . subst e;
-    apply refl;
-  . apply rel_getLast_of_chain'_trans h lh <;> assumption;
+  intro x hx
+  by_cases e : x = l.getLast lh
+  . subst e
+    apply refl
+  . apply rel_getLast_of_chain'_trans h lh <;> assumption
 
 end
 
 def embedding_of_exists_noDup {l : List α} (hl₁ : l.Nodup) (hl₂ : l.length = n) : Fin n ↪ α := by
-  refine ⟨λ ⟨i, hi⟩ => l.get ⟨i, by omega⟩, ?_⟩;
-  . rintro ⟨i, hi⟩ ⟨j, hj⟩ hij;
-    simpa using (List.nodup_iff_injective_get (l := l) |>.mp hl₁) hij;
+  refine ⟨λ ⟨i, hi⟩ => l.get ⟨i, by omega⟩, ?_⟩
+  . rintro ⟨i, hi⟩ ⟨j, hj⟩ hij
+    simpa using (List.nodup_iff_injective_get (l := l) |>.mp hl₁) hij
 
 end List

--- a/Foundation/Vorspiel/List/Supplemental.lean
+++ b/Foundation/Vorspiel/List/Supplemental.lean
@@ -6,43 +6,43 @@ variable {l : List α}
 
 lemma exists_of_not_nil (hl : l ≠ []) : ∃ a, a ∈ l := by
   match l with
-  | [] => tauto;
-  | a :: l => use a; simp only [mem_cons, true_or];
+  | [] => tauto
+  | a :: l => use a; simp only [mem_cons, true_or]
 
 lemma iff_nil_forall : (l = []) ↔ (∀ a ∈ l, a ∈ []) := by
-  constructor;
-  . intro h;
-    subst h;
-    tauto;
-  . contrapose!;
-    rintro h;
-    obtain ⟨a, ha⟩ := exists_of_not_nil h;
-    use a;
-    tauto;
+  constructor
+  . intro h
+    subst h
+    tauto
+  . contrapose!
+    rintro h
+    obtain ⟨a, ha⟩ := exists_of_not_nil h
+    use a
+    tauto
 
 /-- getElem version of `List.nodup_iff_getElem?_ne_getElem?` -/
 lemma nodup_iff_get_ne_get : l.Nodup ↔ ∀ i j : Fin l.length, i < j → l[i] ≠ l[j] := by
-  apply Iff.trans nodup_iff_getElem?_ne_getElem?;
-  constructor;
-  . rintro h ⟨i, _⟩ ⟨j, hj⟩ hij;
-    have := h i j (by omega) hj;
-    simp_all;
-  . rintro h i j hij hj;
-    rw [getElem?_eq_getElem, getElem?_eq_getElem];
-    simpa [Option.some.injEq] using h ⟨i, by omega⟩ ⟨j, by omega⟩ hij;
+  apply Iff.trans nodup_iff_getElem?_ne_getElem?
+  constructor
+  . rintro h ⟨i, _⟩ ⟨j, hj⟩ hij
+    have := h i j (by omega) hj
+    simp_all
+  . rintro h i j hij hj
+    rw [getElem?_eq_getElem, getElem?_eq_getElem]
+    simpa [Option.some.injEq] using h ⟨i, by omega⟩ ⟨j, by omega⟩ hij
 
 
 lemma Nodup.infinite_of_infinite : Infinite {l : List α // l.Nodup} → Infinite α := by
-  contrapose!;
-  simp only [not_infinite_iff_finite];
-  intro _;
-  exact List.Nodup.finite;
+  contrapose!
+  simp only [not_infinite_iff_finite]
+  intro _
+  exact List.Nodup.finite
 
 lemma exists_of_range (h : a ∈ List.map f (List.range n)) : ∃ i < n, a = f i := by
-  obtain ⟨i, ⟨hi, rfl⟩⟩ := List.exists_of_mem_map h;
-  use i;
-  constructor;
-  . simpa using hi;
-  . simp;
+  obtain ⟨i, ⟨hi, rfl⟩⟩ := List.exists_of_mem_map h
+  use i
+  constructor
+  . simpa using hi
+  . simp
 
 end List

--- a/Foundation/Vorspiel/Relation/Supplemental.lean
+++ b/Foundation/Vorspiel/Relation/Supplemental.lean
@@ -83,207 +83,207 @@ section
 variable {α : Type*} {rel : α → α → Prop}
 
 lemma serial_of_refl (hRefl : Reflexive rel) : Serial rel := by
-  rintro w;
-  use w;
-  exact hRefl w;
+  rintro w
+  use w
+  exact hRefl w
 
 instance [IsRefl α rel] : IsSerial α rel := ⟨serial_of_refl IsRefl.reflexive⟩
 
 
 lemma eucl_of_symm_trans (hSymm : Symmetric rel) (hTrans : Transitive rel) : Euclidean rel := by
-  intro x y z Rxy Rxz;
-  have Ryx := hSymm Rxy;
-  exact hSymm $ hTrans Ryx Rxz;
+  intro x y z Rxy Rxz
+  have Ryx := hSymm Rxy
+  exact hSymm $ hTrans Ryx Rxz
 
 instance [IsSymm α rel] [IsTrans α rel] : IsEuclidean α rel := ⟨eucl_of_symm_trans IsSymm.symm IsTrans.trans⟩
 
 
 lemma trans_of_symm_eucl (hSymm : Symmetric rel) (hEucl : Euclidean rel) : Transitive rel := by
-  rintro x y z Rxy Ryz;
-  exact hSymm $ hEucl (hSymm Rxy) Ryz;
+  rintro x y z Rxy Ryz
+  exact hSymm $ hEucl (hSymm Rxy) Ryz
 
 instance [IsSymm α rel] [IsEuclidean α rel] : IsTrans α rel := ⟨trans_of_symm_eucl IsSymm.symm IsEuclidean.euclidean⟩
 
 
 lemma symm_of_refl_eucl (hRefl : Reflexive rel) (hEucl : Euclidean rel) : Symmetric rel := by
-  intro x y Rxy;
-  exact hEucl (hRefl x) Rxy;
+  intro x y Rxy
+  exact hEucl (hRefl x) Rxy
 
 instance [IsRefl α rel] [IsEuclidean α rel] : IsSymm α rel := ⟨symm_of_refl_eucl IsRefl.reflexive IsEuclidean.euclidean⟩
 
 
 lemma trans_of_refl_eucl (hRefl : Reflexive rel) (hEucl : Euclidean rel) : Transitive rel := by
-  have hSymm := symm_of_refl_eucl hRefl hEucl;
-  exact trans_of_symm_eucl hSymm hEucl;
+  have hSymm := symm_of_refl_eucl hRefl hEucl
+  exact trans_of_symm_eucl hSymm hEucl
 
 instance [IsRefl α rel] [IsEuclidean α rel] : IsTrans α rel := ⟨trans_of_refl_eucl IsRefl.reflexive IsEuclidean.euclidean⟩
 
 
 lemma refl_of_symm_serial_eucl (hSymm : Symmetric rel) (hSerial : Serial rel) (hEucl : Euclidean rel) : Reflexive rel := by
-  rintro x;
-  obtain ⟨y, Rxy⟩ := hSerial x;
-  have Ryx := hSymm Rxy;
-  exact trans_of_symm_eucl hSymm hEucl Rxy Ryx;
+  rintro x
+  obtain ⟨y, Rxy⟩ := hSerial x
+  have Ryx := hSymm Rxy
+  exact trans_of_symm_eucl hSymm hEucl Rxy Ryx
 
 instance [IsSymm α rel] [IsSerial α rel] [IsEuclidean α rel] : IsRefl α rel := ⟨refl_of_symm_serial_eucl IsSymm.symm IsSerial.serial IsEuclidean.euclidean⟩
 
 
 lemma corefl_of_refl_assym_eucl (hRefl : Reflexive rel) (hAntisymm : AntiSymmetric rel) (hEucl : Euclidean rel) : Coreflexive rel := by
-  intro x y Rxy;
-  have Ryx := hEucl (hRefl x) Rxy;
-  exact hAntisymm Rxy Ryx;
+  intro x y Rxy
+  have Ryx := hEucl (hRefl x) Rxy
+  exact hAntisymm Rxy Ryx
 
 instance [IsRefl α rel] [IsAntisymm α rel] [IsEuclidean α rel] : IsCoreflexive α rel := ⟨corefl_of_refl_assym_eucl IsRefl.reflexive IsAntisymm.antisymm IsEuclidean.euclidean⟩
 
 
 lemma equality_of_refl_corefl (hRefl : Reflexive rel) (hCorefl : Coreflexive rel) : Equality rel := by
-  intro x y;
-  constructor;
-  . apply hCorefl;
-  . rintro rfl; apply hRefl;
+  intro x y
+  constructor
+  . apply hCorefl
+  . rintro rfl; apply hRefl
 
 instance [IsRefl α rel] [IsCoreflexive α rel] : IsEquality α rel := ⟨equality_of_refl_corefl IsRefl.reflexive IsCoreflexive.coreflexive⟩
 
 
 lemma refl_of_equality (h : Equality rel) : Reflexive rel := by
-  intro x;
-  exact h.mpr rfl;
+  intro x
+  exact h.mpr rfl
 instance [IsEquality α rel] : IsRefl α rel := ⟨refl_of_equality IsEquality.equality⟩
 
 lemma trans_of_equality (h : Equality rel) : Transitive rel := by
-  rintro x y z Rxy Ryz;
-  replace Rxy := h.mp Rxy; subst Rxy;
-  replace Ryz := h.mp Ryz; subst Ryz;
-  apply refl_of_equality h;
+  rintro x y z Rxy Ryz
+  replace Rxy := h.mp Rxy; subst Rxy
+  replace Ryz := h.mp Ryz; subst Ryz
+  apply refl_of_equality h
 instance [IsEquality α rel] : IsTrans α rel := ⟨trans_of_equality IsEquality.equality⟩
 
 lemma antisymm_of_equality (h : Equality rel) : AntiSymmetric rel := by
-  rintro x y Rxy Ryz;
-  replace Rxy := h.mp Rxy; subst Rxy;
-  rfl;
+  rintro x y Rxy Ryz
+  replace Rxy := h.mp Rxy; subst Rxy
+  rfl
 instance [IsEquality α rel] : IsAntisymm α rel := ⟨antisymm_of_equality IsEquality.equality⟩
 
 instance [IsEquality α rel] : IsPartialOrder α rel where
 
 lemma corefl_of_equality (h : Equality rel) : Coreflexive rel := by
-  intro x y Rxy;
-  apply h.mp Rxy;
+  intro x y Rxy
+  apply h.mp Rxy
 
 instance [IsEquality α rel] : IsCoreflexive α rel := ⟨corefl_of_equality IsEquality.equality⟩
 
 
 lemma connected_of_equality (h : Equality rel) : Connected rel := by
-  rintro x y z ⟨Rxy, Ryz⟩;
-  replace Rxy := h.mp Rxy; subst Rxy;
-  replace Ryz := h.mp Ryz; subst Ryz;
-  left;
-  apply refl_of_equality h;
+  rintro x y z ⟨Rxy, Ryz⟩
+  replace Rxy := h.mp Rxy; subst Rxy
+  replace Ryz := h.mp Ryz; subst Ryz
+  left
+  apply refl_of_equality h
 instance [IsEquality α rel] : IsConnected α rel := ⟨connected_of_equality IsEquality.equality⟩
 
 
 lemma irreflexive_of_assymetric (hAssym : Asymmetric rel) : Irreflexive rel := by
-  intro x Rxx;
-  have := hAssym Rxx;
-  contradiction;
+  intro x Rxx
+  have := hAssym Rxx
+  contradiction
 
 instance [IsAsymm α rel] : IsIrrefl α rel := ⟨irreflexive_of_assymetric IsAsymm.asymm⟩
 
 
 lemma symmetric_of_coreflexive (hCorefl : Coreflexive rel) : Symmetric rel := by
-  intro x y Rxy;
-  rwa [hCorefl Rxy] at *;
+  intro x y Rxy
+  rwa [hCorefl Rxy] at *
 instance [IsCoreflexive α rel] : IsSymm α rel := ⟨symmetric_of_coreflexive IsCoreflexive.coreflexive⟩
 
 lemma transitive_of_coreflexive (hCorefl : Coreflexive rel) : Transitive rel := by
-  rintro x y z Rxy Ryz;
-  rwa [hCorefl Rxy, hCorefl Ryz] at *;
+  rintro x y z Rxy Ryz
+  rwa [hCorefl Rxy, hCorefl Ryz] at *
 instance [IsCoreflexive α rel] : IsTrans α rel := ⟨transitive_of_coreflexive IsCoreflexive.coreflexive⟩
 
 
 lemma coreflexive_of_isolated (h : Isolated rel) : Coreflexive rel := by
-  intro x y Rxy;
-  exfalso;
-  exact h Rxy;
+  intro x y Rxy
+  exfalso
+  exact h Rxy
 instance [IsIsolated α rel] : IsCoreflexive α rel := ⟨coreflexive_of_isolated IsIsolated.isolated⟩
 
 lemma irrefl_of_isolated (h : Isolated rel) : Irreflexive rel := by
-  intro x Rxx;
-  exfalso;
-  exact h Rxx;
+  intro x Rxx
+  exfalso
+  exact h Rxx
 instance [IsIsolated α rel] : IsIrrefl α rel := ⟨irrefl_of_isolated IsIsolated.isolated⟩
 
 lemma transitive_of_isolated (h : Isolated rel) : Transitive rel := by
-  rintro x y z Rxy;
-  exfalso;
-  exact h Rxy;
+  rintro x y z Rxy
+  exfalso
+  exact h Rxy
 instance [IsIsolated α rel] : IsTrans α rel := ⟨transitive_of_isolated IsIsolated.isolated⟩
 
 instance [IsIsolated α rel] : IsStrictOrder α rel where
 
 lemma weakConnected_of_isolated (h : Isolated rel) : WeakConnected rel := by
-  rintro x y z ⟨Rxy, Ryz, _⟩;
-  exfalso;
-  exact h Rxy;
+  rintro x y z ⟨Rxy, Ryz, _⟩
+  exfalso
+  exact h Rxy
 instance [IsIsolated α rel] : IsWeakConnected α rel := ⟨weakConnected_of_isolated IsIsolated.isolated⟩
 
 
-lemma refl_of_universal (h : Universal rel) : Reflexive rel := by intro x; exact @h x x;
+lemma refl_of_universal (h : Universal rel) : Reflexive rel := by intro x; exact @h x x
 instance [IsUniversal α rel] : IsRefl α rel := ⟨refl_of_universal IsUniversal.universal⟩
 
-lemma eucl_of_universal (h : Universal rel) : Euclidean rel := by rintro x y z _ _; exact @h z y;
+lemma eucl_of_universal (h : Universal rel) : Euclidean rel := by rintro x y z _ _; exact @h z y
 instance [IsUniversal α rel] : IsEuclidean α rel := ⟨eucl_of_universal IsUniversal.universal⟩
 
 instance [IsUniversal α rel] : IsTrans α rel := inferInstance
 instance [IsUniversal α rel] : IsPreorder α rel where
 
-lemma connected_of_universal (h : Universal rel) : Connected rel := by simp_all [Connected, Universal];
+lemma connected_of_universal (h : Universal rel) : Connected rel := by simp_all [Connected, Universal]
 instance [IsUniversal α rel] : IsConnected α rel := ⟨connected_of_universal IsUniversal.universal⟩
 
 
 
 lemma weakConfluent_of_confluent (hConfl : Confluent rel) : WeakConfluent rel := by
-  rintro x y z ⟨Rxy, Rxz, _⟩;
-  obtain ⟨w, Rwy, Rwz⟩ := hConfl ⟨Rxy, Rxz⟩;
-  use w;
+  rintro x y z ⟨Rxy, Rxz, _⟩
+  obtain ⟨w, Rwy, Rwz⟩ := hConfl ⟨Rxy, Rxz⟩
+  use w
 instance [IsConfluent α rel] : IsWeakConfluent α rel := ⟨weakConfluent_of_confluent IsConfluent.confluent⟩
 
 
 lemma weakConnected_of_connected (hConnected : Connected rel) : WeakConnected rel := by
-  rintro x y z ⟨Rxy, Rxz, _⟩;
-  rcases hConnected ⟨Rxy, Rxz⟩ with (Ryz | Rzy) <;> simp_all;
+  rintro x y z ⟨Rxy, Rxz, _⟩
+  rcases hConnected ⟨Rxy, Rxz⟩ with (Ryz | Rzy) <;> simp_all
 instance [IsConnected α rel] : IsWeakConnected α rel := ⟨weakConnected_of_connected IsConnected.connected⟩
 
 
 lemma connected_of_trichotomy
   (hRefl : Reflexive rel)
   (hTri : Trichotomous rel) : Connected rel := by
-  rintro x y z ⟨Rxy, Rxz⟩;
-  rcases @hTri y z with Rxy | rfl | Ryz;
-  . left; assumption;
-  . left; apply hRefl;
-  . right; assumption;
+  rintro x y z ⟨Rxy, Rxz⟩
+  rcases @hTri y z with Rxy | rfl | Ryz
+  . left; assumption
+  . left; apply hRefl
+  . right; assumption
 instance [IsRefl α rel] [IsTrichotomous α rel] : IsConnected α rel := ⟨connected_of_trichotomy IsRefl.reflexive IsTrichotomous.trichotomous⟩
 
 
 lemma confluent_of_refl_connected (hRefl : Reflexive rel) (hConfl : Connected rel) : Confluent rel := by
-  rintro x y z ⟨Rxy, Rxz⟩;
-  rcases @hConfl x y z ⟨Rxy, Rxz⟩ with (Ryz | Rzy);
-  . use z;
-    constructor;
-    . assumption;
-    . apply hRefl;
-  . use y;
-    constructor;
-    . apply hRefl;
-    . assumption;
+  rintro x y z ⟨Rxy, Rxz⟩
+  rcases @hConfl x y z ⟨Rxy, Rxz⟩ with (Ryz | Rzy)
+  . use z
+    constructor
+    . assumption
+    . apply hRefl
+  . use y
+    constructor
+    . apply hRefl
+    . assumption
 
 instance [IsRefl α rel] [IsConnected α rel] : IsConfluent α rel := ⟨confluent_of_refl_connected IsRefl.reflexive IsConnected.connected⟩
 
 
 instance weakConnected_of_euclidean (h : Euclidean rel) : WeakConnected rel := by
-  rintro x y z ⟨Rxy, Rxz, _⟩;
-  right;
-  exact h Rxy Rxz;
+  rintro x y z ⟨Rxy, Rxz, _⟩
+  right
+  exact h Rxy Rxz
 
 instance [IsEuclidean α rel] : IsWeakConnected α rel := ⟨weakConnected_of_euclidean IsEuclidean.euclidean⟩
 

--- a/Foundation/Vorspiel/Set/Fin.lean
+++ b/Foundation/Vorspiel/Set/Fin.lean
@@ -8,14 +8,14 @@ namespace Fin1
 protected lemma eq_univ : Set.univ (α := Fin 1) = {0} := by ext x; match x with | 0 => simp
 
 protected lemma eq_powerset : Set.powerset (Set.univ : Set (Fin 1)) = {{0}, ∅} := by
-  ext x;
-  simp only [Set.powerset_univ, Set.mem_univ, Fin.isValue, Set.mem_insert_iff, Set.mem_singleton_iff, true_iff];
-  by_cases h : 0 ∈ x;
-  . left; ext i; match i with | 0 => simp_all;
-  . right; ext i; match i with | 0 => simp_all;
+  ext x
+  simp only [Set.powerset_univ, Set.mem_univ, Fin.isValue, Set.mem_insert_iff, Set.mem_singleton_iff, true_iff]
+  by_cases h : 0 ∈ x
+  . left; ext i; match i with | 0 => simp_all
+  . right; ext i; match i with | 0 => simp_all
 
 protected lemma all_cases (s : Set (Fin 1)) : s = {0} ∨ s = ∅ := by
-  simpa using Set.Fin1.eq_powerset.subset (by simp);
+  simpa using Set.Fin1.eq_powerset.subset (by simp)
 
 end Fin1
 
@@ -25,25 +25,25 @@ namespace Fin2
 protected lemma eq_univ : Set.univ (α := Fin 2) = {0, 1} := by ext x; match x with | 0 | 1 => simp
 
 protected lemma eq_powerset : Set.powerset (Set.univ : Set (Fin 2)) = {{0, 1}, {0}, {1}, ∅} := by
-  ext x;
-  simp only [Set.powerset_univ, Set.mem_univ, Fin.isValue, Set.mem_insert_iff, Set.mem_singleton_iff, true_iff];
+  ext x
+  simp only [Set.powerset_univ, Set.mem_univ, Fin.isValue, Set.mem_insert_iff, Set.mem_singleton_iff, true_iff]
   by_cases h0 : 0 ∈ x <;>
-  by_cases h1 : 1 ∈ x;
-  . left;
-    ext i;
-    match i with | 0 | 1 => simp_all;
-  . right; left;
-    ext i;
-    match i with | 0 | 1 => simp_all;
-  . right; right; left;
-    ext i;
-    match i with | 0 | 1 => simp_all;
-  . right; right; right;
-    ext i;
-    match i with | 0 | 1 => simp_all;
+  by_cases h1 : 1 ∈ x
+  . left
+    ext i
+    match i with | 0 | 1 => simp_all
+  . right; left
+    ext i
+    match i with | 0 | 1 => simp_all
+  . right; right; left
+    ext i
+    match i with | 0 | 1 => simp_all
+  . right; right; right
+    ext i
+    match i with | 0 | 1 => simp_all
 
 protected lemma all_cases (s : Set (Fin 2)) : s = {0, 1} ∨ s = {0} ∨ s = {1} ∨ s = ∅ := by
-  simpa using Set.Fin2.eq_powerset.subset (by simp);
+  simpa using Set.Fin2.eq_powerset.subset (by simp)
 
 end Fin2
 

--- a/Foundation/Vorspiel/Set/Supplemental.lean
+++ b/Foundation/Vorspiel/Set/Supplemental.lean
@@ -6,28 +6,28 @@ namespace Set
 variable {α : Type*} {s t : Set α} {a b : α}
 
 lemma doubleton_subset : ({a, b} : Set α) ⊆ s ↔ a ∈ s ∧ b ∈ s := by
-  constructor;
-  . intro h;
-    have ⟨ha, hb⟩ := Set.insert_subset_iff.mp h;
-    tauto;
-  . rintro ⟨ha, hb⟩;
-    apply Set.insert_subset_iff.mpr;
-    constructor;
-    . assumption;
-    . simpa;
+  constructor
+  . intro h
+    have ⟨ha, hb⟩ := Set.insert_subset_iff.mp h
+    tauto
+  . rintro ⟨ha, hb⟩
+    apply Set.insert_subset_iff.mpr
+    constructor
+    . assumption
+    . simpa
 
 lemma iff_subset_insert_subset_diff : s ⊆ insert a t ↔ s \ {a} ⊆ t := by
-  constructor;
-  . intro ha b hb;
-    rcases ha hb.1 with (rfl | hb);
-    . simp at hb;
-    . assumption;
-  . intro ha b hb;
+  constructor
+  . intro ha b hb
+    rcases ha hb.1 with (rfl | hb)
+    . simp at hb
+    . assumption
+  . intro ha b hb
     apply or_iff_not_imp_left.mpr
-    intro h;
-    apply ha;
-    constructor;
-    . assumption;
-    . simpa;
+    intro h
+    apply ha
+    constructor
+    . assumption
+    . simpa
 
 end Set

--- a/Foundation/Vorspiel/Vorspiel.lean
+++ b/Foundation/Vorspiel/Vorspiel.lean
@@ -724,10 +724,10 @@ variable [DecidableEq α]
 lemma remove_nil (a : α) : [].remove a = [] := by simp [List.remove]
 
 @[simp]
-lemma eq_remove_cons {l : List α} : (ψ :: l).remove ψ = l.remove ψ := by induction l <;> simp_all [List.remove];
+lemma eq_remove_cons {l : List α} : (ψ :: l).remove ψ = l.remove ψ := by induction l <;> simp_all [List.remove]
 
 @[simp]
-lemma remove_singleton_of_ne {φ ψ : α} (h : φ ≠ ψ) : [φ].remove ψ = [φ] := by simp_all [List.remove, Ne.symm];
+lemma remove_singleton_of_ne {φ ψ : α} (h : φ ≠ ψ) : [φ].remove ψ = [φ] := by simp_all [List.remove, Ne.symm]
 
 lemma mem_remove_iff {l : List α} : b ∈ l.remove a ↔ b ∈ l ∧ b ≠ a := by
   simp [List.remove, List.of_mem_filter]
@@ -739,7 +739,7 @@ lemma mem_of_mem_remove {a b : α} {l : List α} (h : b ∈ l.remove a) : b ∈ 
   (a :: l).remove a = l.remove a := by simp [remove]
 
 lemma remove_cons_of_ne (l : List α) {a b} (ne : a ≠ b) :
-  (a :: l).remove b = a :: l.remove b := by simp_all [remove];
+  (a :: l).remove b = a :: l.remove b := by simp_all [remove]
 
 @[simp] lemma remove_subset (a) (l : List α) :
     l.remove a ⊆ l := by
@@ -767,7 +767,7 @@ lemma remove_map_substet_map_remove [DecidableEq β] (f : α → β) (l : List �
     (l.map f).remove (f a) ⊆ (l.remove a).map f := by
   simp only [subset_def, mem_remove_iff, mem_map, ne_eq, and_imp, forall_exists_index,
     forall_apply_eq_imp_iff₂]
-  intro b hb neb;
+  intro b hb neb
   exact ⟨b, ⟨hb, by rintro rfl; exact neb rfl⟩, rfl⟩
 
 end remove
@@ -778,12 +778,12 @@ lemma induction_with_singleton
   (hnil : motive [])
   (hsingle : ∀ a, motive [a])
   (hcons : ∀ a as, as ≠ [] → motive as → motive (a :: as)) : ∀ as, motive as := by
-  intro as;
+  intro as
   induction as with
-  | nil => exact hnil;
+  | nil => exact hnil
   | cons a as ih => cases as with
-    | nil => exact hsingle a;
-    | cons b bs => exact hcons a (b :: bs) (by simp) ih;
+    | nil => exact hsingle a
+    | cons b bs => exact hcons a (b :: bs) (by simp) ih
 
 @[elab_as_elim]
 def induction_with_singleton'
@@ -1002,7 +1002,7 @@ lemma projection {f : ℕ →. ℕ} (hf : Nat.Partrec f) (unif : ∀ {m n₁ n�
       case some i =>
         suffices i = a ↔ ∃ x < n + 1, Code.evaln s cf (Nat.pair m x) = Option.some a by simpa [hC]
         constructor
-        · rintro rfl;
+        · rintro rfl
           rcases (ih _).mp hC with ⟨x, hx, Hx⟩
           exact ⟨x, lt_trans hx (by simp), Hx⟩
         · rintro ⟨x, _, Hx⟩
@@ -1057,7 +1057,7 @@ lemma projection {f : α → β →. γ} (hf : Partrec₂ f) (unif : ∀ {a b₁
   suffices (∃ c' ∈ g (Encodable.encode a), Encodable.decode c' = some c) ↔ ∃ b, c ∈ f a b by simpa [g']
   constructor
   · rintro ⟨c', h, hc⟩
-    rcases H.mp h with ⟨a, b, ae, c, habc, rfl⟩;
+    rcases H.mp h with ⟨a, b, ae, c, habc, rfl⟩
     rcases by simpa using hc
     rcases Encodable.encode_inj.mp ae
     exact ⟨b, habc⟩


### PR DESCRIPTION
This aligns the codebase with the conventions used in Mathlib.