### PR TITLE
add(ProvabilityLogic): Provability Logic Relativization

### DIFF
--- a/Foundation/ProvabilityLogic/Arithmetic.lean
+++ b/Foundation/ProvabilityLogic/Arithmetic.lean
@@ -7,17 +7,17 @@ import Foundation.FirstOrder.Internal.FixedPoint
 
 namespace LO.FirstOrder
 
-variable (T : ArithmeticTheory) [T.Δ₁]
+variable (T U : ArithmeticTheory) [T.Δ₁]
 
 /-- Provability logic of arithmetic theory-/
-def ArithmeticTheory.ProvabilityLogic : Modal.Logic ℕ := {A | ∀ f : T.StandardRealization, T ⊢!. f A}
+def ArithmeticTheory.ProvabilityLogic : Modal.Logic ℕ := {A | ∀ f : T.StandardRealization, U ⊢!. f A}
 
-variable {T}
+variable {T U}
 
 namespace ArithmeticTheory.ProvabilityLogic
 
 lemma provable_iff :
-    T.ProvabilityLogic ⊢! A ↔ ∀ f : T.StandardRealization, T ⊢!. f A := by
+    ProvabilityLogic T U ⊢! A ↔ ∀ f : T.StandardRealization, U ⊢!. f A := by
   simp [ArithmeticTheory.ProvabilityLogic]
 
 end ArithmeticTheory.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/GL/Completeness.lean
+++ b/Foundation/ProvabilityLogic/GL/Completeness.lean
@@ -11,6 +11,7 @@ open Entailment Entailment.FiniteContext
 open FirstOrder Arithmetic
 open Modal
 open Modal.Kripke
+open ArithmeticTheory (ProvabilityLogic)
 
 variable {T : ArithmeticTheory} [T.Δ₁] [𝗜𝚺₁ ⪯ T] {A : Modal.Formula _}
 
@@ -75,7 +76,7 @@ theorem GL.arithmetical_completeness_sound_iff [T.SoundOnHierarchy 𝚺 1] {A} :
 
 /-- Provability logic of $\Sigma_1$-sound theory contains $\mathsf{I}\Sigma_1$ is $\mathsf{GL}$-/
 theorem provabilityLogic_eq_GL_of_sigma1_sound [T.SoundOnHierarchy 𝚺 1] :
-    T.ProvabilityLogic ≊ Modal.GL := by
+    ProvabilityLogic T T ≊ Modal.GL := by
   apply Logic.iff_equal_provable_equiv.mp
   ext A
   simpa [ArithmeticTheory.ProvabilityLogic] using
@@ -101,12 +102,12 @@ theorem GLPlusBoxBot.arithmetical_completeness_iff :
 
 /-- Provability logic of theory contains $\mathsf{I}\Sigma_1$ is $\mathsf{GL} + \square^{\text{height of } T} \bot$-/
 theorem provabilityLogic_eq_GLPlusBoxBot :
-    T.ProvabilityLogic ≊ Modal.GLPlusBoxBot T.height.toWithTop := by
+    ProvabilityLogic T T ≊ Modal.GLPlusBoxBot T.height.toWithTop := by
   apply Logic.iff_equal_provable_equiv.mp
   ext A
   simpa [ArithmeticTheory.ProvabilityLogic] using
     GLPlusBoxBot.arithmetical_completeness_iff
 
-instance : 𝗣𝗔.ProvabilityLogic ≊ Modal.GL := provabilityLogic_eq_GL_of_sigma1_sound
+instance : ProvabilityLogic 𝗣𝗔 𝗣𝗔 ≊ Modal.GL := provabilityLogic_eq_GL_of_sigma1_sound
 
 end LO.ProvabilityLogic

--- a/Foundation/ProvabilityLogic/S/Completeness.lean
+++ b/Foundation/ProvabilityLogic/S/Completeness.lean
@@ -3,6 +3,7 @@ import Foundation.Modal.Logic.S.Basic
 import Foundation.ProvabilityLogic.GL.Completeness
 import Foundation.ProvabilityLogic.S.Soundness
 import Foundation.Modal.Boxdot.Basic
+import Foundation.FirstOrder.Incompleteness.Tarski
 import Mathlib.Tactic.TFAE
 
 
@@ -16,6 +17,7 @@ open Entailment
 open Modal
 open FirstOrder
 open Provability
+open ArithmeticTheory (ProvabilityLogic)
 
 variable {T₀ T : ArithmeticTheory} [T₀ ⪯ T] [Diagonalization T₀]
          {𝔅 : Provability T₀ T} [𝔅.HBL] [ℕ ⊧ₘ* T] [𝔅.SoundOnModel ℕ]
@@ -152,6 +154,14 @@ lemma GL_S_TFAE :
   tfae_finish;
 
 theorem S.arithmetical_completeness_iff : Modal.S ⊢! A ↔ ∀ f : T.StandardRealization, ℕ ⊧ₘ₀ f A := GL_S_TFAE.out 1 2
+
+theorem provabilityLogic_PA_TA_eq_S :
+    ProvabilityLogic T 𝗧𝗔 ≊ Modal.S := by
+  apply Logic.iff_equal_provable_equiv.mp
+  ext A;
+  simpa [ArithmeticTheory.ProvabilityLogic, FirstOrderTrueArith.provable_iff₀, ←Logic.iff_provable] using S.arithmetical_completeness_iff.symm;
+
+instance : ProvabilityLogic 𝗣𝗔 𝗧𝗔 ≊ Modal.S := provabilityLogic_PA_TA_eq_S
 
 end ProvabilityLogic
 

--- a/Zoo/modal.typ
+++ b/Zoo/modal.typ
@@ -5,6 +5,8 @@
 #let box = $square$
 #let dia = $diamond$
 
+#let ProvLogic(L1, L2) = $upright("PrL")_(#L1)(#L2)$
+
 #let arrows = json("./modal.json").map(((from, to, type)) => {
   if type == "ssub" {
     return strfmt("\"{}\" -> \"{}\"", from, to)
@@ -120,8 +122,12 @@
       "LO.Modal.Triv": $Logic("Triv")$,
       "LO.Modal.Univ": $bot$,
       "LO.Modal.Ver": $Logic("Ver")$,
-      "𝗣𝗔.ProvabilityLogic": [Provability logic of $Theory("PA")$]
+      "𝗣𝗔.ProvabilityLogic 𝗣𝗔": [$ProvLogic(Theory("PA"), Theory("PA"))$],
+      "𝗣𝗔.ProvabilityLogic 𝗧𝗔": [$ProvLogic(Theory("PA"), Theory("TA"))$],
     ),
     width: 980pt,
   )
 ]
+
+Notes:
+- $ProvLogic(T, U)$ is provability logic of $T$ relative to $U$ where $T$ and $U$ are first-order arithmetical theories.


### PR DESCRIPTION
今後の証明可能性論理の分類のことを考えて，

```
def ArithmeticTheory.ProvabilityLogic (T) : Modal.Logic ℕ := {A | ∀ f : T.StandardRealization, T ⊢!. f A}
```

を

```
def ArithmeticTheory.ProvabilityLogic (T U) : Modal.Logic ℕ := {A | ∀ f : T.StandardRealization, U ⊢!. f A}
```

に相対的に扱えるようにした．それに伴って既存の結果をとりあえず `ProvabilityLogic T T` などで置き換えておいたが，何かしらリファクタリング出来るかもしれない．