### PR TITLE
add(FirstOrder/SetTheory): Draft pr, add parameters to repl blueprint

### DIFF
--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -126,17 +126,20 @@ noncomputable def replRelOverSet (X : V) (R : V → V → Prop) (h : ∀ x ∈ X
 
 namespace Repl
 
+/-- A blueprint for a function constructed by `repl`. -/
 structure Blueprint (arity : ℕ) where
-  graph : SetTheorySemisentence (arity + 2)
+  graph : SetTheorySemiformula V (arity + 2)
 
-def Blueprint.resultDef (b : Blueprint arity) : SetTheorySemisentence (arity + 2) :=
+/-- The resulting formula of a `Blueprint`. -/
+def Blueprint.resultDef (b : Blueprint (V := V) arity) : SetTheorySemiformula V (arity + 2) :=
   “Y X. ∀ y, y ∈ Y ↔ ∃ x ∈ X, !b.graph y x ⋯”
 
 variable (V)
 
 structure Construction {arity : ℕ} (b : Blueprint arity) where
   map : (Fin arity → V) → V → V
-  map_defined : DefinedFunction (fun v ↦ map (v ·.succ) (v 0)) b.graph
+  -- map_defined : DefinedFunction (fun v ↦ map (v ·.succ) (v 0)) b.graph
+  map_defined : IsDefinedByWithParam (fun v ↦ v 0 = map (v ·.succ.succ) (v 1)) b.graph
 
 variable {V}
 
@@ -145,15 +148,18 @@ namespace Construction
 variable {arity : ℕ} {b : Blueprint arity} (c : Construction V b)
 
 instance map_definable :
-  (ℒₛₑₜ).DefinableFunction (fun v ↦ c.map (v ·.succ) (v 0)) := c.map_defined.to_definable
+    (ℒₛₑₜ).DefinableFunction (fun v ↦ c.map (v ·.succ) (v 0)) := by
+  use b.graph
+  intro v
+  simp_all only [Fin.succ_zero_eq_one, c.map_defined]
 
 noncomputable def result (v : Fin arity → V) : V → V := fun x ↦ repl x (c.map v) (by
-  refine ⟨(Rew.embSubsts (#0 :> #1 :> fun i : Fin arity ↦ &(v i))) ▹ b.graph, ?_⟩
+  refine ⟨(Rew.subst (#0 :> #1 :> fun i : Fin arity ↦ &(v i))) ▹ b.graph, ?_⟩
   intro x
   simpa [Semiformula.eval_embSubsts, Matrix.comp_vecCons', Function.comp_def]
     using c.map_defined.iff (x 0 :> x 1 :> v))
 
-lemma result_defined : DefinedFunction (fun v ↦ c.result (v ·.succ) (v 0)) b.resultDef := .mk fun v ↦ by
+lemma result_defined : IsDefinedByWithParam (fun v ↦ v 0 = c.result (v ·.succ.succ) (v 1)) b.resultDef := fun v ↦ by
   constructor
   · intro h
     simp [Blueprint.resultDef] at h
@@ -162,7 +168,7 @@ lemma result_defined : DefinedFunction (fun v ↦ c.result (v ·.succ) (v 0)) b.
   · intro h
     simp [Blueprint.resultDef, result, c.map_defined.iff, h]
 
-@[simp] lemma eval_resultDef : b.resultDef.Evalb v ↔ v 0 = c.result (v ·.succ.succ) (v 1) := c.result_defined.iff v
+@[simp] lemma eval_resultDef : b.resultDef.Eval v id ↔ v 0 = c.result (v ·.succ.succ) (v 1) := c.result_defined.iff v
 
 @[simp] lemma mem_result : y ∈ c.result v X ↔ ∃ x ∈ X, y = c.map v x := by
   simp [result, repl_spec]

--- a/Foundation/Syntax/Predicate/Rew.lean
+++ b/Foundation/Syntax/Predicate/Rew.lean
@@ -26,7 +26,9 @@ namespace FirstOrder
 
 /--
 A structure for maps which rewrite the semiterms occurring in a term.
+
 toFun - A function from `Semiterm L ξ₁ n₁` to `Semiterm L ξ₂ n₂`.
+
 func'' - A proof that `toFun` respects the function symbols of `L`.
 -/
 structure Rew (L : Language) (ξ₁ : Type*) (n₁ : ℕ) (ξ₂ : Type*) (n₂ : ℕ) where
@@ -95,7 +97,7 @@ def rewriteMap (e : ξ₁ → ξ₂) : Rew L ξ₁ n ξ₂ n := rewrite (fun m =
 def map (b : Fin n₁ → Fin n₂) (e : ξ₁ → ξ₂) : Rew L ξ₁ n₁ ξ₂ n₂ :=
   bind (fun n => #(b n)) (fun m => &(e m))
 
-/-- `LO.FirstOrder.Rew.subst v` is a substitution of the bounded variables occurring in a term by `v : Fin n → Semiterm L ξ n'`. -/
+/-- `LO.FirstOrder.Rew.subst v` is a substitution of the bound variables occurring in a term by `v : Fin n → Semiterm L ξ n'`. -/
 def subst {n'} (v : Fin n → Semiterm L ξ n') : Rew L ξ n ξ n' :=
   bind v fvar
 
@@ -119,6 +121,8 @@ def cast {n n' : ℕ} (h : n = n') : Rew L ξ n ξ n' :=
 def castLE {n n' : ℕ} (h : n ≤ n') : Rew L ξ n ξ n' :=
   map (Fin.castLE h) id
 
+/-- `LO.FirstOrder.Rew.embSubsts v` is a substitution of the bound variables occurring in a term with no free variables by `v : Fin n → Semiterm L ξ n'`.
+This closely resembles `LO.FirstOrder.Rew.subst`, however the term is required to have free variables of type `Empty`. -/
 def embSubsts (v : Fin k → Semiterm L ξ n) : Rew L Empty k ξ n := Rew.bind v Empty.elim
 
 protected def q (ω : Rew L ξ₁ n₁ ξ₂ n₂) : Rew L ξ₁ (n₁ + 1) ξ₂ (n₂ + 1) :=


### PR DESCRIPTION
Before I can continue refactoring the [recursion theorem](https://github.com/FormalizedFormalLogic/Foundation/pull/853#issuecomment-5053206608) to use `Repl.Blueprint`, since `F : V → V` may have parameters in its definition, I will need to add parameters to replacement blueprints. This might currently be inelegant because of the use of `·.succ.succ`, but I don't know of a way to improve it without changing `Definability.lean` to add `DefinedFunctionWithParams`. (Since this is a different enough topic than the recursion theorem, I made it its own draft pull request.)