### PR TITLE
ci: Remove concurrency restriction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   push:
   merge_group:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
キャッシュサイズを大幅に小さくした関係で，もはやあまり1PRに対して1つのworkflowしか走らないというのは特に意味がないのかもしれない．