### PR TITLE
refactor(FirstOrder/SetTheory): Refactor recursion theorem

### DIFF
--- a/Foundation/FirstOrder/SetTheory/Basic/Axioms.lean
+++ b/Foundation/FirstOrder/SetTheory/Basic/Axioms.lean
@@ -168,4 +168,6 @@ lemma zc_subset_zfc : 𝗭𝗖 ⊆ 𝗭𝗙𝗖 := Set.union_subset_union_left _
 
 instance : 𝗭𝗖 ⪯ 𝗭𝗙𝗖 := Entailment.WeakerThan.ofSubset zc_subset_zfc
 
+instance : 𝗭 ⪯ 𝗭𝗙𝗖 := Entailment.WeakerThan.trans (inferInstance : 𝗭 ⪯ 𝗭𝗙) inferInstance
+
 end LO.FirstOrder.SetTheory

--- a/Foundation/FirstOrder/SetTheory/Basic/Model.lean
+++ b/Foundation/FirstOrder/SetTheory/Basic/Model.lean
@@ -81,6 +81,14 @@ instance [V↓[ℒₛₑₜ] ⊧* 𝗭] [V↓[ℒₛₑₜ] ⊧* 𝗔𝗖] : V�
 
 instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙] [V↓[ℒₛₑₜ] ⊧* 𝗔𝗖] : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖 := inferInstance
 
+instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙] : V↓[ℒₛₑₜ] ⊧* 𝗭 := models_of_subtheory (inferInstance : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙)
+
+instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖] : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙 := models_of_subtheory (inferInstance : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖)
+
+instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖] : V↓[ℒₛₑₜ] ⊧* 𝗭 := models_of_subtheory (inferInstance : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖)
+
+instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖] : V↓[ℒₛₑₜ] ⊧* 𝗔𝗖 := models_of_subtheory (inferInstance : V↓[ℒₛₑₜ] ⊧* 𝗭𝗙𝗖)
+
 instance : V↓[ℒₛₑₜ] ⊧* (𝗘𝗤 _ : SetTheory) := Structure.Eq.models_eqAxiom' ℒₛₑₜ V
 
 end

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -8,7 +8,7 @@ public import Foundation.FirstOrder.SetTheory.ZF
 
 namespace LO.FirstOrder.SetTheory
 
-variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭]
+variable {V : Type*} [SetStructure V] [Nonempty V]
 
 /-! ### Attempt functions -/
 
@@ -16,40 +16,18 @@ variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭
 `f` is an attempt of length `α` for the function `F`, meaning that the domain of `f` is `α`, and for all `β < α`, it holds that `f(β) = F (f ↾ β)`.
 The "attempt" terminology may be due to Paul Taylor.
 -/
-def IsAttempt (F : V → V) (α f : V) : Prop :=
+def IsAttempt [V↓[ℒₛₑₜ] ⊧* 𝗭] (F : V → V) (α f : V) : Prop :=
   IsOrdinal α ∧ IsFunction f ∧ domain f = α ∧
     ∀ β ∈ α, ∀ y, ⟨β, y⟩ₖ ∈ f ↔ y = F (f ↾ β)
 
-/--
-A `SetTheorySemiformula` defining `IsAttempt F` for a definable function `F`. Pass a formula `φ` defining `F`.
--/
-def IsAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
-  f“α f. !IsOrdinal.dfn' α ∧ !IsFunction.dfn' f ∧ !domain.dfn' f = α ∧
-    ∀ β ∈ α, ∀ y, !kpair.dfn' β y ∈ f ↔ y = !φ (!restrict.dfn' f β)”
-  /- Cast `kpair.dfn` and `restrict.dfn` to a type that allows parameters, to work with `Semiformula.nestFormulaeFunc`. -/
-  where
-    IsOrdinal.dfn' : SetTheorySemiformula V 1 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ IsOrdinal.dfn
-    IsFunction.dfn' : SetTheorySemiformula V 1 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ IsFunction.dfn
-    domain.dfn' : SetTheorySemiformula V 2 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ domain.dfn
-    kpair.dfn' : SetTheorySemiformula V 3 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ kpair.dfn
-    restrict.dfn' : SetTheorySemiformula V 3 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ restrict.dfn
-
-lemma IsAttempt.defined (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    IsDefinedByWithParam (fun v ↦ IsAttempt F (v 0) (v 1)) (IsAttempt.dfn φ) := by
-  intro v
-  simp_all [IsAttempt, IsAttempt.dfn,
-    dfn.IsOrdinal.dfn', dfn.IsFunction.dfn', dfn.domain.dfn', dfn.kpair.dfn', dfn.restrict.dfn',
-    Semiformula.eval_rewriteMap]
-
-lemma IsAttempt.definable (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    ℒₛₑₜ-relation[V] (fun α f ↦ IsAttempt F α f) := by
-  use IsAttempt.dfn φ
-  intro v
-  simp only [IsAttempt.defined F hF, Fin.isValue]
+lemma IsAttempt.definable [V↓[ℒₛₑₜ] ⊧* 𝗭] {F : V → V} (hF : ℒₛₑₜ-function₁ F) :
+    ℒₛₑₜ-relation (IsAttempt F) := by unfold IsAttempt; definability
 
 /-! #### Uniqueness of attempt functions -/
 
 namespace IsAttempt
+
+variable [V↓[ℒₛₑₜ] ⊧* 𝗭]
 
 /--
 Any two attempt functions restrict to the same function.
@@ -101,27 +79,11 @@ lemma isAttempt_restrict_eq_of_le
 /-! #### Existence and choices of attempt functions -/
 
 /-- Existence of an attempt function of a given length. -/
-def ExistsAttempt (F : V → V) (α : V) : Prop :=
+def Exists (F : V → V) (α : V) : Prop :=
   ∃ f : V, IsAttempt F α f
 
-def ExistsAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 1 :=
-  f“α. ∃ f, !(IsAttempt.dfn φ) α f”
-
-lemma ExistsAttempt.defined (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    IsDefinedByWithParam (fun v ↦ ExistsAttempt F (v 0)) (ExistsAttempt.dfn φ) := by
-  intro v
-  simp [ExistsAttempt.dfn, IsAttempt.defined F hF]
-  rfl
-
-lemma ExistsAttempt.definable (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    ℒₛₑₜ-predicate (fun α ↦ ExistsAttempt F α) := by
-  use ExistsAttempt.dfn φ
-  intro v
-  simp [ExistsAttempt.dfn, IsAttempt.defined F hF]
-  rfl
-
-/-- `ExistsAttempt` implies `∃!`. -/
-lemma existsUnique_of_ExistsAttempt (F : V → V) (α : V) (hex : ExistsAttempt F α) :
+/-- `Exists` implies `∃!`. -/
+lemma existsUnique_of_exists (F : V → V) (α : V) (hex : Exists F α) :
     ∃! f : V, IsAttempt F α f := by
   obtain ⟨f, hf⟩ := hex
   have : IsFunction f := hf.2.1
@@ -134,20 +96,20 @@ lemma existsUnique_of_ExistsAttempt (F : V → V) (α : V) (hex : ExistsAttempt 
 
 end IsAttempt
 
+variable [V↓[ℒₛₑₜ] ⊧* 𝗭]
+
 /--
 This lemma is originally by tosiaki.
 -/
 lemma attemptOrEmpty_existsUnique (F : V → V) (α : V) : ∃! y,
-    (IsAttempt.ExistsAttempt F α ∧ IsAttempt F α y) ∨
-    (¬ IsAttempt.ExistsAttempt F α ∧ y = ∅) := by
-  by_cases hexists : IsAttempt.ExistsAttempt F α
-  · refine existsUnique_of_exists_of_unique ⟨hexists.choose, Or.inl ⟨hexists, hexists.choose_spec⟩⟩ ?_
-    intro y₁ y₂ hy₁ hy₂
-    simp_all only [true_and, not_true_eq_false, false_and, or_false]
-    rcases hy₁.1, hy₁.2.1, hy₂.2.1 with ⟨hα, _, _⟩
-    let αo : Ordinal V := IsOrdinal.toOrdinal α
-    rw [← IsOrdinal.toOrdinal_val α] at hy₁
-    exact IsAttempt.isAttempt_unique hy₁ hy₂
+    (IsAttempt.Exists F α ∧ IsAttempt F α y) ∨
+    (¬IsAttempt.Exists F α ∧ y = ∅) := by
+  by_cases hexists : IsAttempt.Exists F α
+  · obtain ⟨f, hf, huniq⟩ := IsAttempt.existsUnique_of_exists F α hexists
+    refine ⟨f, Or.inl ⟨hexists, hf⟩, ?_⟩
+    intro y hy
+    simp only [hexists, true_and, not_true_eq_false, false_and, or_false] at hy
+    exact huniq y hy
   · refine existsUnique_of_exists_of_unique ⟨∅, Or.inr ⟨hexists, rfl⟩⟩ (by aesop)
 
 /--
@@ -158,57 +120,18 @@ noncomputable def attemptOrEmpty (F : V → V) (α : V) : V :=
   Classical.choose! (attemptOrEmpty_existsUnique F α)
 
 /--
-A `SetTheorySemiformula` defining `attemptOrEmpty F` for a definable function `F`. Pass a formula `φ` defining `F`.
--/
-def attemptOrEmpty.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
-  f“y α. !(IsAttempt.ExistsAttempt.dfn φ) α ∧ !(IsAttempt.dfn φ) α y
-    ∨ ¬ !(IsAttempt.ExistsAttempt.dfn φ) α ∧ !isEmpty' y”
-    /- Cast `kpair.dfn` and `restrict.dfn` to a type that allows parameters, to work with `Semiformula.nestFormulaeFunc`. -/
-    where
-      isEmpty' : SetTheorySemiformula V 1 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ isEmpty
-
-lemma attemptOrEmpty.defined {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    IsDefinedByWithParam (fun v ↦ v 0 = attemptOrEmpty F (v 1)) (attemptOrEmpty.dfn φ) := by
-  intro v
-  simp_all [attemptOrEmpty, attemptOrEmpty.dfn, IsAttempt.ExistsAttempt.defined F hF, IsAttempt.defined F hF,
-   dfn.isEmpty', Semiformula.eval_rewriteMap]
-
-lemma attemptOrEmpty.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    ℒₛₑₜ-function₁[V] (attemptOrEmpty F) := by
-  use attemptOrEmpty.dfn φ
-  intro v
-  simp [attemptOrEmpty.defined F hF]
-
-/--
 A pair `⟨α, F f⟩ₖ` of an ordinal `α` and the value of `F` on `attemptOrEmpty F α`.
 This is a technical definition needed for the proof of the transfinite recursion theorem.
 -/
 noncomputable def pairValueAttempt (F : V → V) (α : V) : V :=
   ⟨α, F (attemptOrEmpty F α)⟩ₖ
 
-/--
-A `SetTheorySemiformula` defining `pairValueAttempt F` for a definable function `F`. Pass a formula `φ` defining `F`.
--/
-def pairValueAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
-  f“y α. y = !kpair.dfn' α (!φ (!(attemptOrEmpty.dfn φ) α))”
-  /- Cast `kpair.dfn` and `restrict.dfn` to a type that allows parameters, to work with `Semiformula.nestFormulaeFunc`. -/
-  where
-    kpair.dfn' : SetTheorySemiformula V 3 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ kpair.dfn
-
-lemma pairValueAttempt.defined {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    IsDefinedByWithParam (fun v ↦ v 0 = pairValueAttempt F (v 1)) (pairValueAttempt.dfn φ) := by
-  intro v
-  simp_all [pairValueAttempt.dfn, pairValueAttempt, dfn.kpair.dfn', Semiformula.eval_rewriteMap,
-    attemptOrEmpty.defined F hF]
-
-lemma pairValueAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    ℒₛₑₜ-function₁ (pairValueAttempt F) := by
-  use pairValueAttempt.dfn φ
-  intro v
-  simp [pairValueAttempt.defined F hF]
+lemma kpair_eq_pairValueAttempt_iff {F : V → V} {α : V} {x y : V} :
+    ⟨x, y⟩ₖ = pairValueAttempt F α ↔ x = α ∧ y = F (attemptOrEmpty F α) := by
+  simp [pairValueAttempt]
 
 lemma eq_of_kpair_eq_pairValueAttempt {F : V → V} {α : V} {x y : V} (h : ⟨x, y⟩ₖ = pairValueAttempt F α) : x = α :=
-  (kpair_iff.mp (pairValueAttempt.eq_1 F α ▸ h)).1
+  (kpair_eq_pairValueAttempt_iff.mp h).1
 
 /-! #### Constructing attempt functions using replacement -/
 
@@ -220,19 +143,25 @@ variable [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
 Function that outputs an attempt of length `α`, subject to the assumption that for all `β < α`, there is an attempt of length `β`.
 This is a big function constructed using replacement.
 -/
-noncomputable def replAttemptOrEmpty
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
-    (α : V) : V :=
-  repl α (pairValueAttempt F) (hF := pairValueAttempt.definable F hF)
+noncomputable def replAttemptOrEmpty (F : V → V) (hF : ℒₛₑₜ-function₁ F) : V → V :=
+  repl (pairValueAttempt F) (hF := by
+    have : ℒₛₑₜ-function₁ attemptOrEmpty F := by
+      suffices ℒₛₑₜ-relation[V] (· = attemptOrEmpty F ·) by exact this
+      simp only [attemptOrEmpty, Classical.choose!_eq_iff_right]
+      unfold IsAttempt.Exists
+      have : ℒₛₑₜ-relation (IsAttempt F) := IsAttempt.definable hF
+      definability
+    unfold pairValueAttempt
+    definability)
 
 @[simp] lemma mem_replAttemptOrEmpty_iff
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
+    (F : V → V) (hF : ℒₛₑₜ-function₁ F)
     (α : V) (p : V) :
     p ∈ replAttemptOrEmpty F hF α ↔ ∃ β ∈ α, p = pairValueAttempt F β := by
   apply repl_spec
 
 @[simp] lemma kpair_mem_replAttemptOrEmpty_iff
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
+    (F : V → V) (hF : ℒₛₑₜ-function₁ F)
     {α : Ordinal V} {β y : V} :
     ⟨β, y⟩ₖ ∈ replAttemptOrEmpty F hF α ↔ β ∈ α.val ∧ ⟨β, y⟩ₖ = pairValueAttempt F β := by
   simp only [mem_replAttemptOrEmpty_iff]
@@ -242,30 +171,7 @@ noncomputable def replAttemptOrEmpty
     exact ⟨hβα, h⟩
   · use β
 
-/--
-A `SetTheorySemiformula` defining `replAttemptOrEmpty F` for a definable function `F`. Pass a formula `φ` defining `F`.
--/
-def replAttemptOrEmpty.dfn (φ : SetTheorySemiformula V 2) :
-    SetTheorySemiformula V 2 :=
-  f“Y α. ∀ y, y ∈ Y ↔ ∃ β ∈ α, y = !(pairValueAttempt.dfn φ) β”
-
-lemma replAttemptOrEmpty.defined
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    IsDefinedByWithParam (fun (v : Fin 2 → V) ↦ v 0 = replAttemptOrEmpty F hF (v 1)) (replAttemptOrEmpty.dfn φ) := by
-  intro v
-  simp_all [replAttemptOrEmpty, replAttemptOrEmpty.dfn, pairValueAttempt.defined F hF,
-    mem_ext_iff (x := v 0)]
-
-instance replAttemptOrEmpty.definable
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    ℒₛₑₜ-function₁[V] (replAttemptOrEmpty F (hF := hF)) := by
-  use replAttemptOrEmpty.dfn φ
-  intro v
-  simp [replAttemptOrEmpty.defined F hF]
-
-lemma domain_replAttemptOrEmpty_eq
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
-    (α : Ordinal V) :
+lemma domain_replAttemptOrEmpty_eq (F : V → V) (hF : ℒₛₑₜ-function₁ F) (α : Ordinal V) :
     domain (replAttemptOrEmpty F hF α) = α.val := by
   ext z
   simp only [mem_domain_iff, mem_replAttemptOrEmpty_iff]
@@ -276,22 +182,18 @@ lemma domain_replAttemptOrEmpty_eq
     use z
     simp_all only [true_and, pairValueAttempt, true_and]
 
-instance {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
-    (α : Ordinal V) :
-    IsFunction (replAttemptOrEmpty F hF α) := by
+instance (F : V → V) (hF : ℒₛₑₜ-function₁ F) (α : Ordinal V) : IsFunction (replAttemptOrEmpty F hF α) := by
   -- Name it for brevity
   let f := replAttemptOrEmpty F hF α
   have hdomain : domain f = α.val := domain_replAttemptOrEmpty_eq F hF α
   apply isFunction_iff.mpr
   apply mem_function_iff.mpr
   constructor
-  · -- Show that `f` contains only ordered pairs
-    intro p hpf
-    obtain ⟨β, hβα, f, rfl, hf⟩ := (repl_spec {definable := ⟨pairValueAttempt.dfn φ, pairValueAttempt.defined F hF⟩}).mp hpf
+  · intro p hpf
+    obtain ⟨β, _, f, rfl, _⟩ := (mem_replAttemptOrEmpty_iff F hF _ _).mp hpf
     apply kpair_mem_iff.mpr
     exact And.intro (mem_domain_of_kpair_mem hpf) (mem_range_of_kpair_mem hpf)
-  · -- Show well-definedness of `f`, i.e. uniqueness of output
-    intro x hx
+  · intro x hx
     simp only [kpair_mem_replAttemptOrEmpty_iff]
     apply existsUnique_of_exists_of_unique
     · rw [hdomain] at hx
@@ -303,30 +205,25 @@ instance {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithPara
 An auxiliary lemma about `replAttemptOrEmpty`.
 -/
 lemma replAttemptOrEmpty_aux
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    (α : Ordinal V) →
-    IsAttempt F α (replAttemptOrEmpty F hF α) := by
+    (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
+    (α : Ordinal V) → IsAttempt F α (replAttemptOrEmpty F hF α) := by
   let motive (α : V) : Prop := IsAttempt F α (replAttemptOrEmpty F hF α)
 
-  let motive_dfn : SetTheorySemiformula V 1 :=
-    f“α. !(IsAttempt.dfn φ) α (!(replAttemptOrEmpty.dfn φ) α)”
-
+  have := IsAttempt.definable hF
+  have : ℒₛₑₜ-function₁ replAttemptOrEmpty F hF := by
+    unfold replAttemptOrEmpty
+    definability
   have motive_definable : ℒₛₑₜ-predicate motive := by
-    use motive_dfn
-    intro v
-    simp_all [motive, motive_dfn, replAttemptOrEmpty.defined F hF, IsAttempt.defined F hF]
-
+    unfold motive
+    definability
   refine transfinite_induction motive motive_definable ?_
-  -- Now I just need to prove the transfinite induction.
   intro α ih
   have hα := Ordinal.ordinal α
 
-  -- The case of (restrict) for `α`. This follows from ih for (aux), i.e. `∀ β < α, ((aux) for β)`.
   have hrestrict : ((β : V) → (hβα : β ∈ α.val) → IsAttempt F β ((replAttemptOrEmpty F hF α) ↾ β)) := by
     intro β hβα
     have hβ : IsOrdinal β := IsOrdinal.of_mem hβα
     let βo : Ordinal V := IsOrdinal.toOrdinal β
-    -- Get a case of (aux) that's been proven up to this point in the transfinite induction
     have haux := ih βo hβα
 
     suffices h : (replAttemptOrEmpty F hF α) ↾ β = replAttemptOrEmpty F hF β from h ▸ haux
@@ -342,7 +239,6 @@ lemma replAttemptOrEmpty_aux
       · use γ
         exact And.intro (IsTransitive.mem_trans IsOrdinal.toIsTransitive hγβ hβα) hγ
       · exact ⟨γ, hγβ, F (attemptOrEmpty F γ), hγ⟩
-  -- Proving (aux) for `α`
   refine ⟨hα, inferInstance, domain_replAttemptOrEmpty_eq F hF α, ?_⟩
   intro β hβα y
   have hβ : IsOrdinal β := IsOrdinal.of_mem hβα
@@ -358,7 +254,7 @@ lemma replAttemptOrEmpty_aux
       use (replAttemptOrEmpty F hF (↑α)) ↾ β
       simp only [h₂, true_and]
       exact hrestrict βo hβα
-  have hexists : IsAttempt.ExistsAttempt F β := ⟨replAttemptOrEmpty F hF β, ih βo hβα⟩
+  have hexists : IsAttempt.Exists F β := ⟨replAttemptOrEmpty F hF β, ih βo hβα⟩
   simp_all only [mem_replAttemptOrEmpty_iff, pairValueAttempt, kpair_iff, ↓existsAndEq, true_and,
     motive]
   have hattempt : IsAttempt F β (attemptOrEmpty F β) := by
@@ -376,17 +272,8 @@ lemma replAttemptOrEmpty_aux
 For any ordinal `α`, there exists an attempt function of length `α`.
 -/
 lemma attempt_function_exists
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
-    (α : Ordinal V) → IsAttempt.ExistsAttempt F α := by
-  let motive (α : V) : Prop := IsAttempt.ExistsAttempt F α
-
-  refine transfinite_induction motive (IsAttempt.ExistsAttempt.definable F hF) ?_
-  intro α ih
-  have hexists : ∀ β ∈ α.val, motive β := by
-    intro β hβα
-    have : IsOrdinal β := IsOrdinal.of_mem hβα
-    exact ih (IsOrdinal.toOrdinal β) hβα
-  use replAttemptOrEmpty F hF α
-  exact replAttemptOrEmpty_aux F hF α
+    (F : V → V) (hF : ℒₛₑₜ-function₁ F) :
+    (α : Ordinal V) → IsAttempt.Exists F α :=
+  fun α ↦ ⟨replAttemptOrEmpty F hF α, replAttemptOrEmpty_aux F hF α⟩
 
 end LO.FirstOrder.SetTheory.Replacement

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -10,8 +10,6 @@ namespace LO.FirstOrder.SetTheory
 
 variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭]
 
-namespace IsOrdinal
-
 variable {α β γ : V}
 
 /-! ### Attempt functions -/
@@ -45,9 +43,6 @@ lemma IsAttempt.defined {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDe
     dfn.IsOrdinal.dfn', dfn.IsFunction.dfn', dfn.domain.dfn', dfn.kpair.dfn', dfn.restrict.dfn',
     Semiformula.eval_rewriteMap]
 
-/-
-TODO: Should I make this an `instance`?
--/
 lemma IsAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     ℒₛₑₜ-relation[V] (fun α f ↦ IsAttempt F α f) := by
   use IsAttempt.dfn φ
@@ -58,89 +53,52 @@ lemma IsAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : Is
 
 namespace IsAttempt
 
-lemma attempt_function_coherent (F : V → V) (α : Ordinal V) {f g : V} [IsFunction f] [IsFunction g]
-    (hf : IsAttempt F α f) (hg : IsAttempt F α g) :
-    ∀ β : Ordinal V, β.val ⊆ α.val → f ↾ β.val = g ↾ β.val := by
+/--
+Any two attempt functions restrict to the same function.
+
+Also see lemma 3.7 in chapter 2 of Frank Drake's *Set Theory: An Introduction to Large Cardinals* (Studies in Logic and the Foundations of Mathematics vol. 76, 1974).
+-/
+lemma isAttempt_coherent (F : V → V) {α β : Ordinal V} {f g : V} [IsFunction f] [IsFunction g]
+    (hf : IsAttempt F α f) (hg : IsAttempt F β g) :
+    ∀ γ : Ordinal V, γ.val ⊆ α.val ∧ γ.val ⊆ β.val → f ↾ γ.val = g ↾ γ.val := by
   rcases hf with ⟨_, _, _, testf⟩
   rcases hg with ⟨_, _, _, testg⟩
-  refine transfinite_induction (P := fun x ↦ x ⊆ α.val → f ↾ x = g ↾ x) (by definability) ?_
-  intro β ihβ hβα
+  refine transfinite_induction (P := fun x ↦ x ⊆ α.val ∧ x ⊆ β.val → f ↾ x = g ↾ x) (by definability) ?_
+  rintro γ ihγ ⟨hγα, hγβ⟩
   ext p
   simp only [mem_restrict_iff, and_congr_left_iff, forall_exists_index, and_imp]
-  intro x hxβ y rfl
-  have : IsOrdinal x := IsOrdinal.of_mem hxβ
+  intro x hxγ y rfl
+  have : IsOrdinal x := IsOrdinal.of_mem hxγ
   let xo : Ordinal V := IsOrdinal.toOrdinal x
-  have hxα : x ∈ α.val := hβα x hxβ
-  have hxoα : xo.val ⊆ α.val := subset_trans (β.ordinal.toIsTransitive.transitive x hxβ) hβα
-  have hfxogxo : f ↾ xo = g ↾ xo := ihβ xo hxβ hxoα
-  simp_all only [toOrdinal_val, xo]
+  have hxα : x ∈ α.val := hγα x hxγ
+  have hxβ : x ∈ β.val := hγβ x hxγ
+  have hxoα : xo.val ⊆ α.val := α.ordinal.toIsTransitive.transitive x hxα
+  have hxoβ : xo.val ⊆ β.val := β.ordinal.toIsTransitive.transitive x hxβ
+  have : f ↾ xo = g ↾ xo := ihγ xo hxγ ⟨hxoα, hxoβ⟩
+  simp_all only [IsOrdinal.toOrdinal_val, xo]
 
 /--
 An attempt function of length `α`, if existing, is unique.
 -/
-lemma attempt_function_unique {F : V → V} {α : Ordinal V} {f g : V} [IsFunction f] [IsFunction g]
+lemma isAttempt_unique {F : V → V} {α : Ordinal V} {f g : V} [IsFunction f] [IsFunction g]
     (hf : IsAttempt F α f) (hg : IsAttempt F α g) :
     f = g := by
-  have hrestr :
-      ∀ β : Ordinal V, β.val ⊆ α → f ↾ β.val = g ↾ β.val := by
-    apply attempt_function_coherent <;> assumption
-  have hαfg : f ↾ α.val = g ↾ α.val := hrestr α (subset_refl α.val)
   have hfα : f ↾ α.val = f := IsFunction.restrict_eq_self f α.val (subset_of_eq hf.2.2.1)
   have hgα : g ↾ α.val = g := IsFunction.restrict_eq_self g α.val (subset_of_eq hg.2.2.1)
-  simp_all
+  simpa [hfα, hgα] using isAttempt_coherent F hf hg α ⟨subset_refl α.val, subset_refl α.val⟩
 
 /--
-If `β < α`, an attempt function on `α` restricts to the attempt function on `β`.
+If `β ≤ α`, then an attempt function on `α` restricts to the attempt function on `β`.
 -/
-lemma attempt_function_restrict_eq_of_lt
+lemma isAttempt_restrict_eq_of_le
     (F : V → V)
     {α β : Ordinal V} {f g : V} [IsFunction f] [IsFunction g]
-    (hβα : β < α)
+    (hβα : β ≤ α)
     (hf : IsAttempt F α f)
     (hg : IsAttempt F β g) :
     f ↾ β.val = g := by
-  rcases hf with ⟨_, _, hdf, hrecf⟩
-  have hdg := hg.2.2.1
-  have : IsFunction (f ↾ β.val) := IsFunction.restrict f β.val
-  have hsubseteq : β.val ⊆ α.val := by
-    apply le_of_lt at hβα
-    apply Ordinal.le_def.mp at hβα
-    assumption
-  have hαβ : α.val ∩ β.val = β.val := inter_eq_right_of_subset hsubseteq
-  suffices IsAttempt F β (f ↾ β.val) by
-    rw [← restrict_restrict_of_subset (A := β.val) (subset_refl β.val)]
-    rw [← IsFunction.restrict_eq_self (A := β.val) (f := g) (subset_of_eq hdg)]
-    apply (attempt_function_coherent F β this hg β (subset_refl β.val))
-  unfold IsAttempt
-  simp only [Ordinal.instIsOrdinalVal, this, domain_restrict_eq, hdf, hαβ, true_and]
-  intro γ hγβ y
-  have hγα : γ ∈ α.val := by aesop
-  have : IsOrdinal γ := of_mem hγβ
-  have hγsubsetβ : γ ⊆ β.val := by grind
-  simp_all [mem_restrict_iff]
-
-/-- Any two attempt functions agree on overlapping inputs. -/
-lemma attempt_function_coherent_on
-    (F : V → V)
-    {α β : Ordinal V} {f g x y₁ y₂ : V}
-    [IsFunction f] [IsFunction g]
-    (hf : IsAttempt F α f)
-    (hg : IsAttempt F β g)
-    (hxy₁ : ⟨x, y₁⟩ₖ ∈ f) (hxy₂ : ⟨x, y₂⟩ₖ ∈ g) :
-    y₁ = y₂ := by
-  have := hf.2.1
-  have := hg.2.1
-  rcases IsOrdinal.mem_trichotomy α.val β.val with (hαβ | heq | hβα) <;> simp_all only [← Ordinal.lt_def]
-  · have hrestrict := attempt_function_restrict_eq_of_lt F hαβ hg hf
-    rw [← hrestrict] at hxy₁
-    have hxy₁ := (kpair_mem_restrict_iff.mp hxy₁).1
-    exact IsFunction.unique hxy₁ hxy₂
-  · simp_all only [attempt_function_unique hf hg]
-    exact IsFunction.unique hxy₁ hxy₂
-  · have hrestrict := attempt_function_restrict_eq_of_lt F hβα hf hg
-    rw [← hrestrict] at hxy₂
-    have hxy₂ := (kpair_mem_restrict_iff.mp hxy₂).1
-    exact IsFunction.unique hxy₁ hxy₂
+  have hsubset : domain g ⊆ β.val := subset_of_eq hg.2.2.1
+  exact isAttempt_coherent F hf hg β ⟨hβα, subset_refl β.val⟩ ▸ IsFunction.restrict_eq_self g β.val hsubset
 
 /-! #### Existence and choices of attempt functions -/
 
@@ -174,14 +132,12 @@ lemma existsUnique_of_ExistsAttempt (F : V → V) (α : V) (hex : ExistsAttempt 
   have : IsFunction g := hg.2.1
   have hα : IsOrdinal α := hf.1
   let αo : Ordinal V := IsOrdinal.toOrdinal α
-  apply (IsAttempt.attempt_function_unique (α := αo) hf hg).symm
+  apply (IsAttempt.isAttempt_unique (α := αo) hf hg).symm
 
 end IsAttempt
 
-namespace Replacement
-
 /--
-This lemma is originally by tosiaki
+This lemma is originally by tosiaki.
 -/
 lemma attemptOrEmpty_existsUnique (F : V → V) (α : V) : ∃! y,
     (IsAttempt.ExistsAttempt F α ∧ IsAttempt F α y) ∨
@@ -194,8 +150,8 @@ lemma attemptOrEmpty_existsUnique (F : V → V) (α : V) : ∃! y,
       intro hy₁ hy₂
       rcases hy₁.1, hy₁.2.1, hy₂.2.1 with ⟨hα, _, _⟩
       let αo : Ordinal V := IsOrdinal.toOrdinal α
-      rw [← toOrdinal_val α] at hy₁
-      exact IsAttempt.attempt_function_unique hy₁ hy₂
+      rw [← IsOrdinal.toOrdinal_val α] at hy₁
+      exact IsAttempt.isAttempt_unique hy₁ hy₂
   · refine existsUnique_of_exists_of_unique ?_ ?_
     · exact ⟨∅, Or.inr ⟨hexists, rfl⟩⟩
     · intro y₁ y₂
@@ -204,11 +160,14 @@ lemma attemptOrEmpty_existsUnique (F : V → V) (α : V) : ∃! y,
 
 /--
 An attempt of length `α`, or `∅` if one doesn't exist.
-This definition is by tosiaki
+This definition is by tosiaki.
 -/
 noncomputable def attemptOrEmpty (F : V → V) (α : V) : V :=
   Classical.choose! (attemptOrEmpty_existsUnique F α)
 
+/--
+A `SetTheorySemiformula` defining `attemptOrEmpty F` for a definable function `F`. Pass a formula `φ` defining `F`.
+-/
 def attemptOrEmpty.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
   f“y α. !(IsAttempt.ExistsAttempt.dfn φ) α ∧ !(IsAttempt.dfn φ) α y
     ∨ ¬ !(IsAttempt.ExistsAttempt.dfn φ) α ∧ !isEmpty' y”
@@ -235,6 +194,9 @@ This is a technical definition needed for the proof of the transfinite recursion
 noncomputable def pairValueAttempt (F : V → V) (α : V) : V :=
   ⟨α, F (attemptOrEmpty F α)⟩ₖ
 
+/--
+A `SetTheorySemiformula` defining `pairValueAttempt F` for a definable function `F`. Pass a formula `φ` defining `F`.
+-/
 def pairValueAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
   f“y α. y = !kpair.dfn' α (!φ (!(attemptOrEmpty.dfn φ) α))”
   /- Cast `kpair.dfn` and `restrict.dfn` to a type that allows parameters, to work with `Semiformula.nestFormulaeFunc`. -/
@@ -258,25 +220,26 @@ lemma eq_of_kpair_eq_pairValueAttempt {F : V → V} {α : V} {x y : V} (h : ⟨x
   simp only [pairValueAttempt, kpair_iff] at h
   exact h.1
 
+namespace Replacement
+
+variable [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
+
 /--
 Function that outputs an attempt of length `α`, subject to the assumption that for all `β < α`, there is an attempt of length `β`.
 This is a big function constructed using replacement.
 -/
 noncomputable def replAttemptOrEmpty
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
     (α : V) : V :=
   repl α (pairValueAttempt F) (hF := pairValueAttempt.definable F hF)
 
 @[simp] lemma mem_replAttemptOrEmpty_iff
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
     (α : V) (p : V) :
     p ∈ replAttemptOrEmpty F hF α ↔ ∃ β ∈ α, p = pairValueAttempt F β := by
   apply repl_spec
 
 @[simp] lemma kpair_mem_replAttemptOrEmpty_iff
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
     {α : Ordinal V} {β y : V} :
     ⟨β, y⟩ₖ ∈ replAttemptOrEmpty F hF α ↔ β ∈ α.val ∧ ⟨β, y⟩ₖ = pairValueAttempt F β := by
@@ -287,12 +250,14 @@ noncomputable def replAttemptOrEmpty
     exact ⟨hβα, h⟩
   · use β
 
-def replAttemptOrEmpty.dfn [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙] (φ : SetTheorySemiformula V 2) :
+/--
+A `SetTheorySemiformula` defining `replAttemptOrEmpty F` for a definable function `F`. Pass a formula `φ` defining `F`.
+-/
+def replAttemptOrEmpty.dfn (φ : SetTheorySemiformula V 2) :
     SetTheorySemiformula V 2 :=
   f“Y α. ∀ y, y ∈ Y ↔ ∃ β ∈ α, y = !(pairValueAttempt.dfn φ) β”
 
 lemma replAttemptOrEmpty.defined
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     IsDefinedByWithParam (fun (v : Fin 2 → V) ↦ v 0 = replAttemptOrEmpty F hF (v 1)) (replAttemptOrEmpty.dfn φ) := by
   intro v
@@ -300,7 +265,6 @@ lemma replAttemptOrEmpty.defined
     mem_ext_iff (x := v 0)]
 
 instance replAttemptOrEmpty.definable
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     ℒₛₑₜ-function₁[V] (replAttemptOrEmpty F (hF := hF)) := by
   use replAttemptOrEmpty.dfn φ
@@ -308,7 +272,6 @@ instance replAttemptOrEmpty.definable
   simp [replAttemptOrEmpty.defined F hF]
 
 lemma domain_replAttemptOrEmpty_eq
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
     (α : Ordinal V) :
     domain (replAttemptOrEmpty F hF α) = α.val := by
@@ -321,8 +284,7 @@ lemma domain_replAttemptOrEmpty_eq
     use z
     simp_all only [true_and, pairValueAttempt, true_and]
 
-instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
-    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
+instance {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ)
     (α : Ordinal V) :
     IsFunction (replAttemptOrEmpty F hF α) := by
   -- Name it for brevity
@@ -349,7 +311,7 @@ instance [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
 An auxiliary lemma about `replAttemptOrEmpty`.
 -/
 lemma replAttemptOrEmpty_aux
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙] {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
+    {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     (α : Ordinal V) →
     IsAttempt F α (replAttemptOrEmpty F hF α) := by
   let motive (α : V) : Prop := IsAttempt F α (replAttemptOrEmpty F hF α)
@@ -399,7 +361,7 @@ lemma replAttemptOrEmpty_aux
     · obtain ⟨f, rfl, hf⟩ := h.mp h₂
       have : IsFunction f := hf.2.1
       have : IsFunction ((replAttemptOrEmpty F hF (↑α)) ↾ ↑βo) := inferInstance
-      simp only [IsAttempt.attempt_function_unique hf (hrestrict βo hβα), toOrdinal_val, βo]
+      simp only [IsAttempt.isAttempt_unique hf (hrestrict βo hβα), IsOrdinal.toOrdinal_val, βo]
     · apply h.mpr
       use (replAttemptOrEmpty F hF (↑α)) ↾ β
       simp only [h₂, true_and]
@@ -412,17 +374,16 @@ lemma replAttemptOrEmpty_aux
   constructor <;> intro h
   · use attemptOrEmpty F β
   · obtain ⟨f, hfleft, hfright⟩ := h
-    have heq := toOrdinal_val β
+    have heq := IsOrdinal.toOrdinal_val β
     rw [← heq] at *
     have := hfright.2.1
     have := hattempt.2.1
-    exact (IsAttempt.attempt_function_unique hfright hattempt) ▸ hfleft
+    exact (IsAttempt.isAttempt_unique hfright hattempt) ▸ hfleft
 
 /--
 For any ordinal `α`, there exists an attempt function of length `α`.
 -/
 lemma attempt_function_exists
-    [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
     {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     (α : Ordinal V) → IsAttempt.ExistsAttempt F α := by
   let motive (α : V) : Prop := IsAttempt.ExistsAttempt F α
@@ -436,4 +397,4 @@ lemma attempt_function_exists
   use replAttemptOrEmpty F hF α
   exact replAttemptOrEmpty_aux F hF α
 
-end LO.FirstOrder.SetTheory.IsOrdinal.Replacement
+end LO.FirstOrder.SetTheory.Replacement

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -329,7 +329,7 @@ lemma replAttemptOrEmpty_aux
   intro α ih
   have hα := Ordinal.ordinal α
 
-  -- The case of (restrict) for `α`. This follows from ih for (aux) (i.e. `∀ β < α, ((aux) for β)`).
+  -- The case of (restrict) for `α`. This follows from ih for (aux), i.e. `∀ β < α, ((aux) for β)`.
   have hrestrict : ((β : V) → (hβα : β ∈ α.val) → IsAttempt F β ((replAttemptOrEmpty F hF α) ↾ β)) := by
     intro β hβα
     have hβ : IsOrdinal β := IsOrdinal.of_mem hβα

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -10,12 +10,10 @@ namespace LO.FirstOrder.SetTheory
 
 variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭]
 
-variable {α β γ : V}
-
 /-! ### Attempt functions -/
 
 /--
-`f` is an attempt of length `α` for the function `F`, meaning that the domain of `f` is `α`, and for all `β < α`, it holds that `f(β) = y` iff `y = F (f ↾ β)`.
+`f` is an attempt of length `α` for the function `F`, meaning that the domain of `f` is `α`, and for all `β < α`, it holds that `f(β) = F (f ↾ β)`.
 The "attempt" terminology may be due to Paul Taylor.
 -/
 def IsAttempt (F : V → V) (α f : V) : Prop :=
@@ -36,14 +34,14 @@ def IsAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 2 :=
     kpair.dfn' : SetTheorySemiformula V 3 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ kpair.dfn
     restrict.dfn' : SetTheorySemiformula V 3 := (Rew.rewriteMap (Empty.elim : Empty → V)) ▹ restrict.dfn
 
-lemma IsAttempt.defined {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
+lemma IsAttempt.defined (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     IsDefinedByWithParam (fun v ↦ IsAttempt F (v 0) (v 1)) (IsAttempt.dfn φ) := by
   intro v
   simp_all [IsAttempt, IsAttempt.dfn,
     dfn.IsOrdinal.dfn', dfn.IsFunction.dfn', dfn.domain.dfn', dfn.kpair.dfn', dfn.restrict.dfn',
     Semiformula.eval_rewriteMap]
 
-lemma IsAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
+lemma IsAttempt.definable (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     ℒₛₑₜ-relation[V] (fun α f ↦ IsAttempt F α f) := by
   use IsAttempt.dfn φ
   intro v
@@ -109,13 +107,13 @@ def ExistsAttempt (F : V → V) (α : V) : Prop :=
 def ExistsAttempt.dfn (φ : SetTheorySemiformula V 2) : SetTheorySemiformula V 1 :=
   f“α. ∃ f, !(IsAttempt.dfn φ) α f”
 
-lemma ExistsAttempt.defined {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
+lemma ExistsAttempt.defined (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     IsDefinedByWithParam (fun v ↦ ExistsAttempt F (v 0)) (ExistsAttempt.dfn φ) := by
   intro v
   simp [ExistsAttempt.dfn, IsAttempt.defined F hF]
   rfl
 
-lemma ExistsAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
+lemma ExistsAttempt.definable (F : V → V) {φ : SetTheorySemiformula V 2} (hF : IsDefinedByWithParam (fun v ↦ v 0 = F (v 1)) φ) :
     ℒₛₑₜ-predicate (fun α ↦ ExistsAttempt F α) := by
   use ExistsAttempt.dfn φ
   intro v
@@ -219,6 +217,8 @@ lemma eq_of_kpair_eq_pairValueAttempt {F : V → V} {α : V} {x y : V} (h : ⟨x
     x = α := by
   simp only [pairValueAttempt, kpair_iff] at h
   exact h.1
+
+/-! #### Constructing attempt functions using replacement -/
 
 namespace Replacement
 

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -183,7 +183,6 @@ lemma domain_replAttemptOrEmpty_eq (F : V → V) (hF : ℒₛₑₜ-function₁ 
     simp_all only [true_and, pairValueAttempt, true_and]
 
 instance (F : V → V) (hF : ℒₛₑₜ-function₁ F) (α : Ordinal V) : IsFunction (replAttemptOrEmpty F hF α) := by
-  -- Name it for brevity
   let f := replAttemptOrEmpty F hF α
   have hdomain : domain f = α.val := domain_replAttemptOrEmpty_eq F hF α
   apply isFunction_iff.mpr

--- a/Foundation/FirstOrder/SetTheory/Recursion.lean
+++ b/Foundation/FirstOrder/SetTheory/Recursion.lean
@@ -141,20 +141,14 @@ lemma attemptOrEmpty_existsUnique (F : V → V) (α : V) : ∃! y,
     (IsAttempt.ExistsAttempt F α ∧ IsAttempt F α y) ∨
     (¬ IsAttempt.ExistsAttempt F α ∧ y = ∅) := by
   by_cases hexists : IsAttempt.ExistsAttempt F α
-  · refine existsUnique_of_exists_of_unique ?_ ?_
-    · exact ⟨Classical.choose hexists, Or.inl ⟨hexists, Classical.choose_spec hexists⟩⟩
-    · intro y₁ y₂
-      simp only [hexists, true_and, not_true_eq_false, false_and, or_false]
-      intro hy₁ hy₂
-      rcases hy₁.1, hy₁.2.1, hy₂.2.1 with ⟨hα, _, _⟩
-      let αo : Ordinal V := IsOrdinal.toOrdinal α
-      rw [← IsOrdinal.toOrdinal_val α] at hy₁
-      exact IsAttempt.isAttempt_unique hy₁ hy₂
-  · refine existsUnique_of_exists_of_unique ?_ ?_
-    · exact ⟨∅, Or.inr ⟨hexists, rfl⟩⟩
-    · intro y₁ y₂
-      simp only [hexists, false_and, not_false_eq_true, true_and, false_or]
-      exact fun (hy₁ : y₁ = ∅) (hy₂ : y₂ = ∅) ↦ hy₂ ▸ hy₁
+  · refine existsUnique_of_exists_of_unique ⟨hexists.choose, Or.inl ⟨hexists, hexists.choose_spec⟩⟩ ?_
+    intro y₁ y₂ hy₁ hy₂
+    simp_all only [true_and, not_true_eq_false, false_and, or_false]
+    rcases hy₁.1, hy₁.2.1, hy₂.2.1 with ⟨hα, _, _⟩
+    let αo : Ordinal V := IsOrdinal.toOrdinal α
+    rw [← IsOrdinal.toOrdinal_val α] at hy₁
+    exact IsAttempt.isAttempt_unique hy₁ hy₂
+  · refine existsUnique_of_exists_of_unique ⟨∅, Or.inr ⟨hexists, rfl⟩⟩ (by aesop)
 
 /--
 An attempt of length `α`, or `∅` if one doesn't exist.
@@ -213,10 +207,8 @@ lemma pairValueAttempt.definable {φ : SetTheorySemiformula V 2} (F : V → V) (
   intro v
   simp [pairValueAttempt.defined F hF]
 
-lemma eq_of_kpair_eq_pairValueAttempt {F : V → V} {α : V} {x y : V} (h : ⟨x, y⟩ₖ = pairValueAttempt F α) :
-    x = α := by
-  simp only [pairValueAttempt, kpair_iff] at h
-  exact h.1
+lemma eq_of_kpair_eq_pairValueAttempt {F : V → V} {α : V} {x y : V} (h : ⟨x, y⟩ₖ = pairValueAttempt F α) : x = α :=
+  (kpair_iff.mp (pairValueAttempt.eq_1 F α ▸ h)).1
 
 /-! #### Constructing attempt functions using replacement -/
 

--- a/Foundation/FirstOrder/SetTheory/ZF.lean
+++ b/Foundation/FirstOrder/SetTheory/ZF.lean
@@ -6,7 +6,7 @@ public import Foundation.FirstOrder.SetTheory.Z
 
 namespace LO.FirstOrder.SetTheory
 
-variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭] [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
+variable {V : Type*} [SetStructure V] [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭𝗙]
 
 /-! ## Ersatzaxiom -/
 
@@ -69,12 +69,12 @@ lemma replacement_exists (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F)
 /--
 The axiom of replacement for a relation.
 -/
-noncomputable def replRel (X : V) (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) : V := Classical.choose! (replacement_rel_existsUnique X R h hR)
+noncomputable def replRel (R : V → V → Prop) (h : ∀ x, ∃! y, R x y) (hR : ℒₛₑₜ-relation R := by definability) (X : V) : V := Classical.choose! (replacement_rel_existsUnique X R h hR)
 
 /--
 The axiom of replacement.
 -/
-noncomputable def repl (X : V) (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) : V := Classical.choose! (replacement_existsUnique X F hF)
+noncomputable def repl (F : V → V) (hF : ℒₛₑₜ-function₁ F := by definability) (X : V) : V := Classical.choose! (replacement_existsUnique X F hF)
 
 /-! ## Variants of replacement -/
 
@@ -112,14 +112,19 @@ noncomputable def replRelOverSet (X : V) (R : V → V → Prop) (h : ∀ x ∈ X
 
 /-! ## Various lemmas -/
 
-@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} {h : ∀ x, ∃! y, R x y} (hR : ℒₛₑₜ-relation R) :
-    y ∈ replRel X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique X R h hR) y
+@[simp] lemma replRel_spec {X y : V} {R : V → V → Prop} {h : ∀ x ∈ X, ∃! y, R x y} (hR : ℒₛₑₜ-relation R) :
+    y ∈ replRelOverSet X R h hR ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h hR) y
 
 @[simp] lemma repl_spec {X y : V} {F : V → V} (hF : ℒₛₑₜ-function₁ F) :
-    y ∈ repl X F hF ↔ ∃ x ∈ X, y = F x := Classical.choose!_spec (replacement_existsUnique X F hF) y
+    y ∈ repl F hF X ↔ ∃ x ∈ X, y = F x := Classical.choose!_spec (replacement_existsUnique X F hF) y
 
 @[simp] lemma replRelOverSet_spec {X y : V} {R : V → V → Prop} {h : ∀ x ∈ X, ∃! y, R x y} (hR : ℒₛₑₜ-relation R) :
     y ∈ replRelOverSet X R h ↔ ∃ x ∈ X, R x y := Classical.choose!_spec (replacement_rel_existsUnique_of_mem_existsUnique X R h hR) y
+
+@[simp, definability] instance repl_definable {F : V → V} [hF : ℒₛₑₜ-function₁ F] : ℒₛₑₜ-function₁ (repl F hF) := by
+  suffices ℒₛₑₜ-relation (fun y x ↦ y = repl F hF x) by exact this
+  simp only [repl, choose!_eq_iff_right]
+  definability
 
 /-! ### Definability Gadgets for Replacement -/
 
@@ -146,7 +151,7 @@ variable {arity : ℕ} {b : Blueprint arity} (c : Construction V b)
 instance map_definable :
   (ℒₛₑₜ).DefinableFunction (fun v ↦ c.map (v ·.succ) (v 0)) := c.map_defined.to_definable
 
-noncomputable def result (v : Fin arity → V) : V → V := fun x ↦ repl x (c.map v) (by
+noncomputable def result (v : Fin arity → V) : V → V := repl (c.map v) (by
   refine ⟨(Rew.embSubsts (#0 :> #1 :> fun i : Fin arity ↦ &(v i))) ▹ b.graph, ?_⟩
   intro x
   simpa [Semiformula.eval_embSubsts, Matrix.comp_vecCons', Function.comp_def]


### PR DESCRIPTION
I was able to simplify some things, clean up variables and namespaces, add a few docstrings, and I tried to make it more closely fit the refactoring guidelines.

`Recursion.lean` went from 439 lines to 392, an 11% decrease.