### PR TITLE
ci: trigger CI workflow on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - master
+  # Required so these checks also run against the queue's speculative merge
+  # commit; otherwise a merge queue entry has no status checks to wait on.
+  merge_group:
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add a `merge_group` trigger to `.github/workflows/ci.yml` so the required status checks (`build`, `check-references`, `mk-all-check`) also run against the merge queue's speculative merge commit, not just `push`/`pull_request`.

## Context
A `master` branch ruleset with merge queue enabled was set up separately (GitHub repo settings). Without this workflow change, queue entries would have no status checks to satisfy and could never merge.

🤖 An AI coding agent (Claude) proposed and applied this change.

## Test plan
- [ ] Confirm the `CI` workflow runs and passes when this PR is merged via the merge queue