### PR TITLE
change(Logic/Entailment): make `Consistent.not_bot` instance-based

### DIFF
--- a/Foundation/FirstOrder/Incompleteness/Halting.lean
+++ b/Foundation/FirstOrder/Incompleteness/Halting.lean
@@ -42,7 +42,7 @@ lemma incomplete_of_REPred_not_ComputablePred_Nat' {P : ℕ → Prop} (hRE : REP
     . simpa [hP] using! hd₁;
     . simpa;
   . exfalso;
-    apply Entailment.Consistent.not_bot (𝓢 := T) inferInstance;
+    apply Entailment.Consistent.not_bot (𝓢 := T);
     replace hd₁ : T ⊢ φ/[d] := by simpa [hP] using! hd₁;
     cl_prover [hd₁, hd₂];
 

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
@@ -73,9 +73,8 @@ variable
 lemma unprovable_jeroslow [T₀ ⪯ T] [Consistent T] [𝔚.SoundOn (jeroslow 𝔚)] : T ⊬ jeroslow 𝔚 := by
   by_contra hC;
   apply Entailment.Consistent.not_bot (𝓢 := T);
-  . infer_instance;
-  . have : T ⊢ ∼(jeroslow 𝔚) := Refutability.sound_on $ (Entailment.iff_of_E! $ jeroslow_def') |>.mp hC;
-    exact (N!_iff_CO!.mp this) ⨀ hC;
+  have : T ⊢ ∼(jeroslow 𝔚) := Refutability.sound_on $ (Entailment.iff_of_E! $ jeroslow_def') |>.mp hC;
+  exact (N!_iff_CO!.mp this) ⨀ hC;
 
 end
 

--- a/Foundation/FirstOrder/Incompleteness/Tarski.lean
+++ b/Foundation/FirstOrder/Incompleteness/Tarski.lean
@@ -12,10 +12,9 @@ variable {T : ArithmeticTheory} [𝗜𝚺₁ ⪯ T] [Entailment.Consistent T]
 lemma not_exists_tarski_predicate : ¬∃ τ : ArithmeticSemisentence 1, ∀ σ, T ⊢ σ 🡘 τ/[⌜σ⌝] := by
   rintro ⟨τ, hτ⟩;
   apply Entailment.Consistent.not_bot (𝓢 := T);
-  . infer_instance;
-  . have h₁ : T ⊢ fixedpoint (∼τ) 🡘 τ/[⌜fixedpoint (∼τ)⌝] := by simpa using hτ $ fixedpoint “x. ¬!τ x”;;
-    have h₂ : T ⊢ fixedpoint (∼τ) 🡘 ∼τ/[⌜fixedpoint (∼τ)⌝] := by simpa using diagonal (T := T) “x. ¬!τ x”;
-    cl_prover [h₁, h₂];
+  have h₁ : T ⊢ fixedpoint (∼τ) 🡘 τ/[⌜fixedpoint (∼τ)⌝] := by simpa using hτ $ fixedpoint “x. ¬!τ x”;;
+  have h₂ : T ⊢ fixedpoint (∼τ) 🡘 ∼τ/[⌜fixedpoint (∼τ)⌝] := by simpa using diagonal (T := T) “x. ¬!τ x”;
+  cl_prover [h₁, h₂];
 
 /-- Tarski's Undefinability of Truth Theorem. -/
 theorem undefinability_of_truth : ¬∃ τ : ArithmeticSemisentence 1, ∀ σ : ArithmeticSentence, ℕ↓[ℒₒᵣ] ⊧ σ ↔ ℕ↓[ℒₒᵣ] ⊧ τ/[⌜σ⌝] := by

--- a/Foundation/Logic/Entailment.lean
+++ b/Foundation/Logic/Entailment.lean
@@ -295,7 +295,8 @@ lemma consistent_iff_unprovable_bot {𝓢 : S} :
     Consistent 𝓢 ↔ 𝓢 ⊬ ⊥ := by
   simp [inconsistent_iff_provable_bot, ←not_inconsistent_iff_consistent]
 
-alias ⟨Consistent.not_bot, _⟩ := consistent_iff_unprovable_bot
+@[simp, grind] lemma Consistent.not_bot {𝓢 : S} [Consistent 𝓢] : 𝓢 ⊬ ⊥ :=
+  consistent_iff_unprovable_bot.mp inferInstance
 
 end
 

--- a/Foundation/Logic/Entailment.lean
+++ b/Foundation/Logic/Entailment.lean
@@ -295,7 +295,7 @@ lemma consistent_iff_unprovable_bot {𝓢 : S} :
     Consistent 𝓢 ↔ 𝓢 ⊬ ⊥ := by
   simp [inconsistent_iff_provable_bot, ←not_inconsistent_iff_consistent]
 
-@[simp, grind] lemma Consistent.not_bot {𝓢 : S} [Consistent 𝓢] : 𝓢 ⊬ ⊥ :=
+@[simp, grind .] lemma Consistent.not_bot {𝓢 : S} [Consistent 𝓢] : 𝓢 ⊬ ⊥ :=
   consistent_iff_unprovable_bot.mp inferInstance
 
 end


### PR DESCRIPTION
Closes #450.

`Entailment.Consistent.not_bot` was stated as `Consistent 𝓢 → 𝓢 ⊬ ⊥`, taking the consistency hypothesis as an explicit argument. This makes it awkward to use with automation.

This PR changes it into an instance-based `@[simp, grind]` lemma:

```lean
@[simp, grind] lemma Consistent.not_bot {𝓢 : S} [Consistent 𝓢] : 𝓢 ⊬ ⊥ :=
  consistent_iff_unprovable_bot.mp inferInstance
```

Now, whenever a `Consistent 𝓢` instance is available, `simp`/`grind` automatically rewrite `𝓢 ⊢ ⊥` to `False`. The `consistent_iff_unprovable_bot` iff lemma is kept; only the old explicit-argument `alias` is replaced.

The three call sites (`Tarski.lean`, `ProvabilityAbstraction/Refutability.lean`, `Halting.lean`) are updated to drop the now-inferred consistency argument.

The full repository builds with no new errors or warnings.

---

🤖 This PR was prepared with the assistance of Claude Code.
