### PR TITLE
refactor(Logic): give explicit grind directions in Semantics.lean

### DIFF
--- a/Foundation/Logic/Semantics.lean
+++ b/Foundation/Logic/Semantics.lean
@@ -76,9 +76,18 @@ class Tarski extends
   Semantics.Not M
   where
 
-attribute [simp, grind]
+-- `Top.models_verum`/`Bot.models_falsum` are plain facts (not iffs), so `grind`
+-- can only use them as one-directional "known facts" (`.`), matching the
+-- precedent of `letterless_verum`/`letterless_falsum` in `Propositional/Formula/Basic.lean`.
+attribute [simp, grind .]
   Top.models_verum
   Bot.models_falsum
+
+-- `Not.models_not`/`And.models_and`/`Or.models_or`/`Imp.models_imply` are genuine
+-- bidirectional rewrites decomposing a connective, so `grind =` (equational rewrite
+-- in both directions) applies, matching the precedent of `letterless_and`/`letterless_or`/
+-- `letterless_imp`/`letterless_neg` in `Propositional/Formula/Basic.lean`.
+attribute [simp, grind =]
   Not.models_not
   And.models_and
   Or.models_or

--- a/Foundation/Logic/Semantics.lean
+++ b/Foundation/Logic/Semantics.lean
@@ -76,17 +76,10 @@ class Tarski extends
   Semantics.Not M
   where
 
--- `Top.models_verum`/`Bot.models_falsum` are plain facts (not iffs), so `grind`
--- can only use them as one-directional "known facts" (`.`), matching the
--- precedent of `letterless_verum`/`letterless_falsum` in `Propositional/Formula/Basic.lean`.
 attribute [simp, grind .]
   Top.models_verum
   Bot.models_falsum
 
--- `Not.models_not`/`And.models_and`/`Or.models_or`/`Imp.models_imply` are genuine
--- bidirectional rewrites decomposing a connective, so `grind =` (equational rewrite
--- in both directions) applies, matching the precedent of `letterless_and`/`letterless_or`/
--- `letterless_imp`/`letterless_neg` in `Propositional/Formula/Basic.lean`.
 attribute [simp, grind =]
   Not.models_not
   And.models_and


### PR DESCRIPTION
## Summary
- Split the bare `attribute [simp, grind] ...` block in `Foundation/Logic/Semantics.lean` into directional attributes: `grind .` for the plain-fact `Top.models_verum`/`Bot.models_falsum`, and `grind =` for the iff lemmas decomposing `Not`/`And`/`Or`/`Imp`.
- Follows `contribute/style.md`'s "choose a direction where it matters" guidance for `@[grind]`, and matches the existing `letterless_*` precedent in `Propositional/Formula/Basic.lean`.
- Silences the "Try these: [grind ...]" info that `lake build` was emitting on every build for this line.

🤖 An AI coding agent (Claude) proposed and applied this change.

## Test plan
- [x] `lake build Foundation` succeeds with no errors/warnings and no remaining grind-suggestion info for this file.