### PR TITLE
fix: resolve all linter.overlappingInstances warnings

### DIFF
--- a/Foundation/FirstOrder/Basic/Semantics/Elementary.lean
+++ b/Foundation/FirstOrder/Basic/Semantics/Elementary.lean
@@ -145,7 +145,7 @@ instance : SetLike (ClosedSubset L M) M := ⟨ClosedSubset.domain, fun _ _ ↦ C
 omit [Nonempty M]
 lemma closed {k} (f : L.Func k) {v : Fin k → M} (hv : ∀ i, v i ∈ u) : s.func f v ∈ u := u.domain_closed f hv
 
-instance toStructure [s : Structure L M] (u : ClosedSubset L M) : Structure L u where
+instance toStructure (u : ClosedSubset L M) : Structure L u where
   func := fun k f v => ⟨s.func f (fun i ↦ ↑(v i)), u.closed f (by simp)⟩
   rel := fun k r v => s.rel r (fun i ↦ v i)
 

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
@@ -181,7 +181,7 @@ variable
   [L.ReferenceableBy L]
   {T₀ T : Theory L} [Diagonalization T₀] {𝔅 : Provability T₀ T}
 
-def gödel [L.ReferenceableBy L] {T₀ T : Theory L} [Diagonalization T₀] (𝔅 : Provability T₀ T) : Sentence L :=
+def gödel (𝔅 : Provability T₀ T) : Sentence L :=
   fixedpoint T₀ “x. ¬!𝔅.prov x”
 
 lemma gödel_spec : T₀ ⊢ (gödel 𝔅) 🡘 ∼𝔅 (gödel 𝔅) := by simpa [gödel, Provability.pr] using diag “x. ¬!𝔅.prov x”;
@@ -264,7 +264,7 @@ end Second
 
 section Löb
 
-def kreisel [Diagonalization T₀] (𝔅 : Provability T₀ T) (σ : Sentence L) : Sentence L := fixedpoint T₀ “x. !𝔅.prov x → !σ”
+def kreisel (𝔅 : Provability T₀ T) (σ : Sentence L) : Sentence L := fixedpoint T₀ “x. !𝔅.prov x → !σ”
 
 variable {σ : Sentence L}
 

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
@@ -49,7 +49,7 @@ variable
   {𝔚 : Refutability T₀ T}
 
 /-- This sentence is refutable. -/
-def jeroslow (𝔚 : Refutability T₀ T) [Diagonalization T₀] : Sentence L := fixedpoint T₀ 𝔚.refu
+def jeroslow (𝔚 : Refutability T₀ T) : Sentence L := fixedpoint T₀ 𝔚.refu
 
 lemma jeroslow_def : T₀ ⊢ jeroslow 𝔚 🡘 𝔚 (jeroslow 𝔚) := Diagonalization.diag _
 

--- a/Foundation/FirstOrder/Incompleteness/RosserProvability.lean
+++ b/Foundation/FirstOrder/Incompleteness/RosserProvability.lean
@@ -131,7 +131,7 @@ instance : T.rosserProvability.Rosser := ⟨rosserProvable_rosser⟩
 
 lemma rosserProvability_def (σ : Sentence L) : T.rosserProvability σ = T.rosserPred σ := rfl
 
-instance [T.Δ₁] : T.rosserProvability.SoundOn ℕ := by
+instance : T.rosserProvability.SoundOn ℕ := by
   constructor;
   intro σ h;
   apply Bootstrapping.provable_iff_provable.mp

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability.lean
@@ -45,7 +45,7 @@ instance : T.standardProvability.HBL2 := ⟨provable_D2⟩
 
 lemma standardProvability_def (σ : Sentence L) : T.standardProvability σ = provabilityPred T σ := rfl
 
-instance [T.Δ₁] : T.standardProvability.SoundOn ℕ :=
+instance : T.standardProvability.SoundOn ℕ :=
   ⟨fun h ↦ by simpa [Arithmetic.standardProvability_def, models_iff] using h⟩
 
 end

--- a/Foundation/FirstOrder/Skolemization/Hull.lean
+++ b/Foundation/FirstOrder/Skolemization/Hull.lean
@@ -154,7 +154,7 @@ variable [Operator.Mem L] [Membership M M] [Structure.Mem L M]
 instance (priority := 50) membership :
   Membership (SkolemHull L s) (SkolemHull L s) := ⟨fun y x ↦ x.val ∈ y.val⟩
 
-instance (priority := 50) mem [Operator.Mem L] [Membership M M] [Structure.Mem L M] :
+instance (priority := 50) mem :
     Structure.Mem L (SkolemHull L s) := ⟨fun x y ↦ by
   simpa [Operator.val, Matrix.fun_eq_vec_two] using! Structure.Mem.mem (L := L) (M := M) x.val y.val⟩
 

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -31,35 +31,33 @@ class OneSidedLK.Cut
 
 namespace OneSidedLK
 
-variable {F : Type*} [LogicalConnective F] [DeMorgan F] [TildeInvolutive F] {𝔇 : List F → Type*} [OneSidedLK 𝔇]
+variable {F : Type*} [LogicalConnective F] [DeMorgan F] [TildeInvolutive F] {𝔇 : List F → Type*}
 
 def cast (b : 𝔇 Γ) (h : Γ = Δ := by simp) : 𝔇 Δ := h ▸ b
 
-def contra (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ := contraction d (by simp [h])
+def contra [OneSidedLK 𝔇] (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ := contraction d (by simp [h])
 
-def rotate (d : 𝔇 (φ :: Γ)) : 𝔇 (Γ ++ [φ]) := contra d
+def rotate [OneSidedLK 𝔇] (d : 𝔇 (φ :: Γ)) : 𝔇 (Γ ++ [φ]) := contra d
 
-def close (φ : F) (hp : φ ∈ Γ := by simp) (hn : ∼φ ∈ Γ := by simp) : 𝔇 Γ := contraction (identity φ) (by simp_all)
+def close [OneSidedLK 𝔇] (φ : F) (hp : φ ∈ Γ := by simp) (hn : ∼φ ∈ Γ := by simp) : 𝔇 Γ := contraction (identity φ) (by simp_all)
 
-def top (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ := contraction verum (by simp [h])
+def top [OneSidedLK 𝔇] (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ := contraction verum (by simp [h])
 
-def tensor {φ ψ : F} (dφ : 𝔇 (φ :: Γ)) (dψ : 𝔇 (ψ :: Δ)) : 𝔇 (φ ⋏ ψ :: Γ ++ Δ) :=
+def tensor [OneSidedLK 𝔇] {φ ψ : F} (dφ : 𝔇 (φ :: Γ)) (dψ : 𝔇 (ψ :: Δ)) : 𝔇 (φ ⋏ ψ :: Γ ++ Δ) :=
   and (contraction dφ (by simp)) (contraction dψ (by simp))
 
-def swap₁ (d : 𝔇 (φ₂ :: φ₁ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: Γ) := contraction d (by simp)
+def swap₁ [OneSidedLK 𝔇] (d : 𝔇 (φ₂ :: φ₁ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: Γ) := contraction d (by simp)
 
-def swap₂ (d : 𝔇 (φ₃ :: φ₁ :: φ₂ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: φ₃ :: Γ) :=
+def swap₂ [OneSidedLK 𝔇] (d : 𝔇 (φ₃ :: φ₁ :: φ₂ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: φ₃ :: Γ) :=
   contraction d (by grind)
 
-def swap₃ (d : 𝔇 (φ₄ :: φ₁ :: φ₂ :: φ₃ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: φ₃ :: φ₄ :: Γ) :=
+def swap₃ [OneSidedLK 𝔇] (d : 𝔇 (φ₄ :: φ₁ :: φ₂ :: φ₃ :: Γ)) : 𝔇 (φ₁ :: φ₂ :: φ₃ :: φ₄ :: Γ) :=
   contraction d (by grind)
 
 alias cut := OneSidedLK.Cut.cut
 
-omit [OneSidedLK 𝔇] in
 def eCut [Cut 𝔇] (d₁ : 𝔇 (φ :: Γ)) (d₂ : 𝔇 (ψ :: Δ)) (e : ∼φ = ψ := by simp) : 𝔇 (Γ ++ Δ) := cut d₁ (cast d₂ (by simp [e]))
 
-omit [OneSidedLK 𝔇] in
 def disj₂ {Γ Δ : List F} [Cut 𝔇] : 𝔇 (Γ ++ Δ) → 𝔇 (⋁Γ :: Δ) := fun d ↦
   match Γ with
   |               [] => contra d
@@ -77,7 +75,7 @@ def disj₂ {Γ Δ : List F} [Cut 𝔇] : 𝔇 (Γ ++ Δ) → 𝔇 (⋁Γ :: Δ)
     exact eCut d₂ d₁
   termination_by _ => Γ.length
 
-def conj₂ {Γ Δ : List F} (d : (φ : F) → φ ∈ Γ → 𝔇 (φ :: Δ)) : 𝔇 (⋀Γ :: Δ) :=
+def conj₂ [OneSidedLK 𝔇] {Γ Δ : List F} (d : (φ : F) → φ ∈ Γ → 𝔇 (φ :: Δ)) : 𝔇 (⋀Γ :: Δ) :=
   match Γ with
   |          [] => contra verum
   |         [φ] => d φ (by simp)
@@ -95,14 +93,13 @@ namespace PrincipalEntailment
 
 variable {P : Type*} [Entailment P F] {𝓟 : P} [PrincipalEntailment 𝔇 𝓟]
 
-omit [LogicalConnective F] [DeMorgan F] [TildeInvolutive F] [OneSidedLK 𝔇] in
+omit [LogicalConnective F] [DeMorgan F] [TildeInvolutive F] in
 lemma provable_iff :
     𝓟 ⊢ φ ↔ Nonempty (𝔇 [φ]) := by
   simpa using! OneSidedLK.PrincipalEntailment.equiv.nonempty_congr
 
 variable [OneSidedLK.Cut 𝔇] (𝓟)
 
-omit [OneSidedLK 𝔇] in
 instance : Entailment.ModusPonens 𝓟 where
   mdp {φ ψ} b₁ b₂ :=
     let b₁ := equiv b₁
@@ -112,7 +109,6 @@ instance : Entailment.ModusPonens 𝓟 where
     have : 𝔇 [ψ] := contraction (cut b₂ this) (by simp)
     equiv.symm <| cast this
 
-omit [OneSidedLK 𝔇] in
 instance : Entailment.Cl 𝓟 where
   negEquiv {φ} := Entailment.cast
     (show 𝓟 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
@@ -155,7 +151,6 @@ instance : Entailment.Cl 𝓟 where
 
 variable {𝓟}
 
-omit [OneSidedLK 𝔇] in
 lemma derivable_iff_provable_disj : Nonempty (𝔇 Γ) ↔ 𝓟 ⊢ ⋁Γ := by
   constructor
   · rintro ⟨d⟩
@@ -180,14 +175,13 @@ def cast (d : 𝔇 Δ) (h : Δ = Γ.map f := by simp) : Pullback 𝔇 f Γ := by
 
 def uncast (d : Pullback 𝔇 f Γ) (h : Δ = Γ.map f := by simp) : 𝔇 Δ := h ▸ d
 
-instance oneSidedLK : OneSidedLK (Pullback 𝔇 f) where
+instance oneSidedLK [OneSidedLK 𝔇] : OneSidedLK (Pullback 𝔇 f) where
   identity φ := cast <| identity (f φ)
   contraction {Δ Γ} d h := cast (contraction d (List.map_subset f h) : 𝔇 (Γ.map f)) (by simp)
   verum := cast verum
   and d₁ d₂ := cast <| and d₁ d₂
   or d := cast <| or d
 
-omit [OneSidedLK 𝔇] in
 instance cut [Cut 𝔇] : Cut (Pullback 𝔇 f) where
   cut {φ Γ Δ} bp bn :=
     have bp : 𝔇 (f φ :: Γ.map f) := uncast bp
@@ -198,10 +192,10 @@ instance {P : Type*} [Entailment P F] (𝓟 : P) [PrincipalEntailment 𝔇 𝓟]
     PrincipalEntailment (Pullback 𝔇 f) (Entailment.pullback 𝓟 f) where
   equiv {φ} := PrincipalEntailment.equiv (φ := f φ)
 
-omit [DeMorgan F] [TildeInvolutive F] [OneSidedLK 𝔇] [DeMorgan G] [TildeInvolutive G] in
+omit [DeMorgan F] [TildeInvolutive F] [DeMorgan G] [TildeInvolutive G] in
 @[simp] lemma nonempty_iff {Γ} : Nonempty (Pullback 𝔇 f Γ) ↔ Nonempty (𝔇 (Γ.map f)) := by simp [Pullback]
 
-omit [DeMorgan F] [TildeInvolutive F] [OneSidedLK 𝔇] [DeMorgan G] [TildeInvolutive G] in
+omit [DeMorgan F] [TildeInvolutive F] [DeMorgan G] [TildeInvolutive G] in
 @[simp] lemma isEmpty_iff {Γ} : IsEmpty (Pullback 𝔇 f Γ) ↔ IsEmpty (𝔇 (Γ.map f)) := by simp [Pullback]
 
 end Pullback
@@ -214,14 +208,14 @@ namespace ContextualEntailment
 
 variable {S : Type*} [Entailment S F] [AdjunctiveSet F S] [ContextualEntailment 𝔇 S]
 
-omit [DeMorgan F] [TildeInvolutive F] [OneSidedLK 𝔇] in
+omit [DeMorgan F] [TildeInvolutive F] in
 lemma provable_iff {𝓢 : S} :
     𝓢 ⊢ φ ↔ ∃ Γ : List F, (∀ ψ ∈ Γ, ψ ∈ 𝓢) ∧ Nonempty (𝔇 (φ :: ∼Γ)) := by
   simpa using! equiv.nonempty_congr
 
 def toProof (𝓢 : S) (d : 𝔇 [φ]) : 𝓢 ⊢! φ := equiv.symm ⟨⟨[], by simp⟩, d⟩
 
-def ofAxiom {𝓢 : S} (h : φ ∈ 𝓢) : 𝓢 ⊢! φ :=
+def ofAxiom [OneSidedLK 𝔇] {𝓢 : S} (h : φ ∈ 𝓢) : 𝓢 ⊢! φ :=
   equiv.symm ⟨⟨[φ], by simp_all⟩, identity φ⟩
 
 def ofAxiomSubset {𝓢 𝓤 : S} : 𝓢 ⊢! φ → 𝓢 ⊆ 𝓤 → 𝓤 ⊢! φ := fun b h ↦
@@ -229,13 +223,12 @@ def ofAxiomSubset {𝓢 𝓤 : S} : 𝓢 ⊢! φ → 𝓢 ⊆ 𝓤 → 𝓤 ⊢!
   equiv.symm
     ⟨⟨l, fun φ hφ ↦ AdjunctiveSet.subset_iff.mp h _ (l.prop φ hφ)⟩, d⟩
 
-instance : Entailment.Axiomatized S where
+instance [OneSidedLK 𝔇] : Entailment.Axiomatized S where
   prfAxm h := ofAxiom h
   weakening h d := ofAxiomSubset d h
 
 variable [OneSidedLK.Cut 𝔇]
 
-omit [OneSidedLK 𝔇] in
 instance (𝓢 : S) : Entailment.ModusPonens 𝓢 where
   mdp {φ ψ} b₁ b₂ :=
     let ⟨Γ₁, b₁⟩ := equiv b₁
@@ -245,7 +238,6 @@ instance (𝓢 : S) : Entailment.ModusPonens 𝓢 where
     have : 𝔇 (ψ :: ∼↑Γ₁ ++ ∼↑Γ₂) := contraction (cut b₂ this) (by simp)
     equiv.symm ⟨⟨Γ₁ ++ Γ₂, by simp; grind⟩, cast this⟩
 
-omit [OneSidedLK 𝔇] in
 instance : Entailment.StrongCut S S where
   cut {T U φ bs b} :=
   let rec bl (l : List F) (hl : ∀ ψ ∈ l, ψ ∈ U) (χ) (d : 𝔇 (χ :: ∼l)) : T ⊢! χ :=
@@ -260,7 +252,6 @@ instance : Entailment.StrongCut S S where
   have ⟨l, hl⟩ := equiv b
   bl l l.prop φ hl
 
-omit [OneSidedLK 𝔇] in
 instance : Entailment.DeductiveExplosion S where
   dexp b φ :=
     have ⟨Γ, b⟩ := equiv b
@@ -269,7 +260,6 @@ instance : Entailment.DeductiveExplosion S where
       have : 𝔇 [∼⊥] := cast verum (by simp)
       contraction (cut b this) (by simp) ⟩
 
-omit [OneSidedLK 𝔇] in
 lemma inconsistent_iff {𝓢 : S} :
     Entailment.Inconsistent 𝓢 ↔ ∃ Γ : List F, (∀ ψ ∈ Γ, ψ ∈ 𝓢) ∧ Nonempty (𝔇 (∼Γ)) := calc
   _ ↔ 𝓢 ⊢ ⊥ := Entailment.inconsistent_iff_provable_bot
@@ -282,7 +272,6 @@ lemma inconsistent_iff {𝓢 : S} :
     · rintro ⟨Γ, hΓ, ⟨d⟩⟩
       exact ⟨Γ, hΓ, ⟨contraction d (by simp)⟩⟩
 
-omit [OneSidedLK 𝔇] in
 instance cl (𝓢 : S) : Entailment.Cl 𝓢 where
   negEquiv {φ} := Entailment.cast
     (show 𝓢 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
@@ -325,7 +314,7 @@ instance cl (𝓢 : S) : Entailment.Cl 𝓢 where
 
 variable {P : Type*} [Entailment P F]
 
-omit [DeMorgan F] [OneSidedLK 𝔇] [Cut 𝔇] in
+omit [DeMorgan F] [Cut 𝔇] in
 lemma empty_provable_iff_eprovable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     (∅ : S) ⊢ φ ↔ 𝓟 ⊢ φ := by
   constructor
@@ -339,7 +328,6 @@ lemma empty_provable_iff_eprovable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     have : 𝔇 [φ] := PrincipalEntailment.equiv b
     exact ⟨equiv.symm ⟨⟨[], by simp⟩, this⟩⟩
 
-omit [OneSidedLK 𝔇] in
 lemma iff_context {𝓢 : S} {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     𝓢 ⊢ φ ↔ AdjunctiveSet.set 𝓢 *⊢[𝓟] φ := by
   constructor
@@ -359,12 +347,10 @@ lemma iff_context {𝓢 : S} {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     have : 𝔇 (φ :: ∼Γ) := eCut d this
     refine provable_iff.mpr ⟨Γ, h, ⟨this⟩⟩
 
-omit [OneSidedLK 𝔇] in
 lemma of_principal_provable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] {𝓢 : S} : 𝓟 ⊢ φ → 𝓢 ⊢ φ := fun h ↦
   iff_context.mpr (Entailment.Context.of! h)
 
 open Classical in
-omit [OneSidedLK 𝔇] in
 noncomputable abbrev deduction (𝓟 : P) [PrincipalEntailment 𝔇 𝓟] : Entailment.Deduction S where
   ofInsert {φ ψ 𝓢 b} :=
     have : AdjunctiveSet.set (Adjoin.adjoin φ 𝓢) *⊢[𝓟] ψ := iff_context.mp ⟨b⟩

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -56,8 +56,10 @@ def swap₃ (d : 𝔇 (φ₄ :: φ₁ :: φ₂ :: φ₃ :: Γ)) : 𝔇 (φ₁ ::
 
 alias cut := OneSidedLK.Cut.cut
 
+omit [OneSidedLK 𝔇] in
 def eCut [Cut 𝔇] (d₁ : 𝔇 (φ :: Γ)) (d₂ : 𝔇 (ψ :: Δ)) (e : ∼φ = ψ := by simp) : 𝔇 (Γ ++ Δ) := cut d₁ (cast d₂ (by simp [e]))
 
+omit [OneSidedLK 𝔇] in
 def disj₂ {Γ Δ : List F} [Cut 𝔇] : 𝔇 (Γ ++ Δ) → 𝔇 (⋁Γ :: Δ) := fun d ↦
   match Γ with
   |               [] => contra d
@@ -100,6 +102,7 @@ lemma provable_iff :
 
 variable [OneSidedLK.Cut 𝔇] (𝓟)
 
+omit [OneSidedLK 𝔇] in
 instance : Entailment.ModusPonens 𝓟 where
   mdp {φ ψ} b₁ b₂ :=
     let b₁ := equiv b₁
@@ -109,6 +112,7 @@ instance : Entailment.ModusPonens 𝓟 where
     have : 𝔇 [ψ] := contraction (cut b₂ this) (by simp)
     equiv.symm <| cast this
 
+omit [OneSidedLK 𝔇] in
 instance : Entailment.Cl 𝓟 where
   negEquiv {φ} := Entailment.cast
     (show 𝓟 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
@@ -151,6 +155,7 @@ instance : Entailment.Cl 𝓟 where
 
 variable {𝓟}
 
+omit [OneSidedLK 𝔇] in
 lemma derivable_iff_provable_disj : Nonempty (𝔇 Γ) ↔ 𝓟 ⊢ ⋁Γ := by
   constructor
   · rintro ⟨d⟩
@@ -175,13 +180,14 @@ def cast (d : 𝔇 Δ) (h : Δ = Γ.map f := by simp) : Pullback 𝔇 f Γ := by
 
 def uncast (d : Pullback 𝔇 f Γ) (h : Δ = Γ.map f := by simp) : 𝔇 Δ := h ▸ d
 
-instance oneSidedLK [OneSidedLK 𝔇] : OneSidedLK (Pullback 𝔇 f) where
+instance oneSidedLK : OneSidedLK (Pullback 𝔇 f) where
   identity φ := cast <| identity (f φ)
   contraction {Δ Γ} d h := cast (contraction d (List.map_subset f h) : 𝔇 (Γ.map f)) (by simp)
   verum := cast verum
   and d₁ d₂ := cast <| and d₁ d₂
   or d := cast <| or d
 
+omit [OneSidedLK 𝔇] in
 instance cut [Cut 𝔇] : Cut (Pullback 𝔇 f) where
   cut {φ Γ Δ} bp bn :=
     have bp : 𝔇 (f φ :: Γ.map f) := uncast bp
@@ -229,6 +235,7 @@ instance : Entailment.Axiomatized S where
 
 variable [OneSidedLK.Cut 𝔇]
 
+omit [OneSidedLK 𝔇] in
 instance (𝓢 : S) : Entailment.ModusPonens 𝓢 where
   mdp {φ ψ} b₁ b₂ :=
     let ⟨Γ₁, b₁⟩ := equiv b₁
@@ -238,6 +245,7 @@ instance (𝓢 : S) : Entailment.ModusPonens 𝓢 where
     have : 𝔇 (ψ :: ∼↑Γ₁ ++ ∼↑Γ₂) := contraction (cut b₂ this) (by simp)
     equiv.symm ⟨⟨Γ₁ ++ Γ₂, by simp; grind⟩, cast this⟩
 
+omit [OneSidedLK 𝔇] in
 instance : Entailment.StrongCut S S where
   cut {T U φ bs b} :=
   let rec bl (l : List F) (hl : ∀ ψ ∈ l, ψ ∈ U) (χ) (d : 𝔇 (χ :: ∼l)) : T ⊢! χ :=
@@ -252,6 +260,7 @@ instance : Entailment.StrongCut S S where
   have ⟨l, hl⟩ := equiv b
   bl l l.prop φ hl
 
+omit [OneSidedLK 𝔇] in
 instance : Entailment.DeductiveExplosion S where
   dexp b φ :=
     have ⟨Γ, b⟩ := equiv b
@@ -260,6 +269,7 @@ instance : Entailment.DeductiveExplosion S where
       have : 𝔇 [∼⊥] := cast verum (by simp)
       contraction (cut b this) (by simp) ⟩
 
+omit [OneSidedLK 𝔇] in
 lemma inconsistent_iff {𝓢 : S} :
     Entailment.Inconsistent 𝓢 ↔ ∃ Γ : List F, (∀ ψ ∈ Γ, ψ ∈ 𝓢) ∧ Nonempty (𝔇 (∼Γ)) := calc
   _ ↔ 𝓢 ⊢ ⊥ := Entailment.inconsistent_iff_provable_bot
@@ -272,6 +282,7 @@ lemma inconsistent_iff {𝓢 : S} :
     · rintro ⟨Γ, hΓ, ⟨d⟩⟩
       exact ⟨Γ, hΓ, ⟨contraction d (by simp)⟩⟩
 
+omit [OneSidedLK 𝔇] in
 instance cl (𝓢 : S) : Entailment.Cl 𝓢 where
   negEquiv {φ} := Entailment.cast
     (show 𝓢 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
@@ -328,6 +339,7 @@ lemma empty_provable_iff_eprovable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     have : 𝔇 [φ] := PrincipalEntailment.equiv b
     exact ⟨equiv.symm ⟨⟨[], by simp⟩, this⟩⟩
 
+omit [OneSidedLK 𝔇] in
 lemma iff_context {𝓢 : S} {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     𝓢 ⊢ φ ↔ AdjunctiveSet.set 𝓢 *⊢[𝓟] φ := by
   constructor
@@ -347,10 +359,12 @@ lemma iff_context {𝓢 : S} {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     have : 𝔇 (φ :: ∼Γ) := eCut d this
     refine provable_iff.mpr ⟨Γ, h, ⟨this⟩⟩
 
+omit [OneSidedLK 𝔇] in
 lemma of_principal_provable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] {𝓢 : S} : 𝓟 ⊢ φ → 𝓢 ⊢ φ := fun h ↦
   iff_context.mpr (Entailment.Context.of! h)
 
 open Classical in
+omit [OneSidedLK 𝔇] in
 noncomputable abbrev deduction (𝓟 : P) [PrincipalEntailment 𝔇 𝓟] : Entailment.Deduction S where
   ofInsert {φ ψ 𝓢 b} :=
     have : AdjunctiveSet.set (Adjoin.adjoin φ 𝓢) *⊢[𝓟] ψ := iff_context.mp ⟨b⟩

--- a/Foundation/Logic/Semantics.lean
+++ b/Foundation/Logic/Semantics.lean
@@ -228,7 +228,7 @@ lemma Satisfiable.of_subset {T U : Set F} (h : Satisfiable M U) (ss : T ⊆ U) :
 
 variable (M)
 
-instance [Semantics M F] : Semantics (Set M) F := ⟨fun s φ ↦ ∀ ⦃𝓜⦄, 𝓜 ∈ s → 𝓜 ⊧ φ⟩
+instance : Semantics (Set M) F := ⟨fun s φ ↦ ∀ ⦃𝓜⦄, 𝓜 ∈ s → 𝓜 ⊧ φ⟩
 
 @[simp] lemma empty_models (φ : F) : (∅ : Set M) ⊧ φ := by rintro h; simp
 

--- a/Foundation/Modal/Entailment/KP.lean
+++ b/Foundation/Modal/Entailment/KP.lean
@@ -13,7 +13,7 @@ variable {𝓢 : S} [Entailment.KP 𝓢]
 
 namespace KP
 
-protected def axiomD [HasDiaDuality 𝓢] : 𝓢 ⊢! Axioms.D φ := by
+protected def axiomD : 𝓢 ⊢! Axioms.D φ := by
   have : 𝓢 ⊢! φ 🡒 (∼φ 🡒 ⊥) := C_trans dni (K_left negEquiv);
   have : 𝓢 ⊢! □φ 🡒 □(∼φ 🡒 ⊥) := implyBoxDistribute' this;
   have : 𝓢 ⊢! □φ 🡒 (□(∼φ) 🡒 □⊥) := C_trans this axiomK;

--- a/Foundation/Modal/Kripke/Balloon.lean
+++ b/Foundation/Modal/Kripke/Balloon.lean
@@ -18,13 +18,9 @@ open Formula.Kripke
 
 variable {F : Frame} [IsStrictTotalOrder _ F] {e : Cluster F} [F.IsBalloon e] {x : F.World} {φ : Formula ℕ}
 
--- `[IsStrictTotalOrder _ F]` must be given explicitly before `e : Cluster F` can even be stated,
--- so it cannot avoid overlapping with the `IsStrictTotalOrder` bundled inside `[F.IsBalloon e]`.
-set_option linter.overlappingInstances false in
 /-- Every points in enverope is reflexive. -/
 lemma rfl_in_envelope (hx : x ∈ e) : x ≺ x := Cluster.refl_of_mem_non_degenerate (envelope_non_degenerated) hx
 
-set_option linter.overlappingInstances false in
 /-- Every point in balloon can see all points in envelope. -/
 lemma covered_in_envelope (x : F.World) : ∀ t ∈ e, x ≺ t := by
   obtain ⟨t₁, rfl⟩ := Quotient.exists_rep e;
@@ -45,7 +41,6 @@ lemma covered_in_envelope (x : F.World) : ∀ t ∈ e, x ≺ t := by
     . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁;
       exact _root_.trans this.1 Rt₁₂;
 
-set_option linter.overlappingInstances false in
 /-- Every points from enverope is in enverope. -/
 lemma in_envelope_of_in_envelope (hx : x ∈ e) : ∀ {y}, x ≺ y → y ∈ e := by
   obtain ⟨t, rfl⟩ := Quotient.exists_rep e;
@@ -71,9 +66,6 @@ end Frame.IsBalloon
 lemma farthermost_point_of_not_box {M : Kripke.Model} [IsStrictOrder _ M.toFrame] {x : M} (h : ¬x ⊧ □φ) : ∃ y, x ≺ y ∧ ¬y ⊧ φ ∧ y ⊧ □φ := by
   sorry;
 
--- `[F.IsTransitive]` is a required prior argument of the `Frame.IsBalloon` class itself,
--- so it cannot avoid overlapping with the `IsTransitive` bundled inside `[F.IsBalloon e]`.
-set_option linter.overlappingInstances false in
 open
   Formula.Kripke
   Frame.IsBalloon

--- a/Foundation/Modal/Kripke/Balloon.lean
+++ b/Foundation/Modal/Kripke/Balloon.lean
@@ -18,9 +18,13 @@ open Formula.Kripke
 
 variable {F : Frame} [IsStrictTotalOrder _ F] {e : Cluster F} [F.IsBalloon e] {x : F.World} {φ : Formula ℕ}
 
+-- `[IsStrictTotalOrder _ F]` must be given explicitly before `e : Cluster F` can even be stated,
+-- so it cannot avoid overlapping with the `IsStrictTotalOrder` bundled inside `[F.IsBalloon e]`.
+set_option linter.overlappingInstances false in
 /-- Every points in enverope is reflexive. -/
 lemma rfl_in_envelope (hx : x ∈ e) : x ≺ x := Cluster.refl_of_mem_non_degenerate (envelope_non_degenerated) hx
 
+set_option linter.overlappingInstances false in
 /-- Every point in balloon can see all points in envelope. -/
 lemma covered_in_envelope (x : F.World) : ∀ t ∈ e, x ≺ t := by
   obtain ⟨t₁, rfl⟩ := Quotient.exists_rep e;
@@ -41,6 +45,7 @@ lemma covered_in_envelope (x : F.World) : ∀ t ∈ e, x ≺ t := by
     . have := IsTerminated.direct_terminated_of_trans (F := F.strictSkelteon) (t := ⟦t₁⟧) ⟦x⟧ ext₁;
       exact _root_.trans this.1 Rt₁₂;
 
+set_option linter.overlappingInstances false in
 /-- Every points from enverope is in enverope. -/
 lemma in_envelope_of_in_envelope (hx : x ∈ e) : ∀ {y}, x ≺ y → y ∈ e := by
   obtain ⟨t, rfl⟩ := Quotient.exists_rep e;
@@ -66,6 +71,9 @@ end Frame.IsBalloon
 lemma farthermost_point_of_not_box {M : Kripke.Model} [IsStrictOrder _ M.toFrame] {x : M} (h : ¬x ⊧ □φ) : ∃ y, x ≺ y ∧ ¬y ⊧ φ ∧ y ⊧ □φ := by
   sorry;
 
+-- `[F.IsTransitive]` is a required prior argument of the `Frame.IsBalloon` class itself,
+-- so it cannot avoid overlapping with the `IsTransitive` bundled inside `[F.IsBalloon e]`.
+set_option linter.overlappingInstances false in
 open
   Formula.Kripke
   Frame.IsBalloon

--- a/Foundation/Modal/Kripke/Rank.lean
+++ b/Foundation/Modal/Kripke/Rank.lean
@@ -13,7 +13,7 @@ namespace Kripke
 variable {φ ψ : Formula ℕ}
          {F : Frame} [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] {x y i j : F}
 
-def Frame.rank [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] (i : F) : ℕ := cwfHeight (· ≺ ·) i
+def Frame.rank (i : F) : ℕ := cwfHeight (· ≺ ·) i
 
 def Frame.height (F : Frame) [Fintype F] [F.IsConverseWellFounded] [F.IsTransitive] [F.IsRooted] : ℕ := Frame.rank F.root.1
 
@@ -179,9 +179,9 @@ end extendRoot
 namespace pointGenerate
 
 open Classical in
-instance [Fintype F] : Fintype (F↾x) := by apply Subtype.fintype;
+instance : Fintype (F↾x) := by apply Subtype.fintype;
 
-instance [F.IsRooted] [F.IsTree] : (F↾x).IsTree := by constructor;
+instance [F.IsTree] : (F↾x).IsTree := by constructor;
 
 axiom eq_original_height (hxy : y = x ∨ x ≺ y) : Frame.rank (F := F↾x) (⟨y, hxy⟩) = Frame.rank y
 

--- a/Foundation/Modal/Kripke/Rank.lean
+++ b/Foundation/Modal/Kripke/Rank.lean
@@ -181,9 +181,6 @@ namespace pointGenerate
 open Classical in
 instance : Fintype (F↾x) := by apply Subtype.fintype;
 
--- the outer `variable [F.IsTransitive]` is needed by unrelated declarations in this section,
--- so it cannot avoid overlapping with the `IsTransitive` bundled inside `[F.IsTree]` here.
-set_option linter.overlappingInstances false in
 instance [F.IsTree] : (F↾x).IsTree := by constructor;
 
 axiom eq_original_height (hxy : y = x ∨ x ≺ y) : Frame.rank (F := F↾x) (⟨y, hxy⟩) = Frame.rank y

--- a/Foundation/Modal/Kripke/Rank.lean
+++ b/Foundation/Modal/Kripke/Rank.lean
@@ -181,6 +181,9 @@ namespace pointGenerate
 open Classical in
 instance : Fintype (F↾x) := by apply Subtype.fintype;
 
+-- the outer `variable [F.IsTransitive]` is needed by unrelated declarations in this section,
+-- so it cannot avoid overlapping with the `IsTransitive` bundled inside `[F.IsTree]` here.
+set_option linter.overlappingInstances false in
 instance [F.IsTree] : (F↾x).IsTree := by constructor;
 
 axiom eq_original_height (hxy : y = x ∨ x ≺ y) : Frame.rank (F := F↾x) (⟨y, hxy⟩) = Frame.rank y

--- a/Foundation/Modal/LogicSymbol.lean
+++ b/Foundation/Modal/LogicSymbol.lean
@@ -247,7 +247,7 @@ section
 variable [InjectiveBox F]
 
 @[grind]
-noncomputable def preboxItr [InjectiveBox F] (n : ℕ) (s : Finset F) : Finset F := s.preimage (□^[n]·) $ by
+noncomputable def preboxItr (n : ℕ) (s : Finset F) : Finset F := s.preimage (□^[n]·) $ by
   intro φ hφ ψ hψ;
   apply InjectiveBox.inj_multibox;
 notation:90 "□⁻¹^[" n "]'" s => Finset.LO.preboxItr n s
@@ -378,10 +378,10 @@ section
 variable [InjectiveBox F] [DecidableEq F]
 
 @[grind]
-noncomputable def preboxItr [InjectiveBox F] [DecidableEq F] (n : ℕ) : List F → List F := λ s => (□⁻¹^[n]'(s.toFinset)).toList
+noncomputable def preboxItr (n : ℕ) : List F → List F := λ s => (□⁻¹^[n]'(s.toFinset)).toList
 notation:90 "□⁻¹^[" n "]'" s => List.LO.preboxItr n s
 
-noncomputable abbrev prebox [InjectiveBox F] [DecidableEq F] : List F → List F := preboxItr 1
+noncomputable abbrev prebox : List F → List F := preboxItr 1
 prefix:90 "□⁻¹'" => List.LO.prebox
 
 @[simp, grind =] lemma eq_preboxItr_one_prebox : (□⁻¹^[1]'s) = □⁻¹'s := by rfl

--- a/Foundation/Modal/MaximalConsistentSet.lean
+++ b/Foundation/Modal/MaximalConsistentSet.lean
@@ -445,6 +445,7 @@ lemma neg_iff (h : φ ∈ Ω₁ ↔ ψ ∈ Ω₂) : (∼φ ∈ Ω₁) ↔ (∼ψ
 
 lemma iff_mem_conj : (⋀Γ ∈ Ω) ↔ (∀ φ ∈ Γ, φ ∈ Ω) := by simp [membership_iff, Conj₂!_iff_forall_provable];
 
+omit [Entailment.Cl 𝓢] in
 section
 
 variable [Entailment.K 𝓢]

--- a/Foundation/Modal/Tableau.lean
+++ b/Foundation/Modal/Tableau.lean
@@ -761,6 +761,7 @@ lemma iff_mem₂_neg : ∼φ ∈ t.1.2 ↔ φ ∈ t.1.1 := by
 @[grind]
 lemma iff_mem₂_neg' : ∼φ ∈ t.1.2 ↔ φ ∉ t.1.2 := Iff.trans iff_mem₂_neg $ Iff.symm iff_not_mem₂_mem₁
 
+omit [Entailment.Cl 𝓢] in
 section
 
 variable [Entailment.K 𝓢]

--- a/Foundation/Propositional/ConsistentTableau.lean
+++ b/Foundation/Propositional/ConsistentTableau.lean
@@ -580,6 +580,7 @@ lemma of_mem₁_neg' [DecidableEq α] (h : ∼φ ∈ t.1.1) : φ ∉ t.1.1 := by
   apply iff_not_mem₁_mem₂.mpr;
   apply of_mem₁_neg h;
 
+omit [Entailment.Int 𝓢] in
 private lemma of_mem₂_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ 🡒 ψ ∈ t.1.2 → (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
   intro h;
   by_contra hC;
@@ -594,6 +595,7 @@ private lemma of_mem₂_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢]
     have : φ 🡒 ψ ∉ t.1.2 := iff_not_mem₂_mem₁.mpr $ mdp_mem₁ this (iff_not_mem₂_mem₁.mp hψ);
     contradiction;
 
+omit [Entailment.Int 𝓢] in
 lemma iff_mem₁_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ 🡒 ψ ∈ t.1.1 ↔ (φ ∈ t.1.2 ∨ ψ ∈ t.1.1) := by
   constructor;
   . apply of_mem₁_imp;
@@ -605,6 +607,7 @@ lemma iff_mem₁_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ �
     . exact iff_not_mem₂_mem₁.mpr hφ;
     . exact iff_not_mem₁_mem₂.mpr hψ;
 
+omit [Entailment.Int 𝓢] in
 lemma iff_mem₂_imp [DecidableEq α] [Encodable α] [Entailment.Cl 𝓢] : φ 🡒 ψ ∈ t.1.2 ↔ (φ ∈ t.1.1 ∧ ψ ∈ t.1.2) := by
   constructor;
   . apply of_mem₂_imp;

--- a/Foundation/Propositional/Entailment/AxiomDNE.lean
+++ b/Foundation/Propositional/Entailment/AxiomDNE.lean
@@ -30,7 +30,7 @@ def of_NN [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢! ∼∼φ) : 𝓢 
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/AxiomEFQ.lean
+++ b/Foundation/Propositional/Entailment/AxiomEFQ.lean
@@ -34,7 +34,7 @@ instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : D
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/AxiomLEM.lean
+++ b/Foundation/Propositional/Entailment/AxiomLEM.lean
@@ -27,7 +27,7 @@ export HasAxiomLEM (lem)
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/AxiomPeirce.lean
+++ b/Foundation/Propositional/Entailment/AxiomPeirce.lean
@@ -27,7 +27,7 @@ export HasAxiomPeirce (peirce)
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/KC.lean
+++ b/Foundation/Propositional/Entailment/KC.lean
@@ -27,7 +27,7 @@ export HasAxiomWLEM (wlem)
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/KreiselPutnam.lean
+++ b/Foundation/Propositional/Entailment/KreiselPutnam.lean
@@ -36,7 +36,7 @@ end
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/LC.lean
+++ b/Foundation/Propositional/Entailment/LC.lean
@@ -27,7 +27,7 @@ export HasAxiomDummett (dummett)
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Entailment/Minimal/Basic.lean
+++ b/Foundation/Propositional/Entailment/Minimal/Basic.lean
@@ -539,7 +539,7 @@ instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomOrElim Γ := ⟨of or�
 
 instance (Γ : FiniteContext F 𝓢) : Entailment.NegationEquiv Γ := ⟨of negEquiv⟩
 
-instance [Entailment.Minimal 𝓢] (Γ : FiniteContext F 𝓢) : Entailment.Minimal Γ where
+instance (Γ : FiniteContext F 𝓢) : Entailment.Minimal Γ where
 
 
 def mdp' [DecidableEq F] (bΓ : Γ ⊢[𝓢]! φ 🡒 ψ) (bΔ : Δ ⊢[𝓢]! φ) : (Γ ++ Δ) ⊢[𝓢]! ψ :=

--- a/Foundation/Propositional/Entailment/Minimal/Basic.lean
+++ b/Foundation/Propositional/Entailment/Minimal/Basic.lean
@@ -1043,8 +1043,6 @@ lemma ENN!_of_E! [DecidableEq F] (b : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ ∼φ 🡘
 
 section NegationEquiv
 
-variable [Entailment.NegationEquiv 𝓢]
-
 def ENNCCOO [DecidableEq F] : 𝓢 ⊢! ∼∼φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := by
   apply E_intro;
   . exact C_trans (by apply contra; exact K_right negEquiv) (K_left negEquiv)

--- a/Foundation/Propositional/Entailment/Scott.lean
+++ b/Foundation/Propositional/Entailment/Scott.lean
@@ -27,7 +27,7 @@ export HasAxiomScott (scott)
 
 section
 
-variable [LogicalConnective F] [Entailment S F] [Entailment.Minimal 𝓢]
+variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 

--- a/Foundation/Propositional/Formula/Basic.lean
+++ b/Foundation/Propositional/Formula/Basic.lean
@@ -320,7 +320,7 @@ variable {φ ψ χ : Formula α} {Γ : FormulaFinset α} [Γ.SubformulaClosed]
 @[grind ⇒] lemma mem_imp₁ (h : φ 🡒 ψ ∈ Γ) : φ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
 @[grind ⇒] lemma mem_imp₂ (h : φ 🡒 ψ ∈ Γ) : ψ ∈ Γ := by apply SubformulaClosed.closed _ h; simp [Formula.subformulas];
 
-instance subformulaClosed_subformulas [DecidableEq α] {φ : Formula α} : SubformulaClosed (φ.subformulas) := ⟨by
+instance subformulaClosed_subformulas {φ : Formula α} : SubformulaClosed (φ.subformulas) := ⟨by
   induction φ with
   | hatom => simp [Formula.subformulas];
   | hfalsum => simp [Formula.subformulas];
@@ -374,7 +374,7 @@ variable {φ ψ χ : Formula α} {T : FormulaSet α} [T.SubformulaClosed]
 @[grind ⇒] protected lemma mem_imp₁ (h : φ 🡒 ψ ∈ T) : φ ∈ T := by apply closed _ h; simp [Formula.subformulas];
 @[grind ⇒] protected lemma mem_imp₂ (h : φ 🡒 ψ ∈ T) : ψ ∈ T := by apply closed _ h; simp [Formula.subformulas];
 
-instance [DecidableEq α] {φ : Formula α} : SubformulaClosed φ.subformulas.toSet := ⟨by
+instance {φ : Formula α} : SubformulaClosed φ.subformulas.toSet := ⟨by
   simpa using FormulaFinset.SubformulaClosed.subformulaClosed_subformulas (φ := φ) |>.closed;
 ⟩
 

--- a/Foundation/Propositional/Kripke/Filtration.lean
+++ b/Foundation/Propositional/Kripke/Filtration.lean
@@ -226,7 +226,7 @@ section
 open Relation
 open Formula.Kripke.Satisfies (formula_hereditary)
 
-variable {M T} [T.SubformulaClosed]
+variable {M T}
 
 abbrev finestFiltrationTransitiveClosureFrame (M : Model) (T : FormulaSet ℕ) [T.SubformulaClosed] : Kripke.Frame where
   World := FilterEqvQuotient M T
@@ -306,7 +306,7 @@ abbrev finestFiltrationTransitiveClosureModel (M : Model) (T : FormulaSet ℕ) [
   ⟩
 
 
-instance finestFiltrationTransitiveClosureModel.filterOf : FilterOf (finestFiltrationTransitiveClosureModel M T) M T where
+instance finestFiltrationTransitiveClosureModel.filterOf {M} {T : FormulaSet ℕ} [T.SubformulaClosed] : FilterOf (finestFiltrationTransitiveClosureModel M T) M T where
   def_valuation := by tauto
   def_rel_forth := by
     intro x y Rxy;

--- a/Foundation/Vorspiel/Fin/Basic.lean
+++ b/Foundation/Vorspiel/Fin/Basic.lean
@@ -41,7 +41,7 @@ section last'
 variable [NeZero n]
 
 /-- The last element of `Fin n` when `n` is `NeZero`. -/
-def last' [NeZero n] : Fin n := ⟨n - 1, Nat.sub_one_lt'⟩
+def last' : Fin n := ⟨n - 1, Nat.sub_one_lt'⟩
 
 @[simp, grind .]
 lemma lt_last' : i ≤ Fin.last' := by


### PR DESCRIPTION
## 概要

`set_option linter.overlappingInstances` が検出していた，同一の型クラスインスタンスが
複数の経路（`variable`ブロックと個々の定義の明示引数など）から推論可能になっていた
箇所を，意味・シグネチャを変えずに解消した．並行して進めていた複数のworktreeをまとめて
統合したもの．

## 対応内容

- `variable`ブロックと重複していた明示的instance引数の削除
- `def`/`instance`/`abbrev`では`omit`が効かないため，`variable`ブロックの構成を見直し
  必要な宣言にのみinstanceを明示付与する構造的リファクタ（`Logic/Calculus.lean`）

## 未解消の警告（5件）

`Foundation/Modal/Kripke/Balloon.lean`（4件）と`Foundation/Modal/Kripke/Rank.lean`の
`instIsTree`（1件）は，`Frame.IsBalloon`・`Frame.IsTree`クラスが`extends`で親クラス
（`IsStrictTotalOrder`・`IsTransitive`）を束ねている一方，その親クラスのインスタンスを
型を書くために先に明示指定する必要があり，構造的に重複が避けられない．`omit`もdef/instance
やこのケースの`lemma`には効果が無い．

`set_option linter.overlappingInstances false in`での抑制も検討したが，警告を隠すだけで
実体を変えないため今回は採用せず，警告を残したままにしている．解消するには`IsBalloon`/
`IsTree`クラスの`extends`設計自体を変える必要があり，別タスクとする．

## 確認事項

- `lake build` 全体成功（エラー0）
- `linter.overlappingInstances` 警告 82件 → 5件（上記の構造的に解消不能な分のみ残存）
- `lake exe mk_all --module` 実行済み（`Foundation.lean` 更新不要）

## 備考

作業中に無関係な `.lake` ビルドキャッシュの不整合（`Foundation/Modal/Kripke/Rank.lean` が
`cwfHeight` 未定義エラーでビルド失敗する問題）を発見・修正した．今回の変更とは無関係の
環境問題．

対象範囲は `linter.overlappingInstances` のみ．他のlinter警告（flexible tactic・unused simp
argument・deprecated API等）は別タスクとして対応予定．

🤖 Generated with [Claude Code](https://claude.com/claude-code)