### PR TITLE
add(Incompleteness): First incompleteness theorem from the halting problem

### DIFF
--- a/Foundation/FirstOrder/Incompleteness/Halting.lean
+++ b/Foundation/FirstOrder/Incompleteness/Halting.lean
@@ -56,24 +56,49 @@ lemma incomplete_of_REPred_not_ComputablePred_Nat
   use φ/[⌜a⌝];
   constructor <;> assumption;
 
-/-
-lemma _root_.REPred.iff_decoded_pred {A : α → Prop} [Primcodable α] : REPred A ↔ REPred λ n : ℕ ↦ match Encodable.decode n with | some a => A a | none => False := by
-  sorry;
-
-lemma _root_.ComputablePred.iff_decoded_pred {A : α → Prop} [h : Primcodable α] : ComputablePred A ↔ ComputablePred λ n : ℕ ↦ match Encodable.decode n with | some a => A a | none => False := by
-  sorry;
-
-lemma incomplete_of_REPred_not_ComputablePred₂ {P : α → Prop} [h : Primcodable α] (hRE : REPred P) (hC : ¬ComputablePred P) : ¬Entailment.Complete (T : Axiom ℒₒᵣ) := by
-  apply incomplete_of_REPred_not_ComputablePred (P := λ n : ℕ ↦ match h.decode n with | some a => P a | none => False);
-  . exact REPred.iff_decoded_pred.mp hRE;
-  . exact ComputablePred.iff_decoded_pred.not.mp hC;
+/--
+  Recursive enumerability of a predicate on a `Primcodable` type is equivalent to
+  the recursive enumerability of the corresponding predicate on `ℕ` obtained by decoding.
+-/
+lemma _root_.REPred.iff_decoded_pred {α : Type*} [Primcodable α] {A : α → Prop} :
+    REPred A ↔ REPred fun n : ℕ ↦ (Encodable.decode (α := α) n).elim False A := by
+  constructor
+  · intro hA
+    have hbind : Partrec fun n : ℕ =>
+        (Encodable.decode (α := α) n : Part α).bind
+          fun a => Part.assert (A a) fun _ => Part.some () :=
+      (Computable.ofOption Computable.decode).bind (hA.comp Computable.snd).to₂
+    refine (Partrec.dom_re hbind).of_eq fun n => ?_
+    rcases h : Encodable.decode (α := α) n with _ | a <;> simp [Part.assert]
+  · intro hg
+    refine REPred.of_eq (p := fun a => (Encodable.decode (α := α) (Encodable.encode a)).elim False A)
+      (hg.comp Computable.encode) fun a => ?_
+    simp [Encodable.encodek]
 
 /--
-  Halting problem is r.e. but not recursive, so Gödel's first incompleteness theorem follows.
+  Computability of a predicate on a `Primcodable` type is equivalent to
+  the computability of the corresponding predicate on `ℕ` obtained by decoding.
 -/
-theorem incomplete_of_halting_problem : ¬Entailment.Complete (T : Axiom ℒₒᵣ) := incomplete_of_REPred_not_ComputablePred₂
-  (ComputablePred.halting_problem_re 0)
-  (ComputablePred.halting_problem _)
+lemma _root_.ComputablePred.iff_decoded_pred {α : Type*} [Primcodable α] {A : α → Prop} :
+    ComputablePred A ↔ ComputablePred fun n : ℕ ↦ (Encodable.decode (α := α) n).elim False A := by
+  sorry
+
+/--
+  If an r.e. but not recursive predicate `P` on a `Primcodable` type exists, then incompleteness follows.
 -/
+lemma incomplete_of_REPred_not_ComputablePred {α : Type*} [Primcodable α] {P : α → Prop}
+    (hRE : REPred P) (hC : ¬ComputablePred P) : Entailment.Incomplete T := by
+  apply incomplete_of_REPred_not_ComputablePred_Nat T
+    (P := fun n : ℕ ↦ (Encodable.decode (α := α) n).elim False P)
+  · exact REPred.iff_decoded_pred.mp hRE
+  · exact ComputablePred.iff_decoded_pred.not.mp hC
+
+/--
+  The halting problem is r.e. but not recursive, so Gödel's first incompleteness theorem follows.
+-/
+theorem incomplete_of_halting_problem : Entailment.Incomplete T :=
+  incomplete_of_REPred_not_ComputablePred T
+    (ComputablePred.halting_problem_re 0)
+    (ComputablePred.halting_problem 0)
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Incompleteness/Halting.lean
+++ b/Foundation/FirstOrder/Incompleteness/Halting.lean
@@ -81,7 +81,22 @@ lemma _root_.REPred.iff_decoded_pred {α : Type*} [Primcodable α] {A : α → P
 -/
 lemma _root_.ComputablePred.iff_decoded_pred {α : Type*} [Primcodable α] {A : α → Prop} :
     ComputablePred A ↔ ComputablePred fun n : ℕ ↦ (Encodable.decode (α := α) n).elim False A := by
-  sorry
+  constructor
+  · intro hA
+    refine computablePred_iff_computable_decide.mpr ?_
+    have hcomp := Computable.option_casesOn (o := fun n : ℕ => Encodable.decode (α := α) n)
+      (f := fun _ => false) (g := fun _ a => decide (A a))
+      Computable.decode (Computable.const false) (hA.decide.comp Computable.snd)
+    refine hcomp.of_eq fun n => ?_
+    rcases h : Encodable.decode (α := α) n with _ | a <;> simp
+  · intro hg
+    have hdec : Computable fun a : α =>
+        decide ((Encodable.decode (α := α) (Encodable.encode a)).elim False A) :=
+      hg.decide.comp Computable.encode
+    refine ComputablePred.of_eq
+      (p := fun a => (Encodable.decode (α := α) (Encodable.encode a)).elim False A)
+      (computablePred_iff_computable_decide.mpr hdec) fun a => ?_
+    simp [Encodable.encodek]
 
 /--
   If an r.e. but not recursive predicate `P` on a `Primcodable` type exists, then incompleteness follows.


### PR DESCRIPTION
Derives Gödel's first incompleteness theorem from the undecidability of the halting problem, completing the work started (and abandoned) in #508.

## Changes
`Foundation/FirstOrder/Incompleteness/Halting.lean`:
- `REPred.iff_decoded_pred` / `ComputablePred.iff_decoded_pred`: for a `Primcodable` type `α`, r.e.-ness / computability of a predicate `A : α → Prop` is equivalent to that of the corresponding `ℕ`-predicate obtained via `decode`. Pure mathlib computability lemmas (composition with `decode`/`encode`).
- `incomplete_of_REPred_not_ComputablePred`: `Primcodable` generalization of the existing `incomplete_of_REPred_not_ComputablePred_Nat`. Needed because the halting predicate lives over `Nat.Partrec.Code`, not `ℕ`.
- `incomplete_of_halting_problem`: the halting problem is r.e. but not recursive (`ComputablePred.halting_problem_re` / `ComputablePred.halting_problem`), hence incompleteness.

The core diagonalization lemma `incomplete_of_REPred_not_ComputablePred_Nat` already exists on `master`.

## Verification
- `lake build Foundation.FirstOrder.Incompleteness.Halting` succeeds (forced rebuild), no errors/warnings/`sorry`.
- `incomplete_of_halting_problem` depends only on `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no custom axioms).

Supersedes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)