### PR TITLE
fix(ProvabilityLogic): Remove `instFintypeWorldOfIsFiniteTree`

### DIFF
--- a/Foundation/ProvabilityLogic/Classification/LetterlessTrace.lean
+++ b/Foundation/ProvabilityLogic/Classification/LetterlessTrace.lean
@@ -486,14 +486,14 @@ namespace Kripke
 open Kripke
 open Formula.Kripke
 
-variable {F : Frame} {r : F} [F.IsFiniteTree r]
+variable {F : Frame} {r : F} [F.IsTree r] [Fintype F]
 
 lemma Frame.World.finHeight_lt_of_rel {i j : F} (hij : i ≺ j) : Frame.World.finHeight i > Frame.World.finHeight j := fcwHeight_gt_of hij
 
 lemma Frame.World.exists_of_lt_finHeight {i : F} (hn : n < Frame.World.finHeight i) : ∃ j : F, i ≺ j ∧ Frame.World.finHeight j = n := fcwHeight_lt hn
 
 lemma iff_satisfies_mem_finHeight_spectrum
-  {M : Model} {r : M} [M.IsFiniteTree r] {w : M}
+  {M : Model} {r : M} [Fintype M] [M.IsTree r] {w : M}
   {φ : Formula ℕ} (φ_closed : φ.letterless := by grind)
   : w ⊧ φ ↔ Frame.World.finHeight w ∈ φ.spectrum := by
   induction φ generalizing w with
@@ -545,20 +545,20 @@ end Frame.finiteLinear
 
 lemma spectrum_TFAE (_ : φ.letterless) : [
   n ∈ φ.spectrum,
-  ∀ M : Model, ∀ r, [M.IsFiniteTree r] → ∀ w : M.World, Frame.World.finHeight w = n → w ⊧ φ,
-  ∃ M : Model, ∃ r, ∃ _ : M.IsFiniteTree r, ∃ w : M.World, Frame.World.finHeight w = n ∧ w ⊧ φ
+  ∀ M : Model, ∀ r, [M.IsTree r] → [Fintype M] → ∀ w : M.World, Frame.World.finHeight w = n → w ⊧ φ,
+  ∃ M : Model, ∃ r, ∃ _ : M.IsTree r, ∃ _ : Fintype M, ∃ w : M.World, Frame.World.finHeight w = n ∧ w ⊧ φ
 ].TFAE := by
   tfae_have 1 → 2 := by
-    intro h M r _ w hw;
+    intro h M r _ _ w hw;
     apply iff_satisfies_mem_finHeight_spectrum (by grind) |>.mpr;
     apply hw ▸ h;
   tfae_have 2 → 3 := by
     intro h;
-    refine ⟨⟨Frame.finiteLinear n, λ p i => True⟩, 0, inferInstance, ⟨0, ?_, ?_⟩⟩;
+    refine ⟨⟨Frame.finiteLinear n, λ p i => True⟩, 0, inferInstance, inferInstance, ⟨0, ?_, ?_⟩⟩;
     . simp;
     . apply h; simp;
   tfae_have 3 → 1 := by
-    rintro ⟨M, r, _, w, rfl, hw⟩;
+    rintro ⟨M, r, _, _, w, rfl, hw⟩;
     apply iff_satisfies_mem_finHeight_spectrum (by grind) |>.mp hw;
   tfae_finish;
 
@@ -577,12 +577,13 @@ lemma iff_GL_provable_spectrum_Univ
   constructor;
   . intro h n;
     apply Kripke.spectrum_TFAE (φ := φ) (by grind) |>.out 1 0 |>.mp;
-    intro M r _ w _;
+    intro M r _ _ w _;
     have := GL.Kripke.tree_completeness_TFAE.out 0 2 |>.mp h;
-    apply this M.toFrame r;
+    apply @this M.toFrame r $ by constructor;
   . intro h;
     apply GL.Kripke.tree_completeness_TFAE.out 2 0 |>.mp;
     intro F r _ V w;
+    have : Fintype (⟨F, V⟩ : Kripke.Model).World := Fintype.ofFinite _
     have := Kripke.spectrum_TFAE (φ := φ) (n := Kripke.Frame.World.finHeight w) (by grind) |>.out 0 1 |>.mp;
     apply this (by grind) _ r w rfl;
 

--- a/Foundation/ProvabilityLogic/SolovaySentences.lean
+++ b/Foundation/ProvabilityLogic/SolovaySentences.lean
@@ -19,9 +19,7 @@ namespace LO.Modal.Kripke
 
 section frame
 
-variable {F : Frame} {r : F} [F.IsFiniteTree r]
-
-instance [F.IsFiniteTree r] : Fintype F.World := Fintype.ofFinite (α := F.World)
+variable {F : Frame} [Fintype F] {r : F} [F.IsTree r]
 
 def Frame.World.finHeight (i : F) : ℕ := fcwHeight (· ≺ ·) i
 
@@ -76,8 +74,9 @@ lemma exists_terminal (i : F) : ∃ j, i ≺^[Frame.World.finHeight i] j := le_f
 namespace Frame.extendRoot
 
 @[simp] lemma finHeight_pos : 0 < (F.extendRoot 1).finHeight := by
-  dsimp [finHeight, World.finHeight]
-  convert lt_fcwHeight (R := (F.extendRoot 1).Rel') (n := 0) (a := extendRoot.root) (b := r) (by simp) (by simp);
+  apply lt_fcwHeight ?_ (by simp)
+  · exact Sum.inr r
+  trivial
 
 @[simp] lemma finHeight₁ : (F.extendRoot 1).finHeight = F.finHeight + 1 := by
   let l := World.finHeight (extendRoot.root : F.extendRoot 1)
@@ -116,7 +115,7 @@ end frame
 
 section model
 
-variable {M : Model} {r : M.World} [M.IsFiniteTree r]
+variable {M : Model} {r : M.World} [M.IsFiniteTree r] [Fintype M]
 
 lemma finHeight_lt_iff_satisfies_boxbot {i : M} :
     Frame.World.finHeight i < n ↔ i ⊧ □^[n] ⊥ := by
@@ -147,7 +146,7 @@ variable {L : Language} [L.DecidableEq] [L.ReferenceableBy L]
          {T₀ T : Theory L} [T₀ ⪯ T] (𝔅 : Provability T₀ T) [𝔅.HBL]
          {A B : Modal.Formula _}
 
-structure SolovaySentences (F : Kripke.Frame) (r : F) [F.IsFiniteTree r] where
+structure SolovaySentences (F : Kripke.Frame) (r : F) [F.IsFiniteTree r] [Fintype F] where
   σ : F → Sentence L
   protected SC1 : ∀ i j, i ≠ j → T₀ ⊢!. σ i ➝ ∼σ j
   protected SC2 : ∀ i j, i ≺ j → T₀ ⊢!. σ i ➝ 𝔅.dia (σ j)
@@ -160,9 +159,9 @@ variable {𝔅}
 
 namespace SolovaySentences
 
-instance {F : Kripke.Frame} {r : F} [F.IsFiniteTree r] : CoeFun (SolovaySentences 𝔅 F r) (λ _ => F → Sentence L) := ⟨λ σ => σ.σ⟩
+instance {F : Kripke.Frame} {r : F} [F.IsFiniteTree r] [Fintype F] : CoeFun (SolovaySentences 𝔅 F r) (λ _ => F → Sentence L) := ⟨λ σ => σ.σ⟩
 
-variable {M : Model} {r : M.World} [M.IsFiniteTree r]
+variable {M : Model} {r : M.World} [M.IsFiniteTree r] [Fintype M]
 
 variable (S : SolovaySentences 𝔅 M.toFrame r)
 
@@ -266,7 +265,7 @@ variable {T : ArithmeticTheory} [T.Δ₁]
 
 section frame
 
-variable {F : Kripke.Frame} {r : F} [F.IsFiniteTree r]
+variable {F : Kripke.Frame} {r : F} [F.IsFiniteTree r] [Fintype F]
 
 section model
 


### PR DESCRIPTION
close #553

`SolovaySentences`をもとに戻し，それに伴って`LetterlessTrace`の証明を修正．おそらく大丈夫だと思うが一応レビューしてもらえると助かる．