### PR TITLE
add(FirstOrder/SetTheory): Add ZF.lean and some other changes to set theory

### DIFF
--- a/Foundation.lean
+++ b/Foundation.lean
@@ -117,6 +117,7 @@ public import Foundation.FirstOrder.SetTheory.Ordinal
 public import Foundation.FirstOrder.SetTheory.TransitiveModel
 public import Foundation.FirstOrder.SetTheory.Universe
 public import Foundation.FirstOrder.SetTheory.Z
+public import Foundation.FirstOrder.SetTheory.ZF
 public import Foundation.FirstOrder.Skolemization.Hull
 public import Foundation.FirstOrder.Ultraproduct
 public import Foundation.Init

--- a/Foundation/FirstOrder/Basic/Definability.lean
+++ b/Foundation/FirstOrder/Basic/Definability.lean
@@ -22,6 +22,10 @@ abbrev IsDefinedBy (R : (Fin k → M) → Prop) (φ : Semisentence L k) : Prop :
 class Defined (R : outParam ((Fin k → M) → Prop)) (φ : Semisentence L k) : Prop where
   iff : IsDefinedBy R φ
 
+/--
+The relation `R` is definable by a formula `φ` with parameters over the domain `M`.
+Here, the free variables of `φ` are indexed by the type `M`, so that `φ` may contain finitely many parameters, which are interpreted by using `id : M → M` for the valuation of free variables.
+-/
 abbrev IsDefinedByWithParam (R : (Fin k → M) → Prop) (φ : Semiformula L M k) : Prop :=
   ∀ v, φ.Eval v id ↔ R v
 

--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -298,13 +298,13 @@ lemma separation_existsUnique (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predic
 noncomputable def sep (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : V := Classical.choose! (separation_existsUnique x P hP)
 
 @[simp] lemma mem_sep_iff {P : V → Prop} {hP : ℒₛₑₜ-predicate P} {z x : V} :
-    z ∈ sep x P ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P hP) z
+    z ∈ sep x P (hP := hP) ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P hP) z
 
 @[simp] lemma sep_empty_eq (P : V → Prop) {hP : ℒₛₑₜ-predicate P} :
-    sep ∅ P = ∅ := by ext; simp
+    sep ∅ P (hP := hP) = ∅ := by ext; simp
 
 @[simp] lemma sep_subset {P : V → Prop} {hP : ℒₛₑₜ-predicate P} {x : V} :
-    sep x P ⊆ x := by intro z; simp; tauto
+    sep x P (hP := hP) ⊆ x := by intro z; simp; tauto
 
 section set_notation
 

--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -285,26 +285,26 @@ lemma separation_exists_eval (x : V) (φ : SetTheorySemiformula V 1) : ∃ y : V
   have := by simpa [models_iff, Semiformula.eval_univCl, Axiom.separationSchema] using Theory.models V 𝗭 (Zermelo.axiom_of_separation ψ)
   simpa [ψ, f, Semiformula.eval_rewriteMap, Matrix.constant_eq_singleton] using this f x
 
-lemma separation_exists (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P) : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+lemma separation_exists (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
   rcases hP with ⟨φ, hP⟩
   simpa [hP.iff] using separation_exists_eval x φ
 
-lemma separation_existsUnique (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P) : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
-  rcases separation_exists x P hP with ⟨s, hs⟩
+lemma separation_existsUnique (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+  rcases separation_exists x P with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
   intro u hu
   ext; simp_all
 
-noncomputable def sep (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P) : V := Classical.choose! (separation_existsUnique x P hP)
+noncomputable def sep (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : V := Classical.choose! (separation_existsUnique x P)
 
 @[simp] lemma mem_sep_iff {P : V → Prop} {hP : ℒₛₑₜ-predicate P} {z x : V} :
-    z ∈ sep x P hP ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P hP) z
+    z ∈ sep x P ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P) z
 
-@[simp] lemma sep_empty_eq (P : V → Prop) (hP : ℒₛₑₜ-predicate P) :
-    sep ∅ P hP = ∅ := by ext; simp
+@[simp] lemma sep_empty_eq (P : V → Prop) {hP : ℒₛₑₜ-predicate P} :
+    sep ∅ P = ∅ := by ext; simp
 
 @[simp] lemma sep_subset {P : V → Prop} {hP : ℒₛₑₜ-predicate P} {x : V} :
-    sep x P hP ⊆ x := by intro z; simp; tauto
+    sep x P ⊆ x := by intro z; simp; tauto
 
 section set_notation
 
@@ -318,7 +318,7 @@ syntax (name := internalSetBuilder) "{" binderIdent " ∈ " term " ; " term "}" 
 @[term_elab internalSetBuilder]
 meta def elabInternalSetBuilder : TermElab
   | `({ $x:ident ∈ $s ; $p }), expectedType? => do
-    elabTerm (← `(sep $s (fun $x:ident ↦ $p) (by definability))) expectedType?
+    elabTerm (← `(sep $s (fun $x:ident ↦ $p) (hP := by definability))) expectedType?
   | _, _ => throwUnsupportedSyntax
 
 @[app_unexpander sep]

--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -285,20 +285,20 @@ lemma separation_exists_eval (x : V) (φ : SetTheorySemiformula V 1) : ∃ y : V
   have := by simpa [models_iff, Semiformula.eval_univCl, Axiom.separationSchema] using Theory.models V 𝗭 (Zermelo.axiom_of_separation ψ)
   simpa [ψ, f, Semiformula.eval_rewriteMap, Matrix.constant_eq_singleton] using this f x
 
-lemma separation_exists (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+lemma separation_exists (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P) : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
   rcases hP with ⟨φ, hP⟩
   simpa [hP.iff] using separation_exists_eval x φ
 
-lemma separation_existsUnique (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
-  rcases separation_exists x P with ⟨s, hs⟩
+lemma separation_existsUnique (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P) : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+  rcases separation_exists x P hP with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
   intro u hu
   ext; simp_all
 
-noncomputable def sep (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : V := Classical.choose! (separation_existsUnique x P)
+noncomputable def sep (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : V := Classical.choose! (separation_existsUnique x P hP)
 
 @[simp] lemma mem_sep_iff {P : V → Prop} {hP : ℒₛₑₜ-predicate P} {z x : V} :
-    z ∈ sep x P ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P) z
+    z ∈ sep x P ↔ z ∈ x ∧ P z := Classical.choose!_spec (separation_existsUnique x P hP) z
 
 @[simp] lemma sep_empty_eq (P : V → Prop) {hP : ℒₛₑₜ-predicate P} :
     sep ∅ P = ∅ := by ext; simp
@@ -318,7 +318,7 @@ syntax (name := internalSetBuilder) "{" binderIdent " ∈ " term " ; " term "}" 
 @[term_elab internalSetBuilder]
 meta def elabInternalSetBuilder : TermElab
   | `({ $x:ident ∈ $s ; $p }), expectedType? => do
-    elabTerm (← `(sep $s (fun $x:ident ↦ $p) (hP := by definability))) expectedType?
+    elabTerm (← `(sep $s (fun $x:ident ↦ $p))) expectedType?
   | _, _ => throwUnsupportedSyntax
 
 @[app_unexpander sep]

--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -285,11 +285,11 @@ lemma separation_exists_eval (x : V) (φ : SetTheorySemiformula V 1) : ∃ y : V
   have := by simpa [models_iff, Semiformula.eval_univCl, Axiom.separationSchema] using Theory.models V 𝗭 (Zermelo.axiom_of_separation ψ)
   simpa [ψ, f, Semiformula.eval_rewriteMap, Matrix.constant_eq_singleton] using this f x
 
-lemma separation_exists (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+lemma separation_exists (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
   rcases hP with ⟨φ, hP⟩
   simpa [hP.iff] using separation_exists_eval x φ
 
-lemma separation_existsUnique (x : V) (P : V → Prop) [hP : ℒₛₑₜ-predicate P] : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
+lemma separation_existsUnique (x : V) (P : V → Prop) (hP : ℒₛₑₜ-predicate P := by definability) : ∃! y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ P z := by
   rcases separation_exists x P with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
   intro u hu

--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -64,6 +64,8 @@ open Classical
 
 noncomputable scoped instance : EmptyCollection V := ⟨Classical.choose! empty_existsUnique⟩
 
+noncomputable instance : Inhabited V := Inhabited.mk ∅
+
 @[simp] lemma IsEmpty.empty : IsEmpty (∅ : V) := Classical.choose!_spec empty_existsUnique
 
 @[simp] lemma not_mem_empty {x} : x ∉ (∅ : V) := IsEmpty.empty.not_mem
@@ -277,7 +279,7 @@ instance power.definable : ℒₛₑₜ-function₁[V] power := power.defined.to
 /-! ## Aussonderungsaxiom -/
 
 lemma separation_exists_eval (x : V) (φ : SetTheorySemiformula V 1) : ∃ y : V, ∀ z : V, z ∈ y ↔ z ∈ x ∧ φ.Eval ![z] id := by
-  have : Inhabited V := inhabited_of_nonempty inferInstance
+  -- have : Inhabited V := inhabited_of_nonempty inferInstance
   let f := φ.enumarateFVar
   let ψ := (Rew.rewriteMap φ.idxOfFVar) ▹ φ
   have := by simpa [models_iff, Semiformula.eval_univCl, Axiom.separationSchema] using Theory.models V 𝗭 (Zermelo.axiom_of_separation ψ)

--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -31,7 +31,7 @@ lemma replacement_exists_eval (X : V) (φ : SetTheorySemiformula V 2) (h : (∀ 
 /--
 Replacement exists (for a relation).
 -/
-lemma replacement_exists (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) :
+lemma replacement_rel_exists (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) :
     ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   rcases hR with ⟨φ, hR⟩
   -- Put hR in a useful form
@@ -39,40 +39,87 @@ lemma replacement_exists (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relat
   have cond : ∀ x : V, ∃! y : V, φ.Eval ![x, y] id := by simpa [← hR] using h
   simpa [hR] using replacement_exists_eval X φ cond
 
-lemma replacement_existsUnique (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) :
+/--
+Replacement exists uniquely (for a relation).
+-/
+lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) :
     ∃! Y : V, ∀ y : V, y ∈ Y ↔ ∃ x ∈ X, R x y := by
-  rcases replacement_exists X R hR h with ⟨s, hs⟩
+  rcases replacement_rel_exists X R h with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
   intro u hu
   ext; simp_all
 
 /--
+Replacement exists uniquely for a function.
+-/
+lemma replacement_existsUnique (X : V) (F : V → V) [hF : ℒₛₑₜ-function₁ F] :
+    ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
+  let R (x y : V) : Prop := Function.Graph F y x
+  have h : ∀ (x : V), ∃! y, R x y := by
+    intro x
+    simp only [Function.Graph, existsUnique_eq, R]
+  exact replacement_rel_existsUnique X R (hR := by definability) h
+
+/--
 Replacement exists for a function.
 -/
-lemma replacement_exists_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
-    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
-  let P (x y : V) : Prop := Function.Graph F y x
-  have h : ∀ (x : V), ∃! y, P x y := by
-    intro x
-    simp only [Function.Graph, existsUnique_eq, P]
-  exact replacement_exists X P (by definability) h
+lemma replacement_exists (X : V) (F : V → V) [hF : ℒₛₑₜ-function₁ F] :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := (replacement_existsUnique X F).exists
 
-lemma replacement_existsUnique_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
-    ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
-  let P (x y : V) : Prop := Function.Graph F y x
-  have h : ∀ (x : V), ∃! y, P x y := by
-    intro x
-    simp only [Function.Graph, existsUnique_eq, P]
-  exact replacement_existsUnique X P (by definability) h
+/--
+The axiom of replacement for a relation.
+-/
+noncomputable def replRel (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) : V := Classical.choose! (replacement_rel_existsUnique X R h)
 
 /--
 The axiom of replacement.
 -/
-noncomputable def repl (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) : V := Classical.choose! (replacement_existsUnique X R hR h)
+noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V := Classical.choose! (replacement_existsUnique X F)
+
+/-! ## Various lemmas -/
+
+@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} [hR : ℒₛₑₜ-relation R] {h : ∀ x, ∃! y, R x y} :
+    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h) y
+
+/-! ## Variants of replacement -/
 
 /--
-The axiom of replacement, for a function.
+A stronger variant of (unique existent of) replacement, which only requires uniqueness on `X`.
+The statement of this lemma is thanks to tosiaki.
 -/
-noncomputable def repl_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V := Classical.choose! (replacement_existsUnique_function X F hF)
+lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) :
+    ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
+  /- Proof sketch: Define `R' x y` to hold iff `x ∈ X` and `R x y`, or `x ∉ X` and `y = ∅`.
+  Show that `∀ x, ∃! y, R' x y` holds, by case subdivision on whether `x ∈ X` or not.
+  Obtain `Y` from replacement.
+  Then, for any `y`, we have that `y ∈ Y` iff `∃ x ∈ X, R x y`, iff `∃ x ∈ X, R' x y`.
+  -/
+  let R' (x y : V) : Prop := x ∈ X ∧ R x y ∨ x ∉ X ∧ y = ∅
+  have cond : ∀ x, ∃! y, R' x y := by
+    intro x
+    refine Classical.byCases (p := x ∈ X) ?_ ?_ <;> (intro hx; simp_all [R'])
+  obtain ⟨Y, hY⟩ := replacement_rel_exists X R' (hR := by definability) cond
+  use Y
+  aesop
+
+/--
+A stronger variant of replacement, which only requires uniqueness on `X`.
+The statement of this lemma is thanks to tosiaki.
+-/
+lemma replacement_rel_exists_of_mem_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := (replacement_rel_existsUnique_of_mem_existsUnique X R h).exists
+
+/--
+The axiom of replacement, only assuming uniqueness on `X`.
+-/
+noncomputable def replRelOfMemExistsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) : V :=
+  Classical.choose! (replacement_rel_existsUnique_of_mem_existsUnique X R h)
+
+/--
+`repl_of_mem_existsUnique` agrees with `repl`.
+TODO: This is not very useful, since it already assumes uniqueness on all of `V`.
+-/
+@[simp] lemma replRelOfMemExistsUnique_spec {X y : V} {R : V → V → Prop} [hR : ℒₛₑₜ-relation R] {h : ∀ x ∈ X, ∃! y, R x y} :
+    y ∈ replRelOfMemExistsUnique X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h) y
 
 end LO.FirstOrder.SetTheory

--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -31,7 +31,7 @@ lemma replacement_exists_eval (X : V) (φ : SetTheorySemiformula V 2) (h : (∀ 
 /--
 Replacement exists (for a relation).
 -/
-lemma replacement_rel_exists (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
+lemma replacement_rel_exists (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R) :
     ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   rcases hR with ⟨φ, hR⟩
   -- Put hR in a useful form
@@ -42,9 +42,9 @@ lemma replacement_rel_exists (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, 
 /--
 Replacement exists uniquely (for a relation).
 -/
-lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
+lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R) :
     ∃! Y : V, ∀ y : V, y ∈ Y ↔ ∃ x ∈ X, R x y := by
-  rcases replacement_rel_exists X R h with ⟨s, hs⟩
+  rcases replacement_rel_exists X R h hR with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
   intro u hu
   ext; simp_all
@@ -52,29 +52,29 @@ lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x, �
 /--
 Replacement exists uniquely for a function.
 -/
-lemma replacement_existsUnique (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) :
+lemma replacement_existsUnique (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
     ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
   let R (x y : V) : Prop := Function.Graph F y x
   have h : ∀ (x : V), ∃! y, R x y := by
     intro x
     simp only [Function.Graph, existsUnique_eq, R]
-  exact replacement_rel_existsUnique X R h
+  exact replacement_rel_existsUnique X R h (by definability)
 
 /--
 Replacement exists for a function.
 -/
-lemma replacement_exists (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) :
-    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := (replacement_existsUnique X F).exists
+lemma replacement_exists (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := (replacement_existsUnique X F hF).exists
 
 /--
 The axiom of replacement for a relation.
 -/
-noncomputable def replRel (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V := Classical.choose! (replacement_rel_existsUnique X R h)
+noncomputable def replRel (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V := Classical.choose! (replacement_rel_existsUnique X R h hR)
 
 /--
 The axiom of replacement.
 -/
-noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V := Classical.choose! (replacement_existsUnique X F)
+noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) : V := Classical.choose! (replacement_existsUnique X F hF)
 
 /-! ## Variants of replacement -/
 
@@ -82,7 +82,7 @@ noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
 A stronger variant of (unique existence of) replacement, which only requires uniqueness on `X`.
 The statement of this lemma is thanks to tosiaki.
 -/
-lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
+lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R) :
     ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   /- Proof sketch: Define `R' x y` to hold iff `x ∈ X` and `R x y`, or `x ∉ X` and `y = ∅`.
   Show that `∀ x, ∃! y, R' x y` holds, by case subdivision on whether `x ∈ X` or not.
@@ -93,7 +93,7 @@ lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → 
   have cond : ∀ x, ∃! y, R' x y := by
     intro x
     refine Classical.byCases (p := x ∈ X) ?_ ?_ <;> (intro hx; simp_all [R'])
-  obtain ⟨Y, hY⟩ := replacement_rel_exists X R' cond
+  obtain ⟨Y, hY⟩ := replacement_rel_exists X R' cond (by definability)
   use Y
   aesop
 
@@ -101,24 +101,24 @@ lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → 
 A stronger variant of replacement, which only requires uniqueness on `X`.
 The statement of this lemma is thanks to tosiaki.
 -/
-lemma replacement_rel_exists_of_over_set (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
-    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := (replacement_rel_existsUnique_of_mem_existsUnique X R h).exists
+lemma replacement_rel_exists_of_mem_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R) :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := (replacement_rel_existsUnique_of_mem_existsUnique X R h hR).exists
 
 /--
 The axiom of replacement, only assuming uniqueness on `X`.
 -/
 noncomputable def replRelOverSet (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V :=
-  Classical.choose! (replacement_rel_existsUnique_of_mem_existsUnique X R h)
+  Classical.choose! (replacement_rel_existsUnique_of_mem_existsUnique X R h hR)
 
 /-! ## Various lemmas -/
 
-@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} {h : ∀ x, ∃! y, R x y} (hR : ℒₛₑₜ-relation R := by definability) :
-    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h) y
+@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} {h : ∀ x, ∃! y, R x y} (hR : ℒₛₑₜ-relation R) :
+    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h hR) y
 
-@[simp] lemma repl_spec {X y : V} {F : V → V} (hF : ℒₛₑₜ-function₁ F := by definability) :
+@[simp] lemma repl_spec {X y : V} {F : V → V} (hF : ℒₛₑₜ-function₁ F) :
     y ∈ repl X F hF ↔ ∃ x ∈ X, y = F x := Classical.choose!_spec (replacement_existsUnique X F hF) y
 
-@[simp] lemma replRelOverSet_spec {X y : V} {R : V → V → Prop} {h : ∀ x ∈ X, ∃! y, R x y} (hR : ℒₛₑₜ-relation R := by definability) :
-    y ∈ replRelOverSet X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h) y
+@[simp] lemma replRelOverSet_spec {X y : V} {R : V → V → Prop} {h : ∀ x ∈ X, ∃! y, R x y} (hR : ℒₛₑₜ-relation R) :
+    y ∈ replRelOverSet X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h hR) y
 
 end LO.FirstOrder.SetTheory

--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -31,7 +31,7 @@ lemma replacement_exists_eval (X : V) (φ : SetTheorySemiformula V 2) (h : (∀ 
 /--
 Replacement exists (for a relation).
 -/
-lemma replacement_rel_exists (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) :
+lemma replacement_rel_exists (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
     ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   rcases hR with ⟨φ, hR⟩
   -- Put hR in a useful form
@@ -42,7 +42,7 @@ lemma replacement_rel_exists (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-r
 /--
 Replacement exists uniquely (for a relation).
 -/
-lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) :
+lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
     ∃! Y : V, ∀ y : V, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   rcases replacement_rel_exists X R h with ⟨s, hs⟩
   apply ExistsUnique.intro s hs
@@ -52,42 +52,37 @@ lemma replacement_rel_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛ�
 /--
 Replacement exists uniquely for a function.
 -/
-lemma replacement_existsUnique (X : V) (F : V → V) [hF : ℒₛₑₜ-function₁ F] :
+lemma replacement_existsUnique (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) :
     ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
   let R (x y : V) : Prop := Function.Graph F y x
   have h : ∀ (x : V), ∃! y, R x y := by
     intro x
     simp only [Function.Graph, existsUnique_eq, R]
-  exact replacement_rel_existsUnique X R (hR := by definability) h
+  exact replacement_rel_existsUnique X R h
 
 /--
 Replacement exists for a function.
 -/
-lemma replacement_exists (X : V) (F : V → V) [hF : ℒₛₑₜ-function₁ F] :
+lemma replacement_exists (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) :
     ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := (replacement_existsUnique X F).exists
 
 /--
 The axiom of replacement for a relation.
 -/
-noncomputable def replRel (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x, ∃! y, R x y) : V := Classical.choose! (replacement_rel_existsUnique X R h)
+noncomputable def replRel (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V := Classical.choose! (replacement_rel_existsUnique X R h)
 
 /--
 The axiom of replacement.
 -/
 noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V := Classical.choose! (replacement_existsUnique X F)
 
-/-! ## Various lemmas -/
-
-@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} [hR : ℒₛₑₜ-relation R] {h : ∀ x, ∃! y, R x y} :
-    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h) y
-
 /-! ## Variants of replacement -/
 
 /--
-A stronger variant of (unique existent of) replacement, which only requires uniqueness on `X`.
+A stronger variant of (unique existence of) replacement, which only requires uniqueness on `X`.
 The statement of this lemma is thanks to tosiaki.
 -/
-lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) :
+lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
     ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
   /- Proof sketch: Define `R' x y` to hold iff `x ∈ X` and `R x y`, or `x ∉ X` and `y = ∅`.
   Show that `∀ x, ∃! y, R' x y` holds, by case subdivision on whether `x ∈ X` or not.
@@ -98,7 +93,7 @@ lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → 
   have cond : ∀ x, ∃! y, R' x y := by
     intro x
     refine Classical.byCases (p := x ∈ X) ?_ ?_ <;> (intro hx; simp_all [R'])
-  obtain ⟨Y, hY⟩ := replacement_rel_exists X R' (hR := by definability) cond
+  obtain ⟨Y, hY⟩ := replacement_rel_exists X R' cond
   use Y
   aesop
 
@@ -106,20 +101,24 @@ lemma replacement_rel_existsUnique_of_mem_existsUnique (X : V) (R : V → V → 
 A stronger variant of replacement, which only requires uniqueness on `X`.
 The statement of this lemma is thanks to tosiaki.
 -/
-lemma replacement_rel_exists_of_mem_existsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) :
+lemma replacement_rel_exists_of_over_set (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) :
     ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := (replacement_rel_existsUnique_of_mem_existsUnique X R h).exists
 
 /--
 The axiom of replacement, only assuming uniqueness on `X`.
 -/
-noncomputable def replRelOfMemExistsUnique (X : V) (R : V → V → Prop) [hR : ℒₛₑₜ-relation R] (h : ∀ x ∈ X, ∃! y, R x y) : V :=
+noncomputable def replRelOverSet (X : V) (R : V → V → Prop) (h : ∀ x ∈ X, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V :=
   Classical.choose! (replacement_rel_existsUnique_of_mem_existsUnique X R h)
 
-/--
-`repl_of_mem_existsUnique` agrees with `repl`.
-TODO: This is not very useful, since it already assumes uniqueness on all of `V`.
--/
-@[simp] lemma replRelOfMemExistsUnique_spec {X y : V} {R : V → V → Prop} [hR : ℒₛₑₜ-relation R] {h : ∀ x ∈ X, ∃! y, R x y} :
-    y ∈ replRelOfMemExistsUnique X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h) y
+/-! ## Various lemmas -/
+
+@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} {h : ∀ x, ∃! y, R x y} (hR : ℒₛₑₜ-relation R := by definability) :
+    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h) y
+
+@[simp] lemma repl_spec {X y : V} {F : V → V} (hF : ℒₛₑₜ-function₁ F := by definability) :
+    y ∈ repl X F hF ↔ ∃ x ∈ X, y = F x := Classical.choose!_spec (replacement_existsUnique X F hF) y
+
+@[simp] lemma replRelOverSet_spec {X y : V} {R : V → V → Prop} {h : ∀ x ∈ X, ∃! y, R x y} (hR : ℒₛₑₜ-relation R := by definability) :
+    y ∈ replRelOverSet X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h) y
 
 end LO.FirstOrder.SetTheory

--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -1,0 +1,78 @@
+module
+
+public import Foundation.FirstOrder.SetTheory.Z
+
+@[expose] public section
+
+namespace LO.FirstOrder.SetTheory
+
+variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭] [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
+
+/-! ## Ersatzaxiom -/
+
+open Classical
+
+lemma replacement_exists_eval (X : V) (φ : SetTheorySemiformula V 2) (h : (∀ x : V, ∃! y : V, φ.Eval ![x, y] id)) :
+    ∃ Y : V, ∀ y : V, y ∈ Y ↔ ∃ x ∈ X, φ.Eval ![x, y] id := by
+  /- `φ` can have finitely many free variables of type `V`, these are interpreted by `id : V → V` as finitely many parameters in `V`.
+  `f` enumerates the parameters of `φ`. -/
+  let f := φ.enumarateFVar
+  /- While `φ` has free variables of type `V`, `ψ` has free variables of type `ℕ`.
+  Since `f` enumerates the parameters, it is intended to be the valuation of the free variables of `ψ`. -/
+  let ψ := (Rew.rewriteMap φ.idxOfFVar) ▹ φ
+
+  have whole := by simpa [models_iff, Semiformula.eval_univCl, Axiom.replacementSchema] using Theory.models V 𝗭𝗙 (ZermeloFraenkel.axiom_of_replacement ψ)
+
+  have cond : ∀ x, ∃! y : V, ψ.Eval ![x, y] f := by
+    simpa [ψ, f, Semiformula.eval_rewriteMap]
+
+  simpa [ψ, f, Semiformula.eval_rewriteMap, Matrix.constant_eq_singleton] using whole f cond X
+
+/--
+Replacement exists (for a relation).
+-/
+lemma replacement_exists (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, R x y := by
+  rcases hR with ⟨φ, hR⟩
+  -- Put hR in a useful form
+  have hR {x y : V} := by simpa using hR.iff ![x, y]
+  have cond : ∀ x : V, ∃! y : V, φ.Eval ![x, y] id := by simpa [← hR] using h
+  simpa [hR] using replacement_exists_eval X φ cond
+
+lemma replacement_existsUnique (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) :
+    ∃! Y : V, ∀ y : V, y ∈ Y ↔ ∃ x ∈ X, R x y := by
+  rcases replacement_exists X R hR h with ⟨s, hs⟩
+  apply ExistsUnique.intro s hs
+  intro u hu
+  ext; simp_all
+
+/--
+Replacement exists for a function.
+-/
+lemma replacement_exists_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
+    ∃ Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
+  let P (x y : V) : Prop := Function.Graph F y x
+  have h : ∀ (x : V), ∃! y, P x y := by
+    intro x
+    simp only [Function.Graph, existsUnique_eq, P]
+  exact replacement_exists X P (by definability) h
+
+lemma replacement_existsUnique_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
+    ∃! Y : V, ∀ y, y ∈ Y ↔ ∃ x ∈ X, y = F x := by
+  let P (x y : V) : Prop := Function.Graph F y x
+  have h : ∀ (x : V), ∃! y, P x y := by
+    intro x
+    simp only [Function.Graph, existsUnique_eq, P]
+  exact replacement_existsUnique X P (by definability) h
+
+/--
+The axiom of replacement.
+-/
+noncomputable def repl (X : V) (R : V → V → Prop) (hR : ℒₛₑₜ-relation R) (h : ∀ x, ∃! y, R x y) : V := Classical.choose! (replacement_existsUnique X R hR h)
+
+/--
+The axiom of replacement, for a function.
+-/
+noncomputable def repl_function (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V := Classical.choose! (replacement_existsUnique_function X F hF)
+
+end LO.FirstOrder.SetTheory


### PR DESCRIPTION
Add a file `ZF.lean` for working with replacement, modeled off of `LO.FirstOrder.SetTheory.sep`. I also added two other things, which I have left as comments in the code.