### PR TITLE
add(FirstOrder/Arithmetic): Explicit 𝚺₁-soundness of `𝗜𝚺₁` and `𝗣𝗔`

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/Schemata.lean
+++ b/Foundation/FirstOrder/Arithmetic/Schemata.lean
@@ -387,10 +387,8 @@ instance models_Peano : ℕ↓[ℒₒᵣ] ⊧* 𝗣𝗔 := by
   simp [Peano, InductionScheme]
   grind
 
-/-- `𝗜𝚺₁` is `𝚺₁`-sound: every `𝚺₁` sentence provable in `𝗜𝚺₁` is true in the standard model `ℕ`. -/
 instance sigmaOneSound_ISigmaOne : 𝗜𝚺₁.SoundOnHierarchy 𝚺 1 := inferInstance
 
-/-- `𝗣𝗔` is `𝚺₁`-sound: every `𝚺₁` sentence provable in `𝗣𝗔` is true in the standard model `ℕ`. -/
 instance sigmaOneSound_Peano : 𝗣𝗔.SoundOnHierarchy 𝚺 1 := inferInstance
 
 instance : Entailment.Consistent (𝗜𝗡𝗗 Γ k) := (𝗜𝗡𝗗 Γ k).consistent_of_sound (Eq ⊥) rfl

--- a/Foundation/FirstOrder/Arithmetic/Schemata.lean
+++ b/Foundation/FirstOrder/Arithmetic/Schemata.lean
@@ -387,6 +387,12 @@ instance models_Peano : ℕ↓[ℒₒᵣ] ⊧* 𝗣𝗔 := by
   simp [Peano, InductionScheme]
   grind
 
+/-- `𝗜𝚺₁` is `𝚺₁`-sound: every `𝚺₁` sentence provable in `𝗜𝚺₁` is true in the standard model `ℕ`. -/
+instance sigmaOneSound_ISigmaOne : 𝗜𝚺₁.SoundOnHierarchy 𝚺 1 := inferInstance
+
+/-- `𝗣𝗔` is `𝚺₁`-sound: every `𝚺₁` sentence provable in `𝗣𝗔` is true in the standard model `ℕ`. -/
+instance sigmaOneSound_Peano : 𝗣𝗔.SoundOnHierarchy 𝚺 1 := inferInstance
+
 instance : Entailment.Consistent (𝗜𝗡𝗗 Γ k) := (𝗜𝗡𝗗 Γ k).consistent_of_sound (Eq ⊥) rfl
 
 instance : Entailment.Consistent 𝗣𝗔 := 𝗣𝗔.consistent_of_sound (Eq ⊥) rfl


### PR DESCRIPTION
Closes #890.

`ArithmeticTheory.SoundOnHierarchy Γ k` is an abbreviation of `T.SoundOn (Arithmetic.Hierarchy Γ k)`, and the blanket instance `[ℕ↓[ℒₒᵣ] ⊧* T] : T.SoundOn F` makes `𝗜𝚺₁.SoundOnHierarchy 𝚺 1` and `𝗣𝗔.SoundOnHierarchy 𝚺 1` available only through instance synthesis via `models_ISigmaOne` / `models_Peano`. There was no explicit named declaration stating that these concrete theories are 𝚺₁-sound.

This PR adds two named instances next to `models_ISigmaOne` / `models_Peano` in `Foundation/FirstOrder/Arithmetic/Schemata.lean`:

```lean
instance sigmaOneSound_ISigmaOne : 𝗜𝚺₁.SoundOnHierarchy 𝚺 1 := inferInstance

instance sigmaOneSound_Peano : 𝗣𝗔.SoundOnHierarchy 𝚺 1 := inferInstance
```

No existing result changes; this only makes the 𝚺₁-soundness of `𝗜𝚺₁` and `𝗣𝗔` explicitly stated and citable by name.

### Checks

- `lake build` succeeds for the whole project with no errors or warnings.
- `just axiom-audit` passes (22107 declarations, allowlist only).
- `lake exe mk_all --module` reports no update necessary.

This PR was produced with the assistance of an AI coding agent (Claude Code).
