### PR TITLE
fix(FirstOrder/SetTheory): resolve unusedSectionVars warning in Z.lean

### DIFF
--- a/Foundation/FirstOrder/SetTheory/Z.lean
+++ b/Foundation/FirstOrder/SetTheory/Z.lean
@@ -32,6 +32,7 @@ attribute [ext] mem_ext
 
 @[grind .] lemma subset_antisymm_iff {x y : V} : x ⊆ y ∧ y ⊆ x ↔ x = y := by aesop
 
+omit [Nonempty V] [V↓[ℒₛₑₜ] ⊧* 𝗭] in
 lemma subset_of_eq {x y : V} (h : x = y) : x ⊆ y := h ▸ subset_refl x
 
 lemma SSubset.iff {x y : V} : x ⊊ y ↔ x ⊆ y ∧ ∃ z ∈ y, z ∉ x := by


### PR DESCRIPTION
`lake build Foundation.FirstOrder.SetTheory.Z` emitted a `linter.unusedSectionVars` warning: the lemma `subset_of_eq` does not use the automatically included section variables `[Nonempty V]` and `[V↓[ℒₛₑₜ] ⊧* 𝗭]`. This PR omits them via `omit ... in`, as suggested by the linter. No statement or proof is changed otherwise.

- `lake build` passes with no errors or warnings.
- `just axiom-audit` passes.
- `lake exe mk_all --module` reports no update necessary.

This change was produced with the assistance of an AI agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)