### PR TITLE
ci: parallelize jobs, simplify cache keys, and drive steps through Justfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: .lake/Foundation-x86_64-unknown-linux-gnu.tar.gz
-          # NOTE: including github branch name and SHA for avoding cache key reserving problem
-          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.ref_name }}-${{ github.sha }}
+          # Cache entries are immutable, so the key includes the commit SHA to always save fresh.
+          # Branch isolation is already enforced by the cache's built-in scoping.
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
           restore-keys: |
-            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.ref_name }}
             lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
       - name: Unpack project cache
         if: hashFiles('.lake/Foundation-x86_64-unknown-linux-gnu.tar.gz') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,9 @@ jobs:
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
       - uses: ts-graphviz/setup-graphviz@v2
+      - uses: extractions/setup-just@v3
       - name: Generate import graph
-        run: |
-          lake exe graph ./import_graph.png
-          lake exe graph ./import_graph.pdf
-          lake exe graph ./import_graph.html
+        run: just import-graph
 
       - name: Upload lean artifacts
         uses: actions/upload-artifact@v7
@@ -88,31 +86,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: extractions/setup-just@v3
       - name: Install bibtool
         run: |
           sudo apt-get update
           sudo apt-get install -y bibtool
-      - name: Format references.bib
+      - name: Check references.bib is formatted
         run: |
-          bibtool -r .bibtoolrsc -i references.bib -o references.bib.formatted
-      - name: Check if formatted correctly
-        run: |
-          diff -u references.bib references.bib.formatted || (echo "references.bib is not formatted" && exit 1)
+          just format-references
+          if [ -n "$(git diff)" ]; then
+            echo "references.bib is not formatted. Please run 'just format-references' and commit the changes."
+            exit 1
+          fi
 
   mk-all-check:
     name: Check mk_all executed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: extractions/setup-just@v3
       - name: Setup elan
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Check mk_all executed
         run: |
-          lake exe mk_all --module
+          just mk-all
           if [ -n "$(git diff)" ]; then
-            echo "Files were modified by mk_all. Please run 'lake exe mk_all --module' and commit the changes."
+            echo "Files were modified by mk_all. Please run 'just mk-all' and commit the changes."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,14 +15,11 @@ concurrency:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
     name: Build project
     runs-on: ubuntu-latest
-    needs: mk-all-check
     steps:
       - uses: actions/checkout@v7
       - name: Setup elan
@@ -108,7 +106,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Setup elan
         run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: Check mk_all executed
         run: |
@@ -125,6 +123,10 @@ jobs:
     needs:
       - build
       - check-references
+      - mk-all-check
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Justfile
+++ b/Justfile
@@ -1,11 +1,19 @@
+# List available recipes
+default:
+    @just --list
+
 # Format and regenerate keys of references.bib
 format-references:
     bibtool -F -r .bibtoolrsc -i ./references.bib -o references.bib
     sed -i '1{/^$/d}' references.bib
 
-# Generate the import graph as import_graph.{png,pdf,html} (requires graphviz)
+# Generate the import graph of Foundation as import_graph.{png,pdf,html} (requires graphviz)
 import-graph:
-    lake exe graph import_graph.png import_graph.pdf import_graph.html
+    lake exe graph --to Foundation import_graph.png import_graph.pdf import_graph.html
+
+# Count lines of Lean source in Foundation/, excluding blank and comment lines (requires cloc)
+cloc:
+    cloc --include-lang=Lean Foundation/
 
 # Regenerate Foundation.lean to include all modules (run after adding/removing files)
 mk-all:

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+# Format and regenerate keys of references.bib
+format-references:
+    bibtool -F -r .bibtoolrsc -i ./references.bib -o references.bib
+    sed -i '1{/^$/d}' references.bib
+
+# Generate the import graph as import_graph.{png,pdf,html} (requires graphviz)
+import-graph:
+    lake exe graph import_graph.png import_graph.pdf import_graph.html
+
+# Regenerate Foundation.lean to include all modules (run after adding/removing files)
+mk-all:
+    lake exe mk_all --module
+
+# Remove unused imports/variables and drop unnecessary `public` (run before merging any work)
+shake:
+    lake shake --keep-public --fix

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,3 @@
-
 @InCollection{A.B05,
   author        = {Artemov, Sergei N. and Beklemishev, Lev D.},
   title         = {Provability {{Logic}}},


### PR DESCRIPTION
## 概要

SeqPL・goodstein-independence の CI 設定を参考に，`ci.yml` を効率化した．

## 変更点

- **`build` と `mk-all-check` の並列化**: `build` の `needs: mk-all-check` を外し，両ジョブを並列実行にした（ガードとしての役割は `deploy` の `needs` に `mk-all-check` を追加して維持）．CI の壁時計時間が mk-all-check 分短縮される．
- **`permissions` の絞り込み**: `pages: write`・`id-token: write` をワークフロー全体から `deploy` ジョブのみに限定．
- **キャッシュキーから `github.ref_name` を削除**: ブランチ間の分離は actions/cache のスコープ機構が強制しており，キーの一意性は `github.sha` サフィックスで十分なため．
- **Justfile の導入と CI からの利用**: `format-references`・`import-graph`・`mk-all`・`shake`・`cloc` のレシピを追加し，CI の該当ステップ（references.bib チェック・mk_all チェック・import graph 生成）を just レシピ経由に変更してコマンドの二重管理を解消．import graph は 3 回の `lake exe graph` 呼び出しを 1 回に統合．
- **その他**: `mk-all-check` の elan インストールに `--default-toolchain none` を追加（未使用の stable toolchain のダウンロードを省く）．`workflow_dispatch` トリガを追加．`format-references`（`-F` 付き）で references.bib 先頭の空行を除去．

## 備考

- `just import-graph`（`lake exe graph --to Foundation` の複数出力 1 回呼び出し）はローカルでの実行検証を行っていないため，この PR の CI 実行結果で確認すること．
- 各コミットは actionlint でチェック済み．

この PR の変更は AI エージェント（Claude Code）を用いて作成した．

🤖 Generated with [Claude Code](https://claude.com/claude-code)