### PR TITLE
chore: fix mathlib/Std deprecation warnings

### DIFF
--- a/Foundation/Logic/Semantics.lean
+++ b/Foundation/Logic/Semantics.lean
@@ -336,7 +336,7 @@ lemma conseq_compact [LogicalConnective F] [Semantics.Tarski M] [DecidableEq F] 
   constructor
   · intro ⟨u, ss, hu⟩
     refine ⟨Finset.erase u (∼φ), by simp [ss],?_⟩
-    simp only [Finset.coe_erase, Set.insert_diff_singleton]
+    simp only [Finset.coe_erase, Set.insert_sdiff_singleton]
     intro h; exact hu (Semantics.Satisfiable.of_subset h (by simp))
   · intro ⟨u, ss, hu⟩
     exact ⟨insert (∼φ) u,

--- a/Foundation/Propositional/Kripke/Completeness.lean
+++ b/Foundation/Propositional/Kripke/Completeness.lean
@@ -88,7 +88,7 @@ private lemma truthlemma.himp
         rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
         . simp only [Finset.coe_eq_empty] at hΔ;
           subst hΔ;
-          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_diff_singleton] at hC ⊢;
+          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_sdiff_singleton] at hC ⊢;
           exact of_O! hC;
         . simp only [Finset.coe_eq_singleton] at hΔ;
           subst hΔ;

--- a/Foundation/Propositional/Kripke/Completeness.lean
+++ b/Foundation/Propositional/Kripke/Completeness.lean
@@ -88,7 +88,7 @@ private lemma truthlemma.himp
         rcases Set.subset_singleton_iff_eq.mp hΔ with (hΔ | hΔ);
         . simp only [Finset.coe_eq_empty] at hΔ;
           subst hΔ;
-          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_sdiff_singleton] at hC ⊢;
+          simp only [Finset.disj_empty, Finset.coe_erase, Set.insert_diff_singleton] at hC ⊢;
           exact of_O! hC;
         . simp only [Finset.coe_eq_singleton] at hΔ;
           subst hΔ;

--- a/Foundation/Semantics/CoherenceSpace/Basic.lean
+++ b/Foundation/Semantics/CoherenceSpace/Basic.lean
@@ -17,8 +17,8 @@ namespace LO
 class CoherenceSpace (α : Type*) where
   /-- A coherence relation -/
   Coherence : α → α → Prop
-  reflexive : Reflexive Coherence
-  symmetric : Symmetric Coherence
+  reflexive : ∀ x, Coherence x x
+  symmetric : ∀ x y, Coherence x y → Coherence y x
 
 namespace CoherenceSpace
 
@@ -28,11 +28,11 @@ variable {α : Type*} [CoherenceSpace α]
 
 instance : Std.Refl (α := α) Coherence := ⟨reflexive⟩
 
-instance : Std.Symm (α := α) Coherence := ⟨symmetric⟩
+instance : Std.Symm (α := α) Coherence := ⟨fun x y ↦ symmetric x y⟩
 
 @[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive x
 
-lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric h
+lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric x y h
 
 @[grind =] lemma Coherence.symm_iff {x y : α} : x ⁐ y ↔ y ⁐ x := ⟨symm, symm⟩
 

--- a/Foundation/Semantics/CoherenceSpace/Basic.lean
+++ b/Foundation/Semantics/CoherenceSpace/Basic.lean
@@ -17,8 +17,8 @@ namespace LO
 class CoherenceSpace (α : Type*) where
   /-- A coherence relation -/
   Coherence : α → α → Prop
-  reflexive : ∀ x, Coherence x x
-  symmetric : ∀ ⦃x y⦄, Coherence x y → Coherence y x
+  reflexive : Std.Refl Coherence
+  symmetric : Std.Symm Coherence
 
 namespace CoherenceSpace
 
@@ -26,13 +26,13 @@ infix:40 " ⁐ " => Coherence
 
 variable {α : Type*} [CoherenceSpace α]
 
-instance : Std.Refl (α := α) Coherence := ⟨reflexive⟩
+instance : Std.Refl (α := α) Coherence := reflexive
 
-instance : Std.Symm (α := α) Coherence := ⟨symmetric⟩
+instance : Std.Symm (α := α) Coherence := symmetric
 
-@[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive x
+@[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive.refl x
 
-lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric h
+lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := symmetric.symm x y
 
 @[grind =] lemma Coherence.symm_iff {x y : α} : x ⁐ y ↔ y ⁐ x := ⟨symm, symm⟩
 
@@ -170,13 +170,13 @@ namespace CoherenceSpace
 
 instance : Bot (CoherenceSpace α) := ⟨{
   Coherence := Eq
-  reflexive := refl
-  symmetric _ _ := symm }⟩
+  reflexive := ⟨refl⟩
+  symmetric := ⟨fun _ _ => symm⟩ }⟩
 
 instance : Top (CoherenceSpace α) := ⟨{
   Coherence _ _ := True
-  reflexive _ := by trivial
-  symmetric _ _ _ := by trivial }⟩
+  reflexive := ⟨fun _ => by trivial⟩
+  symmetric := ⟨fun _ _ _ => by trivial⟩ }⟩
 
 inductive Top
 
@@ -221,12 +221,12 @@ inductive Coherence : αᗮ → αᗮ → Prop
 
 instance : CoherenceSpace αᗮ where
   Coherence p q := Coherence p q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by simp)
-  symmetric p q := by
+    exact Coherence.mk (by simp)⟩
+  symmetric := ⟨fun p q => by
     rintro ⟨h⟩
-    exact Coherence.mk (symm h)
+    exact Coherence.mk (symm h)⟩
 
 lemma coherence_def (p q : αᗮ) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -265,12 +265,12 @@ inductive Coherence : Tensor α β → Tensor α β → Prop
 
 instance : CoherenceSpace (Tensor α β) where
   Coherence p q := Coherence p q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p with ⟨a, b⟩
-    exact Coherence.pair (by rfl) (by rfl)
-  symmetric p q := by
+    exact Coherence.pair (by rfl) (by rfl)⟩
+  symmetric := ⟨fun p q => by
     rintro ⟨ha, hb⟩
-    exact Coherence.pair (symm ha) (symm hb)
+    exact Coherence.pair (symm ha) (symm hb)⟩
 
 lemma coherence_def (p q : Tensor α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -301,12 +301,12 @@ inductive Coherence : Par α β → Par α β → Prop
 
 instance : CoherenceSpace (Par α β) where
   Coherence p q := Coherence p q
-  reflexive p := Coherence.refl _
-  symmetric p q := by
+  reflexive := ⟨fun p => Coherence.refl _⟩
+  symmetric := ⟨fun p q => by
     rintro (h | h | h)
     · exact Coherence.refl _
     · exact Coherence.left (symm h)
-    · exact Coherence.right (symm h)
+    · exact Coherence.right (symm h)⟩
 
 lemma coherence_def (p q : Par α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -339,11 +339,11 @@ inductive ArrowParCoherence : (f g : (i : ι) → ρ i) → Prop
 
 instance arrowPar : CoherenceSpace ((i : ι) → ρ i) where
   Coherence f g := ArrowParCoherence f g
-  reflexive f := ArrowParCoherence.refl f
-  symmetric f g := by
+  reflexive := ⟨fun f => ArrowParCoherence.refl f⟩
+  symmetric := ⟨fun f g => by
     rintro (h | ⟨_, h⟩)
     · exact ArrowParCoherence.refl _
-    · exact ArrowParCoherence.pointwise _ (symm h)
+    · exact ArrowParCoherence.pointwise _ (symm h)⟩
 
 lemma arrowPar_coherence_def (f g : (i : ι) → ρ i) : f ⁐ g ↔ ArrowParCoherence f g := by rfl
 
@@ -398,16 +398,16 @@ inductive Coherence : With α β → With α β → Prop
 /-- An additive conjunction of coherence spaces is also a coherence space -/
 instance : CoherenceSpace (With α β) where
   Coherence p q := Coherence p q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p
     · exact Coherence.inl (by rfl)
-    · exact Coherence.inr (by rfl)
-  symmetric p q := by
+    · exact Coherence.inr (by rfl)⟩
+  symmetric := ⟨fun p q => by
     rintro (h | h | _ | _)
     · exact Coherence.inl (symm h)
     · exact Coherence.inr (symm h)
     · exact Coherence.inr_inl _ _
-    · exact Coherence.inl_inr _ _
+    · exact Coherence.inl_inr _ _⟩
 
 lemma coherence_def (p q : With α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -426,13 +426,13 @@ inductive Coherence : BigWith ρ → BigWith ρ → Prop
 
 instance : CoherenceSpace (BigWith ρ) where
   Coherence p q := p.Coherence q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by rfl)
-  symmetric p q := by
+    exact Coherence.mk (by rfl)⟩
+  symmetric := ⟨fun p q => by
     rintro (h | ⟨_, _, h⟩)
     · exact Coherence.mk (symm h)
-    · exact Coherence.of_ne _ _ (Ne.symm h)
+    · exact Coherence.of_ne _ _ (Ne.symm h)⟩
 
 lemma coherence_def (p q : BigWith ρ) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -454,14 +454,14 @@ inductive Coherence : Plus α β → Plus α β → Prop
 /-- An additive conjunction of coherence spaces is also a coherence space -/
 instance : CoherenceSpace (Plus α β) where
   Coherence p q := Coherence p q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p
     · exact Coherence.inl (by rfl)
-    · exact Coherence.inr (by rfl)
-  symmetric p q := by
+    · exact Coherence.inr (by rfl)⟩
+  symmetric := ⟨fun p q => by
     rintro (h | h)
     · exact Coherence.inl (symm h)
-    · exact Coherence.inr (symm h)
+    · exact Coherence.inr (symm h)⟩
 
 lemma coherence_def (p q : Plus α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -479,12 +479,12 @@ inductive Coherence : BigPlus ρ → BigPlus ρ → Prop
 
 instance : CoherenceSpace (BigPlus ρ) where
   Coherence p q := p.Coherence q
-  reflexive p := by
+  reflexive := ⟨fun p => by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by rfl)
-  symmetric p q := by
+    exact Coherence.mk (by rfl)⟩
+  symmetric := ⟨fun p q => by
     rintro ⟨h⟩
-    exact Coherence.mk (symm h)
+    exact Coherence.mk (symm h)⟩
 
 lemma coherence_def (p q : BigPlus ρ) : p ⁐ q ↔ Coherence p q := by rfl
 

--- a/Foundation/Semantics/CoherenceSpace/Basic.lean
+++ b/Foundation/Semantics/CoherenceSpace/Basic.lean
@@ -18,7 +18,7 @@ class CoherenceSpace (α : Type*) where
   /-- A coherence relation -/
   Coherence : α → α → Prop
   reflexive : ∀ x, Coherence x x
-  symmetric : ∀ x y, Coherence x y → Coherence y x
+  symmetric : ∀ ⦃x y⦄, Coherence x y → Coherence y x
 
 namespace CoherenceSpace
 
@@ -28,11 +28,11 @@ variable {α : Type*} [CoherenceSpace α]
 
 instance : Std.Refl (α := α) Coherence := ⟨reflexive⟩
 
-instance : Std.Symm (α := α) Coherence := ⟨fun x y ↦ symmetric x y⟩
+instance : Std.Symm (α := α) Coherence := ⟨symmetric⟩
 
 @[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive x
 
-lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric x y h
+lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric h
 
 @[grind =] lemma Coherence.symm_iff {x y : α} : x ⁐ y ↔ y ⁐ x := ⟨symm, symm⟩
 

--- a/Foundation/Semantics/CoherenceSpace/Basic.lean
+++ b/Foundation/Semantics/CoherenceSpace/Basic.lean
@@ -17,8 +17,8 @@ namespace LO
 class CoherenceSpace (α : Type*) where
   /-- A coherence relation -/
   Coherence : α → α → Prop
-  reflexive : Std.Refl Coherence
-  symmetric : Std.Symm Coherence
+  reflexive : ∀ x, Coherence x x
+  symmetric : ∀ ⦃x y⦄, Coherence x y → Coherence y x
 
 namespace CoherenceSpace
 
@@ -26,13 +26,13 @@ infix:40 " ⁐ " => Coherence
 
 variable {α : Type*} [CoherenceSpace α]
 
-instance : Std.Refl (α := α) Coherence := reflexive
+instance : Std.Refl (α := α) Coherence := ⟨reflexive⟩
 
-instance : Std.Symm (α := α) Coherence := symmetric
+instance : Std.Symm (α := α) Coherence := ⟨symmetric⟩
 
-@[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive.refl x
+@[simp, refl, grind .] protected lemma Coherence.refl (x : α) : x ⁐ x := reflexive x
 
-lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := symmetric.symm x y
+lemma Coherence.symm {x y : α} : x ⁐ y → y ⁐ x := fun h ↦ symmetric h
 
 @[grind =] lemma Coherence.symm_iff {x y : α} : x ⁐ y ↔ y ⁐ x := ⟨symm, symm⟩
 
@@ -170,13 +170,13 @@ namespace CoherenceSpace
 
 instance : Bot (CoherenceSpace α) := ⟨{
   Coherence := Eq
-  reflexive := ⟨refl⟩
-  symmetric := ⟨fun _ _ => symm⟩ }⟩
+  reflexive := refl
+  symmetric _ _ := symm }⟩
 
 instance : Top (CoherenceSpace α) := ⟨{
   Coherence _ _ := True
-  reflexive := ⟨fun _ => by trivial⟩
-  symmetric := ⟨fun _ _ _ => by trivial⟩ }⟩
+  reflexive _ := by trivial
+  symmetric _ _ _ := by trivial }⟩
 
 inductive Top
 
@@ -221,12 +221,12 @@ inductive Coherence : αᗮ → αᗮ → Prop
 
 instance : CoherenceSpace αᗮ where
   Coherence p q := Coherence p q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by simp)⟩
-  symmetric := ⟨fun p q => by
+    exact Coherence.mk (by simp)
+  symmetric p q := by
     rintro ⟨h⟩
-    exact Coherence.mk (symm h)⟩
+    exact Coherence.mk (symm h)
 
 lemma coherence_def (p q : αᗮ) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -265,12 +265,12 @@ inductive Coherence : Tensor α β → Tensor α β → Prop
 
 instance : CoherenceSpace (Tensor α β) where
   Coherence p q := Coherence p q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p with ⟨a, b⟩
-    exact Coherence.pair (by rfl) (by rfl)⟩
-  symmetric := ⟨fun p q => by
+    exact Coherence.pair (by rfl) (by rfl)
+  symmetric p q := by
     rintro ⟨ha, hb⟩
-    exact Coherence.pair (symm ha) (symm hb)⟩
+    exact Coherence.pair (symm ha) (symm hb)
 
 lemma coherence_def (p q : Tensor α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -301,12 +301,12 @@ inductive Coherence : Par α β → Par α β → Prop
 
 instance : CoherenceSpace (Par α β) where
   Coherence p q := Coherence p q
-  reflexive := ⟨fun p => Coherence.refl _⟩
-  symmetric := ⟨fun p q => by
+  reflexive p := Coherence.refl _
+  symmetric p q := by
     rintro (h | h | h)
     · exact Coherence.refl _
     · exact Coherence.left (symm h)
-    · exact Coherence.right (symm h)⟩
+    · exact Coherence.right (symm h)
 
 lemma coherence_def (p q : Par α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -339,11 +339,11 @@ inductive ArrowParCoherence : (f g : (i : ι) → ρ i) → Prop
 
 instance arrowPar : CoherenceSpace ((i : ι) → ρ i) where
   Coherence f g := ArrowParCoherence f g
-  reflexive := ⟨fun f => ArrowParCoherence.refl f⟩
-  symmetric := ⟨fun f g => by
+  reflexive f := ArrowParCoherence.refl f
+  symmetric f g := by
     rintro (h | ⟨_, h⟩)
     · exact ArrowParCoherence.refl _
-    · exact ArrowParCoherence.pointwise _ (symm h)⟩
+    · exact ArrowParCoherence.pointwise _ (symm h)
 
 lemma arrowPar_coherence_def (f g : (i : ι) → ρ i) : f ⁐ g ↔ ArrowParCoherence f g := by rfl
 
@@ -398,16 +398,16 @@ inductive Coherence : With α β → With α β → Prop
 /-- An additive conjunction of coherence spaces is also a coherence space -/
 instance : CoherenceSpace (With α β) where
   Coherence p q := Coherence p q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p
     · exact Coherence.inl (by rfl)
-    · exact Coherence.inr (by rfl)⟩
-  symmetric := ⟨fun p q => by
+    · exact Coherence.inr (by rfl)
+  symmetric p q := by
     rintro (h | h | _ | _)
     · exact Coherence.inl (symm h)
     · exact Coherence.inr (symm h)
     · exact Coherence.inr_inl _ _
-    · exact Coherence.inl_inr _ _⟩
+    · exact Coherence.inl_inr _ _
 
 lemma coherence_def (p q : With α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -426,13 +426,13 @@ inductive Coherence : BigWith ρ → BigWith ρ → Prop
 
 instance : CoherenceSpace (BigWith ρ) where
   Coherence p q := p.Coherence q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by rfl)⟩
-  symmetric := ⟨fun p q => by
+    exact Coherence.mk (by rfl)
+  symmetric p q := by
     rintro (h | ⟨_, _, h⟩)
     · exact Coherence.mk (symm h)
-    · exact Coherence.of_ne _ _ (Ne.symm h)⟩
+    · exact Coherence.of_ne _ _ (Ne.symm h)
 
 lemma coherence_def (p q : BigWith ρ) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -454,14 +454,14 @@ inductive Coherence : Plus α β → Plus α β → Prop
 /-- An additive conjunction of coherence spaces is also a coherence space -/
 instance : CoherenceSpace (Plus α β) where
   Coherence p q := Coherence p q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p
     · exact Coherence.inl (by rfl)
-    · exact Coherence.inr (by rfl)⟩
-  symmetric := ⟨fun p q => by
+    · exact Coherence.inr (by rfl)
+  symmetric p q := by
     rintro (h | h)
     · exact Coherence.inl (symm h)
-    · exact Coherence.inr (symm h)⟩
+    · exact Coherence.inr (symm h)
 
 lemma coherence_def (p q : Plus α β) : p ⁐ q ↔ Coherence p q := by rfl
 
@@ -479,12 +479,12 @@ inductive Coherence : BigPlus ρ → BigPlus ρ → Prop
 
 instance : CoherenceSpace (BigPlus ρ) where
   Coherence p q := p.Coherence q
-  reflexive := ⟨fun p => by
+  reflexive p := by
     rcases p with ⟨a⟩
-    exact Coherence.mk (by rfl)⟩
-  symmetric := ⟨fun p q => by
+    exact Coherence.mk (by rfl)
+  symmetric p q := by
     rintro ⟨h⟩
-    exact Coherence.mk (symm h)⟩
+    exact Coherence.mk (symm h)
 
 lemma coherence_def (p q : BigPlus ρ) : p ⁐ q ↔ Coherence p q := by rfl
 

--- a/Foundation/Vorspiel/List/ChainI.lean
+++ b/Foundation/Vorspiel/List/ChainI.lean
@@ -49,21 +49,31 @@ lemma cons_cons_iff :
   · rintro ⟨rfl, hR, hC⟩
     exact hC.cons hR
 
-lemma not_mem_of_rel (IR : Irreflexive R) (TR : Transitive R) {a b x : α} {l : List α} : ChainI R a b l → R x a → x ∉ l := by
+lemma not_mem_of_rel (IR : Std.Irrefl R) (TR : IsTrans α R) {a b x : α} {l : List α} : ChainI R a b l → R x a → x ∉ l := by
   match l with
   |      [] => simp
   | a' :: l =>
     rintro (_ | _)
-    case singleton => simp; intro hR; rintro rfl; exact IR _ hR
+    case singleton =>
+      simp
+      intro hR
+      rintro rfl
+      letI := IR
+      exact Std.Irrefl.irrefl _ hR
     case cons a' Raa' h =>
     intro Rxa
-    have : x ≠ a := by rintro rfl; exact IR _ Rxa
+    have : x ≠ a := by
+      rintro rfl
+      letI := IR
+      exact Std.Irrefl.irrefl _ Rxa
     have : x ∉ l :=
-      have : R x a' := TR Rxa Raa'
+      have : R x a' := by
+        letI := TR
+        exact IsTrans.trans _ _ _ Rxa Raa'
       not_mem_of_rel IR TR h this
     simp_all
 
-lemma nodup (IR : Irreflexive R) (TR : Transitive R) {a b l} : ChainI R a b l → l.Nodup :=
+lemma nodup (IR : Std.Irrefl R) (TR : IsTrans α R) {a b l} : ChainI R a b l → l.Nodup :=
   match l with
   |      [] => by simp
   | a' :: l => by
@@ -74,7 +84,7 @@ lemma nodup (IR : Irreflexive R) (TR : Transitive R) {a b l} : ChainI R a b l �
       have notin :a ∉ l := not_mem_of_rel IR TR h Raa'
       simp_all
 
-lemma finite_of_irreflexive_of_transitive [Finite α] (IR : Irreflexive R) (TR : Transitive R) (a b : α) :
+lemma finite_of_irreflexive_of_transitive [Finite α] (IR : Std.Irrefl R) (TR : IsTrans α R) (a b : α) :
     Finite {l : List α // l.ChainI R a b} := by
   haveI : Fintype α := Fintype.ofFinite α
   let f : {l : List α // l.ChainI R a b} → {l : List α // l.Nodup} := fun l ↦ ⟨l, l.prop.nodup IR TR⟩

--- a/Foundation/Vorspiel/List/ChainI.lean
+++ b/Foundation/Vorspiel/List/ChainI.lean
@@ -54,22 +54,12 @@ lemma not_mem_of_rel (IR : Std.Irrefl R) (TR : IsTrans α R) {a b x : α} {l : L
   |      [] => simp
   | a' :: l =>
     rintro (_ | _)
-    case singleton =>
-      simp
-      intro hR
-      rintro rfl
-      letI := IR
-      exact Std.Irrefl.irrefl _ hR
+    case singleton => simp; intro hR; rintro rfl; exact IR.irrefl _ hR
     case cons a' Raa' h =>
     intro Rxa
-    have : x ≠ a := by
-      rintro rfl
-      letI := IR
-      exact Std.Irrefl.irrefl _ Rxa
+    have : x ≠ a := by rintro rfl; exact IR.irrefl _ Rxa
     have : x ∉ l :=
-      have : R x a' := by
-        letI := TR
-        exact IsTrans.trans _ _ _ Rxa Raa'
+      have : R x a' := TR.trans _ _ _ Rxa Raa'
       not_mem_of_rel IR TR h this
     simp_all
 

--- a/Foundation/Vorspiel/Nat/Basic.lean
+++ b/Foundation/Vorspiel/Nat/Basic.lean
@@ -1,7 +1,7 @@
 module
 
 public import Mathlib.Data.Nat.Bits
-public import Mathlib.Data.Nat.Lattice
+public import Mathlib.Order.Lattice.Nat
 public import Mathlib.Data.Nat.Pairing
 public import Mathlib.Tactic.Cases
 


### PR DESCRIPTION
## What

Silence current mathlib/Std deprecation warnings in Foundation:

- `Set.insert_diff_singleton` → `Set.insert_sdiff_singleton` (`Logic/Semantics`)
- `Irreflexive`/`Transitive` → `Std.Irrefl`/`IsTrans` (`Vorspiel/List/ChainI`)
- `Reflexive`/`Symmetric Coherence` → raw `∀`-forms (`∀ x`, `∀ ⦃x y⦄`) + `Std.Refl`/`Std.Symm` instances (`Semantics/CoherenceSpace/Basic`)
- `import Mathlib.Data.Nat.Lattice` → `Mathlib.Order.Lattice.Nat` (`Vorspiel/Nat/Basic`)

Pure API-rename cleanup - no change in what's proved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

