### PR TITLE
change(Vorspiel): extend `Wedge`, `Vee`, `Arrow` and `Tilde` to heterogeneous version `HWedge`, `HVee`, `HArrow` and `HTilde`

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/Definability/Hierarchy.lean
+++ b/Foundation/FirstOrder/Arithmetic/Definability/Hierarchy.lean
@@ -312,27 +312,27 @@ def substSigma (φ : 𝚺-[m + 1].Semiformula ξ 1) (F : 𝚺-[m + 1].Semiformul
   suffices (φ.and ψ).val = φ.val ⋏ ψ.val from this
   rcases Γ with ⟨Γ, m⟩; rcases Γ <;> simp [and, val, val_sigma]
 
-@[simp] lemma sigma_and (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋏ ψ).sigma = φ.sigma ⋏ ψ.sigma := by simp [Wedge.wedge, and]
+@[simp] lemma sigma_and (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋏ ψ).sigma = φ.sigma ⋏ ψ.sigma := rfl
 
-@[simp] lemma pi_and (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋏ ψ).pi = φ.pi ⋏ ψ.pi := by simp [Wedge.wedge, and]
+@[simp] lemma pi_and (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋏ ψ).pi = φ.pi ⋏ ψ.pi := rfl
 
 @[simp] lemma val_or (φ ψ : Γ.Semiformula ξ n) : (φ ⋎ ψ).val = φ.val ⋎ ψ.val := by
   suffices (φ.or ψ).val = φ.val ⋎ ψ.val from this
   rcases Γ with ⟨Γ, m⟩; rcases Γ <;> simp [or, val, val_sigma]
 
-@[simp] lemma sigma_or (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋎ ψ).sigma = φ.sigma ⋎ ψ.sigma := by simp [Vee.vee, or]
+@[simp] lemma sigma_or (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋎ ψ).sigma = φ.sigma ⋎ ψ.sigma := rfl
 
-@[simp] lemma pi_or (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋎ ψ).pi = φ.pi ⋎ ψ.pi := by simp [Vee.vee, or]
+@[simp] lemma pi_or (φ ψ : 𝚫-[m].Semiformula ξ n) : (φ ⋎ ψ).pi = φ.pi ⋎ ψ.pi := rfl
 
 @[simp] lemma val_negSigma {m} (φ : 𝚺-[m].Semiformula ξ n) : φ.negSigma.val = ∼φ.val := by simp [negSigma]
 
 @[simp] lemma val_negPi {m} (φ : 𝚷-[m].Semiformula ξ n) : φ.negPi.val = ∼φ.val := by simp [negPi]
 
-lemma val_negDelta {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).val = ∼φ.pi.val := by simp [Tilde.tilde, negDelta]
+lemma val_negDelta {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).val = ∼φ.pi.val := by simp [HTilde.hTilde, Tilde.tilde, negDelta]
 
-@[simp] lemma sigma_negDelta {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).sigma = φ.pi.negPi := by simp [Tilde.tilde, negDelta]
+@[simp] lemma sigma_negDelta {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).sigma = φ.pi.negPi := by simp [HTilde.hTilde, Tilde.tilde, negDelta]
 
-@[simp] lemma sigma_negPi {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).pi = φ.sigma.negSigma := by simp [Tilde.tilde, negDelta]
+@[simp] lemma sigma_negPi {m} (φ : 𝚫-[m].Semiformula ξ n) : (∼φ).pi = φ.sigma.negSigma := by simp [HTilde.hTilde, Tilde.tilde, negDelta]
 
 @[simp] lemma val_ball (t : ArithmeticSemiterm ξ n) (φ : Γ.Semiformula ξ (n + 1)) : (ball t φ).val = ∀¹[“#0 < !!(Rew.bShift t)”] φ.val := by
   rcases Γ with ⟨Γ, m⟩; rcases Γ <;> simp [ball, val, val_sigma]

--- a/Foundation/FirstOrder/Basic/BinderNotation.lean
+++ b/Foundation/FirstOrder/Basic/BinderNotation.lean
@@ -366,16 +366,18 @@ syntax:max "∃¹ " first_order_formula:0 : first_order_formula
 syntax:max "∀¹[" first_order_formula "] " first_order_formula:0 : first_order_formula
 syntax:max "∃¹[" first_order_formula "] " first_order_formula:0 : first_order_formula
 
+#check @HTilde.hTilde _ _ Tilde.instHTilde
+
 macro_rules
   | `(⤫formula($type)[ $binders* | $fbinders* | ($e)          ]) => `(⤫formula($type)[ $binders* | $fbinders* | $e ])
   | `(⤫formula($type)[ $_*       | $_*        | !!$φ:term     ]) => `($φ)
   | `(⤫formula($type)[ $_*       | $_*        | .!!$φ:term    ]) => `(Rewriting.emb $φ)
   | `(⤫formula($type)[ $_*       | $_*        | ⊤             ]) => `(⊤)
   | `(⤫formula($type)[ $_*       | $_*        | ⊥             ]) => `(⊥)
-  | `(⤫formula($type)[ $binders* | $fbinders* | $φ ∧ $ψ       ]) => `(⤫formula($type)[ $binders* | $fbinders* | $φ ] ⋏ ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
-  | `(⤫formula($type)[ $binders* | $fbinders* | $φ ∨ $ψ       ]) => `(⤫formula($type)[ $binders* | $fbinders* | $φ ] ⋎ ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
-  | `(⤫formula($type)[ $binders* | $fbinders* | ¬$φ           ]) => `(∼⤫formula($type)[ $binders* | $fbinders* | $φ ])
-  | `(⤫formula($type)[ $binders* | $fbinders* | $φ → $ψ       ]) => `(⤫formula($type)[ $binders* | $fbinders* | $φ ] 🡒 ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
+  | `(⤫formula($type)[ $binders* | $fbinders* | $φ ∧ $ψ       ]) => `(@HWedge.hWedge _ _ _ Wedge.instHWedge ⤫formula($type)[ $binders* | $fbinders* | $φ ] ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
+  | `(⤫formula($type)[ $binders* | $fbinders* | $φ ∨ $ψ       ]) => `(@HVee.hVee _ _ _ Vee.instHVee ⤫formula($type)[ $binders* | $fbinders* | $φ ] ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
+  | `(⤫formula($type)[ $binders* | $fbinders* | ¬$φ           ]) => `(@HTilde.hTilde _ _ Tilde.instHTilde ⤫formula($type)[ $binders* | $fbinders* | $φ ])
+  | `(⤫formula($type)[ $binders* | $fbinders* | $φ → $ψ       ]) => `(@HArrow.hArrow _ _ _ Arrow.instHArrow ⤫formula($type)[ $binders* | $fbinders* | $φ ] ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
   | `(⤫formula($type)[ $binders* | $fbinders* | $φ ↔ $ψ       ]) => `(⤫formula($type)[ $binders* | $fbinders* | $φ ] 🡘 ⤫formula($type)[ $binders* | $fbinders* | $ψ ])
   | `(⤫formula($type)[ $binders* | $fbinders* | ⋀ $i, $φ      ]) => `(Matrix.conj fun $i ↦ ⤫formula($type)[ $binders* | $fbinders* | $φ ])
   | `(⤫formula($type)[ $binders* | $fbinders* | ⋁ $i, $φ      ]) => `(Matrix.disj fun $i ↦ ⤫formula($type)[ $binders* | $fbinders* | $φ ])
@@ -465,10 +467,10 @@ macro_rules
   | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term < $u:first_order_term ]) => `(Semiformula.Operator.operator Operator.LT.lt ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]])
   | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≤ $u:first_order_term ]) => `(Semiformula.Operator.operator Operator.LE.le ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]])
   | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ∈ $u:first_order_term ]) => `(Semiformula.Operator.operator Operator.Mem.mem ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]])
-  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≠ $u:first_order_term ]) => `(∼(Semiformula.Operator.operator Operator.Eq.eq ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
-  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≮ $u:first_order_term ]) => `(∼(Semiformula.Operator.operator Operator.LT.lt ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
-  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≰ $u:first_order_term ]) => `(∼(Semiformula.Operator.operator Operator.LE.le ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
-  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ∉ $u:first_order_term ]) => `(∼(Semiformula.Operator.operator Operator.Mem.mem ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
+  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≠ $u:first_order_term ]) => `(@HTilde.hTilde _ _ Tilde.instHTilde (Semiformula.Operator.operator Operator.Eq.eq ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
+  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≮ $u:first_order_term ]) => `(@HTilde.hTilde _ _ Tilde.instHTilde (Semiformula.Operator.operator Operator.LT.lt ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
+  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ≰ $u:first_order_term ]) => `(@HTilde.hTilde _ _ Tilde.instHTilde (Semiformula.Operator.operator Operator.LE.le ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
+  | `(⤫formula(lit)[ $binders* | $fbinders* | $t:first_order_term ∉ $u:first_order_term ]) => `(@HTilde.hTilde _ _ Tilde.instHTilde (Semiformula.Operator.operator Operator.Mem.mem ![⤫term(lit)[ $binders* | $fbinders* | $t ], ⤫term(lit)[ $binders* | $fbinders* | $u ]]))
 
 macro_rules
   | `(⤫formula(lit)[ $binders* | $fbinders* | ∀ $x < $t, $φ ]) => do

--- a/Foundation/FirstOrder/Basic/Soundness.lean
+++ b/Foundation/FirstOrder/Basic/Soundness.lean
@@ -80,7 +80,7 @@ theorem Proof.sound_proposition {M : Type*} [s : Structure L M] [Nonempty M] :
   have : φ.Realize M ∨ ∃ ψ, ∼ψ ∈ Sequent.embed Γ ∧ ψ.Evalf f := by simpa using b.sound f
   rcases this with (h | ⟨ψ, hψ, h⟩)
   · assumption
-  · have : ∃ χ, (∼χ : Sentence L) ∈ Γ ∧ ↑χ = ψ := by
+  · have : ∃ χ : Sentence L, ∼χ ∈ Γ ∧ ↑χ = ψ := by
       have : ∃ χ ∈ Γ, χ = ∼ψ := by simpa [Sequent.embed] using hψ
       rcases this with ⟨χ, hχ, e⟩
       refine ⟨∼χ, by simpa using hχ, by simp [e]⟩

--- a/Foundation/FirstOrder/Basic/Soundness.lean
+++ b/Foundation/FirstOrder/Basic/Soundness.lean
@@ -80,7 +80,7 @@ theorem Proof.sound_proposition {M : Type*} [s : Structure L M] [Nonempty M] :
   have : φ.Realize M ∨ ∃ ψ, ∼ψ ∈ Sequent.embed Γ ∧ ψ.Evalf f := by simpa using b.sound f
   rcases this with (h | ⟨ψ, hψ, h⟩)
   · assumption
-  · have : ∃ χ, ∼χ ∈ Γ ∧ ↑χ = ψ := by
+  · have : ∃ χ, (∼χ : Sentence L) ∈ Γ ∧ ↑χ = ψ := by
       have : ∃ χ ∈ Γ, χ = ∼ψ := by simpa [Sequent.embed] using hψ
       rcases this with ⟨χ, hχ, e⟩
       refine ⟨∼χ, by simpa using hχ, by simp [e]⟩

--- a/Foundation/FirstOrder/Basic/Syntax/Formula.lean
+++ b/Foundation/FirstOrder/Basic/Syntax/Formula.lean
@@ -144,13 +144,13 @@ lemma bexs_eq (φ ψ : Semiformula L ξ (n + 1)) : (∃¹[φ] ψ) = ∃¹ (φ �
 @[simp] lemma neg_bexs (φ ψ : Semiformula L ξ (n + 1)) : ∼(∃¹[φ] ψ) = ∀¹[φ] ∼ψ := by
   simp [ball, bexs, imp_eq]
 
-@[simp] lemma and_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformula L ξ n) : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Wedge.wedge]
+@[simp] lemma and_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformula L ξ n) : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| and.injEq _ _ _ _
 
-@[simp] lemma or_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformula L ξ n) : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Vee.vee]
+@[simp] lemma or_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformula L ξ n) : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| or.injEq _ _ _ _
 
-@[simp] lemma all_inj (φ ψ : Semiformula L ξ (n + 1)) : ∀¹ φ = ∀¹ ψ ↔ φ = ψ := by simp [UnivQuantifier.all]
+@[simp] lemma all_inj (φ ψ : Semiformula L ξ (n + 1)) : ∀¹ φ = ∀¹ ψ ↔ φ = ψ := Iff.of_eq <| all.injEq _ _
 
-@[simp] lemma exs_inj (φ ψ : Semiformula L ξ (n + 1)) : ∃¹ φ = ∃¹ ψ ↔ φ = ψ := by simp [ExsQuantifier.exs]
+@[simp] lemma exs_inj (φ ψ : Semiformula L ξ (n + 1)) : ∃¹ φ = ∃¹ ψ ↔ φ = ψ := Iff.of_eq <| exs.injEq _ _
 
 @[simp] lemma allClosure_inj (φ ψ : Semiformula L ξ n) : ∀¹* φ = ∀¹* ψ ↔ φ = ψ := by
   induction n <;> simp [*, allClosure_succ]

--- a/Foundation/FirstOrder/Incompleteness/Consistency.lean
+++ b/Foundation/FirstOrder/Incompleteness/Consistency.lean
@@ -85,7 +85,7 @@ open Entailment
 
 variable (T : ArithmeticTheory) [𝗜𝚺₁ ⪯ T] [T.Δ₁]
 
-instance [ℕ↓[ℒₒᵣ] ⊧* T] : ℕ↓[ℒₒᵣ] ⊧* (T ∪ T.Con) := by
+instance [ℕ↓[ℒₒᵣ] ⊧* T] : ℕ↓[ℒₒᵣ] ⊧* T ∪ T.Con := by
   have : 𝗥₀ ⪯ 𝗜𝚺₁ := inferInstance
   have : 𝗥₀ ⪯ T := Entailment.WeakerThan.trans this inferInstance
   have : Entailment.Consistent T := ArithmeticTheory.consistent_of_sound T (Eq ⊥) rfl

--- a/Foundation/FirstOrder/Incompleteness/Consistency.lean
+++ b/Foundation/FirstOrder/Incompleteness/Consistency.lean
@@ -58,9 +58,9 @@ variable {T}
 
 end
 
-abbrev _root_.LO.FirstOrder.Theory.Con : ArithmeticTheory := {↑T.consistent}
+abbrev _root_.LO.FirstOrder.Theory.Con : ArithmeticTheory := {T.consistent.val}
 
-abbrev _root_.LO.FirstOrder.Theory.Incon : ArithmeticTheory := {∼↑(T.consistent : ArithmeticSentence)}
+abbrev _root_.LO.FirstOrder.Theory.Incon : ArithmeticTheory := {∼T.consistent.val}
 
 noncomputable instance : T.Con.Δ₁ := Theory.Δ₁.singleton _
 

--- a/Foundation/FirstOrder/Incompleteness/Consistency.lean
+++ b/Foundation/FirstOrder/Incompleteness/Consistency.lean
@@ -60,7 +60,7 @@ end
 
 abbrev _root_.LO.FirstOrder.Theory.Con : ArithmeticTheory := {↑T.consistent}
 
-abbrev _root_.LO.FirstOrder.Theory.Incon : ArithmeticTheory := {∼↑T.consistent}
+abbrev _root_.LO.FirstOrder.Theory.Incon : ArithmeticTheory := {∼↑(T.consistent : ArithmeticSentence)}
 
 noncomputable instance : T.Con.Δ₁ := Theory.Δ₁.singleton _
 

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
@@ -271,7 +271,8 @@ variable {σ : Sentence L}
 local notation "𝐊" => kreisel 𝔅
 
 lemma kreisel_spec : T₀ ⊢ (𝐊 σ) 🡘 (𝔅 (𝐊 σ) 🡒 σ) := by
-  simpa [kreisel, Provability.pr, Rew.subst_comp_subst, ←TransitiveRewriting.comp_app] using diag “x. !𝔅.prov x → !σ”;
+  have := diag (T := T₀) “x. !𝔅.prov x → !σ”
+  simpa [kreisel, Provability.pr, Rew.subst_comp_subst, ←TransitiveRewriting.comp_app] using this;
 
 private lemma kreisel_specAux₂ : T₀ ⊢ (𝔅 (𝐊 σ) 🡒 σ) 🡒 (𝐊 σ) := K!_right kreisel_spec
 

--- a/Foundation/FirstOrder/Incompleteness/RestrictedProvability.lean
+++ b/Foundation/FirstOrder/Incompleteness/RestrictedProvability.lean
@@ -34,7 +34,8 @@ instance RestrictedProvable.defined {e} : 𝚷₁-Predicate[V] T.RestrictedProva
 /-- Gödel sentence by restricted provability -/
 noncomputable abbrev restrictedGödel (e : ℕ) (T : Theory L) [T.Δ₁] : ArithmeticSentence := fixedpoint (∼(T.restrictedProvable e))
 
-private noncomputable abbrev restrictedGödel' (e : ℕ) (T : Theory L) [T.Δ₁] : ArithmeticSentence := ∼(T.restrictedProvable e)/[⌜restrictedGödel e T⌝]
+private noncomputable abbrev restrictedGödel' (e : ℕ) (T : Theory L) [T.Δ₁] : ArithmeticSentence :=
+  ∼(T.restrictedProvable e).val/[⌜restrictedGödel e T⌝]
 
 private lemma restrictedGödel'_sigmaOne {e : ℕ} : Hierarchy 𝚺 1 (T.restrictedGödel' e) := by definability;
 
@@ -47,9 +48,9 @@ variable {V : Type} [ORingStructure V] [V↓[ℒₒᵣ] ⊧* 𝗜𝚺₁]
 variable {T U : ArithmeticTheory} [T.Δ₁] -- [𝗜𝚺₁ ⪯ T] [𝗜𝚺₁ ⪯ U]
 variable {e : ℕ}
 
-lemma def_restrictedGödel [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel e 🡘 (∼T.restrictedProvable e)/[⌜T.restrictedGödel e⌝] := diagonal _
+lemma def_restrictedGödel [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel e 🡘 (∼(T.restrictedProvable e).val)/[⌜T.restrictedGödel e⌝] := diagonal _
 
-private lemma def_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel' e 🡘 (∼T.restrictedProvable e)/[⌜T.restrictedGödel e⌝] := by simp;
+private lemma def_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel' e 🡘 (∼(T.restrictedProvable e).val)/[⌜T.restrictedGödel e⌝] := by simp;
 
 private lemma provable_E_restrictedGödel_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel e 🡘 T.restrictedGödel' e := by
   apply Entailment.E!_trans;

--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -18,7 +18,7 @@ variable (T : ArithmeticTheory) [T.Δ₁] [𝗜𝚺₁ ⪯ T]
 theorem consistent_unprovable [Consistent T] : T ⊬ ↑T.consistent :=
   ProvabilityAbstraction.con_unprovable (𝔅 := T.standardProvability)
 
-theorem inconsistent_unprovable [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T ⊬ ∼↑T.consistent :=
+theorem inconsistent_unprovable [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T ⊬ ∼T.consistent.val :=
   ProvabilityAbstraction.con_unrefutable (𝔅 := T.standardProvability)
 
 /-- The consistency statement is independent. -/
@@ -26,12 +26,12 @@ theorem inconsistent_independent [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : 
   ProvabilityAbstraction.con_independent (𝔅 := T.standardProvability)
 
 instance [Consistent T] : T ⪱ T ∪ T.Con :=
-  StrictlyWeakerThan.of_unprovable_provable (φ := ↑T.consistent)
+  StrictlyWeakerThan.of_unprovable_provable (φ := T.consistent)
     (consistent_unprovable T)
     (Entailment.by_axm (by simp))
 
 instance [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T ⪱ T ∪ T.Incon :=
-  StrictlyWeakerThan.of_unprovable_provable (φ := ∼↑T.consistent)
+  StrictlyWeakerThan.of_unprovable_provable (φ := ∼T.consistent)
     (inconsistent_unprovable T)
     (Entailment.by_axm (by simp))
 

--- a/Foundation/FirstOrder/Incompleteness/Second.lean
+++ b/Foundation/FirstOrder/Incompleteness/Second.lean
@@ -15,14 +15,14 @@ open LO.Entailment ProvabilityAbstraction
 variable (T : ArithmeticTheory) [T.Δ₁] [𝗜𝚺₁ ⪯ T]
 
 /-- Gödel's second incompleteness theorem -/
-theorem consistent_unprovable [Consistent T] : T ⊬ ↑T.consistent :=
+theorem consistent_unprovable [Consistent T] : T ⊬ T.consistent.val :=
   ProvabilityAbstraction.con_unprovable (𝔅 := T.standardProvability)
 
 theorem inconsistent_unprovable [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : T ⊬ ∼T.consistent.val :=
   ProvabilityAbstraction.con_unrefutable (𝔅 := T.standardProvability)
 
 /-- The consistency statement is independent. -/
-theorem inconsistent_independent [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : Independent T ↑T.consistent :=
+theorem inconsistent_independent [ArithmeticTheory.SoundOnHierarchy T 𝚺 1] : Independent T T.consistent.val :=
   ProvabilityAbstraction.con_independent (𝔅 := T.standardProvability)
 
 instance [Consistent T] : T ⪱ T ∪ T.Con :=

--- a/Foundation/FirstOrder/Intuitionistic/Formula.lean
+++ b/Foundation/FirstOrder/Intuitionistic/Formula.lean
@@ -84,14 +84,14 @@ instance : ToString (Semiformulaᵢ L ξ n) := ⟨toStr⟩
 
 end ToString
 
-@[simp] lemma and_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformulaᵢ L ξ n) : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by
-  simp [Wedge.wedge]
+@[simp] lemma and_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformulaᵢ L ξ n) : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ :=
+  Iff.of_eq <| and.injEq _ _ _ _
 
-@[simp] lemma or_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformulaᵢ L ξ n) : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by
-  simp [Vee.vee]
+@[simp] lemma or_inj (φ₁ ψ₁ φ₂ ψ₂ : Semiformulaᵢ L ξ n) : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ :=
+  Iff.of_eq <| or.injEq _ _ _ _
 
 @[simp] lemma imp_inj {φ₁ φ₂ ψ₁ ψ₂ : Semiformulaᵢ L ξ n} :
-    φ₁ 🡒 φ₂ = ψ₁ 🡒 ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Arrow.arrow]
+    φ₁ 🡒 φ₂ = ψ₁ 🡒 ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| imp.injEq _ _ _ _
 
 @[simp] lemma all_inj (φ ψ : Semiformulaᵢ L ξ (n + 1)) : ∀¹ φ = ∀¹ ψ ↔ φ = ψ := by
   simp [UnivQuantifier.all]

--- a/Foundation/FirstOrder/Kripke/Intuitionistic.lean
+++ b/Foundation/FirstOrder/Kripke/Intuitionistic.lean
@@ -245,7 +245,7 @@ lemma sound {T : Theoryᵢ L 𝗜𝗻𝘁¹} (b : T ⊢ φ) : W ∀⊩* T → W 
   rcases domain_nonempty' w with ⟨x, hx⟩
   have : (Rewriting.emb '' T.theory) *⊢[𝗜𝗻𝘁¹] ↑φ := b
   rcases Entailment.Context.provable_iff.mp this with ⟨Γ, HΓ, b⟩
-  have : w ⊩[![]|fun _ ↦ x] ⋀Γ 🡒 ↑φ := Forces.sound (L := L) w (fun _ ↦ x) (by simpa using hx) b
+  have : w ⊩[![]|fun _ ↦ x] ⋀Γ 🡒 (φ : Propositionᵢ L) := Forces.sound (L := L) w (fun _ ↦ x) (by simpa using hx) b
   have : w ⊩[![]|fun _ : ℕ ↦ x] ↑φ := by
     apply this w (by rfl)
     suffices ∀ φ ∈ Γ, w ⊩[![]|fun _ ↦ x] φ by simpa

--- a/Foundation/Logic/LogicSymbol.lean
+++ b/Foundation/Logic/LogicSymbol.lean
@@ -62,14 +62,14 @@ section tilde
 
 variable {α : Type*} [Tilde α] [TildeInvolutive α]
 
-@[simp] lemma TildeInvolutive.tilde_injective : Function.Injective (Tilde.tilde : α → α) := by
+@[simp] lemma TildeInvolutive.tilde_injective : Function.Injective (∼· : α → α) := by
   intro φ ψ h
   simpa using congr_arg (∼·) h
 
 @[simp] lemma TildeInvolutive.tilde_eq_tilde_iff_eq {φ ψ : α} : ∼φ = ∼ψ ↔ φ = ψ :=
   Function.Injective.eq_iff TildeInvolutive.tilde_injective
 
-def Tilde.invol : α ↪ α := ⟨Tilde.tilde, TildeInvolutive.tilde_injective⟩
+def Tilde.invol : α ↪ α := ⟨(∼·), TildeInvolutive.tilde_injective⟩
 
 @[simp] lemma Tilde.invol_app (φ : α) : Tilde.invol φ = ∼φ := rfl
 

--- a/Foundation/Propositional/Formula/Basic.lean
+++ b/Foundation/Propositional/Formula/Basic.lean
@@ -63,10 +63,10 @@ instance : ToString (Formula α) := ⟨toStr⟩
 
 end ToString
 
-lemma and_inj : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Wedge.wedge]
-lemma or_inj : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Vee.vee]
-lemma imp_inj : φ₁ 🡒 φ₂ = ψ₁ 🡒 ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := by simp [Arrow.arrow]
-lemma neg_inj : ∼φ = ∼ψ ↔ φ = ψ := by simp [Tilde.tilde]
+lemma and_inj : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| and.injEq _ _ _ _
+lemma or_inj : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| or.injEq _ _ _ _
+lemma imp_inj : φ₁ 🡒 φ₂ = ψ₁ 🡒 ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ := Iff.of_eq <| imp.injEq _ _ _ _
+lemma neg_inj : ∼φ = ∼ψ ↔ φ = ψ := by simp [NegAbbrev.neg, imp_inj]
 
 lemma neg_def : ∼φ = φ 🡒 ⊥ := rfl
 lemma top_def : (⊤ : Formula α) = ⊥ 🡒 ⊥ := rfl

--- a/Foundation/Propositional/Formula/NNFormula.lean
+++ b/Foundation/Propositional/Formula/NNFormula.lean
@@ -83,10 +83,10 @@ lemma imp_eq (φ ψ : NNFormula α) : φ 🡒 ψ = ∼φ ⋎ ψ := rfl
 lemma iff_eq (φ ψ : NNFormula α) : φ 🡘 ψ = (∼φ ⋎ ψ) ⋏ (∼ψ ⋎ φ) := rfl
 
 @[simp] lemma and_inj (φ₁ ψ₁ φ₂ ψ₂ : NNFormula α) : φ₁ ⋏ φ₂ = ψ₁ ⋏ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ :=
-by simp [Wedge.wedge]
+  Iff.of_eq <| and.injEq _ _ _ _
 
 @[simp] lemma or_inj (φ₁ ψ₁ φ₂ ψ₂ : NNFormula α) : φ₁ ⋎ φ₂ = ψ₁ ⋎ ψ₂ ↔ φ₁ = ψ₁ ∧ φ₂ = ψ₂ :=
-by simp [Vee.vee]
+  Iff.of_eq <| or.injEq _ _ _ _
 
 instance : TildeInvolutive (NNFormula α) where
   tilde_involutive := neg_neg

--- a/Foundation/Vorspiel/NotationClass.lean
+++ b/Foundation/Vorspiel/NotationClass.lean
@@ -11,25 +11,69 @@ public import Mathlib.Data.Nat.Basic
 
 namespace LO
 
+/-! ## Heterogeneous notation classes -/
+
+class HTilde (α : Type*) (β : outParam Type*) where
+  hTilde : α → β
+
+prefix:75 "∼" => HTilde.hTilde
+macro_rules | `(∼$x) => `(unop% HTilde.hTilde $x)
+
+class HArrow (α β : Type*) (γ : outParam Type*) where
+  hArrow : α → β → γ
+
+infixr:60 " 🡒 " => HArrow.hArrow
+macro_rules | `($x 🡒 $y) => `(binop% HArrow.hArrow $x $y)
+
+class HWedge (α β : Type*) (γ : outParam Type*) where
+  hWedge : α → β → γ
+
+infixr:69 " ⋏ " => HWedge.hWedge
+macro_rules | `($x ⋏ $y) => `(binop% HWedge.hWedge $x $y)
+
+class HVee (α β : Type*) (γ : outParam Type*) where
+  hVee : α → β → γ
+
+infixr:68 " ⋎ " => HVee.hVee
+macro_rules | `($x ⋎ $y) => `(binop% HVee.hVee $x $y)
+
+attribute [match_pattern]
+  HTilde.hTilde
+  HArrow.hArrow
+  HWedge.hWedge
+  HVee.hVee
+
+/-! ## Homogeneous notation classes -/
+
 class Tilde (α : Type*) where
   tilde : α → α
-
-prefix:75 "∼" => Tilde.tilde
 
 class Arrow (α : Type*) where
   arrow : α → α → α
 
-infixr:60 " 🡒 " => Arrow.arrow
-
 class Wedge (α : Type*) where
   wedge : α → α → α
-
-infixr:69 " ⋏ " => Wedge.wedge
 
 class Vee (α : Type*) where
   vee : α → α → α
 
-infixr:68 " ⋎ " => Vee.vee
+attribute [match_pattern]
+  Tilde.tilde
+  Arrow.arrow
+  Wedge.wedge
+  Vee.vee
+
+@[default_instance]
+instance Tilde.instHTilde [Tilde α] : HTilde α α := ⟨Tilde.tilde⟩
+
+@[default_instance]
+instance Arrow.instHArrow [Arrow α] : HArrow α α α := ⟨Arrow.arrow⟩
+
+@[default_instance]
+instance Wedge.instHWedge [Wedge α] : HWedge α α α := ⟨Wedge.wedge⟩
+
+@[default_instance]
+instance Vee.instHVee [Vee α] : HVee α α α := ⟨Vee.vee⟩
 
 class Box (α : Type*) where
   box : α → α
@@ -46,59 +90,10 @@ class Rhd (α : Type*) where
 
 infixl:70 " ▷ " => Rhd.rhd
 
-class Tensor (α : Type*) where
-  tensor : α → α → α
-
-infixr:69 " ⨂ " => Tensor.tensor
-
-class Par (α : Type*) where
-  par : α → α → α
-
-infixr:68 " ⅋ " => Par.par
-
-class With (α : Type*) where
-  with' : α → α → α
-
-/-- Note that this notation "＆" (U+FF06) is distinct from "&" (U+0026) -/
-infixr:69 " ＆ " => With.with'
-
-class Plus (α : Type*) where
-  plus : α → α → α
-
-infixr:68 " ⨁ " => Plus.plus
-
-class Lolli (α : Type*) where
-  lolli : α → α → α
-
-infixr:60 " ⊸ " => Lolli.lolli
-
-class Bang (α : Type*) where
-  bang : α → α
-
-/-- Note that this notation "！" (U+FF01) is distinct from "!" (U+0021) -/
-prefix:75 "！" => Bang.bang
-
-class Quest (α : Type*) where
-  quest : α → α
-
-/-- Notice that this notation "？" (U+FF1F) is distinct from "?" (U+003F) -/
-prefix:75 "？" => Quest.quest
-
 attribute [match_pattern]
-  Tilde.tilde
-  Arrow.arrow
-  Wedge.wedge
-  Vee.vee
   Box.box
   Dia.dia
   Rhd.rhd
-  Tensor.tensor
-  Par.par
-  With.with'
-  Plus.plus
-  Lolli.lolli
-  Bang.bang
-  Quest.quest
 
 class Exp (α : Type*) where
   exp : α → α


### PR DESCRIPTION
現状の logical connective notations を heterogeneous notation
```lean
class HTilde (α : Type*) (β : outParam Type*) where
  hTilde : α → β

prefix:75 "∼" => HTilde.hTilde
macro_rules | `(∼$x) => `(unop% HTilde.hTilde $x)

class HArrow (α β : Type*) (γ : outParam Type*) where
  hArrow : α → β → γ

infixr:60 " 🡒 " => HArrow.hArrow
macro_rules | `($x 🡒 $y) => `(binop% HArrow.hArrow $x $y)

class HWedge (α β : Type*) (γ : outParam Type*) where
  hWedge : α → β → γ

infixr:69 " ⋏ " => HWedge.hWedge
macro_rules | `($x ⋏ $y) => `(binop% HWedge.hWedge $x $y)

class HVee (α β : Type*) (γ : outParam Type*) where
  hVee : α → β → γ

infixr:68 " ⋎ " => HVee.hVee
macro_rules | `($x ⋎ $y) => `(binop% HVee.hVee $x $y)
```
を大本にして定める．