### PR TITLE
docs(FirstOrder/Arithmetic/Exponential, Logic, Syntax/Predicate): Add more docstrings and fix typos

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/Exponential/Bit.lean
+++ b/Foundation/FirstOrder/Arithmetic/Exponential/Bit.lean
@@ -20,6 +20,7 @@ section model
 
 def Bit (i a : V) : Prop := LenBit (Exp.exp i) a
 
+/-- Support for `∈` notation over a model of arithmetic, implemented by binary encoding. -/
 instance : Membership V V := ⟨fun a i ↦ Bit i a⟩
 
 def _root_.LO.FirstOrder.Arithmetic.bitDef : 𝚺₀.Semisentence 2 := .mkSigma
@@ -99,6 +100,7 @@ def memRel : 𝚺₀.Semisentence 3 := .mkSigma
 def memRel₃ : 𝚺₀.Semisentence 4 := .mkSigma
   “R x y z. ∃ yz <⁺ (y + z + 1)², !pairDef yz y z ∧ ∃ xyz <⁺ (x + yz + 1)², !pairDef xyz x yz ∧ xyz ∈ R”
 
+/-- The relation `⟪x, y⟫ ∈ R` in arithmetic, implemented by binary coding, as an operator. -/
 def memRelOpr : Semiformula.Operator ℒₒᵣ 3 := ⟨memRel.val⟩
 
 def memRel₃Opr : Semiformula.Operator ℒₒᵣ 4 := ⟨memRel₃.val⟩
@@ -120,6 +122,7 @@ macro_rules
     let binders' := binders.insertIdx 0 x
     `(bexsIn ⤫term(lit)[$binders* | $fbinders* | $t] ⤫formula(lit)[$binders'* | $fbinders* | $p])
 
+/-- `x ~[m] y` states that `⟪x, y⟫` is in `m`, where the notion of "in" is implemented by binary coding. -/
 syntax:45 first_order_term:45 " ∼[" first_order_term "]" first_order_term:0 : first_order_formula
 syntax:45 first_order_term:45 " ≁[" first_order_term "]" first_order_term:0 : first_order_formula
 syntax:45 ":⟪" first_order_term ", " first_order_term "⟫:∈ " first_order_term:0 : first_order_formula

--- a/Foundation/FirstOrder/Basic/BinderNotation.lean
+++ b/Foundation/FirstOrder/Basic/BinderNotation.lean
@@ -160,8 +160,8 @@ syntax "⤫term(" first_order.quote_type ")[" ident* " | " ident* " | " first_or
 
 syntax "(" first_order_term ")" : first_order_term
 
-syntax:max ident : first_order_term         -- bounded variable
-syntax:max "#" term:max : first_order_term  -- bounded variable
+syntax:max ident : first_order_term         -- bound variable
+syntax:max "#" term:max : first_order_term  -- bound variable
 syntax:max "&" term:max : first_order_term  -- free variable
 syntax:80 "!" term:max first_order_term:81* (" ⋯")? : first_order_term
 syntax:80 "!!" term:max : first_order_term
@@ -233,7 +233,9 @@ macro_rules
     `(Rew.embSubsts $v $t)
 
 syntax "‘" first_order_term:0 "’" : term
+/-- A term with free variables. -/
 syntax "‘" ident* "| " first_order_term:0 "’" : term
+/-- A term with bound variables. -/
 syntax "‘" ident* ". " first_order_term:0 "’" : term
 
 macro_rules
@@ -247,21 +249,21 @@ macro_rules
 section delab
 
 @[app_unexpander Semiterm.Operator.numeral]
-meta def unexpsnderNatLit : Unexpander
+meta def unexpanderNatLit : Unexpander
   | `($_ $_ $z:num) => `($z:num)
   | _ => throw ()
 
 @[app_unexpander Semiterm.Operator.const]
-meta def unexpsnderOperatorConst : Unexpander
+meta def unexpanderOperatorConst : Unexpander
   | `($_ $z:num) => `(‘ $z:num ’)
   | _ => throw ()
 
 @[app_unexpander Semiterm.Operator.Add.add]
-meta def unexpsnderAdd : Unexpander
+meta def unexpanderAdd : Unexpander
   | `($_) => `(op(+))
 
 @[app_unexpander Semiterm.Operator.Mul.mul]
-meta def unexpsnderMul : Unexpander
+meta def unexpanderMul : Unexpander
   | `($_) => `(op(*))
 
 @[app_unexpander Semiterm.Operator.operator]
@@ -500,11 +502,11 @@ macro_rules
 section delab
 
 @[app_unexpander Language.Eq.eq]
-meta def unexpsnderEq : Unexpander
+meta def unexpanderEq : Unexpander
   | `($_) => `(op(=))
 
 @[app_unexpander Language.LT.lt]
-meta def unexpsnderLe : Unexpander
+meta def unexpanderLe : Unexpander
   | `($_) => `(op(<))
 
 @[app_unexpander Wedge.wedge]
@@ -791,6 +793,7 @@ syntax "f“" ident* "| "  first_order_formula:0 "”" : term
 syntax "f“" ident* ". "  first_order_formula:0 "”" : term
 syntax "f“" first_order_formula:0 "”" : term
 
+/-- A formula in formula-as-function notation. Use `f“⋯ . ⋯”` for bound variables, and `f“⋯ | ⋯”` for free variables. -/
 macro_rules
   | `(f“ $e:first_order_formula ”)              => `(⤫formula(faf)[           |            | $e ])
   | `(f“ $fbinders* | $e:first_order_formula ”) => `(⤫formula(faf)[           | $fbinders* | $e ])

--- a/Foundation/Logic/LogicSymbol.lean
+++ b/Foundation/Logic/LogicSymbol.lean
@@ -328,6 +328,7 @@ section conjunction
 
 variable [Top α] [Wedge α]
 
+/-- The conjunction of a list of elements of type `α`, where `α` is a type with `Wedge α`. -/
 def conj : {n : ℕ} → (Fin n → α) → α
   |     0, _ => ⊤
   | _ + 1, v => v 0 ⋏ conj (vecTail v)
@@ -342,6 +343,7 @@ section disjunction
 
 variable [Bot α] [Vee α]
 
+/-- The disjunction of a list of elements of type `α`, where `α` is a type with `Vee α`. -/
 def disj : {n : ℕ} → (Fin n → α) → α
   |     0, _ => ⊥
   | _ + 1, v => v 0 ⋎ disj (vecTail v)

--- a/Foundation/Syntax/Predicate/Quantifier.lean
+++ b/Foundation/Syntax/Predicate/Quantifier.lean
@@ -163,6 +163,7 @@ def exsItr : (k : ℕ) → α (n + k) → α n
   |     0, a => a
   | k + 1, a => exsItr k (∃¹ a)
 
+/-- Iterated application of `k` existential quantifiers. -/
 notation "∃¹^[" k "] " φ:64 => exsItr k φ
 
 @[simp] lemma exsItr_zero (a : α n) : ∃¹^[0] a = a := rfl
@@ -181,8 +182,10 @@ def ball [UnivQuantifier α] [Arrow (α (n + 1))] (φ : α (n + 1)) (ψ : α (n 
 
 def bexs [ExsQuantifier α] [Wedge (α (n + 1))] (φ : α (n + 1)) (ψ : α (n + 1)) : α n := ∃¹ (φ ⋏ ψ)
 
+/-- A bounded universal quantifier. `∀¹[φ] ψ` is defined as `∀¹ (φ 🡒 ψ)`. -/
 notation:64 "∀¹[" φ "] " ψ => ball φ ψ
 
+/-- A bounded existential quantifier. `∃¹[φ] ψ` is defined as `∃¹ (φ ⋏ ψ)`. -/
 notation:64 "∃¹[" φ "] " ψ => bexs φ ψ
 
 end quantifier

--- a/Foundation/Syntax/Predicate/Rew.lean
+++ b/Foundation/Syntax/Predicate/Rew.lean
@@ -83,15 +83,15 @@ def bindAux (b : Fin n₁ → Semiterm L ξ₂ n₂) (e : ξ₁ → Semiterm L �
   |       &x => e x
   | func f v => func f (fun i => bindAux b e (v i))
 
-/-- `LO.FirstOrder.Rew.bind f` is a rewriting of the bound variables occurring in a term by `b : Fin n₁ → Semiterm L ξ₂ n₂`, and the free variables occurring in a term by `e : ξ₁ → Semiterm L ξ₂ n₂`. -/
+/-- `LO.FirstOrder.Rew.bind f` is a substitution of the bound variables occurring in a term by `b : Fin n₁ → Semiterm L ξ₂ n₂`, and the free variables occurring in a term by `e : ξ₁ → Semiterm L ξ₂ n₂`. -/
 def bind (b : Fin n₁ → Semiterm L ξ₂ n₂) (e : ξ₁ → Semiterm L ξ₂ n₂) : Rew L ξ₁ n₁ ξ₂ n₂ where
   toFun := bindAux b e
   func'' := fun _ _ => rfl
 
-/-- `LO.FirstOrder.Rew.rewrite f` is a rewriting of the free variables occurring in a term by `f : ξ₁ → Semiterm L ξ₂ n`. -/
+/-- `LO.FirstOrder.Rew.rewrite f` is a substitution of the free variables occurring in a term by `f : ξ₁ → Semiterm L ξ₂ n`. -/
 def rewrite (f : ξ₁ → Semiterm L ξ₂ n) : Rew L ξ₁ n ξ₂ n := bind Semiterm.bvar f
 
-/-- `LO.FirstOrder.Rew.rewriteMap` f is a rewriting of the free variables occurring in a term by `e : ξ₁ → ξ₂`. -/
+/-- `LO.FirstOrder.Rew.rewriteMap` f is a substitution of the free variables occurring in a term by `e : ξ₁ → ξ₂`. -/
 def rewriteMap (e : ξ₁ → ξ₂) : Rew L ξ₁ n ξ₂ n := rewrite (fun m => &(e m))
 
 def map (b : Fin n₁ → Fin n₂) (e : ξ₁ → ξ₂) : Rew L ξ₁ n₁ ξ₂ n₂ :=
@@ -101,7 +101,7 @@ def map (b : Fin n₁ → Fin n₂) (e : ξ₁ → ξ₂) : Rew L ξ₁ n₁ ξ�
 def subst {n'} (v : Fin n → Semiterm L ξ n') : Rew L ξ n ξ n' :=
   bind v fvar
 
-/-- `LO.FirstOrder.Rew.emb` is a embedding of a term with no free variables. -/
+/-- `LO.FirstOrder.Rew.emb` is a embedding of a term with no free variables. It can be thought of as a cast from `Semiterm L Empty n` to `Semiterm L ξ n` for any type `ξ`. -/
 def emb {o : Type v₁} [h : IsEmpty o] {ξ : Type v₂} {n} : Rew L o n ξ n := map id h.elim
 
 abbrev embs {o : Type v₁} [IsEmpty o] {n} : Rew L o n ℕ n := emb
@@ -796,6 +796,15 @@ end Semiterm
 
 /-! ### Rewriting system of formulae -/
 
+/--
+A typeclass for `Rew`s which additionally respect quantifiers.
+
+`app` - A notion of application of `Rew`s to formulas.
+
+`app_all` - Application preserves universal quantification.
+
+`app_exs` - Application preserves existential quantification.
+-/
 class Rewriting (L : outParam Language) (ξ : outParam Type*) (F : ℕ → Type*) (ζ : Type*) (G : outParam (ℕ → Type*))
     [LCWQ F] [LCWQ G] where
   app {n₁ n₂} : Rew L ξ n₁ ζ n₂ → F n₁ →ˡᶜ G n₂
@@ -811,6 +820,7 @@ variable [LCWQ F] [LCWQ G] [Rewriting L ξ F ζ G]
 
 attribute [simp] app_all app_exs
 
+/-- Application of a `Rewriting` to a formula. (TODO: Should I change the word "formula" here to something else?) -/
 infixr:73 " ▹ " => app
 
 lemma smul_ext' {ω₁ ω₂ : Rew L ξ n₁ ζ n₂} (h : ω₁ = ω₂) {φ : F n₁} : ω₁ ▹ φ = ω₂ ▹ φ := by rw [h]
@@ -829,8 +839,10 @@ lemma smul_ext' {ω₁ ω₂ : Rew L ξ n₁ ζ n₂} (h : ω₁ = ω₂) {φ : 
 
 abbrev subst [Rewriting L ξ F ξ F] (φ : F n₁) (w : Fin n₁ → Semiterm L ξ n₂) : F n₂ := Rew.subst w ▹ φ
 
+/-- Applies the substitution `LO.FirstOrder.Rew.subst w` to a formula. This substitutes the bound variables occurring in the formula by `w : Fin n₁ → Semiterm L ξ n₂`. -/
 infix:90 " ⇜ " => LO.FirstOrder.Rewriting.subst
 
+/-- Applies the substitution `LO.FirstOrder.Rew.shift` to a formula. This substitutes each free variable `&x` with `&(x + 1)`. -/
 abbrev shift [Rewriting L ℕ F ℕ F] : F n →ˡᶜ F n := app Rew.shift
 
 abbrev free [Rewriting L ℕ F ℕ F] : F (n + 1) →ˡᶜ F n := app Rew.free
@@ -839,6 +851,7 @@ abbrev fix [Rewriting L ℕ F ℕ F] : F n →ˡᶜ F (n + 1) := app Rew.fix
 
 def shifts [Rewriting L ℕ F ℕ F] (Γ : List (F n)) : List (F n) := Γ.map Rewriting.shift
 
+/-- Applies the substitution `LO.FirstOrder.Rew.shift` to each formula in a list of formulas. This substitutes each free variable `&x` with `&(x + 1)`. -/
 scoped[LO.FirstOrder] postfix:max "⁺" => FirstOrder.Rewriting.shifts
 
 @[simp] lemma shifts_nil [Rewriting L ℕ F ℕ F] : ([] : List (F n))⁺ = [] := by rfl
@@ -858,11 +871,14 @@ open Lean PrettyPrinter Delaborator
 
 syntax (name := substNotation) term:max "/[" term,* "]" : term
 
+/-- Slash notation for rewriting bound variables of a formula.
+
+The notation `φ/w` is equivalent to `φ ⇜ w`, which for a formula `φ` with bound variables from `Fin n₁`, substitutes the bound variables occurring in `φ` by `w : Fin n₁ → Semiterm L ξ n₂`. -/
 macro_rules (kind := substNotation)
   | `($φ:term /[$terms:term,*]) => `($φ ⇜ ![$terms,*])
 
 @[app_unexpander Rewriting.subst]
-meta def _root_.unexpsnderSubstitute : Unexpander
+meta def _root_.unexpanderSubstitute : Unexpander
   | `($_ $φ:term ![$ts:term,*]) => `($φ /[ $ts,* ])
   | _                           => throw ()
 

--- a/Foundation/Syntax/Predicate/Rew.lean
+++ b/Foundation/Syntax/Predicate/Rew.lean
@@ -820,7 +820,7 @@ variable [LCWQ F] [LCWQ G] [Rewriting L ξ F ζ G]
 
 attribute [simp] app_all app_exs
 
-/-- Application of a `Rewriting` to a formula. (TODO: Should I change the word "formula" here to something else?) -/
+/-- Application of a `Rewriting` to a formula. -/
 infixr:73 " ▹ " => app
 
 lemma smul_ext' {ω₁ ω₂ : Rew L ξ n₁ ζ n₂} (h : ω₁ = ω₂) {φ : F n₁} : ω₁ ▹ φ = ω₂ ▹ φ := by rw [h]


### PR DESCRIPTION
I added more docstrings, this time mostly focused on BinderNotation and the `x ~[m] y` relation in arithmetic, and fixed a few typos in the identifiers of unexpanders.