### PR TITLE
add(Modal): First-Order interpretation

### DIFF
--- a/Foundation/Modal/Forcing/Basic.lean
+++ b/Foundation/Modal/Forcing/Basic.lean
@@ -1,0 +1,39 @@
+module
+
+public import Foundation.FirstOrder.Bootstrapping.DerivabilityCondition
+public import Foundation.Modal.Hilbert.Normal.Basic
+public import Foundation.FirstOrder.SetTheory.Basic
+public import Foundation.FirstOrder.Kripke.Intuitionistic
+public import Foundation.FirstOrder.NegationTranslation.GoedelGentzen
+
+@[expose] public section
+namespace LO
+
+
+structure FirstOrder.Operation (L : FirstOrder.Language) where
+  val : FirstOrder.Sentence L → FirstOrder.Sentence L
+
+namespace FirstOrder.Operation
+
+instance : CoeFun (Operation L) (fun _ ↦ FirstOrder.Sentence L → FirstOrder.Sentence L) := ⟨fun 𝓞 ↦ 𝓞.val⟩
+
+end FirstOrder.Operation
+
+
+namespace Modal
+
+abbrev FirstOrderInterpretation (L : FirstOrder.Language) (α) := α → FirstOrder.Sentence L
+
+namespace Formula
+
+def interpretFO {L α} (𝓞 : FirstOrder.Operation L) (f : FirstOrderInterpretation L α) : Modal.Formula α → FirstOrder.Sentence L
+  | .atom a => f a
+  |       ⊥ => ⊥
+  |   φ ➝ ψ => (φ.interpretFO 𝓞 f) ➝ (ψ.interpretFO 𝓞 f)
+  |      □φ => 𝓞 (φ.interpretFO 𝓞 f)
+
+end Formula
+
+end Modal
+
+end LO


### PR DESCRIPTION
FormalizedFormalLogic/ModalLogic#21

翻訳 `H : Modal.Formula ℕ → FirstOrder.Sentence L` とすると， `H(□φ)` は「任意の強制概念 `P` の任意の `p` で `p ⊩ H(A)`」を表す**一階述語の論理式へ**飛ばさないと定義にならない．また固定してしまうと「適当な強制概念のクラスの中で任意の」みたいな事態を扱う際に困ると思う．
ということを踏まえ現在の`Provability`の用に抽象化して扱ったほうが良いような気がする．どうだろう．