### PR TITLE
add(FirstOrder): Church's undecidability theorem

### DIFF
--- a/Foundation.lean
+++ b/Foundation.lean
@@ -80,6 +80,7 @@ public import Foundation.FirstOrder.Completeness.CanonicalModel
 public import Foundation.FirstOrder.Completeness.CountableSublanguage
 public import Foundation.FirstOrder.Completeness.CounterModel
 public import Foundation.FirstOrder.Hauptsatz
+public import Foundation.FirstOrder.Incompleteness.Church
 public import Foundation.FirstOrder.Incompleteness.Consistency
 public import Foundation.FirstOrder.Incompleteness.Dense
 public import Foundation.FirstOrder.Incompleteness.Examples

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -96,8 +96,8 @@ lemma d_graph_sigma1 : 𝚺₁-Relation fun n m : ℕ ↦ m = d n := by
   exact (hSN.retraction ![1, 0, 0]).of_iff fun v ↦ by simp [d]
 
 /-- `d` is computable. -/
-lemma d_computable : Computable d := by
-  sorry
+lemma d_computable : Computable d :=
+  computable_of_graph_rePred (rePred_of_sigma1_relation d_graph_sigma1)
 
 /-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
 lemma d_quote_eq (σ : ArithmeticSemisentence 1) : d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) :=

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -15,7 +15,7 @@ public import Mathlib.Computability.Reduce
 the set of `T`-provable sentences is not computable, by a direct diagonalization on the
 self-applied substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak
 representability of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness
-theorem). `church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable,
+theorem). `undecidability_first_order_logic` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable,
 `𝗣𝗔⁻`-provability computably many-one reduces to `∅`-provability, so undecidability transfers
 from `church_theorem_general` without needing the `𝗥₀ ⪯ T` and soundness hypotheses required
 there.
@@ -149,7 +149,7 @@ lemma finite_theory_provable_iff_conj_imp {T : Theory ℒₒᵣ} (hT : Set.Finit
 
 /-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
 computable. -/
-theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := by
+theorem undecidability_first_order_logic : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := by
   by_contra hC
   apply church_theorem_general (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC)
   refine ⟨fun σ ↦ PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -119,9 +119,13 @@ lemma f_computable : Computable f := by
 
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
+-- This direction needs neither `𝗥₀ ⪯ T` nor `𝚺₁`-soundness, only closure of `ComputablePred`
+-- under complement and many-one reduction along the computable `f`.
+omit [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1] in
 /-- If `T`-provability is computable, so is `σ ↦ T ⊬ f σ`. -/
-lemma D_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ f σ) := by
-  sorry
+lemma D_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ f σ) :=
+  ComputablePred.computable_of_manyOneReducible
+    (ManyOneReducible.mk (fun σ ↦ T ⊬ σ) f_computable) hC.not
 
 /-- The diagonal fixed point for `σ ↦ T ⊬ f σ`: a sentence whose `T`-provability and
 `T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -32,6 +32,27 @@ complete proofs, assembled from those (sorry'd) facts.
 
 namespace LO.FirstOrder.Arithmetic
 
+
+namespace ArithmeticTheory
+
+variable {T : ArithmeticTheory}
+
+abbrev codes (T : ArithmeticTheory) : ℕ → Prop := λ n => (Encodable.decode n).elim False (T ⊢ ·)
+
+def RE (T : ArithmeticTheory) : Prop := REPred T.theory
+
+lemma iff_RE_theoryCodes_RE : RE T ↔ REPred (codes T) :=
+  _root_.REPred.iff_decoded_pred
+
+
+def Computable (T : ArithmeticTheory) : Prop := ComputablePred T.theory
+
+lemma iff_Computable_theoryCodes_Computable : Computable T ↔ ComputablePred (codes T) :=
+  _root_.ComputablePred.iff_decoded_pred
+
+end ArithmeticTheory
+
+
 open Bootstrapping Bootstrapping.Arithmetic
 
 section Diagonalization
@@ -40,7 +61,7 @@ section Diagonalization
 
 /-- A total function on `ℕ` whose graph is r.e. is computable. -/
 lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × ℕ ↦ p.2 = g p.1) :
-    Computable g := by
+  Computable g := by
   sorry
 
 /-- A `𝚺₁`-definable binary relation on `ℕ` is r.e. -/
@@ -62,8 +83,7 @@ lemma d_computable : Computable d := by
   sorry
 
 /-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
-lemma d_quote_eq (σ : ArithmeticSemisentence 1) :
-    d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) :=
+lemma d_quote_eq (σ : ArithmeticSemisentence 1) : d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) :=
   substNumeral_app_quote σ σ
 
 /-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
@@ -76,25 +96,21 @@ lemma f_computable : Computable f := by
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
 /-- If `T`-provability is computable, so is `σ ↦ T ⊬ f σ`. -/
-lemma D_computable (hC : ComputablePred {σ : ArithmeticSentence | T ⊢ σ}) :
-    ComputablePred (fun σ : ArithmeticSemisentence 1 ↦ T ⊬ f σ) := by
+lemma D_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ f σ) := by
   sorry
 
 /-- The diagonal fixed point for `σ ↦ T ⊬ f σ`: a sentence whose `T`-provability and
 `T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and
 `re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ f σ`. -/
-lemma D_diagonal (hD : ComputablePred (fun σ : ArithmeticSemisentence 1 ↦ T ⊬ f σ)) :
-    ∃ δ : ArithmeticSemisentence 1, (T ⊬ f δ) ↔ T ⊢ f δ := by
+lemma D_diagonal (hD : ComputablePred (fun σ ↦ T ⊬ f σ)) : ∃ δ : ArithmeticSemisentence 1, (T ⊬ f δ) ↔ T ⊢ f δ := by
   sorry
 
 /-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
 of `T`-provable sentences is not computable. -/
 theorem church_theoremAux : ¬ComputablePred {σ : ArithmeticSentence | T ⊢ σ} := by
-  intro hC
-  obtain ⟨δ, hδ⟩ := D_diagonal (D_computable hC)
-  by_cases h : T ⊢ f δ
-  · exact hδ.mpr h h
-  · exact h (hδ.mp h)
+  by_contra hC;
+  obtain ⟨δ, hδ⟩ := D_diagonal $ D_computable hC;
+  tauto;
 
 end Diagonalization
 
@@ -102,48 +118,37 @@ section PeanoMinusReduction
 
 /-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
+lemma ttt :
+  letI π := PeanoMinus.finite.toFinset.conj
+  (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ ({π} : ArithmeticTheory) ⊢ σ
+  := by
+  sorry;
+
+
+/-
 /-- `𝗣𝗔⁻` is finitely axiomatized. -/
-lemma exists_peanoMinus_list :
-    ∃ Γ : List ArithmeticSentence, ∀ σ, σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ Γ := by
+lemma exists_peanoMinus_list : ∃ Γ : List ArithmeticSentence, ∀ σ, σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ Γ := by
   refine ⟨PeanoMinus.finite.toFinset.toList, fun σ ↦ ?_⟩
   rw [Finset.mem_toList, Set.Finite.mem_toFinset]
-
-open Classical in
-/-- A fixed finite list of axioms for `𝗣𝗔⁻`, chosen once and for all from
-`exists_peanoMinus_list`. -/
-noncomputable def peanoMinusList : List ArithmeticSentence := exists_peanoMinus_list.choose
-
-lemma mem_peanoMinusList_iff {σ : ArithmeticSentence} :
-    σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ peanoMinusList :=
-  exists_peanoMinus_list.choose_spec σ
-
-/-- `𝗣𝗔⁻` proves the conjunction of its own (finitely many) axioms. -/
-lemma peanoMinus_provable_conj : (𝗣𝗔⁻ : ArithmeticTheory) ⊢ peanoMinusList.foldr (· ⋏ ·) ⊤ := by
-  sorry
+-/
 
 /-- The deduction theorem for the finite theory `𝗣𝗔⁻`: `𝗣𝗔⁻` proves `σ` iff `∅` proves the
 conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
-lemma peanoMinus_provable_iff (σ : ArithmeticSentence) :
-    (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ peanoMinusList.foldr (· ⋏ ·) ⊤ 🡒 σ := by
-  sorry
-
-/-- The many-one reduction witness from `𝗣𝗔⁻`-provability to `∅`-provability,
-`σ ↦ (conjunction of 𝗣𝗔⁻'s axioms) 🡒 σ`. -/
-noncomputable def peanoMinusReduction (σ : ArithmeticSentence) : ArithmeticSentence :=
-  peanoMinusList.foldr (· ⋏ ·) ⊤ 🡒 σ
-
-/-- `peanoMinusReduction` is computable: prepending a fixed sentence is elementary. -/
-lemma peanoMinusReduction_computable : Computable peanoMinusReduction := by
-  sorry
+lemma peanoMinus_provable_iff {σ : ArithmeticSentence} :
+  letI π := PeanoMinus.finite.toFinset.conj
+  (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ π 🡒 σ := by
+  apply Iff.trans ttt;
+  sorry;
 
 /-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
 computable. -/
-theorem church_theorem : ¬ComputablePred {σ : ArithmeticSentence | (∅ : ArithmeticTheory) ⊢ σ} := by
-  intro hC
-  have hred : (fun σ : ArithmeticSentence ↦ (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ)
-      ≤₀ (fun σ : ArithmeticSentence ↦ (∅ : ArithmeticTheory) ⊢ σ) :=
-    ⟨peanoMinusReduction, peanoMinusReduction_computable, peanoMinus_provable_iff⟩
-  exact church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible hred hC)
+theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := by
+  by_contra hC;
+  apply church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC);
+  refine ⟨λ σ => PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
+  . sorry;
+  . intro σ;
+    exact peanoMinus_provable_iff;
 
 end PeanoMinusReduction
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -76,7 +76,13 @@ lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × �
 /-- A `𝚺₁`-definable binary relation on `ℕ` is r.e. -/
 lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation R) :
     REPred fun p : ℕ × ℕ ↦ R p.1 p.2 := by
-  sorry
+  obtain ⟨φ, hφ⟩ := h
+  have : REPred fun p : ℕ × ℕ ↦
+      φ.val.Eval (p.1 ::ᵥ p.2 ::ᵥ List.Vector.nil : List.Vector ℕ 2).get id :=
+    (sigma1_re id φ.sigma_prop).comp
+      (Primrec.to_comp <| Primrec.vector_cons.comp .fst
+        (Primrec.vector_cons.comp .snd (.const List.Vector.nil)))
+  exact this.of_eq <| by intro p; simpa [List.Vector.cons_get] using hφ ![p.1, p.2]
 
 /-- The code-level diagonal self-substitution: if `n` is the code of a `Semisentence ℒₒᵣ 1`,
 `d n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -91,7 +91,9 @@ noncomputable def d (n : ℕ) : ℕ := substNumeral (V := ℕ) n n
 
 /-- The graph of `d` is `𝚺₁`-definable. -/
 lemma d_graph_sigma1 : 𝚺₁-Relation fun n m : ℕ ↦ m = d n := by
-  sorry
+  have hSN : 𝚺-[1].Definable (fun w : Fin 3 → ℕ ↦ w 0 = substNumeral (w 1) (w 2)) :=
+    HierarchySymbol.Defined.to_definable ssnum substNumeral.defined
+  exact (hSN.retraction ![1, 0, 0]).of_iff fun v ↦ by simp [d]
 
 /-- `d` is computable. -/
 lemma d_computable : Computable d := by

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -108,7 +108,14 @@ noncomputable def f (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[
 
 /-- `f` is computable. -/
 lemma f_computable : Computable f := by
-  sorry
+  have : Computable (fun σ : ArithmeticSemisentence 1 ↦
+      (Encodable.decode (d (Encodable.encode σ)) : Option ArithmeticSentence).getD ⊤) :=
+    Computable.option_getD (Computable.decode.comp (d_computable.comp Computable.encode))
+      (Computable.const ⊤)
+  refine this.of_eq fun σ ↦ ?_
+  have h : d (Encodable.encode σ) = Encodable.encode (f σ) := by
+    simpa [f, Sentence.quote_eq_encode] using d_quote_eq σ
+  rw [h, Encodable.encodek, Option.getD_some]
 
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -11,12 +11,12 @@ public import Mathlib.Computability.Reduce
 /-!
 # Church's undecidability theorem
 
-`church_theoremAux` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences, the
+`church_theorem_general` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences, the
 set of `T`-provable sentences is not computable, by a direct diagonalization on the self-applied
 substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak representability
 of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness theorem).
 `church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable, `𝗣𝗔⁻`-provability
-computably many-one reduces to `∅`-provability, so undecidability transfers from `church_theoremAux`
+computably many-one reduces to `∅`-provability, so undecidability transfers from `church_theorem_general`
 without needing the `𝗥₀ ⪯ T` and soundness hypotheses required there.
 
 - folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
@@ -59,121 +59,103 @@ lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation
         (Primrec.vector_cons.comp .snd (.const List.Vector.nil)))
   exact this.of_eq <| by intro p; simpa [List.Vector.cons_get] using hφ ![p.1, p.2]
 
-
 /-- The code-level diagonal self-substitution: if `n` is the code of a `Semisentence ℒₒᵣ 1`,
-`d n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`
+`diagCode n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`
 applied to `n` twice, i.e. the same expression as the `D` used in `Incompleteness/First.lean`. -/
-noncomputable def d (n : ℕ) : ℕ := substNumeral (V := ℕ) n n
+noncomputable def diagCode (n : ℕ) : ℕ := substNumeral (V := ℕ) n n
 
-/-- The graph of `d` is `𝚺₁`-definable. -/
-lemma d_graph_sigma1 : 𝚺₁-Relation fun n m : ℕ ↦ m = d n := by
+/-- The graph of `diagCode` is `𝚺₁`-definable. -/
+lemma diagCode_graph_sigma1 : 𝚺₁-Relation fun n m : ℕ ↦ m = diagCode n := by
   have hSN : 𝚺-[1].Definable (fun w : Fin 3 → ℕ ↦ w 0 = substNumeral (w 1) (w 2)) :=
     HierarchySymbol.Defined.to_definable ssnum substNumeral.defined
-  exact (hSN.retraction ![1, 0, 0]).of_iff fun v ↦ by simp [d]
+  exact (hSN.retraction ![1, 0, 0]).of_iff fun v ↦ by simp [diagCode]
 
-/-- `d` is computable. -/
-lemma d_computable : Computable d :=
-  computable_of_graph_rePred (rePred_of_sigma1_relation d_graph_sigma1)
+/-- `diagCode` is computable. -/
+lemma diagCode_computable : Computable diagCode :=
+  computable_of_graph_rePred (rePred_of_sigma1_relation diagCode_graph_sigma1)
 
-/-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
-lemma d_quote_eq (σ : ArithmeticSemisentence 1) : d ⌜σ⌝ = ⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ :=
+/-- `diagCode` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
+lemma diagCode_quote_eq (σ : ArithmeticSemisentence 1) : diagCode ⌜σ⌝ = ⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ :=
   substNumeral_app_quote σ σ
 
-
 /-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
-noncomputable def f (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]
+noncomputable def diagSubst (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]
 
-/-- `f` is computable. -/
-lemma f_computable : Computable f := by
+/-- `diagSubst` is computable. -/
+lemma diagSubst_computable : Computable diagSubst := by
   have : Computable (fun σ : ArithmeticSemisentence 1 ↦
-      (Encodable.decode (d (Encodable.encode σ)) : Option ArithmeticSentence).getD ⊤) :=
-    Computable.option_getD (Computable.decode.comp (d_computable.comp Computable.encode))
+      (Encodable.decode (diagCode (Encodable.encode σ)) : Option ArithmeticSentence).getD ⊤) :=
+    Computable.option_getD (Computable.decode.comp (diagCode_computable.comp Computable.encode))
       (Computable.const ⊤)
   refine this.of_eq fun σ ↦ ?_
-  have h : d (Encodable.encode σ) = Encodable.encode (f σ) := by
-    simpa [f, Sentence.quote_eq_encode] using d_quote_eq σ
+  have h : diagCode (Encodable.encode σ) = Encodable.encode (diagSubst σ) := by
+    simpa [diagSubst, Sentence.quote_eq_encode] using diagCode_quote_eq σ
   rw [h, Encodable.encodek, Option.getD_some]
 
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
 -- This direction needs neither `𝗥₀ ⪯ T` nor `𝚺₁`-soundness, only closure of `ComputablePred`
--- under complement and many-one reduction along the computable `f`.
+-- under complement and many-one reduction along the computable `diagSubst`.
 omit [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1] in
-/-- If `T`-provability is computable, so is `σ ↦ T ⊬ f σ`. -/
-lemma D_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ f σ) :=
+/-- If `T`-provability is computable, so is `σ ↦ T ⊬ diagSubst σ`. -/
+lemma unprovable_diagSubst_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ diagSubst σ) :=
   ComputablePred.computable_of_manyOneReducible
-    (ManyOneReducible.mk (fun σ ↦ T ⊬ σ) f_computable) hC.not
+    (ManyOneReducible.mk (fun σ ↦ T ⊬ σ) diagSubst_computable) hC.not
 
-/-- The diagonal fixed point for `σ ↦ T ⊬ f σ`: a sentence whose `T`-provability and
+/-- The diagonal fixed point for `σ ↦ T ⊬ diagSubst σ`: a sentence whose `T`-provability and
 `T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and
-`re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ f σ`. -/
-lemma D_diagonal (hD : ComputablePred (fun σ ↦ T ⊬ f σ)) : ∃ δ : ArithmeticSemisentence 1, (T ⊬ f δ) ↔ T ⊢ f δ := by
+`re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ diagSubst σ`. -/
+lemma diagSubst_fixedPoint (hD : ComputablePred (fun σ ↦ T ⊬ diagSubst σ)) : ∃ δ : ArithmeticSemisentence 1, (T ⊬ diagSubst δ) ↔ T ⊢ diagSubst δ := by
   have hRe : REPred fun n : ℕ ↦ (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False
-      (fun σ ↦ T ⊬ f σ) := REPred.iff_decoded_pred.mp hD.to_re
+      (fun σ ↦ T ⊬ diagSubst σ) := REPred.iff_decoded_pred.mp hD.to_re
   refine ⟨codeOfREPred fun n : ℕ ↦
-    (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ f σ), ?_⟩
-  simpa [Encodable.encodek, f, Arithmetic.gödelNumber'_eq_coe_encode]
+    (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ diagSubst σ), ?_⟩
+  simpa [Encodable.encodek, diagSubst, Arithmetic.gödelNumber'_eq_coe_encode]
     using re_complete (T := T) hRe (x := Encodable.encode (codeOfREPred fun n : ℕ ↦
-      (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ f σ)))
+      (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ diagSubst σ)))
 
 /-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
 of `T`-provable sentences is not computable. -/
-theorem church_theoremAux : ¬ComputablePred T.theory := by
-  by_contra hC;
-  obtain ⟨δ, hδ⟩ := D_diagonal $ D_computable hC;
-  tauto;
+theorem church_theorem_general : ¬ComputablePred T.theory := by
+  by_contra hC
+  obtain ⟨δ, hδ⟩ := diagSubst_fixedPoint (unprovable_diagSubst_computable hC)
+  tauto
 
 end Diagonalization
-
-
 
 section PeanoMinusReduction
 
 /-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
-lemma ttt {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ hT.toFinset.conj := by
-  apply Entailment.FConj!_iff_forall_provable.mpr;
-  intro σ hσ;
-  apply Entailment.by_axm;
-  simp_all;
+/-- A finite theory proves the conjunction of its own (finite) axiom set. -/
+lemma finite_theory_provable_conj {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ hT.toFinset.conj :=
+  Entailment.FConj!_iff_forall_provable.mpr fun {σ} hσ ↦ Entailment.by_axm (by simp_all)
 
-lemma ttt' {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⪯ ({hT.toFinset.conj} : ArithmeticTheory) := by
-  apply Entailment.WeakerThan.ofAxm!;
-  intro σ hσ;
-  exact Entailment.mdp! (Entailment.left_Fconj!_intro (by simp_all)) (Entailment.by_axm rfl);
+/-- A finite theory is provability-equivalent to the (singleton) theory consisting of the
+conjunction of its own axioms. -/
+lemma finite_theory_equiv_singletonConj {T : Theory ℒₒᵣ} (hT : Set.Finite T) :
+    T ≊ ({hT.toFinset.conj} : ArithmeticTheory) :=
+  Entailment.Equiv.antisymm_iff.mpr
+    ⟨Entailment.WeakerThan.ofAxm! fun {σ} hσ ↦
+        Entailment.mdp! (Entailment.left_Fconj!_intro (by simp_all)) (Entailment.by_axm rfl),
+      Entailment.WeakerThan.ofAxm! fun {σ} hσ ↦ by
+        rcases hσ with rfl; exact finite_theory_provable_conj hT⟩
 
-lemma ttt'' {T : Theory ℒₒᵣ} (hT : Set.Finite T) : ({hT.toFinset.conj} : ArithmeticTheory) ⪯ T := by
-  apply Entailment.WeakerThan.ofAxm!;
-  intro σ hσ;
-  rcases hσ with rfl;
-  exact ttt hT;
-
-lemma eqiiov_of_f {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ≊ ({hT.toFinset.conj} : ArithmeticTheory) := by
-  apply Entailment.Equiv.antisymm_iff.mpr;
-  constructor;
-  . exact ttt' hT;
-  . exact ttt'' hT;
-
-lemma _root_.LO.Entailment.Equiv.iff_iff [Entailment S F] [Entailment T F] {𝓢 : S} {𝓣 : T}
-  : 𝓢 ≊ 𝓣 ↔ (∀ {σ}, 𝓢 ⊢ σ ↔ 𝓣 ⊢ σ) := by
-  apply Iff.trans Entailment.Equiv.antisymm_iff;
-  grind [Entailment.weakerThan_iff];
-
-/-- The deduction theorem for the finite theory `𝗣𝗔⁻`: `𝗣𝗔⁻` proves `σ` iff `∅` proves the
-conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
-lemma peanoMinus_provable_iff {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ hT.toFinset.conj 🡒 σ := by
-  apply Iff.trans $ (Entailment.Equiv.iff_iff.mp $ eqiiov_of_f hT);
-  rw [←insert_empty_eq];
-  exact Entailment.deduction_iff;
+/-- A deduction theorem for finite theories: a finite theory `T` proves `σ` iff `∅` proves the
+implication from the conjunction of `T`'s axioms to `σ`. -/
+lemma finite_theory_provable_iff_conj_imp {T : Theory ℒₒᵣ} (hT : Set.Finite T) :
+    T ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ hT.toFinset.conj 🡒 σ := by
+  rw [Entailment.Equiv.iff.mp (finite_theory_equiv_singletonConj hT) σ, ←insert_empty_eq]
+  exact Entailment.deduction_iff
 
 /-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
 computable. -/
 theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := by
-  by_contra hC;
-  apply church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC);
-  refine ⟨λ σ => PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
-  . set π := PeanoMinus.finite.toFinset.conj;
-    set c := Encodable.encode (∼π : ArithmeticSentence);
+  by_contra hC
+  apply church_theorem_general (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC)
+  refine ⟨fun σ ↦ PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
+  . set π := PeanoMinus.finite.toFinset.conj
+    set c := Encodable.encode (∼π : ArithmeticSentence)
     have hPrim : Primrec fun e : ℕ ↦ (Nat.pair 5 <| Nat.pair c e) + 1 :=
       Primrec.succ.comp (Primrec₂.natPair.comp (Primrec.const 5)
         (Primrec₂.natPair.comp (Primrec.const c) Primrec.id))
@@ -185,8 +167,8 @@ theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := b
     have h : (Nat.pair 5 <| Nat.pair c (Encodable.encode σ)) + 1 = Encodable.encode (π 🡒 σ) := by
       rw [Semiformula.imp_eq, Semiformula.encode_or, ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]
     rw [h, Encodable.encodek, Option.getD_some]
-  . intro σ;
-    exact peanoMinus_provable_iff $ PeanoMinus.finite;
+  . -- specialize `finite_theory_provable_iff_conj_imp` to `T = 𝗣𝗔⁻`
+    exact fun σ ↦ finite_theory_provable_iff_conj_imp PeanoMinus.finite
 
 end PeanoMinusReduction
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -19,10 +19,6 @@ of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompletene
 computably many-one reduces `𝗣𝗔⁻`-provability to itself, removing the `𝗥₀ ⪯ T` and soundness
 hypotheses needed by `church_theoremAux`.
 
-This file is currently a skeleton: every helper lemma (`A2`-`A9`, `C1`-`C4` in the accompanying
-proof plan) is stated with `sorry`; only `church_theoremAux` and `church_theorem` themselves have
-complete proofs, assembled from those (sorry'd) facts.
-
 - folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
   e.g. Rogers, *Theory of Recursive Functions and Effective Computability*, or Smoryński's chapter
   in the *Handbook of Mathematical Logic*.
@@ -152,6 +148,8 @@ section PeanoMinusReduction
 
 /-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
+/-- `𝗣𝗔⁻`-provability agrees with provability from the singleton theory of the conjunction `π` of
+`𝗣𝗔⁻`'s (finitely many) axioms: routine technical bridge, folklore. -/
 lemma ttt {σ : ArithmeticSentence} :
   letI π := PeanoMinus.finite.toFinset.conj
   (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ ({π} : ArithmeticTheory) ⊢ σ
@@ -168,14 +166,6 @@ lemma ttt {σ : ArithmeticSentence} :
       rcases hψ with rfl; exact hπ
   exact ⟨h₁.wk, h₂.wk⟩
 
-
-/-
-/-- `𝗣𝗔⁻` is finitely axiomatized. -/
-lemma exists_peanoMinus_list : ∃ Γ : List ArithmeticSentence, ∀ σ, σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ Γ := by
-  refine ⟨PeanoMinus.finite.toFinset.toList, fun σ ↦ ?_⟩
-  rw [Finset.mem_toList, Set.Finite.mem_toFinset]
--/
-
 /-- The deduction theorem for the finite theory `𝗣𝗔⁻`: `𝗣𝗔⁻` proves `σ` iff `∅` proves the
 conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
 lemma peanoMinus_provable_iff {σ : ArithmeticSentence} :
@@ -191,7 +181,19 @@ theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := b
   by_contra hC;
   apply church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC);
   refine ⟨λ σ => PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
-  . sorry;
+  . set π := PeanoMinus.finite.toFinset.conj
+    set c := Encodable.encode (∼π : ArithmeticSentence)
+    have hPrim : Primrec fun e : ℕ ↦ (Nat.pair 5 <| Nat.pair c e) + 1 :=
+      Primrec.succ.comp (Primrec₂.natPair.comp (Primrec.const 5)
+        (Primrec₂.natPair.comp (Primrec.const c) Primrec.id))
+    have : Computable (fun σ : ArithmeticSentence ↦
+        (Encodable.decode ((Nat.pair 5 <| Nat.pair c (Encodable.encode σ)) + 1) : Option ArithmeticSentence).getD ⊤) :=
+      Computable.option_getD (Computable.decode.comp (hPrim.to_comp.comp Computable.encode))
+        (Computable.const ⊤)
+    refine this.of_eq fun σ ↦ ?_
+    have h : (Nat.pair 5 <| Nat.pair c (Encodable.encode σ)) + 1 = Encodable.encode (π 🡒 σ) := by
+      rw [Semiformula.imp_eq, Semiformula.encode_or, ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]
+    rw [h, Encodable.encodek, Option.getD_some]
   . intro σ;
     exact peanoMinus_provable_iff;
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -103,7 +103,13 @@ lemma D_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T
 `T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and
 `re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ f σ`. -/
 lemma D_diagonal (hD : ComputablePred (fun σ ↦ T ⊬ f σ)) : ∃ δ : ArithmeticSemisentence 1, (T ⊬ f δ) ↔ T ⊢ f δ := by
-  sorry
+  have hRe : REPred fun n : ℕ ↦ (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False
+      (fun σ ↦ T ⊬ f σ) := REPred.iff_decoded_pred.mp hD.to_re
+  refine ⟨codeOfREPred fun n : ℕ ↦
+    (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ f σ), ?_⟩
+  simpa [Encodable.encodek, f, Arithmetic.gödelNumber'_eq_coe_encode]
+    using re_complete (T := T) hRe (x := Encodable.encode (codeOfREPred fun n : ℕ ↦
+      (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False (fun σ ↦ T ⊬ f σ)))
 
 /-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
 of `T`-provable sentences is not computable. -/

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -11,13 +11,14 @@ public import Mathlib.Computability.Reduce
 /-!
 # Church's undecidability theorem
 
-`church_theorem_general` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences, the
-set of `T`-provable sentences is not computable, by a direct diagonalization on the self-applied
-substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak representability
-of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness theorem).
-`church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable, `𝗣𝗔⁻`-provability
-computably many-one reduces to `∅`-provability, so undecidability transfers from `church_theorem_general`
-without needing the `𝗥₀ ⪯ T` and soundness hypotheses required there.
+`church_theorem_general` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences,
+the set of `T`-provable sentences is not computable, by a direct diagonalization on the
+self-applied substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak
+representability of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness
+theorem). `church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable,
+`𝗣𝗔⁻`-provability computably many-one reduces to `∅`-provability, so undecidability transfers
+from `church_theorem_general` without needing the `𝗥₀ ⪯ T` and soundness hypotheses required
+there.
 
 - folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
   e.g. Rogers, *Theory of Recursive Functions and Effective Computability*, or Smoryński's chapter
@@ -36,7 +37,7 @@ section Diagonalization
 
 /-- A total function on `ℕ` whose graph is r.e. is computable. -/
 lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × ℕ ↦ p.2 = g p.1) :
-  Computable g := by
+    Computable g := by
   have hF : Partrec₂ fun a b : ℕ ↦ (Part.assert (b = g a) fun _ ↦ Part.some ()).map fun _ ↦ b :=
     Partrec.map h (Primrec.snd.comp Primrec.fst).to_comp
   obtain ⟨k, hk, Hk⟩ := Partrec.projection hF (by
@@ -59,6 +60,15 @@ lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation
         (Primrec.vector_cons.comp .snd (.const List.Vector.nil)))
   exact this.of_eq <| by intro p; simpa [List.Vector.cons_get] using hφ ![p.1, p.2]
 
+/-- If `g : α → ℕ` is a computable numeric code for `F : α → β` (i.e. `g a` decodes back to
+`F a` for every `a`), then `F` is computable. -/
+lemma computable_of_computable_encode {α β : Type*} [Primcodable α] [Primcodable β]
+    {g : α → ℕ} (hg : Computable g) {F : α → β} (h : ∀ a, g a = Encodable.encode (F a))
+    (default : β) : Computable F := by
+  have : Computable (fun a ↦ (Encodable.decode (g a) : Option β).getD default) :=
+    Computable.option_getD (Computable.decode.comp hg) (Computable.const default)
+  exact this.of_eq fun a ↦ by rw [h, Encodable.encodek, Option.getD_some]
+
 /-- The code-level diagonal self-substitution: if `n` is the code of a `Semisentence ℒₒᵣ 1`,
 `diagCode n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`
 applied to `n` twice, i.e. the same expression as the `D` used in `Incompleteness/First.lean`. -/
@@ -75,22 +85,17 @@ lemma diagCode_computable : Computable diagCode :=
   computable_of_graph_rePred (rePred_of_sigma1_relation diagCode_graph_sigma1)
 
 /-- `diagCode` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
-lemma diagCode_quote_eq (σ : ArithmeticSemisentence 1) : diagCode ⌜σ⌝ = ⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ :=
+lemma diagCode_quote_eq (σ : ArithmeticSemisentence 1) :
+    diagCode ⌜σ⌝ = ⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ :=
   substNumeral_app_quote σ σ
 
 /-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
 noncomputable def diagSubst (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]
 
 /-- `diagSubst` is computable. -/
-lemma diagSubst_computable : Computable diagSubst := by
-  have : Computable (fun σ : ArithmeticSemisentence 1 ↦
-      (Encodable.decode (diagCode (Encodable.encode σ)) : Option ArithmeticSentence).getD ⊤) :=
-    Computable.option_getD (Computable.decode.comp (diagCode_computable.comp Computable.encode))
-      (Computable.const ⊤)
-  refine this.of_eq fun σ ↦ ?_
-  have h : diagCode (Encodable.encode σ) = Encodable.encode (diagSubst σ) := by
-    simpa [diagSubst, Sentence.quote_eq_encode] using diagCode_quote_eq σ
-  rw [h, Encodable.encodek, Option.getD_some]
+lemma diagSubst_computable : Computable diagSubst :=
+  computable_of_computable_encode (diagCode_computable.comp Computable.encode)
+    (fun σ ↦ by simpa [diagSubst, Sentence.quote_eq_encode] using diagCode_quote_eq σ) ⊤
 
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
@@ -98,14 +103,16 @@ variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 -- under complement and many-one reduction along the computable `diagSubst`.
 omit [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1] in
 /-- If `T`-provability is computable, so is `σ ↦ T ⊬ diagSubst σ`. -/
-lemma unprovable_diagSubst_computable (hC : ComputablePred T.theory) : ComputablePred (fun σ ↦ T ⊬ diagSubst σ) :=
+lemma unprovable_diagSubst_computable (hC : ComputablePred T.theory) :
+    ComputablePred (fun σ ↦ T ⊬ diagSubst σ) :=
   ComputablePred.computable_of_manyOneReducible
     (ManyOneReducible.mk (fun σ ↦ T ⊬ σ) diagSubst_computable) hC.not
 
 /-- The diagonal fixed point for `σ ↦ T ⊬ diagSubst σ`: a sentence whose `T`-provability and
 `T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and
 `re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ diagSubst σ`. -/
-lemma diagSubst_fixedPoint (hD : ComputablePred (fun σ ↦ T ⊬ diagSubst σ)) : ∃ δ : ArithmeticSemisentence 1, (T ⊬ diagSubst δ) ↔ T ⊢ diagSubst δ := by
+lemma diagSubst_fixedPoint (hD : ComputablePred (fun σ ↦ T ⊬ diagSubst σ)) :
+    ∃ δ : ArithmeticSemisentence 1, (T ⊬ diagSubst δ) ↔ T ⊢ diagSubst δ := by
   have hRe : REPred fun n : ℕ ↦ (Encodable.decode (α := ArithmeticSemisentence 1) n).elim False
       (fun σ ↦ T ⊬ diagSubst σ) := REPred.iff_decoded_pred.mp hD.to_re
   refine ⟨codeOfREPred fun n : ℕ ↦
@@ -159,14 +166,9 @@ theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := b
     have hPrim : Primrec fun e : ℕ ↦ (Nat.pair 5 <| Nat.pair c e) + 1 :=
       Primrec.succ.comp (Primrec₂.natPair.comp (Primrec.const 5)
         (Primrec₂.natPair.comp (Primrec.const c) Primrec.id))
-    have : Computable (fun σ : ArithmeticSentence ↦
-        (Encodable.decode ((Nat.pair 5 <| Nat.pair c (Encodable.encode σ)) + 1) : Option ArithmeticSentence).getD ⊤) :=
-      Computable.option_getD (Computable.decode.comp (hPrim.to_comp.comp Computable.encode))
-        (Computable.const ⊤)
-    refine this.of_eq fun σ ↦ ?_
-    have h : (Nat.pair 5 <| Nat.pair c (Encodable.encode σ)) + 1 = Encodable.encode (π 🡒 σ) := by
-      rw [Semiformula.imp_eq, Semiformula.encode_or, ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]
-    rw [h, Encodable.encodek, Option.getD_some]
+    exact computable_of_computable_encode (hPrim.to_comp.comp Computable.encode)
+      (fun σ ↦ by rw [Semiformula.imp_eq, Semiformula.encode_or,
+        ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]) ⊤
   . -- specialize `finite_theory_provable_iff_conj_imp` to `T = 𝗣𝗔⁻`
     exact fun σ ↦ finite_theory_provable_iff_conj_imp PeanoMinus.finite
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -59,6 +59,7 @@ lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation
         (Primrec.vector_cons.comp .snd (.const List.Vector.nil)))
   exact this.of_eq <| by intro p; simpa [List.Vector.cons_get] using hφ ![p.1, p.2]
 
+
 /-- The code-level diagonal self-substitution: if `n` is the code of a `Semisentence ℒₒᵣ 1`,
 `d n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`
 applied to `n` twice, i.e. the same expression as the `D` used in `Incompleteness/First.lean`. -/
@@ -75,8 +76,9 @@ lemma d_computable : Computable d :=
   computable_of_graph_rePred (rePred_of_sigma1_relation d_graph_sigma1)
 
 /-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
-lemma d_quote_eq (σ : ArithmeticSemisentence 1) : d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) :=
+lemma d_quote_eq (σ : ArithmeticSemisentence 1) : d ⌜σ⌝ = ⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ :=
   substNumeral_app_quote σ σ
+
 
 /-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
 noncomputable def f (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]
@@ -116,43 +118,53 @@ lemma D_diagonal (hD : ComputablePred (fun σ ↦ T ⊬ f σ)) : ∃ δ : Arithm
 
 /-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
 of `T`-provable sentences is not computable. -/
-theorem church_theoremAux : ¬ComputablePred {σ : ArithmeticSentence | T ⊢ σ} := by
+theorem church_theoremAux : ¬ComputablePred T.theory := by
   by_contra hC;
   obtain ⟨δ, hδ⟩ := D_diagonal $ D_computable hC;
   tauto;
 
 end Diagonalization
 
+
+
 section PeanoMinusReduction
 
 /-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
-/-- `𝗣𝗔⁻`-provability agrees with provability from the singleton theory of the conjunction `π` of
-`𝗣𝗔⁻`'s (finitely many) axioms: routine technical bridge, folklore. -/
-lemma peanoMinus_iff_singletonConj_provable {σ : ArithmeticSentence} :
-  letI π := PeanoMinus.finite.toFinset.conj
-  (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ ({π} : ArithmeticTheory) ⊢ σ
-  := by
-  set π := PeanoMinus.finite.toFinset.conj
-  have hπ : (𝗣𝗔⁻ : ArithmeticTheory) ⊢ π :=
-    Entailment.FConj!_iff_forall_provable.mpr fun ψ hψ ↦
-      Entailment.by_axm (by simpa using hψ)
-  have h₁ : (𝗣𝗔⁻ : ArithmeticTheory) ⪯ ({π} : ArithmeticTheory) :=
-    Entailment.WeakerThan.ofAxm! fun {ψ} hψ ↦
-      Entailment.mdp! (Entailment.left_Fconj!_intro (by simpa using hψ)) (Entailment.by_axm rfl)
-  have h₂ : ({π} : ArithmeticTheory) ⪯ (𝗣𝗔⁻ : ArithmeticTheory) :=
-    Entailment.WeakerThan.ofAxm! fun {ψ} hψ ↦ by
-      rcases hψ with rfl; exact hπ
-  exact ⟨h₁.wk, h₂.wk⟩
+lemma ttt {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ hT.toFinset.conj := by
+  apply Entailment.FConj!_iff_forall_provable.mpr;
+  intro σ hσ;
+  apply Entailment.by_axm;
+  simp_all;
+
+lemma ttt' {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⪯ ({hT.toFinset.conj} : ArithmeticTheory) := by
+  apply Entailment.WeakerThan.ofAxm!;
+  intro σ hσ;
+  exact Entailment.mdp! (Entailment.left_Fconj!_intro (by simp_all)) (Entailment.by_axm rfl);
+
+lemma ttt'' {T : Theory ℒₒᵣ} (hT : Set.Finite T) : ({hT.toFinset.conj} : ArithmeticTheory) ⪯ T := by
+  apply Entailment.WeakerThan.ofAxm!;
+  intro σ hσ;
+  rcases hσ with rfl;
+  exact ttt hT;
+
+lemma eqiiov_of_f {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ≊ ({hT.toFinset.conj} : ArithmeticTheory) := by
+  apply Entailment.Equiv.antisymm_iff.mpr;
+  constructor;
+  . exact ttt' hT;
+  . exact ttt'' hT;
+
+lemma _root_.LO.Entailment.Equiv.iff_iff [Entailment S F] [Entailment T F] {𝓢 : S} {𝓣 : T}
+  : 𝓢 ≊ 𝓣 ↔ (∀ {σ}, 𝓢 ⊢ σ ↔ 𝓣 ⊢ σ) := by
+  apply Iff.trans Entailment.Equiv.antisymm_iff;
+  grind [Entailment.weakerThan_iff];
 
 /-- The deduction theorem for the finite theory `𝗣𝗔⁻`: `𝗣𝗔⁻` proves `σ` iff `∅` proves the
 conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
-lemma peanoMinus_provable_iff {σ : ArithmeticSentence} :
-  letI π := PeanoMinus.finite.toFinset.conj
-  (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ π 🡒 σ := by
-  apply Iff.trans peanoMinus_iff_singletonConj_provable;
-  rw [← insert_empty_eq PeanoMinus.finite.toFinset.conj]
-  exact Entailment.deduction_iff
+lemma peanoMinus_provable_iff {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ hT.toFinset.conj 🡒 σ := by
+  apply Iff.trans $ (Entailment.Equiv.iff_iff.mp $ eqiiov_of_f hT);
+  rw [←insert_empty_eq];
+  exact Entailment.deduction_iff;
 
 /-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
 computable. -/
@@ -160,8 +172,8 @@ theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := b
   by_contra hC;
   apply church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC);
   refine ⟨λ σ => PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
-  . set π := PeanoMinus.finite.toFinset.conj
-    set c := Encodable.encode (∼π : ArithmeticSentence)
+  . set π := PeanoMinus.finite.toFinset.conj;
+    set c := Encodable.encode (∼π : ArithmeticSentence);
     have hPrim : Primrec fun e : ℕ ↦ (Nat.pair 5 <| Nat.pair c e) + 1 :=
       Primrec.succ.comp (Primrec₂.natPair.comp (Primrec.const 5)
         (Primrec₂.natPair.comp (Primrec.const c) Primrec.id))
@@ -174,7 +186,7 @@ theorem church_theorem : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := b
       rw [Semiformula.imp_eq, Semiformula.encode_or, ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]
     rw [h, Encodable.encodek, Option.getD_some]
   . intro σ;
-    exact peanoMinus_provable_iff;
+    exact peanoMinus_provable_iff $ PeanoMinus.finite;
 
 end PeanoMinusReduction
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -19,10 +19,6 @@ theorem). `church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is
 `𝗣𝗔⁻`-provability computably many-one reduces to `∅`-provability, so undecidability transfers
 from `church_theorem_general` without needing the `𝗥₀ ⪯ T` and soundness hypotheses required
 there.
-
-- folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
-  e.g. Rogers, *Theory of Recursive Functions and Effective Computability*, or Smoryński's chapter
-  in the *Handbook of Mathematical Logic*.
 -/
 
 @[expose] public section

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -15,9 +15,9 @@ public import Mathlib.Computability.Reduce
 set of `T`-provable sentences is not computable, by a direct diagonalization on the self-applied
 substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak representability
 of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness theorem).
-`church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable, `∅`-provability
-computably many-one reduces `𝗣𝗔⁻`-provability to itself, removing the `𝗥₀ ⪯ T` and soundness
-hypotheses needed by `church_theoremAux`.
+`church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable, `𝗣𝗔⁻`-provability
+computably many-one reduces to `∅`-provability, so undecidability transfers from `church_theoremAux`
+without needing the `𝗥₀ ⪯ T` and soundness hypotheses required there.
 
 - folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
   e.g. Rogers, *Theory of Recursive Functions and Effective Computability*, or Smoryński's chapter
@@ -27,27 +27,6 @@ hypotheses needed by `church_theoremAux`.
 @[expose] public section
 
 namespace LO.FirstOrder.Arithmetic
-
-
-namespace ArithmeticTheory
-
-variable {T : ArithmeticTheory}
-
-abbrev codes (T : ArithmeticTheory) : ℕ → Prop := λ n => (Encodable.decode n).elim False (T ⊢ ·)
-
-def RE (T : ArithmeticTheory) : Prop := REPred T.theory
-
-lemma iff_RE_theoryCodes_RE : RE T ↔ REPred (codes T) :=
-  _root_.REPred.iff_decoded_pred
-
-
-def Computable (T : ArithmeticTheory) : Prop := ComputablePred T.theory
-
-lemma iff_Computable_theoryCodes_Computable : Computable T ↔ ComputablePred (codes T) :=
-  _root_.ComputablePred.iff_decoded_pred
-
-end ArithmeticTheory
-
 
 open Bootstrapping Bootstrapping.Arithmetic
 
@@ -150,7 +129,7 @@ section PeanoMinusReduction
 
 /-- `𝗣𝗔⁻`-provability agrees with provability from the singleton theory of the conjunction `π` of
 `𝗣𝗔⁻`'s (finitely many) axioms: routine technical bridge, folklore. -/
-lemma ttt {σ : ArithmeticSentence} :
+lemma peanoMinus_iff_singletonConj_provable {σ : ArithmeticSentence} :
   letI π := PeanoMinus.finite.toFinset.conj
   (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ ({π} : ArithmeticTheory) ⊢ σ
   := by
@@ -171,7 +150,7 @@ conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
 lemma peanoMinus_provable_iff {σ : ArithmeticSentence} :
   letI π := PeanoMinus.finite.toFinset.conj
   (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ π 🡒 σ := by
-  apply Iff.trans ttt;
+  apply Iff.trans peanoMinus_iff_singletonConj_provable;
   rw [← insert_empty_eq PeanoMinus.finite.toFinset.conj]
   exact Entailment.deduction_iff
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -63,8 +63,8 @@ lemma d_computable : Computable d := by
 
 /-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
 lemma d_quote_eq (σ : ArithmeticSemisentence 1) :
-    d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) := by
-  sorry
+    d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) :=
+  substNumeral_app_quote σ σ
 
 /-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
 noncomputable def f (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -62,7 +62,16 @@ section Diagonalization
 /-- A total function on `ℕ` whose graph is r.e. is computable. -/
 lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × ℕ ↦ p.2 = g p.1) :
   Computable g := by
-  sorry
+  have hF : Partrec₂ fun a b : ℕ ↦ (Part.assert (b = g a) fun _ ↦ Part.some ()).map fun _ ↦ b :=
+    Partrec.map h (Primrec.snd.comp Primrec.fst).to_comp
+  obtain ⟨k, hk, Hk⟩ := Partrec.projection hF (by
+    rintro a b₁ b₂ c₁ c₂ h₁ h₂
+    simp only [Part.mem_map_iff, Part.mem_assert_iff] at h₁ h₂
+    obtain ⟨-, ⟨rfl, -⟩, rfl⟩ := h₁
+    obtain ⟨-, ⟨rfl, -⟩, rfl⟩ := h₂
+    rfl)
+  refine hk.of_eq_tot fun a ↦ ?_
+  exact (Hk (g a) a).mpr ⟨g a, by simp [Part.mem_map_iff, Part.mem_assert_iff]⟩
 
 /-- A `𝚺₁`-definable binary relation on `ℕ` is r.e. -/
 lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation R) :

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -29,8 +29,6 @@ open Bootstrapping Bootstrapping.Arithmetic
 
 section Diagonalization
 
-/-! ### Part I: Church's theorem for an arbitrary theory `T ⊇ 𝗥₀` -/
-
 /-- A total function on `ℕ` whose graph is r.e. is computable. -/
 lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × ℕ ↦ p.2 = g p.1) :
     Computable g := by
@@ -127,8 +125,6 @@ theorem church_theorem_general : ¬ComputablePred T.theory := by
 end Diagonalization
 
 section PeanoMinusReduction
-
-/-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
 /-- A finite theory proves the conjunction of its own (finite) axiom set. -/
 lemma finite_theory_provable_conj {T : Theory ℒₒᵣ} (hT : Set.Finite T) : T ⊢ hT.toFinset.conj :=

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -105,7 +105,8 @@ section PeanoMinusReduction
 /-- `𝗣𝗔⁻` is finitely axiomatized. -/
 lemma exists_peanoMinus_list :
     ∃ Γ : List ArithmeticSentence, ∀ σ, σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ Γ := by
-  sorry
+  refine ⟨PeanoMinus.finite.toFinset.toList, fun σ ↦ ?_⟩
+  rw [Finset.mem_toList, Set.Finite.mem_toFinset]
 
 open Classical in
 /-- A fixed finite list of axioms for `𝗣𝗔⁻`, chosen once and for all from

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -1,0 +1,151 @@
+module
+
+public import Foundation.FirstOrder.Basic.Coding
+public import Foundation.Vorspiel.Computability
+public import Foundation.FirstOrder.Basic.PrimrecCoding
+public import Foundation.FirstOrder.Incompleteness.RosserProvability
+public import Foundation.FirstOrder.Arithmetic.R0.Representation
+public import Foundation.FirstOrder.Incompleteness.Halting
+public import Mathlib.Computability.Reduce
+
+/-!
+# Church's undecidability theorem
+
+`church_theoremAux` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences, the
+set of `T`-provable sentences is not computable, by a direct diagonalization on the self-applied
+substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak representability
+of r.e. predicates, `re_complete`, is needed, unlike Gödel's first incompleteness theorem).
+`church_theorem` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable, `∅`-provability
+computably many-one reduces `𝗣𝗔⁻`-provability to itself, removing the `𝗥₀ ⪯ T` and soundness
+hypotheses needed by `church_theoremAux`.
+
+This file is currently a skeleton: every helper lemma (`A2`-`A9`, `C1`-`C4` in the accompanying
+proof plan) is stated with `sorry`; only `church_theoremAux` and `church_theorem` themselves have
+complete proofs, assembled from those (sorry'd) facts.
+
+- folklore; the standard proof of Church's theorem via undecidability of `𝚺₁`-completeness, see
+  e.g. Rogers, *Theory of Recursive Functions and Effective Computability*, or Smoryński's chapter
+  in the *Handbook of Mathematical Logic*.
+-/
+
+@[expose] public section
+
+namespace LO.FirstOrder.Arithmetic
+
+open Bootstrapping Bootstrapping.Arithmetic
+
+section Diagonalization
+
+/-! ### Part I: Church's theorem for an arbitrary theory `T ⊇ 𝗥₀` -/
+
+/-- A total function on `ℕ` whose graph is r.e. is computable. -/
+lemma computable_of_graph_rePred {g : ℕ → ℕ} (h : REPred fun p : ℕ × ℕ ↦ p.2 = g p.1) :
+    Computable g := by
+  sorry
+
+/-- A `𝚺₁`-definable binary relation on `ℕ` is r.e. -/
+lemma rePred_of_sigma1_relation {R : ℕ → ℕ → Prop} (h : 𝚺₁-Relation R) :
+    REPred fun p : ℕ × ℕ ↦ R p.1 p.2 := by
+  sorry
+
+/-- The code-level diagonal self-substitution: if `n` is the code of a `Semisentence ℒₒᵣ 1`,
+`d n` is the code of its self-substitution `n/[⌜n⌝]`. This is `Bootstrapping.Arithmetic.substNumeral`
+applied to `n` twice, i.e. the same expression as the `D` used in `Incompleteness/First.lean`. -/
+noncomputable def d (n : ℕ) : ℕ := substNumeral (V := ℕ) n n
+
+/-- The graph of `d` is `𝚺₁`-definable. -/
+lemma d_graph_sigma1 : 𝚺₁-Relation fun n m : ℕ ↦ m = d n := by
+  sorry
+
+/-- `d` is computable. -/
+lemma d_computable : Computable d := by
+  sorry
+
+/-- `d` applied to the code of `σ` is the code of `σ`'s diagonal self-substitution. -/
+lemma d_quote_eq (σ : ArithmeticSemisentence 1) :
+    d (⌜σ⌝ : ℕ) = (⌜(σ/[⌜σ⌝] : ArithmeticSentence)⌝ : ℕ) := by
+  sorry
+
+/-- The diagonal substitution `σ ↦ σ/[⌜σ⌝]`. -/
+noncomputable def f (σ : ArithmeticSemisentence 1) : ArithmeticSentence := σ/[⌜σ⌝]
+
+/-- `f` is computable. -/
+lemma f_computable : Computable f := by
+  sorry
+
+variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
+
+/-- If `T`-provability is computable, so is `σ ↦ T ⊬ f σ`. -/
+lemma D_computable (hC : ComputablePred {σ : ArithmeticSentence | T ⊢ σ}) :
+    ComputablePred (fun σ : ArithmeticSemisentence 1 ↦ T ⊬ f σ) := by
+  sorry
+
+/-- The diagonal fixed point for `σ ↦ T ⊬ f σ`: a sentence whose `T`-provability and
+`T`-unprovability (after diagonal substitution) coincide, obtained from `codeOfREPred` and
+`re_complete` applied to the decode-lifted predicate `σ ↦ T ⊬ f σ`. -/
+lemma D_diagonal (hD : ComputablePred (fun σ : ArithmeticSemisentence 1 ↦ T ⊬ f σ)) :
+    ∃ δ : ArithmeticSemisentence 1, (T ⊬ f δ) ↔ T ⊢ f δ := by
+  sorry
+
+/-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
+of `T`-provable sentences is not computable. -/
+theorem church_theoremAux : ¬ComputablePred {σ : ArithmeticSentence | T ⊢ σ} := by
+  intro hC
+  obtain ⟨δ, hδ⟩ := D_diagonal (D_computable hC)
+  by_cases h : T ⊢ f δ
+  · exact hδ.mpr h h
+  · exact h (hδ.mp h)
+
+end Diagonalization
+
+section PeanoMinusReduction
+
+/-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
+
+/-- `𝗣𝗔⁻` is finitely axiomatized. -/
+lemma exists_peanoMinus_list :
+    ∃ Γ : List ArithmeticSentence, ∀ σ, σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ Γ := by
+  sorry
+
+open Classical in
+/-- A fixed finite list of axioms for `𝗣𝗔⁻`, chosen once and for all from
+`exists_peanoMinus_list`. -/
+noncomputable def peanoMinusList : List ArithmeticSentence := exists_peanoMinus_list.choose
+
+lemma mem_peanoMinusList_iff {σ : ArithmeticSentence} :
+    σ ∈ (𝗣𝗔⁻ : ArithmeticTheory) ↔ σ ∈ peanoMinusList :=
+  exists_peanoMinus_list.choose_spec σ
+
+/-- `𝗣𝗔⁻` proves the conjunction of its own (finitely many) axioms. -/
+lemma peanoMinus_provable_conj : (𝗣𝗔⁻ : ArithmeticTheory) ⊢ peanoMinusList.foldr (· ⋏ ·) ⊤ := by
+  sorry
+
+/-- The deduction theorem for the finite theory `𝗣𝗔⁻`: `𝗣𝗔⁻` proves `σ` iff `∅` proves the
+conjunction of `𝗣𝗔⁻`'s axioms implies `σ`. -/
+lemma peanoMinus_provable_iff (σ : ArithmeticSentence) :
+    (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ peanoMinusList.foldr (· ⋏ ·) ⊤ 🡒 σ := by
+  sorry
+
+/-- The many-one reduction witness from `𝗣𝗔⁻`-provability to `∅`-provability,
+`σ ↦ (conjunction of 𝗣𝗔⁻'s axioms) 🡒 σ`. -/
+noncomputable def peanoMinusReduction (σ : ArithmeticSentence) : ArithmeticSentence :=
+  peanoMinusList.foldr (· ⋏ ·) ⊤ 🡒 σ
+
+/-- `peanoMinusReduction` is computable: prepending a fixed sentence is elementary. -/
+lemma peanoMinusReduction_computable : Computable peanoMinusReduction := by
+  sorry
+
+/-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
+computable. -/
+theorem church_theorem : ¬ComputablePred {σ : ArithmeticSentence | (∅ : ArithmeticTheory) ⊢ σ} := by
+  intro hC
+  have hred : (fun σ : ArithmeticSentence ↦ (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ)
+      ≤₀ (fun σ : ArithmeticSentence ↦ (∅ : ArithmeticTheory) ⊢ σ) :=
+    ⟨peanoMinusReduction, peanoMinusReduction_computable, peanoMinus_provable_iff⟩
+  exact church_theoremAux (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible hred hC)
+
+end PeanoMinusReduction
+
+end LO.FirstOrder.Arithmetic
+
+end

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -182,7 +182,8 @@ lemma peanoMinus_provable_iff {σ : ArithmeticSentence} :
   letI π := PeanoMinus.finite.toFinset.conj
   (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ π 🡒 σ := by
   apply Iff.trans ttt;
-  sorry;
+  rw [← insert_empty_eq PeanoMinus.finite.toFinset.conj]
+  exact Entailment.deduction_iff
 
 /-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
 computable. -/

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -152,11 +152,21 @@ section PeanoMinusReduction
 
 /-! ### Part II: Church's theorem for `T = ∅`, via a reduction through `𝗣𝗔⁻` -/
 
-lemma ttt :
+lemma ttt {σ : ArithmeticSentence} :
   letI π := PeanoMinus.finite.toFinset.conj
   (𝗣𝗔⁻ : ArithmeticTheory) ⊢ σ ↔ ({π} : ArithmeticTheory) ⊢ σ
   := by
-  sorry;
+  set π := PeanoMinus.finite.toFinset.conj
+  have hπ : (𝗣𝗔⁻ : ArithmeticTheory) ⊢ π :=
+    Entailment.FConj!_iff_forall_provable.mpr fun ψ hψ ↦
+      Entailment.by_axm (by simpa using hψ)
+  have h₁ : (𝗣𝗔⁻ : ArithmeticTheory) ⪯ ({π} : ArithmeticTheory) :=
+    Entailment.WeakerThan.ofAxm! fun {ψ} hψ ↦
+      Entailment.mdp! (Entailment.left_Fconj!_intro (by simpa using hψ)) (Entailment.by_axm rfl)
+  have h₂ : ({π} : ArithmeticTheory) ⪯ (𝗣𝗔⁻ : ArithmeticTheory) :=
+    Entailment.WeakerThan.ofAxm! fun {ψ} hψ ↦ by
+      rcases hψ with rfl; exact hπ
+  exact ⟨h₁.wk, h₂.wk⟩
 
 
 /-


### PR DESCRIPTION
## Summary

- Adds `church_theorem_general`: for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences, the set of `T`-provable sentences is not computable.
- Adds `church_theorem`: the set of purely logically (i.e. `∅`-)provable sentences is not computable, obtained from `church_theorem_general` via a computable many-one reduction through the finitely axiomatized `𝗣𝗔⁻`.
- Both proofs avoid the strong representation theorem and the fixed-point/diagonal lemma (`Bootstrapping/FixedPoint.lean`'s `diag`/`fixedpoint`/`diagonal`), relying only on the semi-representation ("weak representation") theorem `re_complete` already proved for `𝗥₀`, via a direct diagonalization on the self-applied substitution `σ ↦ σ/[⌜σ⌝]`. This follows the approach suggested by @iehality in review discussion on #491 ([comment](https://github.com/FormalizedFormalLogic/Foundation/pull/491#issuecomment-3146669999), [comment](https://github.com/FormalizedFormalLogic/Foundation/pull/491#issuecomment-3148942595)); #491 itself is superseded by this PR (its branch predates the current `re_complete`/`R0` API and is stale).

## AI involvement

This PR was produced with substantial assistance from Claude (Anthropic), including proof planning, formalization of each lemma, and refactoring/naming cleanup. Every commit carries a `Co-Authored-By: Claude` trailer.

## Test plan

- [x] `lake build Foundation.FirstOrder.Incompleteness.Church` succeeds with no errors/warnings (no remaining `sorry`)
- [x] `lake exe mk_all --module` run, `Foundation.lean` up to date
- [x] No stale plan-reference/skeleton-era comments (`grep -n "see plan\|issue #\|Step [0-9]\|§[0-9]\|L[0-9]-[0-9]"` is empty)