### PR TITLE
fix: rename `fcwHeight` to `cwfHeight`

### DIFF
--- a/Foundation/Modal/Kripke/Rank.lean
+++ b/Foundation/Modal/Kripke/Rank.lean
@@ -13,15 +13,15 @@ namespace Kripke
 variable {φ ψ : Formula ℕ}
          {F : Frame} [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] {x y i j : F}
 
-def Frame.rank [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] (i : F) : ℕ := fcwHeight (· ≺ ·) i
+def Frame.rank [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] (i : F) : ℕ := cwfHeight (· ≺ ·) i
 
 def Frame.height (F : Frame) [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] [F.IsRooted] : ℕ := Frame.rank F.root.1
 
 namespace Frame
 
-lemma rank_lt_of_rel (hij : i ≺ j) : F.rank i > Frame.rank j := fcwHeight_gt_of hij
+lemma rank_lt_of_rel (hij : i ≺ j) : F.rank i > Frame.rank j := cwfHeight_gt_of hij
 
-lemma exists_of_lt_height (hn : n < F.rank i) : ∃ j : F, i ≺ j ∧ Frame.rank j = n := fcwHeight_lt hn
+lemma exists_of_lt_height (hn : n < F.rank i) : ∃ j : F, i ≺ j ∧ Frame.rank j = n := cwfHeight_lt hn
 
 lemma height_lt_iff_relItr {i : F} :
     F.rank i < n ↔ ∀ j, ¬i ≺^[n] j  := by
@@ -37,8 +37,8 @@ lemma height_lt_iff_relItr {i : F} :
         _ ↔ ∀ k j, i ≺ j → ¬j ≺^[n] k    := by grind
         _ ↔ ∀ j, ¬i ≺^[n + 1] j  := by simp
     constructor
-    · exact fun h j hij ↦ lt_of_lt_of_le (fcwHeight_gt_of hij) h
-    · exact fcwHeight_le
+    · exact fun h j hij ↦ lt_of_lt_of_le (cwfHeight_gt_of hij) h
+    · exact cwfHeight_le
 
 lemma le_height_iff_relItr {i : F} :
     n ≤ F.rank i ↔ ∃ j, i ≺^[n] j := calc
@@ -64,7 +64,7 @@ lemma terminal_rel_height (h : x ≺^[rank x] y) : ∀ z, ¬y ≺ z := by
 variable [F.IsRooted]
 
 @[grind <=]
-lemma rank_lt_whole_height {i : F} (hi : F.root ≺ i) : F.rank i < F.height := fcwHeight_gt_of hi
+lemma rank_lt_whole_height {i : F} (hi : F.root ≺ i) : F.rank i < F.height := cwfHeight_gt_of hi
 
 @[grind .]
 lemma rank_le_whole_height (i : F) : F.rank i ≤ F.height := by
@@ -92,7 +92,7 @@ lemma eq_extendRoot_height_rank_extendRoot_root : (F.extendRoot n).height = Fram
 @[simp]
 lemma height_pos : 0 < (Frame.extendRoot F n).height := by
   rw [eq_extendRoot_height_rank_extendRoot_root];
-  apply lt_fcwHeight ?_ (by simp);
+  apply lt_cwfHeight ?_ (by simp);
   · exact ↑F.root.1;
   . simp only [Frame.Rel', Frame.root, default];
 
@@ -202,7 +202,7 @@ lemma height_lt_iff_satisfies_boxbot {i : M} :
 lemma height_pos_of_dia {i : M} (hA : i ⊧ ◇A) : 0 < M.rank i := by
   have : ∃ j, i ≺ j ∧ j ⊧ A := Formula.Kripke.Satisfies.dia_def.mp hA
   rcases this with ⟨j, hj, _⟩
-  apply lt_fcwHeight hj (by simp)
+  apply lt_cwfHeight hj (by simp)
 
 @[simp]
 lemma Model.extendRoot.height₁ [M.IsRooted] : (Frame.extendRoot M.toFrame 1).height = (M.height) + 1 := Frame.extendRoot.height_succ

--- a/Foundation/Modal/Logic/D/Basic.lean
+++ b/Foundation/Modal/Logic/D/Basic.lean
@@ -152,12 +152,8 @@ noncomputable abbrev Formula.dzSubformula (φ : Formula ℕ) := (□⁻¹'φ.sub
 
 namespace Kripke
 
-instance {F : Frame} [F.IsFinite] [F.IsIrreflexive] [F.IsTransitive] : F.IsConverseWellFounded := ⟨by
-  apply Finite.converseWellFounded_of_trans_irrefl';
-  . infer_instance;
-  . intro x y z; apply F.trans;
-  . intro x; apply F.irrefl;
-⟩
+instance {F : Frame} [F.IsFinite] [F.IsIrreflexive] [F.IsTransitive] : F.IsConverseWellFounded :=
+  ⟨Finite.converseWellFounded_of_trans_of_irrefl⟩
 
 namespace Model
 

--- a/Foundation/Vorspiel/Rel/CWF.lean
+++ b/Foundation/Vorspiel/Rel/CWF.lean
@@ -29,17 +29,13 @@ lemma ConverseWellFounded.iff_has_max : ConverseWellFounded R ↔ (∀ (s : Set 
 lemma ConverseWellFounded.has_max (h : ConverseWellFounded R) : ∀ (s : Set α), Set.Nonempty s → ∃ m ∈ s, ∀ x ∈ s, ¬(R m x) := by
   apply ConverseWellFounded.iff_has_max.mp h;
 
-instance [Finite α] [IsTrans α R] [Std.Irrefl R] : IsConverseWellFounded _ R := ⟨by
+theorem Finite.converseWellFounded_of_trans_of_irrefl [Finite α] [IsTrans α R] [Std.Irrefl R] : ConverseWellFounded R := by
   apply @Finite.wellFounded_of_trans_of_irrefl _ _ _
     ⟨by intro a b c rba rcb; exact IsTrans.trans c b a rcb rba⟩
     ⟨by simp [flip, Std.Irrefl.irrefl]⟩
-⟩
 
-lemma Finite.converseWellFounded_of_trans_irrefl'
-    (hFinite : Finite α) (hTrans : Transitive R) (hIrrefl : Irreflexive R) : ConverseWellFounded R :=
-  @Finite.wellFounded_of_trans_of_irrefl _ _ _
-    ⟨by simp [flip]; intro a b c ba cb; exact hTrans cb ba;⟩
-    ⟨by simp [flip]; exact hIrrefl⟩
+instance [Finite α] [IsTrans α R] [Std.Irrefl R] : IsConverseWellFounded _ R :=
+  ⟨Finite.converseWellFounded_of_trans_of_irrefl⟩
 
 namespace IsConverseWellFounded
 
@@ -51,114 +47,133 @@ end IsConverseWellFounded
 variable (R)
 
 open Classical in
-noncomputable def fcwHeight [IsConverseWellFounded α R] [Fintype α] : α → ℕ :=
+noncomputable def cwfHeight [IsConverseWellFounded α R] [Fintype α] : α → ℕ :=
   WellFounded.fix (r := flip R) (C := fun _ ↦ ℕ) IsConverseWellFounded.cwf fun x ih ↦
     Finset.univ.sup fun y : {y : α // R x y} ↦ ih y y.prop + 1
 
 variable {R}
 
-section fcwHeight
+section cwfHeight
 
 variable [Fintype α] [IsConverseWellFounded α R]
 
 open Classical
 
-lemma fcwHeight_eq (a : α) :
-    fcwHeight R a = Finset.sup {x : α | R a x} (fun b ↦ fcwHeight R b + 1) := by
-  have h : fcwHeight R a = Finset.univ.sup fun b : {y : α // R a y} ↦ fcwHeight R b + 1 :=
+lemma cwfHeight_eq (a : α) :
+    cwfHeight R a = Finset.sup {x : α | R a x} (fun b ↦ cwfHeight R b + 1) := by
+  have h : cwfHeight R a = Finset.univ.sup fun b : {y : α // R a y} ↦ cwfHeight R b + 1 :=
     WellFounded.fix_eq _ _ a
   suffices
-    Finset.univ.sup (fun b : {y : α // R a y} ↦ fcwHeight R b + 1) =
-    Finset.sup {y : α | R a y} fun b ↦ fcwHeight R b + 1 from h.trans this
+    Finset.univ.sup (fun b : {y : α // R a y} ↦ cwfHeight R b + 1) =
+    Finset.sup {y : α | R a y} fun b ↦ cwfHeight R b + 1 from h.trans this
   apply eq_of_le_of_ge
   · apply Finset.sup_le
     intro b _
-    exact Finset.le_sup (f := fun b ↦ fcwHeight R b + 1) (by simp [b.prop])
+    exact Finset.le_sup (f := fun b ↦ cwfHeight R b + 1) (by simp [b.prop])
   · apply Finset.sup_le
     intro b hb
-    simpa using Finset.le_sup (f := fun b : {y : α // R a y} ↦ fcwHeight R b + 1)
+    simpa using Finset.le_sup (f := fun b : {y : α // R a y} ↦ cwfHeight R b + 1)
       (b := ⟨b, by simpa using hb⟩) (s := Finset.univ) (by simp)
 
-lemma fcwHeight_gt_of {a b} :
-    R a b → fcwHeight R a > fcwHeight R b := fun h ↦ calc
-  fcwHeight R a = Finset.sup {x : α | R a x} fun b ↦ fcwHeight R b + 1 := fcwHeight_eq a
-  _               ≥ fcwHeight R b + 1 := Finset.le_sup (f := fun b ↦ fcwHeight R b + 1) (by simp [h])
+lemma cwfHeight_gt_of {a b} :
+    R a b → cwfHeight R a > cwfHeight R b := fun h ↦ calc
+  cwfHeight R a = Finset.sup {x : α | R a x} fun b ↦ cwfHeight R b + 1 := cwfHeight_eq a
+  _               ≥ cwfHeight R b + 1 := Finset.le_sup (f := fun b ↦ cwfHeight R b + 1) (by simp [h])
 
-lemma fcwHeight_eq_zero_iff {a : α} :
-    fcwHeight R a = 0 ↔ ∀ b, ¬R a b := by
+lemma cwfHeight_eq_zero_iff {a : α} :
+    cwfHeight R a = 0 ↔ ∀ b, ¬R a b := by
   constructor
   · intro h b hb
-    have : fcwHeight R a > fcwHeight R b := fcwHeight_gt_of hb
-    exact Nat.not_succ_le_zero (fcwHeight R b) (h ▸ this)
+    have : cwfHeight R a > cwfHeight R b := cwfHeight_gt_of hb
+    exact Nat.not_succ_le_zero (cwfHeight R b) (h ▸ this)
   · intro ha
     apply Nat.eq_zero_of_le_zero
     calc
-      fcwHeight R a = Finset.sup {x : α | R a x} fun b ↦ fcwHeight R b + 1 := fcwHeight_eq a
+      cwfHeight R a = Finset.sup {x : α | R a x} fun b ↦ cwfHeight R b + 1 := cwfHeight_eq a
       _               ≤ 0 := Finset.sup_le fun b hb ↦ False.elim <| ha b (by simpa using hb)
 
-lemma fcwHeight_le {a : α}
-    (h : ∀ b, R a b → fcwHeight R b < n) : fcwHeight R a ≤ n := by
-  rw [fcwHeight_eq]
+lemma cwfHeight_le {a : α}
+    (h : ∀ b, R a b → cwfHeight R b < n) : cwfHeight R a ≤ n := by
+  rw [cwfHeight_eq]
   apply Finset.sup_le
   intro b hab
   exact h b (by simpa using hab)
 
-lemma lt_fcwHeight {a : α} (hb : R a b) (h : n ≤ fcwHeight R b) : n < fcwHeight R a := by
-  have : fcwHeight R b < fcwHeight R a := by
+lemma lt_cwfHeight {a : α} (hb : R a b) (h : n ≤ cwfHeight R b) : n < cwfHeight R a := by
+  have : cwfHeight R b < cwfHeight R a := by
     apply Nat.lt_of_succ_le
-    rw [fcwHeight_eq a]
+    rw [cwfHeight_eq a]
     exact Finset.le_sup (s := {x : α | R a x})
-      (f := fun b ↦ fcwHeight R b + 1) (b := b) (by simp [hb])
+      (f := fun b ↦ cwfHeight R b + 1) (b := b) (by simp [hb])
   exact lt_of_le_of_lt h this
 
-lemma fcwHeight_eq_of_lt_of_le {a : α}
-    (hR : ∀ b, R a b → fcwHeight R b < n) (h : ∃ b, R a b ∧ n ≤ fcwHeight R b + 1) : fcwHeight R a = n := by
-  suffices fcwHeight R a ≤ n ∧ fcwHeight R a ≥ n from Nat.eq_iff_le_and_ge.mpr this
+lemma cwfHeight_eq_of_lt_of_le {a : α}
+    (hR : ∀ b, R a b → cwfHeight R b < n) (h : ∃ b, R a b ∧ n ≤ cwfHeight R b + 1) : cwfHeight R a = n := by
+  suffices cwfHeight R a ≤ n ∧ cwfHeight R a ≥ n from Nat.eq_iff_le_and_ge.mpr this
   constructor
-  · exact fcwHeight_le hR
+  · exact cwfHeight_le hR
   · rcases h with ⟨b, hb, hn⟩
-    suffices n - 1 < fcwHeight R a from Nat.le_of_pred_lt this
-    apply lt_fcwHeight hb
+    suffices n - 1 < cwfHeight R a from Nat.le_of_pred_lt this
+    apply lt_cwfHeight hb
     exact Nat.sub_le_of_le_add hn
 
-lemma fcwHeight_eq_succ {a : α} (h : fcwHeight R a ≠ 0) :
-    ∃ b, R a b ∧ fcwHeight R a = fcwHeight R b + 1 := by
+lemma cwfHeight_eq_succ {a : α} (h : cwfHeight R a ≠ 0) :
+    ∃ b, R a b ∧ cwfHeight R a = cwfHeight R b + 1 := by
   have : ∃ b, R a b := by
     by_contra A
-    have : fcwHeight R a = 0 := fcwHeight_eq_zero_iff.mpr <| by simpa using A
+    have : cwfHeight R a = 0 := cwfHeight_eq_zero_iff.mpr <| by simpa using A
     simp_all
   have : ({x : α | R a x} : Finset α).Nonempty := by simpa [Finset.filter_nonempty_iff] using this
-  simpa [fcwHeight_eq (R := R) a] using Finset.exists_mem_eq_sup _ this (fun b ↦ fcwHeight R b + 1)
+  simpa [cwfHeight_eq (R := R) a] using Finset.exists_mem_eq_sup _ this (fun b ↦ cwfHeight R b + 1)
 
-lemma fcwHeight_eq_succ_fcwHeight {a b : α} (h : R a b) (hb : ∀ c, R a c → R b c ∨ b = c) :
-    fcwHeight R a = fcwHeight R b + 1 := by
-  apply fcwHeight_eq_of_lt_of_le
+lemma cwfHeight_eq_succ_cwfHeight {a b : α} (h : R a b) (hb : ∀ c, R a c → R b c ∨ b = c) :
+    cwfHeight R a = cwfHeight R b + 1 := by
+  apply cwfHeight_eq_of_lt_of_le
   · intro c Rac
     rcases hb c Rac with (Rbc | rfl)
-    · suffices fcwHeight R c < fcwHeight R b from Nat.lt_add_right 1 this
-      exact fcwHeight_gt_of Rbc
+    · suffices cwfHeight R c < cwfHeight R b from Nat.lt_add_right 1 this
+      exact cwfHeight_gt_of Rbc
     · simp
   · use b
 
-lemma fcwHeight_lt [IsTrans α R] {a : α} :
-    ∀ {n}, n < fcwHeight R a → ∃ b, R a b ∧ fcwHeight R b = n := by
+lemma cwfHeight_lt [IsTrans α R] {a : α} :
+    ∀ {n}, n < cwfHeight R a → ∃ b, R a b ∧ cwfHeight R b = n := by
   apply WellFounded.induction (r := flip R) IsConverseWellFounded.cwf a
   intro a ih
-  rcases ha : fcwHeight R a with (_ | n)
+  rcases ha : cwfHeight R a with (_ | n)
   · simp
   · intro k hk
-    have : ∃ b, R a b ∧ fcwHeight R b = n := by
-      rcases fcwHeight_eq_succ (R := R) (a := a) (by simp [ha]) with ⟨b, hb, e⟩
+    have : ∃ b, R a b ∧ cwfHeight R b = n := by
+      rcases cwfHeight_eq_succ (R := R) (a := a) (by simp [ha]) with ⟨b, hb, e⟩
       exact ⟨b, hb, by grind⟩
     rcases this with ⟨b, hb, rfl⟩
-    have : k = fcwHeight R b ∨ k < fcwHeight R b := Nat.eq_or_lt_of_le <| Nat.le_of_lt_succ hk
+    have : k = cwfHeight R b ∨ k < cwfHeight R b := Nat.eq_or_lt_of_le <| Nat.le_of_lt_succ hk
     rcases this with (rfl | hk)
     · exact ⟨b, hb, rfl⟩
-    · have : ∃ c, R b c ∧ fcwHeight R c = k := ih b hb hk
+    · have : ∃ c, R b c ∧ cwfHeight R c = k := ih b hb hk
       rcases this with ⟨c, hc, rfl⟩
       exact ⟨c, IsTrans.trans _ _ _ hb hc, rfl⟩
 
-end fcwHeight
+/-- `cwfHeight` is invariant under an equivalence of relations: if `f : α ≃ β` carries `R`
+to `R'`, then the heights of corresponding points agree. -/
+lemma cwfHeight_congr {β} [Fintype β] {R' : Rel β β} [IsConverseWellFounded β R']
+    (f : α ≃ β) (hf : ∀ a b, R a b ↔ R' (f a) (f b)) (a : α) :
+    cwfHeight R a = cwfHeight R' (f a) := by
+  apply WellFounded.induction (r := flip R) IsConverseWellFounded.cwf a
+  intro a ih
+  apply le_antisymm
+  · apply cwfHeight_le
+    intro b hab
+    rw [ih b hab]
+    exact cwfHeight_gt_of ((hf a b).mp hab)
+  · apply cwfHeight_le
+    intro b' hab'
+    obtain ⟨b, rfl⟩ := f.surjective b'
+    have hab : R a b := (hf a b).mpr hab'
+    rw [← ih b hab]
+    exact cwfHeight_gt_of hab
+
+end cwfHeight
 
 end
 


### PR DESCRIPTION
## Summary

- `fcwHeight` was a naming mistake; the correct name (an acronym of `ConverseWellFounded`) is `cwfHeight`. Ported the fix from [FormalizedFormalLogic/ProvabilityLogic's `SeqPL/Vorspiel/CWF.lean`](https://github.com/FormalizedFormalLogic/ProvabilityLogic/blob/main/SeqPL/Vorspiel/CWF.lean).
- Renamed `fcwHeight` and all related lemmas (`fcwHeight_eq_succ_fcwHeight` → `cwfHeight_eq_succ_cwfHeight`, etc.) in `Foundation/Vorspiel/Rel/CWF.lean`.
- Split `Finite.converseWellFounded_of_trans_irrefl'` (explicit `Transitive`/`Irreflexive` args) into `Finite.converseWellFounded_of_trans_of_irrefl` (instance args, matching the ported design), keeping the existing `IsConverseWellFounded`-deriving `instance` as a thin wrapper since other call sites (e.g. `ExtendRoot.lean`'s `infer_instance`) rely on it.
- Ported `cwfHeight_congr` (invariance of `cwfHeight` under a relation-preserving equivalence).
- Updated call sites: `Foundation/Modal/Kripke/Rank.lean` (renamed `fcwHeight` usages) and `Foundation/Modal/Logic/D/Basic.lean` (simplified to use the new theorem directly).

Not ported: the upstream `instance [Std.Irrefl (flip R)] : Std.Irrefl R` and `ConverseWellFounded.irrefl` lemma. The former caused typeclass-search timeouts elsewhere in this repo's larger Kripke-frame hierarchy (`Foundation/Modal/Kripke/Root.lean`), and the latter hijacked existing dot-notation resolution (`F.cwf.irrefl.swap` in `AxiomL.lean`). Neither is needed for the rename fix.

## Test plan

- [x] `lake build` succeeds for the full project (1664 jobs)
- [x] `lake exe mk_all --module` run (no update necessary)