### PR TITLE
refactor(Propositional/Entailment): align the `!` in lemma names with `⊢!`

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/PeanoMinus/Basic.lean
+++ b/Foundation/FirstOrder/Arithmetic/PeanoMinus/Basic.lean
@@ -139,10 +139,10 @@ open FirstOrder Arithmetic Language
 lemma equiv_singleton_finiteConj :
     𝗣𝗔⁻ ≊ ({finite.toFinset.conj} : ArithmeticTheory) := by
   have hConj : 𝗣𝗔⁻ ⊢ finite.toFinset.conj :=
-    Entailment.FConj!_iff_forall_provable.mpr fun {σ} hσ ↦ Entailment.by_axm (by simp_all)
+    Entailment.FConj_iff_forall_provable.mpr fun {σ} hσ ↦ Entailment.by_axm (by simp_all)
   exact Entailment.Equiv.antisymm_iff.mpr
     ⟨Entailment.WeakerThan.ofAxm! fun {σ} hσ ↦
-        Entailment.mdp! (Entailment.left_Fconj!_intro (by simp_all)) (Entailment.by_axm rfl),
+        Entailment.mdp (Entailment.left_Fconj_intro (by simp_all)) (Entailment.by_axm rfl),
       Entailment.WeakerThan.ofAxm! fun {σ} hσ ↦ by
         rcases hσ with rfl; exact hConj⟩
 

--- a/Foundation/FirstOrder/Basic/Padding.lean
+++ b/Foundation/FirstOrder/Basic/Padding.lean
@@ -46,15 +46,15 @@ open Entailment
 
 def Entailment.paddingIff [L.DecidableEq] [DecidableEq ξ] [Entailment S (Formula L ξ)] {𝓢 : S} [Entailment.Minimal 𝓢] (φ k) :
     𝓢 ⊢! φ.padding k 🡘 φ := by
-  apply E_intro
-  · apply and₁
-  · apply right_K_intro
-    · apply C_id
-    · apply dhyp
-      apply Conj_intro
+  apply E!_intro
+  · apply and₁!
+  · apply right_K!_intro
+    · apply C!_id
+    · apply dhyp!
+      apply Conj!_intro
       intro φ hφ
       have : k ≠ 0 ∧ φ = ⊤ := by simpa using hφ;
-      exact this.2 ▸ HasAxiomVerum.verum
+      exact this.2 ▸ HasAxiomVerum.verum!
 
 @[simp] theorem Entailment.padding_iff [L.DecidableEq] [DecidableEq ξ] [Entailment S (Formula L ξ)] {𝓢 : S} [Entailment.Minimal 𝓢] (φ k) :
     𝓢 ⊢ φ.padding k 🡘 φ := ⟨paddingIff φ k⟩

--- a/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/D3.lean
+++ b/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/D3.lean
@@ -118,14 +118,14 @@ theorem bold_sigma_one_complete {n} {φ : ArithmeticSemisentence n} (hp : Hierar
   case hAnd =>
     intro n φ ψ _ _ ihφ ihψ w h
     have H : V ⊧/w φ ∧ V ⊧/w ψ := by simpa using  h
-    simpa using K!_intro (ihφ H.1) (ihψ H.2)
+    simpa using K_intro (ihφ H.1) (ihψ H.2)
   case hOr =>
     intro n φ ψ _ _ ihφ ihψ w h
     suffices T.internalize V ⊢ (toNumVec w ⤔ ⌜φ⌝) ⋎ (toNumVec w ⤔ ⌜ψ⌝) by simpa
     have : V ⊧/w φ ∨ V ⊧/w ψ := by simpa using h
     rcases this with (h | h)
-    · apply A!_intro_left (ihφ h)
-    · apply A!_intro_right (ihψ h)
+    · apply A_intro_left (ihφ h)
+    · apply A_intro_right (ihψ h)
   case hBall =>
     intro n t φ _ ih w h
     have h : ∀ i < t.valb w, V ⊧/(i :> w) φ := by

--- a/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/EquationalTheory.lean
+++ b/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/EquationalTheory.lean
@@ -65,7 +65,7 @@ variable {T}
 
 lemma eq_comm_ctx {t u : Term V ℒₒᵣ} :
     Γ ⊢[T.internalize V] t ≐ u → Γ ⊢[T.internalize V] u ≐ t := fun b ↦
-  of'! (eq_symm T t u) ⨀ b
+  of' (eq_symm T t u) ⨀ b
 
 lemma eq_trans {t₁ t₂ t₃ : Term V ℒₒᵣ} :
     T.internalize V ⊢ t₁ ≐ t₂ → T.internalize V ⊢ t₂ ≐ t₃ → T.internalize V ⊢ t₁ ≐ t₃ := fun h₁ h₂ ↦
@@ -135,7 +135,7 @@ lemma term_replace_aux (t : V) :
         T.internalize V ⊢ ∀¹ ∀¹ ((#'1 ≐ #'0) 🡒 (typedNumeral 0 ≐ typedNumeral 0)) by simpa
       suffices T.internalize V ⊢ (&'1 ≐ &'0) 🡒 (typedNumeral 0 ≐ typedNumeral 0) by
         apply TProof.all₂!; simpa [Semiformula.free]
-      apply Entailment.dhyp! (eq_refl _ _)
+      apply Entailment.dhyp (eq_refl _ _)
     · rcases show v = 0 by simpa using hv
       suffices
           T.internalize V ⊢ ∀¹ ∀¹ ((#'1 ≐ #'0) 🡒 ((typedNumeral 1).subst ![#'1] ≐ (typedNumeral 1).subst ![#'0])) by
@@ -145,7 +145,7 @@ lemma term_replace_aux (t : V) :
         T.internalize V ⊢ ∀¹ ∀¹ ((#'1 ≐ #'0) 🡒 (typedNumeral 1 ≐ typedNumeral 1)) by simpa
       suffices T.internalize V ⊢ (&'1 ≐ &'0) 🡒 (typedNumeral 1 ≐ typedNumeral 1) by
         apply TProof.all₂!; simpa [Semiformula.free]
-      apply Entailment.dhyp! (eq_refl _ _)
+      apply Entailment.dhyp (eq_refl _ _)
     · let t : Semiterm V ℒₒᵣ 1 := ⟨v.[0], by simpa using hv.nth (by simp)⟩
       let u : Semiterm V ℒₒᵣ 1 := ⟨v.[1], by simpa using hv.nth (by simp)⟩
       have veq : v = ?[t.val, u.val] := by simp [t, u, vec2_eq hv.lh]
@@ -172,7 +172,7 @@ lemma term_replace_aux (t : V) :
         simpa [Semiterm.shift_substs, Semiterm.substs_substs] using! this
       have := subst_add_eq_add T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
         (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0])
-      exact of'! this ⨀ iht ⨀ ihu
+      exact of' this ⨀ iht ⨀ ihu
     · let t : Semiterm V ℒₒᵣ 1 := ⟨v.[0], by simpa using hv.nth (by simp)⟩
       let u : Semiterm V ℒₒᵣ 1 := ⟨v.[1], by simpa using hv.nth (by simp)⟩
       have veq : v = ?[t.val, u.val] := by simp [t, u, vec2_eq hv.lh]
@@ -199,7 +199,7 @@ lemma term_replace_aux (t : V) :
         simpa [Semiterm.shift_substs, Semiterm.substs_substs] using! this
       have := subst_mul_eq_mul T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
         (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0])
-      exact of'! this ⨀ iht ⨀ ihu
+      exact of' this ⨀ iht ⨀ ihu
   case hbvar =>
     intro z hz
     have : z = 0 := lt_one_iff_eq_zero.mp hz
@@ -216,7 +216,7 @@ lemma term_replace_aux (t : V) :
       simpa [-substs_equals, val_all] using this
     suffices T.internalize V ⊢ (&'1 ≐ &'0) 🡒 (&'(x + 1 + 1) ≐ &'(x + 1 + 1)) by
       apply TProof.all₂!; simpa [Semiformula.free]
-    apply Entailment.dhyp! (eq_refl T _)
+    apply Entailment.dhyp (eq_refl T _)
 
 lemma term_replace (t : Semiterm V ℒₒᵣ 1) :
     T.internalize V ⊢ ∀¹ ∀¹ ((#'1 ≐ #'0) 🡒 (t.subst ![#'1] ≐ t.subst ![#'0])) := by
@@ -240,16 +240,16 @@ lemma replace_eq (t u : Semiterm V ℒₒᵣ 1) :
   let Γ : List (Formula V ℒₒᵣ) := [t⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'1], &'1 ≐ &'0]
   suffices
       Γ ⊢[T.internalize V] t⇞⇞.subst ![&'0] ≐ u⇞⇞.subst ![&'0] by
-    apply deduct'!
-    apply deduct!
+    apply deduct'
+    apply deduct
     exact this
   have hh : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'1] :=
-    by_axm₀!
+    by_axm₀
   have ht : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≐ t⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁!
+    of' (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁
   have hu : Γ ⊢[T.internalize V] u⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁!
-  exact of'!
+    of' (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁
+  exact of'
     (subst_eq T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
       (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0]))
     ⨀ ht ⨀ hu ⨀ hh
@@ -266,16 +266,16 @@ lemma replace_lt (t u : Semiterm V ℒₒᵣ 1) :
   let Γ : List (Formula V ℒₒᵣ) := [t⇞⇞.subst ![&'1] <' u⇞⇞.subst ![&'1], &'1 ≐ &'0]
   suffices
       Γ ⊢[T.internalize V] t⇞⇞.subst ![&'0] <' u⇞⇞.subst ![&'0] by
-    apply deduct'!
-    apply deduct!
+    apply deduct'
+    apply deduct
     exact this
   have hh : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] <' u⇞⇞.subst ![&'1] :=
-    by_axm₀!
+    by_axm₀
   have ht : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≐ t⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁!
+    of' (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁
   have hu : Γ ⊢[T.internalize V] u⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁!
-  exact of'!
+    of' (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁
+  exact of'
     (subst_lt T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
       (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0]))
     ⨀ ht ⨀ hu ⨀ hh
@@ -292,16 +292,16 @@ lemma replace_ne (t u : Semiterm V ℒₒᵣ 1) :
   let Γ : List (Formula V ℒₒᵣ) := [t⇞⇞.subst ![&'1] ≉ u⇞⇞.subst ![&'1], &'1 ≐ &'0]
   suffices
       Γ ⊢[T.internalize V] t⇞⇞.subst ![&'0] ≉ u⇞⇞.subst ![&'0] by
-    apply deduct'!
-    apply deduct!
+    apply deduct'
+    apply deduct
     exact this
   have hh : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≉ u⇞⇞.subst ![&'1] :=
-    by_axm₀!
+    by_axm₀
   have ht : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≐ t⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁!
+    of' (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁
   have hu : Γ ⊢[T.internalize V] u⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁!
-  exact of'!
+    of' (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁
+  exact of'
     (subst_ne T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
       (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0]))
     ⨀ ht ⨀ hu ⨀ hh
@@ -318,16 +318,16 @@ lemma replace_nlt (t u : Semiterm V ℒₒᵣ 1) :
   let Γ : List (Formula V ℒₒᵣ) := [t⇞⇞.subst ![&'1] ≮' u⇞⇞.subst ![&'1], &'1 ≐ &'0]
   suffices
       Γ ⊢[T.internalize V] t⇞⇞.subst ![&'0] ≮' u⇞⇞.subst ![&'0] by
-    apply deduct'!
-    apply deduct!
+    apply deduct'
+    apply deduct
     exact this
   have hh : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≮' u⇞⇞.subst ![&'1] :=
-    by_axm₀!
+    by_axm₀
   have ht : Γ ⊢[T.internalize V] t⇞⇞.subst ![&'1] ≐ t⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁!
+    of' (term_replace' T t⇞⇞ &'1 &'0) ⨀ by_axm₁
   have hu : Γ ⊢[T.internalize V] u⇞⇞.subst ![&'1] ≐ u⇞⇞.subst ![&'0] :=
-    of'! (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁!
-  exact of'!
+    of' (term_replace' T u⇞⇞ &'1 &'0) ⨀ by_axm₁
+  exact of'
     (subst_nlt T (t⇞⇞.subst ![&'1]) (t⇞⇞.subst ![&'0])
       (u⇞⇞.subst ![&'1]) (u⇞⇞.subst ![&'0]))
     ⨀ ht ⨀ hu ⨀ hh
@@ -398,7 +398,7 @@ lemma replace_aux (φ : V) :
     suffices Theory.internalize V T ⊢ (&'1 ≐ &'0) 🡒 ⊤ 🡒 ⊤ by
       apply TProof.all₂!
       simpa
-    apply dhyp!; exact CV!
+    apply dhyp; exact CV
   case hfalsum =>
     suffices T.internalize V ⊢ ∀¹ ∀¹ ((#'1 ≐ #'0) 🡒 ⊥ 🡒 ⊥) by
       have := (tprovable_iff_provable (T := T)).mp this
@@ -406,7 +406,7 @@ lemma replace_aux (φ : V) :
     suffices Theory.internalize V T ⊢ (&'1 ≐ &'0) 🡒 ⊥ 🡒 ⊥ by
       apply TProof.all₂!
       simpa
-    apply dhyp!; exact efq!
+    apply dhyp; exact efq
   case hrel =>
     intro k R v hR hv
     rcases isRel_iff_LOR.mp hR with (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
@@ -456,9 +456,9 @@ lemma replace_aux (φ : V) :
     suffices
         T.internalize V ⊢ (&'1 ≐ &'0) 🡒 ∀¹ φ⤉⤉.subst ![#'0, &'1] 🡒 ∀¹ φ⤉⤉.subst ![#'0, &'0] by
       apply TProof.all₂!; simpa [Semiformula.free, SemitermVec.q, Semiformula.shift_substs, Semiformula.substs_substs]
-    apply deduct'!
+    apply deduct'
     apply TProof.all_imp_all!
-    apply deductInv'!
+    apply deductInv'
     simpa [Semiformula.free1, Semiformula.free, SemitermVec.q,
       Semiformula.shift_substs, Semiformula.substs_substs, one_add_one_eq_two]
     using TProof.specialize₂! ih (&'1) (&'2)
@@ -477,9 +477,9 @@ lemma replace_aux (φ : V) :
     suffices
         T.internalize V ⊢ (&'1 ≐ &'0) 🡒 ∃¹ φ⤉⤉.subst ![#'0, &'1] 🡒 ∃¹ φ⤉⤉.subst ![#'0, &'0] by
       apply TProof.all₂!; simpa [Semiformula.free, SemitermVec.q, Semiformula.shift_substs, Semiformula.substs_substs]
-    apply deduct'!
+    apply deduct'
     apply TProof.exs_imp_exs!
-    apply deductInv'!
+    apply deductInv'
     simpa [Semiformula.free1, Semiformula.free, SemitermVec.q,
       Semiformula.shift_substs, Semiformula.substs_substs, one_add_one_eq_two]
       using TProof.specialize₂! ih (&'1) (&'2)

--- a/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/PeanoMinus.lean
+++ b/Foundation/FirstOrder/Bootstrapping/DerivabilityCondition/PeanoMinus.lean
@@ -235,7 +235,7 @@ lemma ball_intro (φ : Semiformula V ℒₒᵣ 1) (n : V)
   suffices T.internalize V ⊢ (&'0 <' 𝕹 n) 🡒 φ⤉.subst ![&'0] by
     simpa [imp_def, Semiformula.free, SemitermVec.q, Semiterm.shift_substs, Semiterm.substs_substs]
   suffices T.internalize V ⊢ substItrDisj ![&'0] (#'1 ≐ #'0) n 🡒 φ⤉.subst ![&'0] from
-    C!_trans (K!_left (lt_iff_substItrDisj T &'0 n)) this
+    C_trans (K_left (lt_iff_substItrDisj T &'0 n)) this
   apply TProof.substItrDisj_left_intro
   · intro i hi
     suffices T.internalize V ⊢ (&'0 ≐ 𝕹 i) 🡒 φ⤉.subst ![&'0] by simpa
@@ -251,7 +251,7 @@ lemma bexs_intro (φ : Semiformula V ℒₒᵣ 1) (n : V) {i}
     T.internalize V ⊢ φ.bexs (𝕹 n) := by
   apply TProof.exs! (𝕹 i)
   suffices T.internalize V ⊢ (𝕹 i <' 𝕹 n) ⋏ φ.subst ![𝕹 i] by simpa
-  apply K!_intro
+  apply K_intro
   · exact numeral_lt T hi
   · exact b
 

--- a/Foundation/FirstOrder/Bootstrapping/FixedPoint.lean
+++ b/Foundation/FirstOrder/Bootstrapping/FixedPoint.lean
@@ -187,7 +187,7 @@ theorem exclusiveMultidiagonal (θ : Fin k → ArithmeticSemisentence k) :
     T ⊢ exclusiveMultifixedpoint θ i 🡘 (Rew.subst fun j ↦ ⌜exclusiveMultifixedpoint θ j⌝) ▹ θ i := by
   have : T ⊢ exclusiveMultifixedpoint θ i 🡘 ((Rew.subst fun j ↦ ⌜exclusiveMultifixedpoint θ j⌝) ▹ θ i).padding ↑i := by
     simpa using! multidiagonal (T := T) (fun j ↦ (θ j).padding j) (i := i)
-  exact Entailment.E!_trans this (Entailment.padding_iff _ _)
+  exact Entailment.E_trans this (Entailment.padding_iff _ _)
 
 lemma multifixedpoint_pi {θ : Fin k → ArithmeticSemisentence k} (h : ∀ i, Hierarchy 𝚷 (m + 1) (θ i)) :
     Hierarchy 𝚷 (m + 1) (multifixedpoint θ i) := by

--- a/Foundation/FirstOrder/Bootstrapping/Syntax/Proof/Typed.lean
+++ b/Foundation/FirstOrder/Bootstrapping/Syntax/Proof/Typed.lean
@@ -313,7 +313,7 @@ lemma of_subset (h : T ⊆ U) {φ : Formula V L} : T ⊢ φ → U ⊢ φ := by
 noncomputable instance : Entailment.ModusPonens T := ⟨modusPonens⟩
 
 noncomputable instance : Entailment.NegationEquiv T where
-  negEquiv {φ} := by
+  negEquiv! {φ} := by
     suffices T ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) by
       simpa [Axioms.NegEquiv, LO.LogicalConnective.iff, Semiformula.imp_def]
     apply TDerivation.and
@@ -327,14 +327,14 @@ noncomputable instance : Entailment.NegationEquiv T where
       · exact TDerivation.verum
 
 noncomputable instance : Entailment.Minimal T where
-  verum := TDerivation.toTProof <| TDerivation.verum
-  implyK {φ ψ} := by
+  verum! := TDerivation.toTProof <| TDerivation.verum
+  implyK! {φ ψ} := by
     simp only [Axioms.ImplyK, Semiformula.imp_def]
     apply TDerivation.or
     apply TDerivation.rotate₁
     apply TDerivation.or
     exact TDerivation.em φ
-  implyS {φ ψ r} := by
+  implyS! {φ ψ r} := by
     simp only [Axioms.ImplyS, Semiformula.imp_def, LogicalConnective.DeMorgan.or, LogicalNeutral.DeMorgan.neg]
     apply TDerivation.or
     apply TDerivation.rotate₁
@@ -350,17 +350,17 @@ noncomputable instance : Entailment.Minimal T where
       · apply TDerivation.and
         · exact TDerivation.em ψ
         · exact TDerivation.em r
-  and₁ {φ ψ} := by
+  and₁! {φ ψ} := by
     simp only [Axioms.AndElim₁, Semiformula.imp_def, LogicalConnective.DeMorgan.and]
     apply TDerivation.or
     apply TDerivation.or
     exact TDerivation.em φ
-  and₂ {φ ψ} := by
+  and₂! {φ ψ} := by
     simp only [Axioms.AndElim₂, Semiformula.imp_def, LogicalConnective.DeMorgan.and]
     apply TDerivation.or
     apply TDerivation.or
     exact TDerivation.em ψ
-  and₃ {φ ψ} := by
+  and₃! {φ ψ} := by
     simp only [Axioms.AndInst, Semiformula.imp_def]
     apply TDerivation.or
     apply TDerivation.rotate₁
@@ -369,20 +369,20 @@ noncomputable instance : Entailment.Minimal T where
     apply TDerivation.and
     · exact TDerivation.em φ
     · exact TDerivation.em ψ
-  or₁ {φ ψ} := by
+  or₁! {φ ψ} := by
     simp only [Axioms.OrInst₁, Semiformula.imp_def]
     apply TDerivation.or
     apply TDerivation.rotate₁
     apply TDerivation.or
     exact TDerivation.em φ
-  or₂ {φ ψ} := by
+  or₂! {φ ψ} := by
     suffices T ⊢! ∼ψ ⋎ φ ⋎ ψ by
       simpa [Axioms.OrInst₂, Semiformula.imp_def]
     apply TDerivation.or
     apply TDerivation.rotate₁
     apply TDerivation.or
     exact TDerivation.em ψ
-  or₃ {φ ψ r} := by
+  or₃! {φ ψ r} := by
     suffices T ⊢! φ ⋏ ∼r ⋎ ψ ⋏ ∼r ⋎ ∼φ ⋏ ∼ψ ⋎ r by
       simpa [Axioms.OrElim, Semiformula.imp_def]
     apply TDerivation.or
@@ -401,7 +401,7 @@ noncomputable instance : Entailment.Minimal T where
       · exact TDerivation.em r
 
 noncomputable instance : Entailment.Cl T where
-  dne {φ} := by simpa [Axioms.DNE, Semiformula.imp_def] using! TDerivation.or (TDerivation.em φ)
+  dne! {φ} := by simpa [Axioms.DNE, Semiformula.imp_def] using! TDerivation.or (TDerivation.em φ)
 
 noncomputable def exsIntro (φ : Semiformula V L 1) (t : Term V L) (b : T ⊢! φ.subst ![t]) : T ⊢! (∃¹ φ) := TDerivation.exs t b
 
@@ -484,9 +484,9 @@ lemma conj_shift (Γ : List (Formula V L)) : (⋀Γ).shift = ⋀(Γ.map .shift) 
       simp [hps, ih]
 
 noncomputable def generalize {Γ} {φ : Semiformula V L 1} (d : Γ.map .shift ⊢[T]! φ.free) : Γ ⊢[T]! ∀¹ φ := by
-  apply Entailment.FiniteContext.ofDef
+  apply Entailment.FiniteContext.ofDef!
   apply generalizeAux
-  simpa [conj_shift] using Entailment.FiniteContext.toDef d
+  simpa [conj_shift] using Entailment.FiniteContext.toDef! d
 
 lemma generalize! {Γ} {φ : Semiformula V L 1} (d : Γ.map .shift ⊢[T] φ.free) : Γ ⊢[T] ∀¹ φ := ⟨generalize d.get⟩
 
@@ -505,24 +505,24 @@ open Entailment.FiniteContext Classical
 
 noncomputable def allImpAll {Γ} {φ ψ : Semiformula V L 1} (d : Γ.map .shift ⊢[T]! φ.free 🡒 ψ.free) :
     Γ ⊢[T]! ∀¹ φ 🡒 ∀¹ ψ := by
-  apply deduct
+  apply deduct!
   apply generalize
   suffices ((∀¹ φ.shift) :: Γ.map Semiformula.shift) ⊢[T]! ψ.free by simpa
   have hφ : ((∀¹ φ.shift) :: Γ.map Semiformula.shift) ⊢[T]! φ.free := by
     apply specializeWithCtx
-    apply byAxm₀
+    apply byAxm₀!
   have h : ((∀¹ φ.shift) :: Γ.map Semiformula.shift) ⊢[T]! φ.free 🡒 ψ.free :=
-    Entailment.FiniteContext.weakening (by simp) d
+    Entailment.FiniteContext.weakening! (by simp) d
   exact h ⨀ hφ
 
 theorem all_imp_all! {Γ} {φ ψ : Semiformula V L 1} (d : Γ.map .shift ⊢[T] φ.free 🡒 ψ.free) :
     Γ ⊢[T] ∀¹ φ 🡒 ∀¹ ψ := ⟨allImpAll d.get⟩
 
 noncomputable def exsImpExs {Γ} {φ ψ : Semiformula V L 1} (d : Γ.map .shift ⊢[T]! φ.free 🡒 ψ.free) : Γ ⊢[T]! ∃¹ φ 🡒 ∃¹ ψ := by
-  apply Entailment.C_of_CNN
+  apply Entailment.C!_of_CNN!
   suffices Γ ⊢[T]! ∀¹ ∼ψ 🡒 ∀¹ ∼φ by simpa
   apply allImpAll
-  apply Entailment.C_of_CNN
+  apply Entailment.C!_of_CNN!
   simpa [Semiformula.free] using d
 
 theorem exs_imp_exs! {Γ} {φ ψ : Semiformula V L 1} (d : Γ.map .shift ⊢[T] φ.free 🡒 ψ.free) :
@@ -562,7 +562,7 @@ lemma substItrDisj_right {i z : V}
 lemma substItrDisj_right_intro {ψ} {i z : V} {w : TermVec V ℒₒᵣ m} {φ : Semiformula V ℒₒᵣ (m + 1)}
     (hi : i < z) (h : A ⊢ ψ 🡒 φ.subst (𝕹 i :> w)) :
      A ⊢ ψ 🡒 φ.substItrDisj w z :=
-  Entailment.C!_trans h (substItrDisj_right A w φ hi)
+  Entailment.C_trans h (substItrDisj_right A w φ hi)
 
 lemma substItrConj_right_intro {ψ} {w : TermVec V ℒₒᵣ m} {φ : Semiformula V ℒₒᵣ (m + 1)} {z : V}
     (h : ∀ i < z, A ⊢ ψ 🡒 φ.subst (𝕹 i :> w)) :
@@ -584,11 +584,11 @@ open Classical in
 lemma substItrDisj_left_intro {ψ} {w : TermVec V ℒₒᵣ m} {φ : Semiformula V ℒₒᵣ (m + 1)} {z : V}
     (h : ∀ i < z, A ⊢ φ.subst (𝕹 i :> w) 🡒 ψ) :
     A ⊢ φ.substItrDisj w z 🡒 ψ := by
-  apply Entailment.C!_of_CNN!
+  apply Entailment.C_of_CNN
   simp only [Semiformula.substItrDisj_neg]
   apply substItrConj_right_intro
   intro i hi
-  apply Entailment.C!_of_CNN!
+  apply Entailment.C_of_CNN
   simpa using h i hi
 
 end TProof

--- a/Foundation/FirstOrder/Completeness/CounterModel.lean
+++ b/Foundation/FirstOrder/Completeness/CounterModel.lean
@@ -32,7 +32,7 @@ def decidablePoints (φ : Proposition K) : DenseSet ℙ⁻ where
   set := {p | p ⊩ᶜ φ ∨ p ⊩ᶜ ∼φ}
   is_dense := by
     intro p
-    have : p ⊩ᶜ φ ⋎ ∼φ := IsWeaklyForced.complete.mpr Entailment.lem! p
+    have : p ⊩ᶜ φ ⋎ ∼φ := IsWeaklyForced.complete.mpr Entailment.lem p
     have : ∀ q ≤ p, ∃ r ≤ q, r ⊩ᶜ φ ∨ r ⊩ᶜ ∼φ := by simpa using this
     simpa using this p (by rfl)
 
@@ -45,7 +45,7 @@ def henkinPoints (φ : Semiproposition K 1) : DenseSet ℙ⁻ where
     intro p
     suffices ∃ q ≤ p, ∀ q_1 ≤ q, (∀ q ≤ q_1, ∃ r ≤ q, ∃ t, r ⊩ᶜ φ/[t]) → ∃ t, q_1 ⊩ᶜ φ/[t] by
       simpa only [IsWeaklyForced.exs, Set.mem_ofPred_eq]
-    have : p ⊩ᶜ (∃¹ φ) ⋎ (∀¹ ∼φ) := IsWeaklyForced.complete.mpr Entailment.lem! p
+    have : p ⊩ᶜ (∃¹ φ) ⋎ (∀¹ ∼φ) := IsWeaklyForced.complete.mpr Entailment.lem p
     have : ∀ q ≤ p, ∃ r ≤ q, (∀ q ≤ r, ∃ r ≤ q, ∃ t, r ⊩ᶜ φ/[t]) ∨ (∀ t, ∀ q ≤ r, ¬q ⊩ᶜ φ/[t]) := by simpa using this
     rcases this p (by rfl) with ⟨q, hqp, (h | h)⟩
     · rcases h q (by rfl) with ⟨r, hrq, t, ht⟩
@@ -220,10 +220,10 @@ variable {L : Language.{u}} {T : Theory L}
 theorem small_satisfiable_of_consistent :
     Consistent T → Satisfiable T := fun consistent ↦ compact.mpr fun u hu ↦ by
   let σ := ⋀u.toList
-  have : T ⊢ σ := Conj₂!_intro fun φ hφ ↦ by_axm <| hu (by simpa using hφ)
+  have : T ⊢ σ := Conj₂_intro fun φ hφ ↦ by_axm <| hu (by simpa using hφ)
   have : 𝐋𝐊¹ ⊬ ∼(σ : Proposition L) := fun h ↦
     have : T ⊢ ∼σ := Theory.Proof.of_LK_provable (φ := ∼σ) (by simpa using h)
-    have : T ⊢ ⊥ := neg_mdp! this (by assumption)
+    have : T ⊢ ⊥ := neg_mdp this (by assumption)
     consistent_iff_unprovable_bot.mp consistent this
   have : Satisfiable {σ} := LK.satisfiable_of_irrefutable σ this
   simpa [σ] using this

--- a/Foundation/FirstOrder/Completeness/CounterModel.lean
+++ b/Foundation/FirstOrder/Completeness/CounterModel.lean
@@ -223,7 +223,7 @@ theorem small_satisfiable_of_consistent :
   have : T ⊢ σ := Conj₂!_intro fun φ hφ ↦ by_axm <| hu (by simpa using hφ)
   have : 𝐋𝐊¹ ⊬ ∼(σ : Proposition L) := fun h ↦
     have : T ⊢ ∼σ := Theory.Proof.of_LK_provable (φ := ∼σ) (by simpa using h)
-    have : T ⊢ ⊥ := neg_mdp this (by assumption)
+    have : T ⊢ ⊥ := neg_mdp! this (by assumption)
     consistent_iff_unprovable_bot.mp consistent this
   have : Satisfiable {σ} := LK.satisfiable_of_irrefutable σ this
   simpa [σ] using this

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -333,7 +333,7 @@ end Forces
 
 /-- Cut elimination theorem of $\mathbf{LK}$. -/
 def hauptsatz [L.DecidableEq] {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := fun d ↦
-  let d : 𝗠𝗶𝗻¹ ⊢! ⋀(∼Γ)ᴺ 🡒 ⊥ := Entailment.FiniteContext.toDef (Derivation.gödelGentzen d)
+  let d : 𝗠𝗶𝗻¹ ⊢! ⋀(∼Γ)ᴺ 🡒 ⊥ := Entailment.FiniteContext.toDef! (Derivation.gödelGentzen d)
   let ff : Forces (∼Γ) (⋀(∼Γ)ᴺ 🡒 ⊥) := Forces.sound d (∼Γ)
   let fc : Forces (∼Γ) (⋀(∼Γ)ᴺ) := Forces.conj' fun φ hφ ↦
     (Forces.refl φ).monotone (StrongerThan.ofSubset <| List.cons_subset.mpr ⟨hφ, by simp⟩)

--- a/Foundation/FirstOrder/Incompleteness/Jeroslow.lean
+++ b/Foundation/FirstOrder/Incompleteness/Jeroslow.lean
@@ -75,10 +75,10 @@ lemma def_jeroslow [𝗜𝚺₁ ⪯ U] : U ⊢ T.jeroslow 🡘 (T.refutable)/[�
 
 private lemma def_jeroslow' [𝗜𝚺₁ ⪯ U] : U ⊢ T.jeroslow' 🡘 (T.refutable)/[⌜T.jeroslow⌝] := by simp;
 
-private lemma provable_E_jeroslow_jeroslow' [𝗜𝚺₁ ⪯ U] : U ⊢ T.jeroslow 🡘 T.jeroslow' := Entailment.E!_trans def_jeroslow def_jeroslow'
+private lemma provable_E_jeroslow_jeroslow' [𝗜𝚺₁ ⪯ U] : U ⊢ T.jeroslow 🡘 T.jeroslow' := Entailment.E_trans def_jeroslow def_jeroslow'
 
 private lemma iff_provable_jeroslow_provable_jeroslow' [𝗜𝚺₁ ⪯ U] : U ⊢ (T.jeroslow) ↔ U ⊢ (T.jeroslow') := by
-  apply Entailment.iff_of_E! provable_E_jeroslow_jeroslow';
+  apply Entailment.iff_of_E provable_E_jeroslow_jeroslow';
 
 open LO.Entailment in
 instance [𝗜𝚺₁ ⪯ T] [T.SoundOnHierarchy 𝚺 1] : T.standardRefutability.SoundOn (ProvabilityAbstraction.jeroslow T.standardRefutability) := by
@@ -96,7 +96,7 @@ instance [𝗜𝚺₁ ⪯ T] : T.standardProvability.FormalizedCompleteOn (Prova
   apply provable_sigma_one_complete_of_E;
   . show Hierarchy 𝚺 1 T.jeroslow';
     exact jeroslow'_sigmaOne;
-  . apply Entailment.E!_symm $ provable_E_jeroslow_jeroslow';
+  . apply Entailment.E_symm $ provable_E_jeroslow_jeroslow';
 
 end
 

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Basic.lean
@@ -129,11 +129,11 @@ variable
 lemma bew_distribute_imply [𝔅.HBL2] (h : T₀ ⊢ 𝔅 (σ 🡒 τ)) : T₀ ⊢ 𝔅 σ 🡒 𝔅 τ := D2 ⨀ h
 
 instance [𝔅.HBL2] : 𝔅.Mono := ⟨λ h => bew_distribute_imply $ D1 h⟩
-instance [𝔅.HBL2] : 𝔅.Ext := ⟨λ h => E!_intro (mono (K!_left h)) (mono (K!_right h))⟩
+instance [𝔅.HBL2] : 𝔅.Ext := ⟨λ h => E_intro (mono (K_left h)) (mono (K_right h))⟩
 
 lemma bew_distribute_and [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢ 𝔅 (σ ⋏ τ) 🡒 𝔅 σ ⋏ 𝔅 τ := by
-  have h₁ : T₀ ⊢ 𝔅 (σ ⋏ τ) 🡒 𝔅 σ := bew_distribute_imply $ D1 and₁!;
-  have h₂ : T₀ ⊢ 𝔅 (σ ⋏ τ) 🡒 𝔅 τ := bew_distribute_imply $ D1 and₂!;
+  have h₁ : T₀ ⊢ 𝔅 (σ ⋏ τ) 🡒 𝔅 σ := bew_distribute_imply $ D1 and₁;
+  have h₂ : T₀ ⊢ 𝔅 (σ ⋏ τ) 🡒 𝔅 τ := bew_distribute_imply $ D1 and₂;
   cl_prover [h₁, h₂];
 
 lemma bew_distribute_and' [𝔅.HBL2] [L₀.DecidableEq] : T₀ ⊢ 𝔅 (σ ⋏ τ) → T₀ ⊢ 𝔅 σ ⋏ 𝔅 τ := λ h => bew_distribute_and ⨀ h
@@ -202,7 +202,7 @@ theorem unprovable_gödel : T ⊬ (gödel 𝔅) := by
 theorem unrefutable_gödel [𝔅.Kreisel] : T ⊬ ∼(gödel 𝔅) := by
   intro h₂;
   have h₁ : T ⊢ (gödel 𝔅) := WeakerThan.pbl $ 𝔅.KR $ by cl_prover [gödel_spec (T₀ := T₀), h₂];
-  have : T ⊢ ⊥ := (N!_iff_CO!.mp $ WeakerThan.pbl $ h₂) ⨀ h₁;
+  have : T ⊢ ⊥ := (N_iff_CO.mp $ WeakerThan.pbl $ h₂) ⨀ h₁;
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr <| inconsistent_iff_provable_bot.mpr this
   contradiction;
 
@@ -222,7 +222,7 @@ section Second
 variable [𝔅.HBL]
 
 omit [Diagonalization T₀] in
-lemma formalized_consistent_of_existance_unprovable [L.DecidableEq] : T₀ ⊢ ∼𝔅 σ 🡒 𝔅.con := contra! $ mdp! D2 $ D1 efq!
+lemma formalized_consistent_of_existance_unprovable [L.DecidableEq] : T₀ ⊢ ∼𝔅 σ 🡒 𝔅.con := contra $ mdp D2 $ D1 efq
 
 local notation "𝐆" => gödel 𝔅
 
@@ -274,40 +274,40 @@ lemma kreisel_spec : T₀ ⊢ (𝐊 σ) 🡘 (𝔅 (𝐊 σ) 🡒 σ) := by
   have := diag (T := T₀) “x. !𝔅.prov x → !σ”
   simpa [kreisel, Provability.pr, Rew.subst_comp_subst, ←TransitiveRewriting.comp_app] using this;
 
-private lemma kreisel_specAux₂ : T₀ ⊢ (𝔅 (𝐊 σ) 🡒 σ) 🡒 (𝐊 σ) := K!_right kreisel_spec
+private lemma kreisel_specAux₂ : T₀ ⊢ (𝔅 (𝐊 σ) 🡒 σ) 🡒 (𝐊 σ) := K_right kreisel_spec
 
 variable [𝔅.HBL]
 
 private lemma kreisel_specAux₁ [L.DecidableEq] [T₀ ⪯ T] : T₀ ⊢ 𝔅 (𝐊 σ) 🡒 𝔅 σ :=
-  Entailment.mdp₁! (C!_trans (mdp! D2 (D1 (WeakerThan.pbl <| K!_left (kreisel_spec)))) D2) D3
+  Entailment.mdp₁ (C_trans (mdp D2 (D1 (WeakerThan.pbl <| K_left (kreisel_spec)))) D2) D3
 
 variable [L.DecidableEq] [T₀ ⪯ T]
 
 theorem löb_theorem (H : T ⊢ 𝔅 σ 🡒 σ) : T ⊢ σ := by
-  have d₁ : T ⊢ 𝔅 (𝐊 σ) 🡒 σ := C!_trans (WeakerThan.pbl kreisel_specAux₁) H;
+  have d₁ : T ⊢ 𝔅 (𝐊 σ) 🡒 σ := C_trans (WeakerThan.pbl kreisel_specAux₁) H;
   have d₂ : T ⊢ 𝔅 (𝐊 σ)     := WeakerThan.pbl $ D1 $ WeakerThan.pbl kreisel_specAux₂ ⨀ d₁;
   exact d₁ ⨀ d₂;
 
 theorem formalized_löb_theorem : T₀ ⊢ 𝔅 (𝔅 σ 🡒 σ) 🡒 𝔅 σ := by
   have h₁ : T₀ ⊢ 𝔅 (𝐊 σ) 🡒 𝔅 σ := kreisel_specAux₁;
-  have h₂ : T₀ ⊢ (𝔅 σ 🡒 σ) 🡒 (𝔅 (𝐊 σ) 🡒 σ) := CCC!_of_C!_left h₁;
-  have h₃ : T ⊢ (𝔅 σ 🡒 σ) 🡒 𝐊 σ := WeakerThan.pbl $ C!_trans (CCC!_of_C!_left h₁) kreisel_specAux₂;
-  exact C!_trans (D2 ⨀ (D1 h₃)) h₁;
+  have h₂ : T₀ ⊢ (𝔅 σ 🡒 σ) 🡒 (𝔅 (𝐊 σ) 🡒 σ) := CCC_of_C_left h₁;
+  have h₃ : T ⊢ (𝔅 σ 🡒 σ) 🡒 𝐊 σ := WeakerThan.pbl $ C_trans (CCC_of_C_left h₁) kreisel_specAux₂;
+  exact C_trans (D2 ⨀ (D1 h₃)) h₁;
 
 lemma formalized_unprovable_not_con [Consistent T] [𝔅.Kreisel] : T ⊬ 𝔅.con 🡒 ∼𝔅 (∼𝔅.con) := by
   by_contra hC;
-  have : T ⊢ ∼𝔅.con := löb_theorem $ CN!_of_CN!_right hC;
+  have : T ⊢ ∼𝔅.con := löb_theorem $ CN_of_CN_right hC;
   have : T ⊬ ∼𝔅.con := con_unrefutable;
   contradiction;
 
 lemma formalized_unrefutable_gödel [Consistent T] [𝔅.Kreisel] : T ⊬ 𝔅.con 🡒 ∼𝔅 (∼(gödel 𝔅)) := by
   by_contra hC;
   have : T ⊬ 𝔅.con 🡒 ∼𝔅 (∼𝔅.con) := formalized_unprovable_not_con;
-  have : T ⊢ 𝔅.con 🡒 ∼𝔅 (∼𝔅.con) := C!_trans hC
+  have : T ⊢ 𝔅.con 🡒 ∼𝔅 (∼𝔅.con) := C_trans hC
     $ WeakerThan.pbl
-    $ K!_left $ ENN!_of_E!
+    $ K_left $ ENN_of_E
     $ 𝔅.ext
-    $ ENN!_of_E!
+    $ ENN_of_E
     $ WeakerThan.pbl gödel_iff_con
   contradiction;
 
@@ -322,9 +322,9 @@ local notation "𝐑" => gödel 𝔅
 
 theorem unrefutable_rosser [𝔅.Rosser] : T ⊬ ∼𝐑 := by
   intro hnρ;
-  have hρ : T ⊢ 𝐑 := WeakerThan.pbl $ (K!_right gödel_spec) ⨀ (Ros hnρ);
+  have hρ : T ⊢ 𝐑 := WeakerThan.pbl $ (K_right gödel_spec) ⨀ (Ros hnρ);
   have : ¬Consistent T := not_consistent_iff_inconsistent.mpr $ inconsistent_iff_provable_bot.mpr <|
-    (N!_iff_CO!.mp hnρ) ⨀ hρ;
+    (N_iff_CO.mp hnρ) ⨀ hρ;
   contradiction
 
 theorem rosser_independent [L.DecidableEq] [𝔅.Rosser] : Independent T 𝐑 := by
@@ -338,7 +338,7 @@ theorem rosser_first_incompleteness [L.DecidableEq] (𝔅 : Provability T₀ T) 
 omit [Diagonalization T₀] [Consistent T] in
 /-- If `𝔅` satisfies Rosser provability condition, then `𝔅.con` is provable from `T`. -/
 theorem kreisel_remark [𝔅.Rosser] : T ⊢ 𝔅.con := by
-  have : T₀ ⊢ ∼𝔅 ⊥ := Ros (N!_iff_CO!.mpr (by simp));
+  have : T₀ ⊢ ∼𝔅 ⊥ := Ros (N_iff_CO.mpr (by simp));
   exact WeakerThan.pbl $ this;
 
 end Rosser

--- a/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
+++ b/Foundation/FirstOrder/Incompleteness/ProvabilityAbstraction/Refutability.lean
@@ -73,8 +73,8 @@ variable
 lemma unprovable_jeroslow [T₀ ⪯ T] [Consistent T] [𝔚.SoundOn (jeroslow 𝔚)] : T ⊬ jeroslow 𝔚 := by
   by_contra hC;
   apply Entailment.Consistent.not_bot (𝓢 := T);
-  have : T ⊢ ∼(jeroslow 𝔚) := Refutability.sound_on $ (Entailment.iff_of_E! $ jeroslow_def') |>.mp hC;
-  exact (N!_iff_CO!.mp this) ⨀ hC;
+  have : T ⊢ ∼(jeroslow 𝔚) := Refutability.sound_on $ (Entailment.iff_of_E $ jeroslow_def') |>.mp hC;
+  exact (N_iff_CO.mp this) ⨀ hC;
 
 end
 
@@ -117,12 +117,12 @@ lemma unprovable_flon [consis : Consistent T] [𝔅.FormalizedCompleteOn 𝐉] :
   contrapose! consis;
   replace consis : T ⊢ ∀¹ safe 𝔅 𝔚 := by simpa [flon] using consis;
   have h₁ : T ⊢ ∼(𝔅 𝐉 ⋏ 𝔚 𝐉) := by simpa [safe] using! FirstOrder.Theory.Proof.specialize _ _ ⨀ consis;
-  have h₂ : T ⊢ ∼𝐉 := (contra! jeroslow_not_safe) ⨀ h₁;
+  have h₂ : T ⊢ ∼𝐉 := (contra jeroslow_not_safe) ⨀ h₁;
   have h₃ : T ⊢ 𝐉 🡘 𝔚 𝐉 := jeroslow_def';
   have h₄ : T ⊢ 𝔚 𝐉 := R1' h₂;
   have h₅ : T ⊢ 𝔚 𝐉 🡒 𝐉 := by cl_prover [h₃];
   have h₆ : T ⊢ 𝐉 := h₅ ⨀ h₄;
-  exact not_consistent_iff_inconsistent.mpr <| inconsistent_iff_provable_bot.mpr $ (N!_iff_CO!.mp h₂) ⨀ h₆;
+  exact not_consistent_iff_inconsistent.mpr <| inconsistent_iff_provable_bot.mpr $ (N_iff_CO.mp h₂) ⨀ h₆;
 
 end
 

--- a/Foundation/FirstOrder/Incompleteness/RestrictedProvability.lean
+++ b/Foundation/FirstOrder/Incompleteness/RestrictedProvability.lean
@@ -53,12 +53,12 @@ lemma def_restrictedGödel [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel e 🡘
 private lemma def_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel' e 🡘 (∼(T.restrictedProvable e).val)/[⌜T.restrictedGödel e⌝] := by simp;
 
 private lemma provable_E_restrictedGödel_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ T.restrictedGödel e 🡘 T.restrictedGödel' e := by
-  apply Entailment.E!_trans;
+  apply Entailment.E_trans;
   . exact def_restrictedGödel;
-  . exact Entailment.E!_symm $ def_restrictedGödel';
+  . exact Entailment.E_symm $ def_restrictedGödel';
 
 private lemma iff_provable_restrictedGödel_provable_restrictedGödel' [𝗜𝚺₁ ⪯ U] : U ⊢ (T.restrictedGödel e) ↔ U ⊢ (T.restrictedGödel' e) := by
-  apply Entailment.iff_of_E! provable_E_restrictedGödel_restrictedGödel';
+  apply Entailment.iff_of_E provable_E_restrictedGödel_restrictedGödel';
 
 private lemma iff_true_restrictedGödel_true_restrictedGödel' : ℕ↓[ℒₒᵣ] ⊧ (T.restrictedGödel e) ↔ ℕ↓[ℒₒᵣ] ⊧ (T.restrictedGödel' e) := by
   apply Semantics.models_iff.mp;

--- a/Foundation/FirstOrder/Incompleteness/StandardProvability.lean
+++ b/Foundation/FirstOrder/Incompleteness/StandardProvability.lean
@@ -68,10 +68,10 @@ theorem provable_D3 [𝗣𝗔⁻ ⪯ T] {σ : ArithmeticSentence} :
 open LO.Entailment LO.Entailment.FiniteContext
 
 lemma provable_D2_context [𝗜𝚺₁ ⪯ U] {Γ σ π} (hσπ : Γ ⊢[U] □(σ 🡒 π)) (hσ : Γ ⊢[U] □σ) :
-    Γ ⊢[U] □π := FiniteContext.of'! (weakening inferInstance provable_D2) ⨀ hσπ ⨀ hσ
+    Γ ⊢[U] □π := FiniteContext.of' (weakening inferInstance provable_D2) ⨀ hσπ ⨀ hσ
 
 lemma provable_D3_context [𝗣𝗔⁻ ⪯ T] [𝗜𝚺₁ ⪯ U] {Γ σ} (hσπ : Γ ⊢[U] □σ) :
-  Γ ⊢[U] □□σ := FiniteContext.of'! (weakening inferInstance provable_D3) ⨀ hσπ
+  Γ ⊢[U] □□σ := FiniteContext.of' (weakening inferInstance provable_D3) ⨀ hσπ
 
 lemma provable_sound [U.SoundOnHierarchy 𝚺 1] {σ} : U ⊢ □σ → T ⊢ σ := fun h ↦ by
   have : ℕ↓[ℒₒᵣ] ⊧ provabilityPred T σ := ArithmeticTheory.SoundOn.sound (F := Arithmetic.Hierarchy 𝚺 1) h (by simp)
@@ -93,7 +93,7 @@ open LO.Entailment in
 -/
 lemma provable_sigma_one_complete_of_E {σ π} [𝗜𝚺₁ ⪯ T]
   (hσ : Hierarchy 𝚺 1 σ) (hσπ : 𝗜𝚺₁ ⊢ σ 🡘 π) : 𝗜𝚺₁ ⊢ π 🡒 □π := by
-  apply C!_replace ?_ ?_ $ provable_sigma_one_complete (T := T) $ hσ;
+  apply C_replace ?_ ?_ $ provable_sigma_one_complete (T := T) $ hσ;
   . cl_prover [hσπ];
   . apply T.standardProvability.mono';
     cl_prover [hσπ];

--- a/Foundation/FirstOrder/Intuitionistic/Deduction.lean
+++ b/Foundation/FirstOrder/Intuitionistic/Deduction.lean
@@ -90,22 +90,22 @@ instance : Entailment.HasAxiomImplyK Λ := ⟨implyK _ _⟩
 instance : Entailment.HasAxiomImplyS Λ := ⟨implyS _ _ _⟩
 
 instance : Entailment.Minimal Λ where
-  mdp := mdp
-  verum := verum
-  implyK := implyK _ _
-  implyS := implyS _ _ _
-  and₁ := and₁ _ _
-  and₂ := and₂ _ _
-  and₃ := and₃ _ _
-  or₁ := or₁ _ _
-  or₂ := or₂ _ _
-  or₃ := or₃ _ _ _
-  negEquiv := Entailment.E_id
+  mdp! := mdp
+  verum! := verum
+  implyK! := implyK _ _
+  implyS! := implyS _ _ _
+  and₁! := and₁ _ _
+  and₂! := and₂ _ _
+  and₃! := and₃ _ _
+  or₁! := or₁ _ _
+  or₂! := or₂ _ _
+  or₃! := or₃ _ _ _
+  negEquiv! := Entailment.E!_id
 
 variable {Λ}
 
 instance : Entailment.Int (𝗜𝗻𝘁¹ : Hilbertᵢ L) where
-  efq := eaxm <| by simp [Hilbertᵢ.Intuitionistic]
+  efq! := eaxm <| by simp [Hilbertᵢ.Intuitionistic]
 
 protected def cast {φ ψ} (b : Λ ⊢! φ) (e : φ = ψ := by simp) : Λ ⊢! ψ := e ▸ b
 
@@ -144,73 +144,73 @@ def implyAll {φ ψ} (b : Λ ⊢! shift φ 🡒 free ψ) : Λ ⊢! φ 🡒 ∀¹
   all₂ φ ψ ⨀ this
 
 def geNOverFiniteContext {Γ φ} (b : Γ⁺ ⊢[Λ]! free φ) : Γ ⊢[Λ]! ∀¹ φ :=
-  ofDef <| implyAll <| by simpa [shift_conj₂] using toDef b
+  ofDef! <| implyAll <| by simpa [shift_conj₂] using toDef! b
 
 def specializeOverContext {Γ φ} (b : Γ ⊢[Λ]! ∀¹ φ) (t) : Γ ⊢[Λ]! φ/[t] :=
-  ofDef <| Entailment.C_trans (toDef b) (all₁ φ t)
+  ofDef! <| Entailment.C!_trans (toDef! b) (all₁ φ t)
 
 def allImplyAllOfAllImply (φ ψ) : Λ ⊢! ∀¹ (φ 🡒 ψ) 🡒 ∀¹ φ 🡒 ∀¹ ψ := by
-  apply deduct'
-  apply deduct
+  apply deduct'!
+  apply deduct!
   apply geNOverFiniteContext
   have b₁ : [∀¹ shift φ, ∀¹ (shift φ 🡒 shift ψ)] ⊢[Λ]! free φ 🡒 free ψ :=
-    Entailment.cast (specializeOverContext (nthAxm 1) &0)
+    Entailment.cast (specializeOverContext (nthAxm! 1) &0)
   have b₂ : [∀¹ shift φ, ∀¹ (shift φ 🡒 shift ψ)] ⊢[Λ]! free φ :=
-    Entailment.cast (specializeOverContext (nthAxm 0) &0)
+    Entailment.cast (specializeOverContext (nthAxm! 0) &0)
   have : [∀¹ φ, ∀¹ (φ 🡒 ψ)]⁺ ⊢[Λ]! free ψ := cast (by simp) (b₁ ⨀ b₂)
   exact this
 
-def allIffAllOfIff {φ ψ} (b : Λ ⊢! free φ 🡘 free ψ) : Λ ⊢! ∀¹ φ 🡘 ∀¹ ψ := Entailment.K_intro
-  (allImplyAllOfAllImply φ ψ ⨀ gen (Entailment.cast (Entailment.K_left b)))
-  (allImplyAllOfAllImply ψ φ ⨀ gen (Entailment.cast (Entailment.K_right b)))
+def allIffAllOfIff {φ ψ} (b : Λ ⊢! free φ 🡘 free ψ) : Λ ⊢! ∀¹ φ 🡘 ∀¹ ψ := Entailment.K!_intro
+  (allImplyAllOfAllImply φ ψ ⨀ gen (Entailment.cast (Entailment.K!_left b)))
+  (allImplyAllOfAllImply ψ φ ⨀ gen (Entailment.cast (Entailment.K!_right b)))
 
 def dneOfNegative [L.DecidableEq] : {φ : Propositionᵢ L} → φ.IsNegative → Λ ⊢! ∼∼φ 🡒 φ
-  | ⊥,     _ => Entailment.CNNOO
+  | ⊥,     _ => Entailment.CNNOO!
   | φ ⋏ ψ, h =>
     have ihφ : Λ ⊢! ∼∼φ 🡒 φ := dneOfNegative (by simp [by simpa using h])
     have ihψ : Λ ⊢! ∼∼ψ 🡒 ψ := dneOfNegative (by simp [by simpa using h])
-    have : Λ ⊢! ∼φ 🡒 ∼(φ ⋏ ψ) := Entailment.contra Entailment.and₁
-    have dφ : [∼∼(φ ⋏ ψ)] ⊢[Λ]! φ := of ihφ ⨀ (deduct <| byAxm₁ ⨀ (of this ⨀ byAxm₀))
-    have : Λ ⊢! ∼ψ 🡒 ∼(φ ⋏ ψ) := Entailment.contra Entailment.and₂
-    have dψ : [∼∼(φ ⋏ ψ)] ⊢[Λ]! ψ := of ihψ ⨀ (deduct <| byAxm₁ ⨀ (of this ⨀ byAxm₀))
-    deduct' (Entailment.K_intro dφ dψ)
+    have : Λ ⊢! ∼φ 🡒 ∼(φ ⋏ ψ) := Entailment.contra! Entailment.and₁!
+    have dφ : [∼∼(φ ⋏ ψ)] ⊢[Λ]! φ := of! ihφ ⨀ (deduct! <| byAxm₁! ⨀ (of! this ⨀ byAxm₀!))
+    have : Λ ⊢! ∼ψ 🡒 ∼(φ ⋏ ψ) := Entailment.contra! Entailment.and₂!
+    have dψ : [∼∼(φ ⋏ ψ)] ⊢[Λ]! ψ := of! ihψ ⨀ (deduct! <| byAxm₁! ⨀ (of! this ⨀ byAxm₀!))
+    deduct'! (Entailment.K!_intro dφ dψ)
   | φ 🡒 ψ, h =>
     let ihψ : Λ ⊢! ∼∼ψ 🡒 ψ := dneOfNegative (by simp [by simpa using h])
-    have : [∼ψ, φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ∼(φ 🡒 ψ) := deduct <| byAxm₁ ⨀ (byAxm₀ ⨀ byAxm₂)
-    have : [∼ψ, φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ⊥ := byAxm₂ ⨀ this
-    have : [φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ψ := (of ihψ) ⨀ (deduct this)
-    deduct' (deduct this)
+    have : [∼ψ, φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ∼(φ 🡒 ψ) := deduct! <| byAxm₁! ⨀ (byAxm₀! ⨀ byAxm₂!)
+    have : [∼ψ, φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ⊥ := byAxm₂! ⨀ this
+    have : [φ, ∼∼(φ 🡒 ψ)] ⊢[Λ]! ψ := (of! ihψ) ⨀ (deduct! this)
+    deduct'! (deduct! this)
   | ∀¹ φ,  h =>
     have ihφ : Λ ⊢! ∼∼(free φ) 🡒 free φ := dneOfNegative (by simp [by simpa using h])
     have : [∀¹ shift φ, ∼(free φ), ∼∼(∀¹ shift φ)] ⊢[Λ]! ⊥ :=
-      have : [∀¹ shift φ, ∼(free φ), ∼∼(∀¹ shift φ)] ⊢[Λ]! ∀¹ shift φ := byAxm₀
-      byAxm₁ ⨀ Entailment.cast (specializeOverContext this &0)
-    have : [∼∼(∀¹ shift φ)] ⊢[Λ]! free φ := of ihφ ⨀ deduct (byAxm₁ ⨀ deduct this)
-    implyAll (Entailment.cast (deduct' this))
+      have : [∀¹ shift φ, ∼(free φ), ∼∼(∀¹ shift φ)] ⊢[Λ]! ∀¹ shift φ := byAxm₀!
+      byAxm₁! ⨀ Entailment.cast (specializeOverContext this &0)
+    have : [∼∼(∀¹ shift φ)] ⊢[Λ]! free φ := of! ihφ ⨀ deduct! (byAxm₁! ⨀ deduct! this)
+    implyAll (Entailment.cast (deduct'! this))
   termination_by φ _ => φ.complexity
 
 def ofDNOfNegative [L.DecidableEq] {φ : Propositionᵢ L} {Γ} (b : Γ ⊢[Λ]! ∼∼φ) (h : φ.IsNegative) : Γ ⊢[Λ]! φ :=
-  Entailment.C_trans (toDef b) (dneOfNegative h)
+  Entailment.C!_trans (toDef! b) (dneOfNegative h)
 
 def DN_of_isNegative [L.DecidableEq] {φ : Propositionᵢ L} (h : φ.IsNegative) : Λ ⊢! ∼∼φ 🡘 φ :=
-  Entailment.K_intro (dneOfNegative h) Entailment.dni
+  Entailment.K!_intro (dneOfNegative h) Entailment.dni!
 
 def efqOfNegative : {φ : Propositionᵢ L} → φ.IsNegative → Λ ⊢! ⊥ 🡒 φ
-  | ⊥,     _ => Entailment.C_id
+  | ⊥,     _ => Entailment.C!_id
   | φ ⋏ ψ, h =>
     have ihφ : Λ ⊢! ⊥ 🡒 φ := efqOfNegative (by simp [by simpa using h])
     have ihψ : Λ ⊢! ⊥ 🡒 ψ := efqOfNegative (by simp [by simpa using h])
-    Entailment.CK_of_C_of_C ihφ ihψ
+    Entailment.CK!_of_C!_of_C! ihφ ihψ
   | φ 🡒 ψ, h =>
     have ihψ : Λ ⊢! ⊥ 🡒 ψ := efqOfNegative (by simp [by simpa using h])
-    Entailment.C_trans ihψ Entailment.implyK
+    Entailment.C!_trans ihψ Entailment.implyK!
   | ∀¹ φ,  h =>
     have ihφ : Λ ⊢! ⊥ 🡒 free φ := efqOfNegative (by simp [by simpa using h])
     implyAll <| Entailment.cast ihφ
   termination_by φ _ => φ.complexity
 
 def iffnegOfNegIff [L.DecidableEq] {φ ψ : Propositionᵢ L} (h : φ.IsNegative) (b : Λ ⊢! ∼φ 🡘 ψ) : Λ ⊢! φ 🡘 ∼ψ :=
-  Entailment.E_trans (Entailment.E_symm <| DN_of_isNegative h) (Entailment.ENN_of_E b)
+  Entailment.E!_trans (Entailment.E!_symm <| DN_of_isNegative h) (Entailment.ENN!_of_E! b)
 
 def rewrite (f : ℕ → SyntacticTerm L) : Λ ⊢! φ → Λ ⊢! Rew.rewrite f ▹ φ
   | mdp b d        => rewrite f b ⨀ rewrite f d
@@ -313,7 +313,7 @@ lemma provable_def {φ : Sentenceᵢ L} : T ⊢ φ ↔ (Rewriting.emb '' T.theor
 def Proof.cast! (e : φ = ψ) : T ⊢! φ → T ⊢! ψ := fun b ↦ e ▸ b
 
 def Proof.weakening! [L.DecidableEq] (ss : T ⊆ U) : T ⊢! φ → U ⊢! φ :=
-  Context.weakening (Set.image_mono ss)
+  Context.weakening! (Set.image_mono ss)
 
 open Context
 
@@ -322,22 +322,22 @@ variable [L.DecidableEq]
 instance : Axiomatized (Theoryᵢ L 𝓗) where
   prfAxm {T} φ h := by
     show (Rewriting.emb '' T.theory) *⊢[𝓗]! ↑φ
-    exact Context.byAxm (Set.mem_image_of_mem _ (by simpa [mem_def] using h))
+    exact Context.byAxm! (Set.mem_image_of_mem _ (by simpa [mem_def] using h))
   weakening {φ T U} ss b := by
     show (Rewriting.emb '' U.theory) *⊢[𝓗]! ↑φ
-    apply Context.weakening ?_ b
+    apply Context.weakening! ?_ b
     exact Set.image_mono ss
 
-def ofHilbert {φ : Sentenceᵢ L} : 𝓗 ⊢! ↑φ → T ⊢! φ := Context.of
+def ofHilbert {φ : Sentenceᵢ L} : 𝓗 ⊢! ↑φ → T ⊢! φ := Context.of!
 
 def deduct! {φ ψ} (b : adjoin φ T ⊢! ψ) : T ⊢! φ 🡒 ψ :=
   have : (Rewriting.emb '' T.theory) *⊢[𝓗]! ↑φ 🡒 ↑ψ :=
-    Context.deduct <| Context.weakening (by simp [-Set.image_subset_iff, Set.image_insert_eq]) b
+    Context.deduct! <| Context.weakening! (by simp [-Set.image_subset_iff, Set.image_insert_eq]) b
   this
 
 def deductInv! {φ ψ} (b : T ⊢! φ 🡒 ψ) : adjoin φ T ⊢! ψ :=
-  have : insert ↑φ (Rewriting.emb '' T.theory) *⊢[𝓗]! ↑ψ := Context.deductInv b
-  Context.weakening (by simp [Set.image_insert_eq]) this
+  have : insert ↑φ (Rewriting.emb '' T.theory) *⊢[𝓗]! ↑ψ := Context.deductInv! b
+  Context.weakening! (by simp [Set.image_insert_eq]) this
 
 instance : Deduction (Theoryᵢ L 𝓗) where
   ofInsert := deduct!
@@ -350,10 +350,10 @@ instance : Entailment.Minimal T :=
     fun φ ↦ (Equiv.refl ((Rewriting.emb '' T.theory) *⊢[𝓗]! ↑φ))
 
 instance minimal [Entailment.Int 𝓗] : Entailment.Int T where
-  efq := ofHilbert <| efq
+  efq! := ofHilbert <| efq!
 
 instance cl [Entailment.Cl 𝓗] : Entailment.Cl T where
-  dne := ofHilbert <| dne
+  dne! := ofHilbert <| dne!
 
 end Theoryᵢ
 

--- a/Foundation/FirstOrder/Intuitionistic/Deduction.lean
+++ b/Foundation/FirstOrder/Intuitionistic/Deduction.lean
@@ -100,7 +100,7 @@ instance : Entailment.Minimal Λ where
   or₁ := or₁ _ _
   or₂ := or₂ _ _
   or₃ := or₃ _ _ _
-  negEquiv := Entailment.E_Id
+  negEquiv := Entailment.E_id
 
 variable {Λ}
 

--- a/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
+++ b/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
@@ -95,33 +95,33 @@ variable {L : Language} [L.DecidableEq] {T : Theory L} {Λ : Hilbertᵢ L}
 open Rewriting LO.Entailment Entailment.FiniteContext HilbertProofᵢ
 
 def negDoubleNegation : (φ : Proposition L) → Λ ⊢! ∼φᴺ 🡘 (∼φ)ᴺ
-  | .rel r v => Entailment.tneIff (φ := Semiformulaᵢ.rel r v)
-  | .nrel r v => Entailment.E_id (φ := ∼∼(Semiformulaᵢ.rel r v))
-  | ⊤ => Entailment.ENNOO
-  | ⊥ => Entailment.E_id (φ := ∼⊥)
+  | .rel r v => Entailment.tneIff! (φ := Semiformulaᵢ.rel r v)
+  | .nrel r v => Entailment.E!_id (φ := ∼∼(Semiformulaᵢ.rel r v))
+  | ⊤ => Entailment.ENNOO!
+  | ⊥ => Entailment.E!_id (φ := ∼⊥)
   | φ ⋏ ψ =>
     have ihφ : Λ ⊢! ∼φᴺ 🡘 (∼φ)ᴺ := negDoubleNegation φ
     have ihψ : Λ ⊢! ∼ψᴺ 🡘 (∼ψ)ᴺ := negDoubleNegation ψ
     have : Λ ⊢! φᴺ ⋏ ψᴺ 🡘 ∼(∼φ)ᴺ ⋏ ∼(∼ψ)ᴺ :=
-      Entailment.EKK_of_E_of_E (iffnegOfNegIff (by simp) ihφ) (iffnegOfNegIff (by simp) ihψ)
-    Entailment.ENN_of_E this
+      Entailment.EKK!_of_E!_of_E! (iffnegOfNegIff (by simp) ihφ) (iffnegOfNegIff (by simp) ihψ)
+    Entailment.ENN!_of_E! this
   | φ ⋎ ψ =>
     have ihφ : Λ ⊢! ∼φᴺ 🡘 (∼φ)ᴺ := negDoubleNegation φ
     have ihψ : Λ ⊢! ∼ψᴺ 🡘 (∼ψ)ᴺ := negDoubleNegation ψ
-    have : Λ ⊢! ∼φᴺ ⋏ ∼ψᴺ 🡘 (∼φ)ᴺ ⋏ (∼ψ)ᴺ := Entailment.EKK_of_E_of_E ihφ ihψ
-    have : Λ ⊢! ∼∼(∼φᴺ ⋏ ∼ψᴺ) 🡘 (∼φ)ᴺ ⋏ (∼ψ)ᴺ := Entailment.E_trans (DN_of_isNegative (by simp)) this
+    have : Λ ⊢! ∼φᴺ ⋏ ∼ψᴺ 🡘 (∼φ)ᴺ ⋏ (∼ψ)ᴺ := Entailment.EKK!_of_E!_of_E! ihφ ihψ
+    have : Λ ⊢! ∼∼(∼φᴺ ⋏ ∼ψᴺ) 🡘 (∼φ)ᴺ ⋏ (∼ψ)ᴺ := Entailment.E!_trans (DN_of_isNegative (by simp)) this
     this
   | ∀¹ φ =>
     have ihφ : Λ ⊢! ∼(free φ)ᴺ 🡘 (∼(free φ))ᴺ := negDoubleNegation (free φ)
     have : Λ ⊢! (free φ)ᴺ 🡘 (∼(∼(free φ))ᴺ) := iffnegOfNegIff (by simp) ihφ
     have : Λ ⊢! ∀¹ φᴺ 🡘 ∀¹ ∼(∼φ)ᴺ :=
       allIffAllOfIff <| Entailment.cast this (by simp [Semiformula.rew_doubleNegation])
-    Entailment.ENN_of_E this
+    Entailment.ENN!_of_E! this
   | ∃¹ φ =>
     have ihφ : Λ ⊢! ∼(free φ)ᴺ 🡘 (∼(free φ))ᴺ := negDoubleNegation (free φ)
     have : Λ ⊢! ∀¹ ∼φᴺ 🡘 ∀¹ (∼φ)ᴺ :=
       allIffAllOfIff <| Entailment.cast ihφ (by simp [Semiformula.rew_doubleNegation])
-    have : Λ ⊢! ∼∼(∀¹ ∼φᴺ) 🡘 ∀¹ (∼φ)ᴺ := Entailment.E_trans (DN_of_isNegative (by simp)) this
+    have : Λ ⊢! ∼∼(∀¹ ∼φᴺ) 🡘 ∀¹ (∼φ)ᴺ := Entailment.E!_trans (DN_of_isNegative (by simp)) this
     this
   termination_by φ => φ.complexity
 
@@ -135,55 +135,55 @@ lemma imply_doubleNegation (φ ψ : Proposition L) : Λ ⊢ (φᴺ 🡒 ψᴺ) �
   suffices Λ ⊢ (φᴺ 🡒 ψᴺ) 🡘 ∼(∼(∼φ)ᴺ ⋏ ∼ψᴺ) by simpa [Semiformula.doubleNegation_imply]
   have hφ₀ : Λ ⊢ ∼(∼φ)ᴺ 🡘 φᴺ := by simpa using neg_doubleNegation (∼φ)
   have hψ : Λ ⊢ ∼∼ψᴺ 🡘 ψᴺ := ⟨DN_of_isNegative (by simp)⟩
-  apply Entailment.E!_intro
-  · apply FiniteContext.deduct'!
-    apply FiniteContext.deduct!
+  apply Entailment.E_intro
+  · apply FiniteContext.deduct'
+    apply FiniteContext.deduct
     let Γ := [∼(∼φ)ᴺ ⋏ ∼ψᴺ, φᴺ 🡒 ψᴺ]
-    have : Γ ⊢[Λ] φᴺ := of'! (K!_left hφ₀) ⨀ (K!_left by_axm₀!)
-    have : Γ ⊢[Λ] ψᴺ := by_axm₁! ⨀ this
-    exact K!_right by_axm₀! ⨀ this
-  · apply FiniteContext.deduct'!
-    apply FiniteContext.deduct!
-    refine of'! (K!_left hψ) ⨀ ?_
-    apply FiniteContext.deduct!
+    have : Γ ⊢[Λ] φᴺ := of' (K_left hφ₀) ⨀ (K_left by_axm₀)
+    have : Γ ⊢[Λ] ψᴺ := by_axm₁ ⨀ this
+    exact K_right by_axm₀ ⨀ this
+  · apply FiniteContext.deduct'
+    apply FiniteContext.deduct
+    refine of' (K_left hψ) ⨀ ?_
+    apply FiniteContext.deduct
     let Γ := [∼ψᴺ, φᴺ, ∼(∼(∼φ)ᴺ ⋏ ∼ψᴺ)]
-    have : Γ ⊢[Λ] ∼(∼φ)ᴺ := of'! (Γ := Γ) (K!_right hφ₀) ⨀ by_axm₁!
-    exact by_axm₂! ⨀ (K!_intro this by_axm₀!)
+    have : Γ ⊢[Λ] ∼(∼φ)ᴺ := of' (Γ := Γ) (K_right hφ₀) ⨀ by_axm₁
+    exact by_axm₂ ⨀ (K_intro this by_axm₀)
 
 open Entailment
 
 def gödelGentzen {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → (∼Γ)ᴺ ⊢[Λ]! ⊥
-  | identity r v => nthAxm 1 ⨀ nthAxm 0
-  | verum => nthAxm 0
+  | identity r v => nthAxm! 1 ⨀ nthAxm! 0
+  | verum => nthAxm! 0
   | and (Γ := Γ) (φ := φ) (ψ := ψ) dφ dψ =>
     have ihφ : ((∼φ)ᴺ :: (∼Γ)ᴺ) ⊢[Λ]! ⊥ := gödelGentzen dφ
     have ihψ : ((∼ψ)ᴺ :: (∼Γ)ᴺ) ⊢[Λ]! ⊥ := gödelGentzen dψ
-    have : (∼Γ)ᴺ ⊢[Λ]! ∼(∼φ)ᴺ ⋏ ∼(∼ψ)ᴺ := Entailment.K_intro (deduct ihφ) (deduct ihψ)
-    deductInv (Entailment.dni' this)
+    have : (∼Γ)ᴺ ⊢[Λ]! ∼(∼φ)ᴺ ⋏ ∼(∼ψ)ᴺ := Entailment.K!_intro (deduct! ihφ) (deduct! ihψ)
+    deductInv! (Entailment.dni'! this)
   | or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
-    have : (∼Γ)ᴺ ⊢[Λ]! (∼ψ)ᴺ 🡒 (∼φ)ᴺ 🡒 ⊥ := deduct <| deduct  <| gödelGentzen d
+    have : (∼Γ)ᴺ ⊢[Λ]! (∼ψ)ᴺ 🡒 (∼φ)ᴺ 🡒 ⊥ := deduct! <| deduct!  <| gödelGentzen d
     have : ((∼φ)ᴺ ⋏ (∼ψ)ᴺ :: (∼Γ)ᴺ) ⊢[Λ]! ⊥ :=
-      Entailment.FiniteContext.weakening (by simp) this ⨀ (Entailment.K_right (nthAxm 0)) ⨀ (Entailment.K_left (nthAxm 0))
+      Entailment.FiniteContext.weakening! (by simp) this ⨀ (Entailment.K!_right (nthAxm! 0)) ⨀ (Entailment.K!_left (nthAxm! 0))
     this
   | all (Γ := Γ) (φ := φ) d =>
     have eΓ : (∼Γ⁺)ᴺ = ((∼Γ)ᴺ)⁺ := by simp [Sequent.shift_doubleNegation]
     have : ((∼Γ)ᴺ)⁺ ⊢[Λ]! free (∼(∼φ)ᴺ) :=
-      FiniteContext.cast (deduct (gödelGentzen d)) eΓ (by simp [Semiformula.rew_doubleNegation]; rfl)
-    deductInv <| dni' <| geNOverFiniteContext this
+      FiniteContext.cast! (deduct! (gödelGentzen d)) eΓ (by simp [Semiformula.rew_doubleNegation]; rfl)
+    deductInv! <| dni'! <| geNOverFiniteContext this
   | exs (Γ := Γ) (φ := φ) (t := t) d =>
     have ih : (∼Γ)ᴺ ⊢[Λ]! ∼((∼φ)ᴺ/[t]) :=
-      Entailment.cast (deduct (gödelGentzen d)) (by simp [Semiformula.rew_doubleNegation]; rfl)
-    have : ((∀¹ (∼φ)ᴺ) :: (∼Γ)ᴺ) ⊢[Λ]! (∼φ)ᴺ/[t] := specializeOverContext (nthAxm 0) t
-    (FiniteContext.weakening (by simp) ih) ⨀ this
+      Entailment.cast (deduct! (gödelGentzen d)) (by simp [Semiformula.rew_doubleNegation]; rfl)
+    have : ((∀¹ (∼φ)ᴺ) :: (∼Γ)ᴺ) ⊢[Λ]! (∼φ)ᴺ/[t] := specializeOverContext (nthAxm! 0) t
+    (FiniteContext.weakening! (by simp) ih) ⨀ this
   | cut (Γ := Γ) (Δ := Δ) (φ := φ) dp dn =>
     have ihp : ((∼φ)ᴺ :: (∼Γ)ᴺ) ⊢[Λ]! ⊥ := gödelGentzen dp
     have ihn : (φᴺ :: (∼Δ)ᴺ) ⊢[Λ]! ⊥ := cast (by simp) (gödelGentzen dn)
     have b₁ : (∼(Γ ++ Δ))ᴺ ⊢[Λ]! ∼∼φᴺ :=
-      FiniteContext.weakening (by simp) <| Entailment.C_trans (of <| Entailment.K_left (negDoubleNegation φ)) (deduct ihp)
-    have b₂ : (∼(Γ ++ Δ))ᴺ ⊢[Λ]! ∼φᴺ := FiniteContext.weakening (by simp) <| deduct ihn
+      FiniteContext.weakening! (by simp) <| Entailment.C!_trans (of! <| Entailment.K!_left (negDoubleNegation φ)) (deduct! ihp)
+    have b₂ : (∼(Γ ++ Δ))ᴺ ⊢[Λ]! ∼φᴺ := FiniteContext.weakening! (by simp) <| deduct! ihn
     b₁ ⨀ b₂
   | contraction (Γ := Γ) (Δ := Δ) d h =>
-    FiniteContext.weakening
+    FiniteContext.weakening!
       (List.map_subset _ <| List.map_subset _ h)
       (gödelGentzen d)
 
@@ -194,6 +194,6 @@ open Classical
 theorem Provable.gödel_gentzen {φ : Proposition L} {Λ : Hilbertᵢ L} : 𝐋𝐊¹ ⊢ φ → Λ ⊢ φᴺ := by
   rintro ⟨d⟩
   have : Λ ⊢ ∼(∼φ)ᴺ := ⟨Derivation.gödelGentzen d⟩
-  exact Entailment.K!_left (Derivation.neg_doubleNegation' φ) ⨀ this
+  exact Entailment.K_left (Derivation.neg_doubleNegation' φ) ⨀ this
 
 end LO.FirstOrder

--- a/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
+++ b/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
@@ -96,9 +96,9 @@ open Rewriting LO.Entailment Entailment.FiniteContext HilbertProofᵢ
 
 def negDoubleNegation : (φ : Proposition L) → Λ ⊢! ∼φᴺ 🡘 (∼φ)ᴺ
   | .rel r v => Entailment.tneIff (φ := Semiformulaᵢ.rel r v)
-  | .nrel r v => Entailment.E_Id (φ := ∼∼(Semiformulaᵢ.rel r v))
+  | .nrel r v => Entailment.E_id (φ := ∼∼(Semiformulaᵢ.rel r v))
   | ⊤ => Entailment.ENNOO
-  | ⊥ => Entailment.E_Id (φ := ∼⊥)
+  | ⊥ => Entailment.E_id (φ := ∼⊥)
   | φ ⋏ ψ =>
     have ihφ : Λ ⊢! ∼φᴺ 🡘 (∼φ)ᴺ := negDoubleNegation φ
     have ihψ : Λ ⊢! ∼ψᴺ 🡘 (∼ψ)ᴺ := negDoubleNegation ψ

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -105,7 +105,7 @@ lemma provable_iff :
 variable [OneSidedLK.Cut 𝔇] (𝓟)
 
 instance : Entailment.ModusPonens 𝓟 where
-  mdp {φ ψ} b₁ b₂ :=
+  mdp! {φ ψ} b₁ b₂ :=
     let b₁ := equiv b₁
     let b₂ := equiv b₂
     have : 𝔇 [∼(φ 🡒 ψ), ∼φ, ψ] := cast (tensor (𝔇 := 𝔇) (identity φ) (identity (∼ψ))) (by simp [LogicalConnective.DeMorgan.imply])
@@ -114,42 +114,42 @@ instance : Entailment.ModusPonens 𝓟 where
     equiv.symm <| cast this
 
 instance : Entailment.Cl 𝓟 where
-  negEquiv {φ} := Entailment.cast
+  negEquiv! {φ} := Entailment.cast
     (show 𝓟 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
       equiv.symm <| and (or <| swap₁ <| or <| close φ) (or <| and (identity φ) top))
     (by simp [Axioms.NegEquiv, LogicalConnective.DeMorgan.imply, LogicalConnective.iff])
-  verum := equiv.symm <| verum
-  implyK {φ ψ} :=
+  verum! := equiv.symm <| verum
+  implyK! {φ ψ} :=
     have : 𝓟 ⊢! ∼φ ⋎ ∼ψ ⋎ φ := equiv.symm <| or <| swap₁ <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  implyS {φ ψ χ} :=
+  implyS! {φ ψ χ} :=
     have : 𝓟 ⊢! φ ⋏ ψ ⋏ ∼χ ⋎ φ ⋏ ∼ψ ⋎ ∼φ ⋎ χ :=
       equiv.symm <| or <| swap₁ <| or <| swap₁ <| or <| swap₃ <| and
         (close φ)
         (and (swap₃ <| and (close φ) (close ψ)) (close χ))
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₁ {φ ψ} :=
+  and₁! {φ ψ} :=
     have : 𝓟 ⊢! (∼φ ⋎ ∼ψ) ⋎ φ :=  equiv.symm <|or <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₂ {φ ψ} :=
+  and₂! {φ ψ} :=
     have : 𝓟 ⊢! (∼φ ⋎ ∼ψ) ⋎ ψ := equiv.symm <| or <| or <| close ψ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₃ {φ ψ} :=
+  and₃! {φ ψ} :=
     have : 𝓟 ⊢! ∼φ ⋎ ∼ψ ⋎ φ ⋏ ψ := equiv.symm <| or <| swap₁ <| or <| swap₁ <| and (close φ) (close ψ)
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₁ {φ ψ} :=
+  or₁! {φ ψ} :=
     have : 𝓟 ⊢! ∼φ ⋎ φ ⋎ ψ := equiv.symm <| or <| swap₁ <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₂ {φ ψ} :=
+  or₂! {φ ψ} :=
     have : 𝓟 ⊢! ∼ψ ⋎ φ ⋎ ψ := equiv.symm <| or <| swap₁ <| or <| close ψ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₃ {φ ψ χ} :=
+  or₃! {φ ψ χ} :=
     have : 𝓟 ⊢! φ ⋏ ∼χ ⋎ ψ ⋏ ∼ χ ⋎ ∼φ ⋏ ∼ψ ⋎ χ :=
       equiv.symm <| or <| swap₁ <| or <| swap₁ <| or <| and
         (swap₃ <| and (close φ) (close χ))
         (swap₂ <| and (close ψ) (close χ))
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  dne {φ} :=
+  dne! {φ} :=
     have : 𝓟 ⊢! ∼φ ⋎ φ := equiv.symm <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
 
@@ -237,7 +237,7 @@ instance [OneSidedLK 𝔇] : Entailment.Axiomatized S where
 variable [OneSidedLK.Cut 𝔇]
 
 instance (𝓢 : S) : Entailment.ModusPonens 𝓢 where
-  mdp {φ ψ} b₁ b₂ :=
+  mdp! {φ ψ} b₁ b₂ :=
     let ⟨Γ₁, b₁⟩ := equiv b₁
     let ⟨Γ₂, b₂⟩ := equiv b₂
     have : 𝔇 [∼(φ 🡒 ψ), ∼φ, ψ] := cast (tensor (𝔇 := 𝔇) (identity φ) (identity (∼ψ))) (by simp [LogicalConnective.DeMorgan.imply])
@@ -255,7 +255,7 @@ instance : Entailment.StrongCut S S where
         Entailment.cast (bl l (by simp at hl; grind) (∼ψ ⋎ χ) (OneSidedLK.or <| OneSidedLK.swap₁ d))
         (by simp [LogicalConnective.DeMorgan.imply])
       have bψ : T ⊢! ψ := bs (show ψ ∈ U by simp at hl; grind)
-      Entailment.mdp bχ bψ
+      Entailment.mdp! bχ bψ
   have ⟨l, hl⟩ := equiv b
   bl l l.prop φ hl
 
@@ -280,42 +280,42 @@ lemma inconsistent_iff {𝓢 : S} :
       exact ⟨Γ, hΓ, ⟨contraction d (by simp)⟩⟩
 
 instance cl (𝓢 : S) : Entailment.Cl 𝓢 where
-  negEquiv {φ} := Entailment.cast
+  negEquiv! {φ} := Entailment.cast
     (show 𝓢 ⊢! (φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ) from
       toProof _ <| and (or <| swap₁ <| or <| close φ) (or <| and (identity φ) top))
     (by simp [Axioms.NegEquiv, LogicalConnective.DeMorgan.imply, LogicalConnective.iff])
-  verum := toProof _ <| verum
-  implyK {φ ψ} :=
+  verum! := toProof _ <| verum
+  implyK! {φ ψ} :=
     have : 𝓢 ⊢! ∼φ ⋎ ∼ψ ⋎ φ := toProof _ <| or <| swap₁ <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  implyS {φ ψ χ} :=
+  implyS! {φ ψ χ} :=
     have : 𝓢 ⊢! φ ⋏ ψ ⋏ ∼χ ⋎ φ ⋏ ∼ψ ⋎ ∼φ ⋎ χ :=
       toProof _ <| or <| swap₁ <| or <| swap₁ <| or <| swap₃ <| and
         (close φ)
         (and (swap₃ <| and (close φ) (close ψ)) (close χ))
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₁ {φ ψ} :=
+  and₁! {φ ψ} :=
     have : 𝓢 ⊢! (∼φ ⋎ ∼ψ) ⋎ φ :=  toProof _ <|or <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₂ {φ ψ} :=
+  and₂! {φ ψ} :=
     have : 𝓢 ⊢! (∼φ ⋎ ∼ψ) ⋎ ψ := toProof _ <| or <| or <| close ψ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  and₃ {φ ψ} :=
+  and₃! {φ ψ} :=
     have : 𝓢 ⊢! ∼φ ⋎ ∼ψ ⋎ φ ⋏ ψ := toProof _ <| or <| swap₁ <| or <| swap₁ <| and (close φ) (close ψ)
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₁ {φ ψ} :=
+  or₁! {φ ψ} :=
     have : 𝓢 ⊢! ∼φ ⋎ φ ⋎ ψ := toProof _ <| or <| swap₁ <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₂ {φ ψ} :=
+  or₂! {φ ψ} :=
     have : 𝓢 ⊢! ∼ψ ⋎ φ ⋎ ψ := toProof _ <| or <| swap₁ <| or <| close ψ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  or₃ {φ ψ χ} :=
+  or₃! {φ ψ χ} :=
     have : 𝓢 ⊢! φ ⋏ ∼χ ⋎ ψ ⋏ ∼ χ ⋎ ∼φ ⋏ ∼ψ ⋎ χ :=
       toProof _ <| or <| swap₁ <| or <| swap₁ <| or <| and
         (swap₃ <| and (close φ) (close χ))
         (swap₂ <| and (close ψ) (close χ))
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
-  dne {φ} :=
+  dne! {φ} :=
     have : 𝓢 ⊢! ∼φ ⋎ φ := toProof _ <| or <| close φ
     Entailment.cast this (by simp [LogicalConnective.DeMorgan.imply])
 
@@ -355,16 +355,16 @@ lemma iff_context {𝓢 : S} {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] :
     refine provable_iff.mpr ⟨Γ, h, ⟨this⟩⟩
 
 lemma of_principal_provable {𝓟 : P} [PrincipalEntailment 𝔇 𝓟] {𝓢 : S} : 𝓟 ⊢ φ → 𝓢 ⊢ φ := fun h ↦
-  iff_context.mpr (Entailment.Context.of! h)
+  iff_context.mpr (Entailment.Context.of h)
 
 open Classical in
 noncomputable abbrev deduction (𝓟 : P) [PrincipalEntailment 𝔇 𝓟] : Entailment.Deduction S where
   ofInsert {φ ψ 𝓢 b} :=
     have : AdjunctiveSet.set (Adjoin.adjoin φ 𝓢) *⊢[𝓟] ψ := iff_context.mp ⟨b⟩
-    have : AdjunctiveSet.set 𝓢 *⊢[𝓟] φ 🡒 ψ := Context.deduct! <| by simpa using this
+    have : AdjunctiveSet.set 𝓢 *⊢[𝓟] φ 🡒 ψ := Context.deduct <| by simpa using this
     (iff_context.mpr this).get
   inv {φ ψ 𝓢 b} :=
-    have : AdjunctiveSet.set (Adjoin.adjoin φ 𝓢) *⊢[𝓟] ψ := by simpa using Context.deductInv! (iff_context.mp ⟨b⟩)
+    have : AdjunctiveSet.set (Adjoin.adjoin φ 𝓢) *⊢[𝓟] ψ := by simpa using Context.deductInv (iff_context.mp ⟨b⟩)
     (iff_context.mpr this).get
 
 end ContextualEntailment

--- a/Foundation/Logic/Disjunctive.lean
+++ b/Foundation/Logic/Disjunctive.lean
@@ -27,7 +27,7 @@ lemma iff_complete_disjunctive [DecidableEq F] {𝓢 : S} [Entailment.Cl 𝓢] :
     intro φ ψ hpq;
     rcases (hComp.con φ) with (hp | hnp);
     . left; assumption;
-    . right; exact of_C!_of_C!_of_A! (C_of_N hnp) C!_id hpq;
+    . right; exact of_C!_of_C!_of_A! (C!_of_N! hnp) C!_id hpq;
   . intro hDisj;
     refine ⟨fun φ ↦ ?_⟩
     replace hDisj : ∀ {φ ψ}, 𝓢 ⊢ φ ⋎ ψ → 𝓢 ⊢ φ ∨ 𝓢 ⊢ ψ := iff_disjunctive.mp hDisj;

--- a/Foundation/Logic/Disjunctive.lean
+++ b/Foundation/Logic/Disjunctive.lean
@@ -27,11 +27,11 @@ lemma iff_complete_disjunctive [DecidableEq F] {𝓢 : S} [Entailment.Cl 𝓢] :
     intro φ ψ hpq;
     rcases (hComp.con φ) with (hp | hnp);
     . left; assumption;
-    . right; exact of_C!_of_C!_of_A! (C!_of_N! hnp) C!_id hpq;
+    . right; exact of_C_of_C_of_A (C_of_N hnp) C_id hpq;
   . intro hDisj;
     refine ⟨fun φ ↦ ?_⟩
     replace hDisj : ∀ {φ ψ}, 𝓢 ⊢ φ ⋎ ψ → 𝓢 ⊢ φ ∨ 𝓢 ⊢ ψ := iff_disjunctive.mp hDisj;
-    exact @hDisj φ (∼φ) lem!;
+    exact @hDisj φ (∼φ) lem;
 
 end LO.Entailment
 

--- a/Foundation/Logic/LindenbaumAlgebra.lean
+++ b/Foundation/Logic/LindenbaumAlgebra.lean
@@ -43,7 +43,7 @@ variable [Entailment.Minimal 𝓢]
 lemma of_eq_of {φ ψ : F} : (⟦φ⟧ : LindenbaumAlgebra 𝓢) = ⟦ψ⟧ ↔ φ ≡ ψ := Quotient.eq (r := ProvablyEquivalent.setoid 𝓢)
 
 instance [DecidableEq F] : LE (LindenbaumAlgebra 𝓢) :=
-  ⟨Quotient.lift₂ (fun φ ψ ↦ 𝓢 ⊢ φ 🡒 ψ) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by simp only [C!_repalce hp hq]⟩
+  ⟨Quotient.lift₂ (fun φ ψ ↦ 𝓢 ⊢ φ 🡒 ψ) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by simp only [C!_iff_C!_of_E!_of_E! hp hq]⟩
 
 lemma le_def [DecidableEq F] {φ ψ : F} : (⟦φ⟧ : LindenbaumAlgebra 𝓢) ≤ ⟦ψ⟧ ↔ 𝓢 ⊢ φ 🡒 ψ := iff_of_eq rfl
 

--- a/Foundation/Logic/LindenbaumAlgebra.lean
+++ b/Foundation/Logic/LindenbaumAlgebra.lean
@@ -17,16 +17,16 @@ def ProvablyEquivalent (φ ψ : F) : Prop := 𝓢 ⊢ φ 🡘 ψ
 
 local infix:45 " ≡ " => ProvablyEquivalent 𝓢
 
-protected lemma ProvablyEquivalent.refl [Entailment.Minimal 𝓢] (φ : F) : φ ≡ φ := E!_id
+protected lemma ProvablyEquivalent.refl [Entailment.Minimal 𝓢] (φ : F) : φ ≡ φ := E_id
 
 variable {𝓢}
 
-protected lemma ProvablyEquivalent.symm [Entailment.Minimal 𝓢] {φ ψ : F} : φ ≡ ψ → ψ ≡ φ := E!_symm
+protected lemma ProvablyEquivalent.symm [Entailment.Minimal 𝓢] {φ ψ : F} : φ ≡ ψ → ψ ≡ φ := E_symm
 
-protected lemma ProvablyEquivalent.trans [Entailment.Minimal 𝓢] {φ ψ χ : F} : φ ≡ ψ → ψ ≡ χ → φ ≡ χ := E!_trans
+protected lemma ProvablyEquivalent.trans [Entailment.Minimal 𝓢] {φ ψ χ : F} : φ ≡ ψ → ψ ≡ χ → φ ≡ χ := E_trans
 
 lemma provable_iff_provablyEquivalent_verum [Entailment.Minimal 𝓢] {φ : F} : 𝓢 ⊢ φ ↔ φ ≡ ⊤ :=
-  ⟨fun h ↦ E!_intro CV! (C!_of_conseq! h), fun h ↦ (K!_right h) ⨀ verum!⟩
+  ⟨fun h ↦ E_intro CV (C_of_conseq h), fun h ↦ (K_right h) ⨀ verum⟩
 
 variable (𝓢)
 
@@ -43,7 +43,7 @@ variable [Entailment.Minimal 𝓢]
 lemma of_eq_of {φ ψ : F} : (⟦φ⟧ : LindenbaumAlgebra 𝓢) = ⟦ψ⟧ ↔ φ ≡ ψ := Quotient.eq (r := ProvablyEquivalent.setoid 𝓢)
 
 instance [DecidableEq F] : LE (LindenbaumAlgebra 𝓢) :=
-  ⟨Quotient.lift₂ (fun φ ψ ↦ 𝓢 ⊢ φ 🡒 ψ) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by simp only [C!_iff_C!_of_E!_of_E! hp hq]⟩
+  ⟨Quotient.lift₂ (fun φ ψ ↦ 𝓢 ⊢ φ 🡒 ψ) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by simp only [C_iff_C_of_E_of_E hp hq]⟩
 
 lemma le_def [DecidableEq F] {φ ψ : F} : (⟦φ⟧ : LindenbaumAlgebra 𝓢) ≤ ⟦ψ⟧ ↔ 𝓢 ⊢ φ 🡒 ψ := iff_of_eq rfl
 
@@ -52,16 +52,16 @@ instance : Top (LindenbaumAlgebra 𝓢) := ⟨⟦⊤⟧⟩
 instance : Bot (LindenbaumAlgebra 𝓢) := ⟨⟦⊥⟧⟩
 
 instance [DecidableEq F] : Min (LindenbaumAlgebra 𝓢) := ⟨Quotient.lift₂ (fun φ ψ ↦ ⟦φ ⋏ ψ⟧) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by
-  simp only [Quotient.eq]; exact EKK!_of_E!_of_E! hp hq⟩
+  simp only [Quotient.eq]; exact EKK_of_E_of_E hp hq⟩
 
 instance [DecidableEq F] : Max (LindenbaumAlgebra 𝓢) := ⟨Quotient.lift₂ (fun φ ψ ↦ ⟦φ ⋎ ψ⟧) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by
-  simp only [Quotient.eq]; exact EAA!_of_E!_of_E! hp hq⟩
+  simp only [Quotient.eq]; exact EAA_of_E_of_E hp hq⟩
 
 instance [DecidableEq F] : HImp (LindenbaumAlgebra 𝓢) := ⟨Quotient.lift₂ (fun φ ψ ↦ ⟦φ 🡒 ψ⟧) fun φ₁ ψ₁ φ₂ ψ₂ hp hq ↦ by
-  simp only [Quotient.eq]; exact ECC!_of_E!_of_E! hp hq⟩
+  simp only [Quotient.eq]; exact ECC_of_E_of_E hp hq⟩
 
 instance [DecidableEq F] : Compl (LindenbaumAlgebra 𝓢) := ⟨Quotient.lift (fun φ ↦ ⟦∼φ⟧) fun φ₁ φ₂ hp ↦ by
-  simp only [Quotient.eq]; exact ENN!_of_E! hp⟩
+  simp only [Quotient.eq]; exact ENN_of_E hp⟩
 
 lemma top_def : (⊤ : LindenbaumAlgebra 𝓢) = ⟦⊤⟧ := rfl
 
@@ -86,54 +86,54 @@ instance [DecidableEq F] : GeneralizedHeytingAlgebra (LindenbaumAlgebra 𝓢) wh
     induction' ψ using Quotient.ind with ψ
     induction' χ using Quotient.ind with χ
     simp only [le_def]
-    exact C!_trans
+    exact C_trans
   le_antisymm φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     simp only [le_def, of_eq_of]
-    intro hp hq; exact E!_intro hp hq
+    intro hp hq; exact E_intro hp hq
   inf_le_left φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     simp only [inf_def, le_def]
-    exact and₁!
+    exact and₁
   inf_le_right φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     simp only [inf_def, le_def]
-    exact and₂!
+    exact and₂
   le_inf φ ψ χ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     induction' χ using Quotient.ind with χ
     simp only [inf_def, le_def]
-    exact right_K!_intro
+    exact right_K_intro
   le_sup_left φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     simp only [sup_def, le_def]
-    exact or₁!
+    exact or₁
   le_sup_right φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     simp only [sup_def, le_def]
-    exact or₂!
+    exact or₂
   sup_le φ ψ χ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     induction' χ using Quotient.ind with χ
     simp only [sup_def, le_def]
-    exact left_A!_intro
+    exact left_A_intro
   le_top φ := by
     induction' φ using Quotient.ind with φ
     simp only [top_def, le_def]
-    exact CV!
+    exact CV
   le_himp_iff φ ψ χ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     induction' χ using Quotient.ind with χ
     simp only [himp_def, le_def, inf_def]
-    exact Iff.symm CK!_iff_CC!
+    exact Iff.symm CK_iff_CC
 
 variable {𝓢}
 
@@ -172,11 +172,11 @@ instance LindenbaumAlgebra.heyting [DecidableEq F] : HeytingAlgebra (LindenbaumA
   bot_le φ := by
     induction' φ using Quotient.ind with φ
     simp only [bot_def, le_def]
-    exact efq!
+    exact efq
   himp_bot φ := by
     induction' φ using Quotient.ind with φ
     simp only [bot_def, himp_def, compl_def, Quotient.eq]
-    exact CEE! ⨀ neg_equiv!
+    exact CEE ⨀ neg_equiv
 
 end intuitionistic
 
@@ -189,25 +189,25 @@ variable [Entailment.Cl 𝓢]
 instance LindenbaumAlgebra.boolean [DecidableEq F] : BooleanAlgebra (LindenbaumAlgebra 𝓢) where
   inf_compl_le_bot φ := by
     induction' φ using Quotient.ind with φ
-    simp only [compl_def, inf_def, bot_def, le_def, CKNO!]
+    simp only [compl_def, inf_def, bot_def, le_def, CKNO]
   top_le_sup_compl φ := by
     induction' φ using Quotient.ind with φ
     simp only [top_def, compl_def, sup_def, le_def]
-    apply C!_of_conseq! lem!
+    apply C_of_conseq lem
   le_top φ := by
     induction' φ using Quotient.ind with φ
     simp only [top_def, le_def]
-    exact CV!
+    exact CV
   bot_le φ := by
     induction' φ using Quotient.ind with φ
     simp only [bot_def, le_def]
-    exact efq!
+    exact efq
   himp_eq φ ψ := by
     induction' φ using Quotient.ind with φ
     induction' ψ using Quotient.ind with ψ
     rw [sup_comm]
     simp only [himp_def, compl_def, sup_def, Quotient.eq]
-    exact ECAN!
+    exact ECAN
 
 end classical
 

--- a/Foundation/Meta/TwoSided.lean
+++ b/Foundation/Meta/TwoSided.lean
@@ -23,7 +23,7 @@ namespace TwoSided
 variable {Γ Γ₁ Γ₂ Δ Δ₁ Δ₂ : List F} {φ ψ χ : F}
 
 lemma weakening (h : Γ₁ ⟹ Δ₁) (HΓ : Γ₁ ⊆ Γ₂ := by simp) (HΔ : Δ₁ ⊆ Δ₂ := by simp) : Γ₂ ⟹ Δ₂ :=
-  FiniteContext.weakening! HΓ <| left_Disj!_intro Δ₁ (fun _ hψ ↦ right_Disj!_intro _ (HΔ hψ)) ⨀ h
+  FiniteContext.weakening HΓ <| left_Disj_intro Δ₁ (fun _ hψ ↦ right_Disj_intro _ (HΔ hψ)) ⨀ h
 
 lemma remove_left (hφ : Γ ⟹ Δ) : φ :: Γ ⟹ Δ := weakening hφ
 
@@ -43,18 +43,18 @@ lemma rotate_left_inv (hφ : (φ :: Γ) ⟹ Δ) : (Γ ++ [φ]) ⟹ Δ := weakeni
 -- elaboration, so the false-positive warning is suppressed here.
 set_option linter.unusedSectionVars false in
 lemma to_provable {φ} (h : [] ⟹ [φ]) : 𝓢 ⊢ φ :=
-  FiniteContext.provable_iff_provable.mpr <| left_Disj!_intro [φ] (by simp) ⨀ h
+  FiniteContext.provable_iff_provable.mpr <| left_Disj_intro [φ] (by simp) ⨀ h
 
 lemma add_hyp {𝒯 : S} [𝒯 ⪯ 𝓢] (hφ : 𝒯 ⊢ φ) (h : (φ :: Γ) ⟹ Δ) : Γ ⟹ Δ :=
-  deduct! h ⨀ of'! (WeakerThan.pbl hφ)
+  deduct h ⨀ of' (WeakerThan.pbl hφ)
 
-lemma right_closed (h : φ ∈ Γ) : Γ ⟹ φ :: Δ := right_Disj!_intro _ (φ := φ) (by simp) ⨀ (by_axm! h)
+lemma right_closed (h : φ ∈ Γ) : Γ ⟹ φ :: Δ := right_Disj_intro _ (φ := φ) (by simp) ⨀ (FiniteContext.by_axm h)
 
-lemma left_closed (h : φ ∈ Δ) : (φ :: Γ) ⟹ Δ := right_Disj!_intro _ (φ := φ) h ⨀ (by_axm!)
-lemma verum_right : Γ ⟹ ⊤ :: Δ := right_Disj!_intro _ (φ := ⊤) (by simp) ⨀ (by simp)
+lemma left_closed (h : φ ∈ Δ) : (φ :: Γ) ⟹ Δ := right_Disj_intro _ (φ := φ) h ⨀ FiniteContext.by_axm
+lemma verum_right : Γ ⟹ ⊤ :: Δ := right_Disj_intro _ (φ := ⊤) (by simp) ⨀ (by simp)
 
 omit [DecidableEq F] in
-lemma falsum_left : (⊥ :: Γ) ⟹ Δ := efq! ⨀ by_axm₀!
+lemma falsum_left : (⊥ :: Γ) ⟹ Δ := efq ⨀ by_axm₀
 
 lemma falsum_right (h : Γ ⟹ Δ) : Γ ⟹ ⊥ :: Δ := weakening h
 
@@ -62,65 +62,65 @@ lemma verum_left (h : Γ ⟹ Δ) : (⊤ :: Γ) ⟹ Δ := weakening h
 
 lemma and_right (hφ : Γ ⟹ Δ ++ [φ]) (hψ : Γ ⟹ Δ ++ [ψ]) : Γ ⟹ φ ⋏ ψ :: Δ := by
   have : Γ ⊢[𝓢] (φ :: Δ).disj 🡒 (ψ :: Δ).disj 🡒 (φ ⋏ ψ :: Δ).disj := by
-    apply left_Disj!_intro
+    apply left_Disj_intro
     rintro χ hχ
     rcases show χ = φ ∨ χ ∈ Δ by simpa using hχ with (rfl | hχ)
-    · apply deduct!
-      apply left_Disj!_intro
+    · apply deduct
+      apply left_Disj_intro
       intro ξ hξ
       rcases show ξ = ψ ∨ ξ ∈ Δ by simpa using hξ with (rfl | hξ)
-      · exact deduct! <| right_Disj!_intro (χ ⋏ ξ :: Δ) (φ := χ ⋏ ξ) List.mem_cons_self ⨀ (K!_intro by_axm₁! by_axm₀!)
-      · exact right_Disj!_intro _ (by simp [hξ])
-    · exact deduct! <|  dhyp! <| right_Disj!_intro _ (φ := χ) (by simp [hχ]) ⨀ by_axm₀!
+      · exact deduct <| right_Disj_intro (χ ⋏ ξ :: Δ) (φ := χ ⋏ ξ) List.mem_cons_self ⨀ (K_intro by_axm₁ by_axm₀)
+      · exact right_Disj_intro _ (by simp [hξ])
+    · exact deduct <|  dhyp <| right_Disj_intro _ (φ := χ) (by simp [hχ]) ⨀ by_axm₀
   exact this ⨀ weakening hφ ⨀ weakening hψ
 
 lemma or_left (hφ : Γ ++ [φ] ⟹ Δ) (hψ : Γ ++ [ψ] ⟹ Δ) : φ ⋎ ψ :: Γ ⟹ Δ := by
-  apply deductInv!
-  apply left_A!_intro
-  · apply deduct! <| weakening hφ
-  · apply deduct! <| weakening hψ
+  apply deductInv
+  apply left_A_intro
+  · apply deduct <| weakening hφ
+  · apply deduct <| weakening hψ
 
 lemma or_right (h : Γ ⟹ Δ ++ [φ, ψ]) : Γ ⟹ φ ⋎ ψ :: Δ := by
   have : Γ ⊢[𝓢] (φ :: ψ :: Δ).disj 🡒 (φ ⋎ ψ :: Δ).disj := by
-    apply left_Disj!_intro
+    apply left_Disj_intro
     intro χ hχ
     rcases show χ = φ ∨ χ = ψ ∨ χ ∈ Δ by simpa using hχ with (rfl | rfl | hχ)
-    · apply right_Disj!_intro' (χ ⋎ ψ :: Δ) (φ := χ ⋎ ψ) (by simp) or₁!
-    · apply right_Disj!_intro' (φ ⋎ χ :: Δ) (φ := φ ⋎ χ) (by simp) or₂!
-    · apply right_Disj!_intro _ (by simp [hχ])
+    · apply right_Disj_intro' (χ ⋎ ψ :: Δ) (φ := χ ⋎ ψ) (by simp) or₁
+    · apply right_Disj_intro' (φ ⋎ χ :: Δ) (φ := φ ⋎ χ) (by simp) or₂
+    · apply right_Disj_intro _ (by simp [hχ])
   exact this ⨀ weakening h
 
 lemma and_left (h : Γ ++ [φ, ψ] ⟹ Δ) : (φ ⋏ ψ :: Γ) ⟹ Δ := by
   have : φ :: ψ :: Γ ⟹ Δ := weakening h
-  have : (φ ⋏ ψ :: Γ) ⊢[𝓢] ψ 🡒 φ 🡒 Δ.disj := wk! (by simp) (deduct! <| deduct! this)
-  exact this ⨀ (deductInv! and₂!) ⨀ (deductInv! and₁!)
+  have : (φ ⋏ ψ :: Γ) ⊢[𝓢] ψ 🡒 φ 🡒 Δ.disj := wk! (by simp) (deduct <| deduct this)
+  exact this ⨀ (deductInv and₂) ⨀ (deductInv and₁)
 
 lemma neg_right_int (h : Γ ++ [φ] ⟹ []) : Γ ⟹ ∼φ :: Δ := by
   have : φ :: Γ ⟹ [] := weakening h
-  have : Γ ⊢[𝓢] ∼φ := N!_iff_CO!.mpr <| deduct! this
-  have : Γ ⟹ [∼φ] := (right_Disj!_intro _ (by simp)) ⨀ this
+  have : Γ ⊢[𝓢] ∼φ := N_iff_CO.mpr <| deduct this
+  have : Γ ⟹ [∼φ] := (right_Disj_intro _ (by simp)) ⨀ this
   exact weakening this
 
 omit [Entailment.Int 𝓢] in
 lemma neg_right_cl [Entailment.Cl 𝓢] (h : Γ ++ [φ] ⟹ Δ) : Γ ⟹ ∼φ :: Δ := by
   have hφ : Γ ⊢[𝓢] φ 🡒 (∼φ :: Δ).disj := by
-    apply deduct!
+    apply deduct
     suffices (φ :: Γ) ⊢[𝓢] Δ.disj 🡒 (∼φ :: Δ).disj from this ⨀ weakening h
-    apply left_Disj!_intro
+    apply left_Disj_intro
     intro ψ hψ
-    apply right_Disj!_intro _ (by simp [hψ])
-  have hnφ : Γ ⊢[𝓢] ∼φ 🡒 (∼φ :: Δ).disj := right_Disj!_intro _ (by simp)
-  exact left_A!_intro hφ hnφ ⨀ lem!
+    apply right_Disj_intro _ (by simp [hψ])
+  have hnφ : Γ ⊢[𝓢] ∼φ 🡒 (∼φ :: Δ).disj := right_Disj_intro _ (by simp)
+  exact left_A_intro hφ hnφ ⨀ lem
 
 lemma neg_left_int (h : Γ ++ [∼φ] ⟹ Δ ++ [φ]) : ∼φ :: Γ ⟹ Δ := by
   have h : ∼φ :: Γ ⟹ φ :: Δ := weakening h
   suffices (∼φ :: Γ) ⊢[𝓢] (φ :: Δ).disj 🡒 Δ.disj from this ⨀ (wk! (by simp) h)
-  apply left_Disj!_intro
+  apply left_Disj_intro
   intro ψ hψ
   rcases show ψ = φ ∨ ψ ∈ Δ by simpa using hψ with (rfl | hψ)
-  · apply deductInv!
-    exact CNC!
-  · apply right_Disj!_intro _ (by simp [hψ])
+  · apply deductInv
+    exact CNC
+  · apply right_Disj_intro _ (by simp [hψ])
 
 lemma neg_left (h : Γ ⟹ Δ ++ [φ]) : ∼φ :: Γ ⟹ Δ :=
   neg_left_int (weakening h)
@@ -129,39 +129,39 @@ lemma imply_left_int (hφ : Γ ++ [φ 🡒 ψ] ⟹ Δ ++ [φ]) (hψ : Γ ++ [ψ]
   have hφ : (φ 🡒 ψ) :: Γ ⟹ φ :: Δ := weakening hφ
   have hψ : ψ :: Γ ⟹ Δ := weakening hψ
   suffices ((φ 🡒 ψ) :: Γ) ⊢[𝓢] (φ :: Δ).disj 🡒 Δ.disj from this ⨀ wk! (by simp) hφ
-  apply left_Disj!_intro
+  apply left_Disj_intro
   intro χ hχ
   rcases show χ = φ ∨ χ ∈ Δ by simpa using hχ with (rfl | hχ)
-  · apply deduct!
-    have : Γ ⊢[𝓢] ψ 🡒 Δ.disj := deduct! hψ
-    apply (wk! (by simp) this) ⨀ (by_axm₁! ⨀ by_axm₀!)
-  · apply right_Disj!_intro _ (by simp [hχ])
+  · apply deduct
+    have : Γ ⊢[𝓢] ψ 🡒 Δ.disj := deduct hψ
+    apply (wk! (by simp) this) ⨀ (by_axm₁ ⨀ by_axm₀)
+  · apply right_Disj_intro _ (by simp [hχ])
 
 lemma imply_left (hφ : Γ ⟹ Δ ++ [φ]) (hψ : Γ ++ [ψ] ⟹ Δ) : (φ 🡒 ψ) :: Γ ⟹ Δ :=
   imply_left_int (weakening hφ) (weakening hψ)
 
 lemma imply_right_int (h : Γ ++ [φ] ⟹ [ψ]) : Γ ⟹ (φ 🡒 ψ) :: Δ := by
   have h : φ :: Γ ⟹ [ψ] := weakening h
-  have : (φ :: Γ) ⊢[𝓢] ψ := (left_Disj!_intro _ <| by simp) ⨀ h
-  exact (right_Disj!_intro _ <| by simp) ⨀ deduct! this
+  have : (φ :: Γ) ⊢[𝓢] ψ := (left_Disj_intro _ <| by simp) ⨀ h
+  exact (right_Disj_intro _ <| by simp) ⨀ deduct this
 
 omit [Entailment.Int 𝓢] in
 lemma imply_right_cl [Entailment.Cl 𝓢] (h : Γ ++ [φ] ⟹ Δ ++ [ψ]) : Γ ⟹ (φ 🡒 ψ) :: Δ := by
   have h : φ :: Γ ⟹ ψ :: Δ := weakening h
   have hnφ : Γ ⊢[𝓢] ∼φ 🡒 ((φ 🡒 ψ) :: Δ).disj := by
-    apply right_Disj!_intro' ((φ 🡒 ψ) :: Δ) (φ := φ 🡒 ψ) (by simp)
-    exact CNC!
+    apply right_Disj_intro' ((φ 🡒 ψ) :: Δ) (φ := φ 🡒 ψ) (by simp)
+    exact CNC
   have hφ : Γ ⊢[𝓢] φ 🡒 ((φ 🡒 ψ) :: Δ).disj := by
-    apply deduct!
+    apply deduct
     suffices (φ :: Γ) ⊢[𝓢] (ψ :: Δ).disj 🡒 ((φ 🡒 ψ) :: Δ).disj from this ⨀ h
-    apply left_Disj!_intro
+    apply left_Disj_intro
     intro χ hχ
     rcases show χ = ψ ∨ χ ∈ Δ by simpa using hχ with (rfl | hχ)
-    · apply right_Disj!_intro' _ (φ := φ 🡒 χ) (by simp)
-      exact implyK!
-    · apply right_Disj!_intro
+    · apply right_Disj_intro' _ (φ := φ 🡒 χ) (by simp)
+      exact implyK
+    · apply right_Disj_intro
       simp [hχ]
-  exact left_A!_intro hφ hnφ ⨀ lem!
+  exact left_A_intro hφ hnφ ⨀ lem
 
 omit [Entailment.Int 𝓢] in
 lemma iff_right_cl [Entailment.Cl 𝓢] (hr : Γ ++ [φ] ⟹ Δ ++ [ψ]) (hl : Γ ++ [ψ] ⟹ Δ ++ [φ]) : Γ ⟹ (φ 🡘 ψ) :: Δ := by
@@ -180,13 +180,13 @@ lemma iff_left (hr : Γ ⟹ Δ ++ [φ, ψ]) (hl : Γ ++ [φ, ψ] ⟹ Δ) : (φ �
   · apply imply_left
     · exact weakening hr
     · suffices (φ :: Γ) ⟹ φ :: Δ from weakening this
-      apply deductInv!
-      apply right_Disj!_intro _ (by simp)
+      apply deductInv
+      apply right_Disj_intro _ (by simp)
   · suffices (ψ 🡒 φ) :: ψ :: Γ ⟹ Δ from weakening this
     apply imply_left
     · suffices (ψ :: Γ) ⟹ ψ :: Δ from weakening this
-      apply deductInv!
-      apply right_Disj!_intro _ (by simp)
+      apply deductInv
+      apply right_Disj_intro _ (by simp)
     · exact weakening hl
 
 end TwoSided

--- a/Foundation/Propositional/Boolean/Tait.lean
+++ b/Foundation/Propositional/Boolean/Tait.lean
@@ -125,7 +125,7 @@ lemma maximalConsistentTheory_consistent' {φ} :
   intro h hn
   have : Inconsistent (maximalConsistentTheory consisT) :=
     Entailment.inconsistent_iff_provable_bot.mpr
-      (neg_mdp (mem_maximalConsistentTheory_iff.mp hn) (mem_maximalConsistentTheory_iff.mp h))
+      (neg_mdp! (mem_maximalConsistentTheory_iff.mp hn) (mem_maximalConsistentTheory_iff.mp h))
   have := this.not_con
   simp_all
 
@@ -134,7 +134,7 @@ lemma not_mem_maximalConsistentTheory_iff :
   by_cases hp : φ ∈ maximalConsistentTheory consisT <;> simp [hp]
   · intro bnp
     have : Inconsistent (maximalConsistentTheory consisT) :=
-      Entailment.inconsistent_of_provable (neg_mdp bnp (mem_maximalConsistentTheory_iff.mp hp))
+      Entailment.inconsistent_of_provable (neg_mdp! bnp (mem_maximalConsistentTheory_iff.mp hp))
     have := this.not_con
     simp_all
   · exact mem_maximalConsistentTheory_iff.mp

--- a/Foundation/Propositional/Entailment/Cl.lean
+++ b/Foundation/Propositional/Entailment/Cl.lean
@@ -25,13 +25,13 @@ variable {S F : Type*} [LogicalConnective F] [Entailment S F]
 variable {𝓢 : S} {φ ψ χ : F}
 
 class HasAxiomDNE (𝓢 : S)  where
-  dne {φ : F} : 𝓢 ⊢! Axioms.DNE φ
-export HasAxiomDNE (dne)
+  dne! {φ : F} : 𝓢 ⊢! Axioms.DNE φ
+export HasAxiomDNE (dne!)
 
-@[simp] lemma dne! [HasAxiomDNE 𝓢] : 𝓢 ⊢ ∼∼φ 🡒 φ  := ⟨dne⟩
+@[simp] lemma dne [HasAxiomDNE 𝓢] : 𝓢 ⊢ ∼∼φ 🡒 φ  := ⟨dne!⟩
 
-def of_NN [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢! ∼∼φ) : 𝓢 ⊢! φ := dne ⨀ b
-@[grind ⇒] lemma of_NN! [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢ ∼∼φ) : 𝓢 ⊢ φ := ⟨of_NN h.some⟩
+def of_NN! [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (b : 𝓢 ⊢! ∼∼φ) : 𝓢 ⊢! φ := dne! ⨀ b
+@[grind ⇒] lemma of_NN [ModusPonens 𝓢] [HasAxiomDNE 𝓢] (h : 𝓢 ⊢ ∼∼φ) : 𝓢 ⊢ φ := ⟨of_NN! h.some⟩
 
 section
 
@@ -39,14 +39,14 @@ variable [LogicalNeutral F] [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 
-instance [Entailment.HasAxiomDNE 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomDNE Γ := ⟨of dne⟩
+instance [Entailment.HasAxiomDNE 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomDNE Γ := ⟨of! dne!⟩
 
 end FiniteContext
 
 
 namespace Context
 
-instance [Entailment.HasAxiomDNE 𝓢] (Γ : Context F 𝓢) : HasAxiomDNE Γ := ⟨of dne⟩
+instance [Entailment.HasAxiomDNE 𝓢] (Γ : Context F 𝓢) : HasAxiomDNE Γ := ⟨of! dne!⟩
 
 end Context
 
@@ -54,10 +54,10 @@ end
 
 
 class HasAxiomLEM (𝓢 : S)  where
-  lem {φ : F} : 𝓢 ⊢! Axioms.LEM φ
-export HasAxiomLEM (lem)
+  lem! {φ : F} : 𝓢 ⊢! Axioms.LEM φ
+export HasAxiomLEM (lem!)
 
-@[simp] lemma lem! [HasAxiomLEM 𝓢] : 𝓢 ⊢ φ ⋎ ∼φ := ⟨lem⟩
+@[simp] lemma lem [HasAxiomLEM 𝓢] : 𝓢 ⊢ φ ⋎ ∼φ := ⟨lem!⟩
 
 
 section
@@ -66,14 +66,14 @@ variable [LogicalNeutral F] [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 
-instance [Entailment.HasAxiomLEM 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomLEM Γ := ⟨of lem⟩
+instance [Entailment.HasAxiomLEM 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomLEM Γ := ⟨of! lem!⟩
 
 end FiniteContext
 
 
 namespace Context
 
-instance [Entailment.HasAxiomLEM 𝓢] (Γ : Context F 𝓢) : HasAxiomLEM Γ := ⟨of lem⟩
+instance [Entailment.HasAxiomLEM 𝓢] (Γ : Context F 𝓢) : HasAxiomLEM Γ := ⟨of! lem!⟩
 
 end Context
 
@@ -81,10 +81,10 @@ end
 
 
 class HasAxiomPeirce (𝓢 : S)  where
-  peirce {φ ψ : F} : 𝓢 ⊢! Axioms.Peirce φ ψ
-export HasAxiomPeirce (peirce)
+  peirce! {φ ψ : F} : 𝓢 ⊢! Axioms.Peirce φ ψ
+export HasAxiomPeirce (peirce!)
 
-@[simp] lemma peirce! [LogicalNeutral F] [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((φ 🡒 ψ) 🡒 φ) 🡒 φ := ⟨peirce⟩
+@[simp] lemma peirce [LogicalNeutral F] [HasAxiomPeirce 𝓢] : 𝓢 ⊢ ((φ 🡒 ψ) 🡒 φ) 🡒 φ := ⟨peirce!⟩
 
 
 section
@@ -93,14 +93,14 @@ variable [LogicalNeutral F] [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 
-instance [Entailment.HasAxiomPeirce 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomPeirce Γ := ⟨of peirce⟩
+instance [Entailment.HasAxiomPeirce 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomPeirce Γ := ⟨of! peirce!⟩
 
 end FiniteContext
 
 
 namespace Context
 
-instance [Entailment.HasAxiomPeirce 𝓢] (Γ : Context F 𝓢) : HasAxiomPeirce Γ := ⟨of peirce⟩
+instance [Entailment.HasAxiomPeirce 𝓢] (Γ : Context F 𝓢) : HasAxiomPeirce Γ := ⟨of! peirce!⟩
 
 end Context
 
@@ -108,10 +108,10 @@ end
 
 
 class HasAxiomElimContra (𝓢 : S)  where
-  elimContra {φ ψ : F} : 𝓢 ⊢! Axioms.ElimContra φ ψ
-export HasAxiomElimContra (elimContra)
+  elimContra! {φ ψ : F} : 𝓢 ⊢! Axioms.ElimContra φ ψ
+export HasAxiomElimContra (elimContra!)
 
-@[simp] lemma elim_contra! [HasAxiomElimContra 𝓢] : 𝓢 ⊢ (∼ψ 🡒 ∼φ) 🡒 (φ 🡒 ψ)  := ⟨elimContra⟩
+@[simp] lemma elim_contra [HasAxiomElimContra 𝓢] : 𝓢 ⊢ (∼ψ 🡒 ∼φ) 🡒 (φ 🡒 ψ)  := ⟨elimContra!⟩
 
 
 variable {F : Type*} [LogicalConnective F] [LogicalNeutral F] [DecidableEq F]
@@ -137,119 +137,120 @@ open NegationEquiv
 open FiniteContext
 open List
 
-def dn : 𝓢 ⊢! φ 🡘 ∼∼φ := E_intro dni dne
-@[simp] lemma dn! : 𝓢 ⊢ φ 🡘 ∼∼φ := ⟨dn⟩
+def dn! : 𝓢 ⊢! φ 🡘 ∼∼φ := E!_intro dni! dne!
+@[simp] lemma dn : 𝓢 ⊢ φ 🡘 ∼∼φ := ⟨dn!⟩
 
-def A_of_ANNNN (d : 𝓢 ⊢! ∼∼φ ⋎ ∼∼ψ) : 𝓢 ⊢! φ ⋎ ψ := of_C_of_C_of_A (C_trans dne or₁) (C_trans dne or₂) d
-omit [DecidableEq F] in lemma A!_of_ANNNN! (d : 𝓢 ⊢ ∼∼φ ⋎ ∼∼ψ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A_of_ANNNN d.some⟩
+def A!_of_ANNNN! (d : 𝓢 ⊢! ∼∼φ ⋎ ∼∼ψ) : 𝓢 ⊢! φ ⋎ ψ := of_C!_of_C!_of_A! (C!_trans dne! or₁!) (C!_trans dne! or₂!) d
+omit [DecidableEq F] in lemma A_of_ANNNN (d : 𝓢 ⊢ ∼∼φ ⋎ ∼∼ψ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A!_of_ANNNN! d.some⟩
 
-def CN_of_CN_left (b : 𝓢 ⊢! ∼φ 🡒 ψ) : 𝓢 ⊢! ∼ψ 🡒 φ := C_trans (contra b) dne
-lemma CN!_of_CN!_left (b : 𝓢 ⊢ ∼φ 🡒 ψ) : 𝓢 ⊢ ∼ψ 🡒 φ := ⟨CN_of_CN_left b.some⟩
+def CN!_of_CN!_left (b : 𝓢 ⊢! ∼φ 🡒 ψ) : 𝓢 ⊢! ∼ψ 🡒 φ := C!_trans (contra! b) dne!
+lemma CN_of_CN_left (b : 𝓢 ⊢ ∼φ 🡒 ψ) : 𝓢 ⊢ ∼ψ 🡒 φ := ⟨CN!_of_CN!_left b.some⟩
 
-def CCNCN' : 𝓢 ⊢! (∼φ 🡒 ψ) 🡒 (∼ψ 🡒 φ) := deduct' $ CN_of_CN_left FiniteContext.id
-@[simp] lemma CCNCN'! : 𝓢 ⊢ (∼φ 🡒 ψ) 🡒 (∼ψ 🡒 φ) := ⟨CCNCN'⟩
-
-
-def C_of_CNN (b : 𝓢 ⊢! ∼φ 🡒 ∼ψ) : 𝓢 ⊢! ψ 🡒 φ := C_trans dni (CN_of_CN_left b)
-lemma C!_of_CNN! (b : 𝓢 ⊢ ∼φ 🡒 ∼ψ) : 𝓢 ⊢ ψ 🡒 φ := ⟨C_of_CNN b.some⟩
+def CCNCN'! : 𝓢 ⊢! (∼φ 🡒 ψ) 🡒 (∼ψ 🡒 φ) := deduct'! $ CN!_of_CN!_left FiniteContext.id!
+@[simp] lemma CCNCN' : 𝓢 ⊢ (∼φ 🡒 ψ) 🡒 (∼ψ 🡒 φ) := ⟨CCNCN'!⟩
 
 
-def CCNNC : 𝓢 ⊢! (∼φ 🡒 ∼ψ) 🡒 (ψ 🡒 φ) :=  deduct' $ C_of_CNN FiniteContext.id
-@[simp] lemma CCNNC! : 𝓢 ⊢ (∼φ 🡒 ∼ψ) 🡒 (ψ 🡒 φ) := ⟨CCNNC⟩
-
-def EN_of_EN_right (h : 𝓢 ⊢! φ 🡘 ∼ψ) : 𝓢 ⊢! ∼φ 🡘 ψ := by
-  apply E_intro;
-  . apply CN_of_CN_left $  K_right h;
-  . apply CN_of_CN_right $  K_left h;
-lemma EN!_of_EN!_right (h : 𝓢 ⊢ φ 🡘 ∼ψ) : 𝓢 ⊢ ∼φ 🡘 ψ := ⟨EN_of_EN_right h.some⟩
-
-def EN_of_EN_left (h : 𝓢 ⊢! ∼φ 🡘 ψ) : 𝓢 ⊢! φ 🡘 ∼ψ := E_symm $ EN_of_EN_right $ E_symm h
-lemma EN!_of_EN!_left (h : 𝓢 ⊢ ∼φ 🡘 ψ) : 𝓢 ⊢ φ 🡘 ∼ψ := ⟨EN_of_EN_left h.some⟩
-
-def ECCOO : 𝓢 ⊢! φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := E_trans dn ENNCCOO
-lemma ECCOO! : 𝓢 ⊢ φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := ⟨ECCOO⟩
+def C!_of_CNN! (b : 𝓢 ⊢! ∼φ 🡒 ∼ψ) : 𝓢 ⊢! ψ 🡒 φ := C!_trans dni! (CN!_of_CN!_left b)
+lemma C_of_CNN (b : 𝓢 ⊢ ∼φ 🡒 ∼ψ) : 𝓢 ⊢ ψ 🡒 φ := ⟨C!_of_CNN! b.some⟩
 
 
-def CNKANN : 𝓢 ⊢! ∼(φ ⋏ ψ) 🡒 (∼φ ⋎ ∼ψ) := by
-  apply CN_of_CN_left;
-  apply deduct';
-  exact K_replace (KNN_of_NA $ FiniteContext.id) dne dne;
-@[simp] lemma CNKANN! : 𝓢 ⊢ ∼(φ ⋏ ψ) 🡒 (∼φ ⋎ ∼ψ) := ⟨CNKANN⟩
+def CCNNC! : 𝓢 ⊢! (∼φ 🡒 ∼ψ) 🡒 (ψ 🡒 φ) :=  deduct'! $ C!_of_CNN! FiniteContext.id!
+@[simp] lemma CCNNC : 𝓢 ⊢ (∼φ 🡒 ∼ψ) 🡒 (ψ 🡒 φ) := ⟨CCNNC!⟩
 
-def ANN_of_NK (b : 𝓢 ⊢! ∼(φ ⋏ ψ)) : 𝓢 ⊢! ∼φ ⋎ ∼ψ := CNKANN ⨀ b
-lemma ANN!_of_NK! (b : 𝓢 ⊢ ∼(φ ⋏ ψ)) : 𝓢 ⊢ ∼φ ⋎ ∼ψ := ⟨ANN_of_NK b.some⟩
+def EN!_of_EN!_right (h : 𝓢 ⊢! φ 🡘 ∼ψ) : 𝓢 ⊢! ∼φ 🡘 ψ := by
+  apply E!_intro;
+  . apply CN!_of_CN!_left $  K!_right h;
+  . apply CN!_of_CN!_right $  K!_left h;
+lemma EN_of_EN_right (h : 𝓢 ⊢ φ 🡘 ∼ψ) : 𝓢 ⊢ ∼φ 🡘 ψ := ⟨EN!_of_EN!_right h.some⟩
 
-def AN_of_C (d : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼φ ⋎ ψ := by
-  apply of_NN;
-  apply N_of_CO;
-  apply deduct';
-  have d₁ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼∼φ ⋏ ∼ψ := KNN_of_NA $ FiniteContext.id;
-  have d₂ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼φ 🡒 ⊥ := CO_of_N $ K_left d₁;
-  have d₃ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼φ := (of (Γ := [∼(∼φ ⋎ ψ)]) $ contra d) ⨀ (K_right d₁);
+def EN!_of_EN!_left (h : 𝓢 ⊢! ∼φ 🡘 ψ) : 𝓢 ⊢! φ 🡘 ∼ψ := E!_symm $ EN!_of_EN!_right $ E!_symm h
+lemma EN_of_EN_left (h : 𝓢 ⊢ ∼φ 🡘 ψ) : 𝓢 ⊢ φ 🡘 ∼ψ := ⟨EN!_of_EN!_left h.some⟩
+
+def ECCOO! : 𝓢 ⊢! φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := E!_trans dn! ENNCCOO!
+lemma ECCOO : 𝓢 ⊢ φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := ⟨ECCOO!⟩
+
+
+def CNKANN! : 𝓢 ⊢! ∼(φ ⋏ ψ) 🡒 (∼φ ⋎ ∼ψ) := by
+  apply CN!_of_CN!_left;
+  apply deduct'!;
+  exact K!_replace (KNN!_of_NA! $ FiniteContext.id!) dne! dne!;
+@[simp] lemma CNKANN : 𝓢 ⊢ ∼(φ ⋏ ψ) 🡒 (∼φ ⋎ ∼ψ) := ⟨CNKANN!⟩
+
+def ANN!_of_NK! (b : 𝓢 ⊢! ∼(φ ⋏ ψ)) : 𝓢 ⊢! ∼φ ⋎ ∼ψ := CNKANN! ⨀ b
+lemma ANN_of_NK (b : 𝓢 ⊢ ∼(φ ⋏ ψ)) : 𝓢 ⊢ ∼φ ⋎ ∼ψ := ⟨ANN!_of_NK! b.some⟩
+
+def AN!_of_C! (d : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼φ ⋎ ψ := by
+  apply of_NN!;
+  apply N!_of_CO!;
+  apply deduct'!;
+  have d₁ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼∼φ ⋏ ∼ψ := KNN!_of_NA! $ FiniteContext.id!;
+  have d₂ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼φ 🡒 ⊥ := CO!_of_N! $ K!_left d₁;
+  have d₃ : [∼(∼φ ⋎ ψ)] ⊢[𝓢]! ∼φ := (of! (Γ := [∼(∼φ ⋎ ψ)]) $ contra! d) ⨀ (K!_right d₁);
   exact d₂ ⨀ d₃;
-lemma AN!_of_C! (d : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼φ ⋎ ψ := ⟨AN_of_C d.some⟩
+lemma AN_of_C (d : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼φ ⋎ ψ := ⟨AN!_of_C! d.some⟩
 
-def CCAN : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼φ ⋎ ψ) := by
-  apply deduct';
-  apply AN_of_C;
-  exact FiniteContext.byAxm;
-lemma CCAN! : 𝓢 ⊢ (φ 🡒 ψ) 🡒 ∼φ ⋎ ψ := ⟨CCAN⟩
+def CCAN! : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼φ ⋎ ψ) := by
+  apply deduct'!;
+  apply AN!_of_C!;
+  exact FiniteContext.byAxm!;
+lemma CCAN : 𝓢 ⊢ (φ 🡒 ψ) 🡒 ∼φ ⋎ ψ := ⟨CCAN!⟩
 
 
 instance : HasAxiomEFQ 𝓢 where
-  efq {φ} := by
-    apply C_of_CNN;
-    exact C_trans (K_left negEquiv) $ C_trans (C_swap implyK) (K_right negEquiv);
+  efq! {φ} := by
+    apply C!_of_CNN!;
+    exact C!_trans (K!_left negEquiv!) $ C!_trans (C!_swap implyK!) (K!_right negEquiv!);
 
 instance : Entailment.Int 𝓢 where
 
 
 instance : HasAxiomElimContra 𝓢 where
-  elimContra {φ ψ} := by
-    apply deduct';
-    have : [∼ψ 🡒 ∼φ] ⊢[𝓢]! ∼ψ 🡒 ∼φ := FiniteContext.byAxm;
-    exact C_of_CNN this;
+  elimContra! {φ ψ} := by
+    apply deduct'!;
+    have : [∼ψ 🡒 ∼φ] ⊢[𝓢]! ∼ψ 🡒 ∼φ := FiniteContext.byAxm!;
+    exact C!_of_CNN! this;
 
-instance : HasAxiomLEM 𝓢 := ⟨A_of_ANNNN $ AN_of_C dni⟩
+instance : HasAxiomLEM 𝓢 := ⟨A!_of_ANNNN! $ AN!_of_C! dni!⟩
 
 
-lemma CNC!_of_C!_of_CN! (hpq : 𝓢 ⊢ φ 🡒 ψ) (hpnr : 𝓢 ⊢ φ 🡒 ∼ξ) : 𝓢 ⊢ φ 🡒 ∼(ψ 🡒 ξ) :=
-  deduct'! $ (contra! $ CCAN!) ⨀ (NA!_of_KNN! $ K!_intro (dni'! $ of'! hpq ⨀ (by_axm!)) (of'! hpnr ⨀ (by_axm!)))
+lemma CNC_of_C_of_CN (hpq : 𝓢 ⊢ φ 🡒 ψ) (hpnr : 𝓢 ⊢ φ 🡒 ∼ξ) : 𝓢 ⊢ φ 🡒 ∼(ψ 🡒 ξ) :=
+  deduct' $ (contra $ CCAN) ⨀
+    (NA_of_KNN $ K_intro (dni' $ of' hpq ⨀ FiniteContext.by_axm) (of' hpnr ⨀ FiniteContext.by_axm))
 
-def of_A_of_N (b : 𝓢 ⊢! φ ⋎ ψ) (d : 𝓢 ⊢! ∼φ) : 𝓢 ⊢! ψ := A_cases (C_of_CNN (dhyp d)) (C_id) b
+def of_A!_of_N! (b : 𝓢 ⊢! φ ⋎ ψ) (d : 𝓢 ⊢! ∼φ) : 𝓢 ⊢! ψ := A!_cases (C!_of_CNN! (dhyp! d)) (C!_id) b
 
-theorem of_A!_of_N! (b : 𝓢 ⊢ φ ⋎ ψ) (d : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ ψ := ⟨of_A_of_N b.get d.get⟩
+theorem of_A_of_N (b : 𝓢 ⊢ φ ⋎ ψ) (d : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ ψ := ⟨of_A!_of_N! b.get d.get⟩
 
-def ECAN : 𝓢 ⊢! (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := E_intro CCAN (deduct' (A_cases CNC implyK byAxm₀))
-theorem ECAN! : 𝓢 ⊢ (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := ⟨ECAN⟩
+def ECAN! : 𝓢 ⊢! (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := E!_intro CCAN! (deduct'! (A!_cases CNC! implyK! byAxm₀!))
+theorem ECAN : 𝓢 ⊢ (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := ⟨ECAN!⟩
 
 
 
 section
 
 @[simp]
-lemma CNDisj₂NConj₂! {Γ : List F} : 𝓢 ⊢ ∼⋁(Γ.map (∼·)) 🡒 ⋀Γ := by
+lemma CNDisj₂NConj₂ {Γ : List F} : 𝓢 ⊢ ∼⋁(Γ.map (∼·)) 🡒 ⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
   | hcons φ Γ hΓ ih =>
     simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
     suffices 𝓢 ⊢ ∼(∼φ ⋎ ∼∼⋁List.map (fun x ↦ ∼x) Γ) 🡒 φ ⋏ ⋀Γ by
-      apply C!_trans ?_ this;
-      apply contra!;
-      apply CAA!_of_C!_right;
-      exact dne!;
-    apply C!_trans CNAKNN! ?_;
-    apply CKK!_of_C!_of_C!;
-    . exact dne!;
-    . exact C!_trans dne! ih;
+      apply C_trans ?_ this;
+      apply contra;
+      apply CAA_of_C_right;
+      exact dne;
+    apply C_trans CNAKNN ?_;
+    apply CKK_of_C_of_C;
+    . exact dne;
+    . exact C_trans dne ih;
 
-lemma CNFdisj₂NFconj₂! {Γ : Finset F} : 𝓢 ⊢ ∼(Γ.image (∼·)).disj 🡒 Γ.conj := by
-  apply C!_replace ?_ ?_ $ CNDisj₂NConj₂! (Γ := Γ.toList);
-  . apply contra!;
-    apply left_Disj₂!_intro;
+lemma CNFdisj₂NFconj₂ {Γ : Finset F} : 𝓢 ⊢ ∼(Γ.image (∼·)).disj 🡒 Γ.conj := by
+  apply C_replace ?_ ?_ $ CNDisj₂NConj₂ (Γ := Γ.toList);
+  . apply contra;
+    apply left_Disj₂_intro;
     intro ψ hψ;
-    apply right_Fdisj!_intro;
+    apply right_Fdisj_intro;
     simpa using hψ;
   . simp;
 
@@ -271,7 +272,7 @@ lemma provable_iff_inconsistent_adjoin {φ : F} :
     · exact Axiomatized.adjoin! _ _
   · intro h
     have : 𝓢 ⊢ ∼φ 🡒 ⊥ := Deduction.of_insert! (h _)
-    refine of_NN! <| N!_iff_CO!.mpr this
+    refine of_NN <| N_iff_CO.mpr this
 
 lemma unprovable_iff_consistent_adjoin {φ : F} :
     𝓢 ⊬ φ ↔ Consistent (adjoin (∼φ) 𝓢) := by
@@ -285,13 +286,13 @@ end consistency
 section
 
 instance : HasAxiomPeirce 𝓢 where
-  peirce {φ ψ} := by
-    apply of_C_of_C_of_A implyK ?_ lem;
-    apply deduct';
-    apply deduct;
-    refine (FiniteContext.byAxm (φ := (φ 🡒 ψ) 🡒 φ)) ⨀ ?_;
-    apply deduct;
-    apply efq_of_mem_either (φ := φ);
+  peirce! {φ ψ} := by
+    apply of_C!_of_C!_of_A! implyK! ?_ lem!;
+    apply deduct'!;
+    apply deduct!;
+    refine (FiniteContext.byAxm! (φ := (φ 🡒 ψ) 🡒 φ)) ⨀ ?_;
+    apply deduct!;
+    apply efq_of_mem_either! (φ := φ);
     . simp;
     . simp;
 
@@ -306,20 +307,20 @@ section
 variable {G T : Type*} [Entailment T G] [LogicalConnective G] [LogicalNeutral G] {𝓣 : T}
 
 abbrev Cl.ofEquiv (𝓢 : S) [Entailment.Cl 𝓢] (𝓣 : T) (f : G →ˡᶜ F) (e : (φ : G) → 𝓢 ⊢! f φ ≃ 𝓣 ⊢! φ) : Entailment.Cl 𝓣 where
-  mdp {φ ψ dpq dp} := (e ψ) (
+  mdp! {φ ψ dpq dp} := (e ψ) (
     let d : 𝓢 ⊢! f φ 🡒 f ψ := by simpa using (e (φ 🡒 ψ)).symm dpq
     d ⨀ ((e φ).symm dp))
-  negEquiv := e _ (by simpa using negEquiv)
-  verum := e _ (by simpa using verum)
-  implyK := e _ (by simpa using implyK)
-  implyS := e _ (by simpa using implyS)
-  and₁ := e _ (by simpa using and₁)
-  and₂ := e _ (by simpa using and₂)
-  and₃ := e _ (by simpa using and₃)
-  or₁ := e _ (by simpa using or₁)
-  or₂ := e _ (by simpa using or₂)
-  or₃ := e _ (by simpa using or₃)
-  dne := e _ (by simpa using dne)
+  negEquiv! := e _ (by simpa using negEquiv!)
+  verum! := e _ (by simpa using verum!)
+  implyK! := e _ (by simpa using implyK!)
+  implyS! := e _ (by simpa using implyS!)
+  and₁! := e _ (by simpa using and₁!)
+  and₂! := e _ (by simpa using and₂!)
+  and₃! := e _ (by simpa using and₃!)
+  or₁! := e _ (by simpa using or₁!)
+  or₂! := e _ (by simpa using or₂!)
+  or₃! := e _ (by simpa using or₃!)
+  dne! := e _ (by simpa using dne!)
 
 end
 
@@ -332,14 +333,14 @@ variable {S F : Type*} [LogicalConnective F] [LogicalNeutral F] [DecidableEq F] 
 open FiniteContext
 
 instance [HasAxiomLEM 𝓢] : HasAxiomDNE 𝓢 where
-  dne {φ} := by
-    apply deduct';
-    exact of_C_of_C_of_A C_id (by
-      apply deduct;
-      have nnp : [∼φ, ∼∼φ] ⊢[𝓢]! ∼φ 🡒 ⊥ := CO_of_N $ FiniteContext.byAxm;
-      have np : [∼φ, ∼∼φ] ⊢[𝓢]! ∼φ := FiniteContext.byAxm;
-      exact of_O $ nnp ⨀ np;
-    ) $ of lem;
+  dne! {φ} := by
+    apply deduct'!;
+    exact of_C!_of_C!_of_A! C!_id (by
+      apply deduct!;
+      have nnp : [∼φ, ∼∼φ] ⊢[𝓢]! ∼φ 🡒 ⊥ := CO!_of_N! $ FiniteContext.byAxm!;
+      have np : [∼φ, ∼∼φ] ⊢[𝓢]! ∼φ := FiniteContext.byAxm!;
+      exact of_O! $ nnp ⨀ np;
+    ) $ of! lem!;
 
 instance [HasAxiomLEM 𝓢] : Entailment.Cl 𝓢 where
 

--- a/Foundation/Propositional/Entailment/Cl.lean
+++ b/Foundation/Propositional/Entailment/Cl.lean
@@ -213,12 +213,12 @@ instance : HasAxiomElimContra 𝓢 where
 instance : HasAxiomLEM 𝓢 := ⟨A_of_ANNNN $ AN_of_C dni⟩
 
 
-lemma not_imply_prem''! (hpq : 𝓢 ⊢ φ 🡒 ψ) (hpnr : 𝓢 ⊢ φ 🡒 ∼ξ) : 𝓢 ⊢ φ 🡒 ∼(ψ 🡒 ξ) :=
+lemma CNC!_of_C!_of_CN! (hpq : 𝓢 ⊢ φ 🡒 ψ) (hpnr : 𝓢 ⊢ φ 🡒 ∼ξ) : 𝓢 ⊢ φ 🡒 ∼(ψ 🡒 ξ) :=
   deduct'! $ (contra! $ CCAN!) ⨀ (NA!_of_KNN! $ K!_intro (dni'! $ of'! hpq ⨀ (by_axm!)) (of'! hpnr ⨀ (by_axm!)))
 
-def ofAOfN (b : 𝓢 ⊢! φ ⋎ ψ) (d : 𝓢 ⊢! ∼φ) : 𝓢 ⊢! ψ := A_cases (C_of_CNN (dhyp d)) (C_id) b
+def of_A_of_N (b : 𝓢 ⊢! φ ⋎ ψ) (d : 𝓢 ⊢! ∼φ) : 𝓢 ⊢! ψ := A_cases (C_of_CNN (dhyp d)) (C_id) b
 
-theorem of_a!_of_n! (b : 𝓢 ⊢ φ ⋎ ψ) (d : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ ψ := ⟨ofAOfN b.get d.get⟩
+theorem of_A!_of_N! (b : 𝓢 ⊢ φ ⋎ ψ) (d : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ ψ := ⟨of_A_of_N b.get d.get⟩
 
 def ECAN : 𝓢 ⊢! (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := E_intro CCAN (deduct' (A_cases CNC implyK byAxm₀))
 theorem ECAN! : 𝓢 ⊢ (φ 🡒 ψ) 🡘 (∼φ ⋎ ψ) := ⟨ECAN⟩

--- a/Foundation/Propositional/Entailment/Int.lean
+++ b/Foundation/Propositional/Entailment/Int.lean
@@ -20,16 +20,16 @@ variable {S F : Type*} [LogicalConnective F] [LogicalNeutral F] [Entailment S F]
 variable {𝓢 : S} {φ ψ χ : F}
 
 class HasAxiomEFQ (𝓢 : S)  where
-  efq {φ : F} : 𝓢 ⊢! Axioms.EFQ φ
-export HasAxiomEFQ (efq)
+  efq! {φ : F} : 𝓢 ⊢! Axioms.EFQ φ
+export HasAxiomEFQ (efq!)
 
-@[simp] lemma efq! [Entailment.HasAxiomEFQ 𝓢] : 𝓢 ⊢ ⊥ 🡒 φ := ⟨efq⟩
+@[simp] lemma efq [Entailment.HasAxiomEFQ 𝓢] : 𝓢 ⊢ ⊥ 🡒 φ := ⟨efq!⟩
 
-def of_O [ModusPonens 𝓢] [Entailment.HasAxiomEFQ 𝓢] (b : 𝓢 ⊢! ⊥) : 𝓢 ⊢! φ := efq ⨀ b
-@[grind ⇒] lemma of_O! [ModusPonens 𝓢]  [Entailment.HasAxiomEFQ 𝓢] (h : 𝓢 ⊢ ⊥) : 𝓢 ⊢ φ := ⟨of_O h.some⟩
+def of_O! [ModusPonens 𝓢] [Entailment.HasAxiomEFQ 𝓢] (b : 𝓢 ⊢! ⊥) : 𝓢 ⊢! φ := efq! ⨀ b
+@[grind ⇒] lemma of_O [ModusPonens 𝓢]  [Entailment.HasAxiomEFQ 𝓢] (h : 𝓢 ⊢ ⊥) : 𝓢 ⊢ φ := ⟨of_O! h.some⟩
 
 
-instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq ⨀ b⟩
+instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq! ⨀ b⟩
 
 
 section
@@ -38,7 +38,7 @@ variable [Entailment.Minimal 𝓢]
 
 namespace FiniteContext
 
-instance [Entailment.HasAxiomEFQ 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomEFQ Γ := ⟨of efq⟩
+instance [Entailment.HasAxiomEFQ 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomEFQ Γ := ⟨of! efq!⟩
 
 instance [Entailment.HasAxiomEFQ 𝓢] : DeductiveExplosion (FiniteContext F 𝓢) := inferInstance
 
@@ -47,7 +47,7 @@ end FiniteContext
 
 namespace Context
 
-instance [Entailment.HasAxiomEFQ 𝓢] (Γ : Context F 𝓢) : HasAxiomEFQ Γ := ⟨of efq⟩
+instance [Entailment.HasAxiomEFQ 𝓢] (Γ : Context F 𝓢) : HasAxiomEFQ Γ := ⟨of! efq!⟩
 
 instance [Entailment.HasAxiomEFQ 𝓢] : DeductiveExplosion (FiniteContext F 𝓢) := inferInstance
 
@@ -86,58 +86,58 @@ open NegationEquiv
 open FiniteContext
 open List
 
-def efq_of_mem_either (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ψ := of_O $ bot_of_mem_either h₁ h₂
-@[simp] lemma efq_of_mem_either! (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ψ := ⟨efq_of_mem_either h₁ h₂⟩
+def efq_of_mem_either! (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ψ := of_O! $ bot_of_mem_either! h₁ h₂
+@[simp] lemma efq_of_mem_either (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ψ := ⟨efq_of_mem_either! h₁ h₂⟩
 
-def CNC : 𝓢 ⊢! ∼φ 🡒 φ 🡒 ψ := by
-  apply deduct';
-  apply deduct;
-  apply efq_of_mem_either (φ := φ) (by simp) (by simp);
-@[simp] lemma CNC! : 𝓢 ⊢ ∼φ 🡒 φ 🡒 ψ := ⟨CNC⟩
+def CNC! : 𝓢 ⊢! ∼φ 🡒 φ 🡒 ψ := by
+  apply deduct'!;
+  apply deduct!;
+  apply efq_of_mem_either! (φ := φ) (by simp) (by simp);
+@[simp] lemma CNC : 𝓢 ⊢ ∼φ 🡒 φ 🡒 ψ := ⟨CNC!⟩
 
-def CCN : 𝓢 ⊢! φ 🡒 ∼φ 🡒 ψ := by
-  apply deduct';
-  apply deduct;
-  apply efq_of_mem_either (φ := φ) (by simp) (by simp);
-@[simp] lemma CCN! : 𝓢 ⊢ φ 🡒 ∼φ 🡒 ψ := ⟨CCN⟩
+def CCN! : 𝓢 ⊢! φ 🡒 ∼φ 🡒 ψ := by
+  apply deduct'!;
+  apply deduct!;
+  apply efq_of_mem_either! (φ := φ) (by simp) (by simp);
+@[simp] lemma CCN : 𝓢 ⊢ φ 🡒 ∼φ 🡒 ψ := ⟨CCN!⟩
 
-lemma C!_of_N! (h : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ φ 🡒 ψ := by
+lemma C_of_N (h : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ φ 🡒 ψ := by
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
-  have dnp : [φ] ⊢[𝓢] φ 🡒 ⊥ := of'! $ N!_iff_CO!.mp h;
-  exact of_O! (dnp ⨀ FiniteContext.id!);
+  have dnp : [φ] ⊢[𝓢] φ 🡒 ⊥ := of' $ N_iff_CO.mp h;
+  exact of_O (dnp ⨀ FiniteContext.id);
 
-lemma CN!_of_! (h : 𝓢 ⊢ φ) : 𝓢 ⊢ ∼φ 🡒 ψ := CCN! ⨀ h
+lemma CN_of_ (h : 𝓢 ⊢ φ) : 𝓢 ⊢ ∼φ 🡒 ψ := CCN ⨀ h
 
-def CANC : 𝓢 ⊢! (∼φ ⋎ ψ) 🡒 (φ 🡒 ψ) := left_A_intro (by
-    apply emptyPrf;
-    apply deduct;
-    apply deduct;
-    exact efq_of_mem_either (φ := φ) (by simp) (by simp)
-  ) implyK
-@[simp] lemma CANC! : 𝓢 ⊢ (∼φ ⋎ ψ) 🡒 (φ 🡒 ψ) := ⟨CANC⟩
+def CANC! : 𝓢 ⊢! (∼φ ⋎ ψ) 🡒 (φ 🡒 ψ) := left_A!_intro (by
+    apply emptyPrf!;
+    apply deduct!;
+    apply deduct!;
+    exact efq_of_mem_either! (φ := φ) (by simp) (by simp)
+  ) implyK!
+@[simp] lemma CANC : 𝓢 ⊢ (∼φ ⋎ ψ) 🡒 (φ 🡒 ψ) := ⟨CANC!⟩
 
-def C_of_AN (b : 𝓢 ⊢! ∼φ ⋎ ψ) : 𝓢 ⊢! φ 🡒 ψ := CANC ⨀ b
-lemma C!_of_AN! (b : 𝓢 ⊢ ∼φ ⋎ ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨C_of_AN b.some⟩
+def C!_of_AN! (b : 𝓢 ⊢! ∼φ ⋎ ψ) : 𝓢 ⊢! φ 🡒 ψ := CANC! ⨀ b
+lemma C_of_AN (b : 𝓢 ⊢ ∼φ ⋎ ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨C!_of_AN! b.some⟩
 
-def CCNNNNNNC : 𝓢 ⊢! (∼∼φ 🡒 ∼∼ψ) 🡒 ∼∼(φ 🡒 ψ) := by
-  apply deduct';
-  apply N_of_CO;
-  exact C_trans
+def CCNNNNNNC! : 𝓢 ⊢! (∼∼φ 🡒 ∼∼ψ) 🡒 ∼∼(φ 🡒 ψ) := by
+  apply deduct'!;
+  apply N!_of_CO!;
+  exact C!_trans
     (by
-      apply deductInv;
-      apply CC_of_CK;
-      apply deduct;
-      have d₁ : [(∼∼φ 🡒 ∼∼ψ) ⋏ ∼(φ 🡒 ψ)] ⊢[𝓢]! ∼∼φ 🡒 ∼∼ψ := K_left (ψ := ∼(φ 🡒 ψ)) $ FiniteContext.id;
-      have d₂ : [(∼∼φ 🡒 ∼∼ψ) ⋏ ∼(φ 🡒 ψ)] ⊢[𝓢]! ∼∼φ ⋏ ∼ψ := KNN_of_NA $ (contra CANC) ⨀ (K_right (φ := (∼∼φ 🡒 ∼∼ψ)) $ FiniteContext.id)
-      exact K_intro (K_right d₂) (d₁ ⨀ (K_left d₂))
+      apply deductInv!;
+      apply CC!_of_CK!;
+      apply deduct!;
+      have d₁ : [(∼∼φ 🡒 ∼∼ψ) ⋏ ∼(φ 🡒 ψ)] ⊢[𝓢]! ∼∼φ 🡒 ∼∼ψ := K!_left (ψ := ∼(φ 🡒 ψ)) $ FiniteContext.id!;
+      have d₂ : [(∼∼φ 🡒 ∼∼ψ) ⋏ ∼(φ 🡒 ψ)] ⊢[𝓢]! ∼∼φ ⋏ ∼ψ := KNN!_of_NA! $ (contra! CANC!) ⨀ (K!_right (φ := (∼∼φ 🡒 ∼∼ψ)) $ FiniteContext.id!)
+      exact K!_intro (K!_right d₂) (d₁ ⨀ (K!_left d₂))
     )
-    (CKNO (φ := ∼ψ));
+    (CKNO! (φ := ∼ψ));
 
-@[simp] lemma CCNNNNNNC! : 𝓢 ⊢ (∼∼φ 🡒 ∼∼ψ) 🡒 ∼∼(φ 🡒 ψ) := ⟨CCNNNNNNC⟩
+@[simp] lemma CCNNNNNNC : 𝓢 ⊢ (∼∼φ 🡒 ∼∼ψ) 🡒 ∼∼(φ 🡒 ψ) := ⟨CCNNNNNNC!⟩
 
-def NNC_of_CNNNN (b : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ) : 𝓢 ⊢! ∼∼(φ 🡒 ψ) := CCNNNNNNC ⨀ b
-lemma NNC!_of_CNNNN! (b : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ) : 𝓢 ⊢ ∼∼(φ 🡒 ψ) := ⟨NNC_of_CNNNN b.some⟩
+def NNC!_of_CNNNN! (b : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ) : 𝓢 ⊢! ∼∼(φ 🡒 ψ) := CCNNNNNNC! ⨀ b
+lemma NNC_of_CNNNN (b : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ) : 𝓢 ⊢ ∼∼(φ 🡒 ψ) := ⟨NNC!_of_CNNNN! b.some⟩
 
 section Conjunction
 
@@ -145,104 +145,104 @@ end Conjunction
 
 section disjunction
 
-def left_Disj_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! Γ.disj 🡒 φ :=
+def left_Disj!_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! Γ.disj 🡒 φ :=
   match Γ with
-  |     [] => efq
-  | ψ :: Γ => left_A_intro (b ψ (by simp)) <| left_Disj_intro Γ fun ψ h ↦ b ψ (by simp [h])
+  |     [] => efq!
+  | ψ :: Γ => left_A!_intro (b ψ (by simp)) <| left_Disj!_intro Γ fun ψ h ↦ b ψ (by simp [h])
 omit [DecidableEq F] in
-theorem left_Disj!_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ Γ.disj 🡒 φ :=
-  ⟨left_Disj_intro Γ fun ψ h ↦ (b ψ h).get⟩
+theorem left_Disj_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ Γ.disj 🡒 φ :=
+  ⟨left_Disj!_intro Γ fun ψ h ↦ (b ψ h).get⟩
 
-def left_Disj₂_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! ⋁Γ 🡒 φ :=
+def left_Disj₂!_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! ⋁Γ 🡒 φ :=
   match Γ with
-  |     [] => efq
+  |     [] => efq!
   |    [ψ] => b _ (by simp)
-  | ψ :: χ :: Γ => left_A_intro (b ψ (by simp)) <| left_Disj₂_intro _ fun ψ h ↦ b ψ (by simp [h])
+  | ψ :: χ :: Γ => left_A!_intro (b ψ (by simp)) <| left_Disj₂!_intro _ fun ψ h ↦ b ψ (by simp [h])
 
 omit [DecidableEq F] in
-lemma left_Disj₂!_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ ⋁Γ 🡒 φ :=
-  ⟨left_Disj₂_intro Γ fun ψ h ↦ (b ψ h).get⟩
+lemma left_Disj₂_intro (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ ⋁Γ 🡒 φ :=
+  ⟨left_Disj₂!_intro Γ fun ψ h ↦ (b ψ h).get⟩
 
-def left_Disj'_intro (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢! ψ i 🡒 φ) : 𝓢 ⊢! l.disj' ψ 🡒 φ :=
-  left_Disj₂_intro _ fun χ h ↦
+def left_Disj'!_intro (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢! ψ i 🡒 φ) : 𝓢 ⊢! l.disj' ψ 🡒 φ :=
+  left_Disj₂!_intro _ fun χ h ↦
     let ⟨i, hi, e⟩ := l.chooseX (ψ · = χ) (by simpa using h);
     haveI := b i hi;
     e ▸ this
-lemma left_Disj'!_intro (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ l.disj' ψ 🡒 φ :=
-  ⟨left_Disj'_intro l ψ fun i hi ↦ (b i hi).get⟩
+lemma left_Disj'_intro (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ l.disj' ψ 🡒 φ :=
+  ⟨left_Disj'!_intro l ψ fun i hi ↦ (b i hi).get⟩
 
-lemma left_Fdisj!_intro (s : Finset F) (b : (ψ : F) → ψ ∈ s → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ s.disj 🡒 φ :=
-  left_Disj₂!_intro _ fun ψ h ↦ b ψ (by simpa using h)
+lemma left_Fdisj_intro (s : Finset F) (b : (ψ : F) → ψ ∈ s → 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ s.disj 🡒 φ :=
+  left_Disj₂_intro _ fun ψ h ↦ b ψ (by simpa using h)
 
-lemma left_Fdisj'!_intro (s : Finset ι) (ψ : ι → F) (b : ∀ i ∈ s, 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ (⩖ i ∈ s, ψ i) 🡒 φ :=
-  left_Disj'!_intro _ _ (by simpa)
-
-omit [DecidableEq F] in
-lemma left_Udisj!_intro [DecidableEq F] [Fintype ι] (ψ : ι → F) (b : (i : ι) → 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ (⩖ i, ψ i) 🡒 φ :=
-  left_Fdisj'!_intro _ _ (by simpa)
+lemma left_Fdisj'_intro (s : Finset ι) (ψ : ι → F) (b : ∀ i ∈ s, 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ (⩖ i ∈ s, ψ i) 🡒 φ :=
+  left_Disj'_intro _ _ (by simpa)
 
 omit [DecidableEq F] in
-lemma EDisj₂AppendADisj₂Disj₂! : 𝓢 ⊢ ⋁(Γ ++ Δ) 🡘 ⋁Γ ⋎ ⋁Δ := by
+lemma left_Udisj_intro [DecidableEq F] [Fintype ι] (ψ : ι → F) (b : (i : ι) → 𝓢 ⊢ ψ i 🡒 φ) : 𝓢 ⊢ (⩖ i, ψ i) 🡒 φ :=
+  left_Fdisj'_intro _ _ (by simpa)
+
+omit [DecidableEq F] in
+lemma EDisj₂AppendADisj₂Disj₂ : 𝓢 ⊢ ⋁(Γ ++ Δ) 🡘 ⋁Γ ⋎ ⋁Δ := by
   induction Γ using List.induction_with_singleton generalizing Δ <;> induction Δ using List.induction_with_singleton;
   case hnil.hnil =>
-    apply E!_intro;
+    apply E_intro;
     . simp;
-    . exact left_A!_intro efq! efq!;
+    . exact left_A_intro efq efq;
   case hnil.hsingle =>
-    apply E!_intro;
+    apply E_intro;
     . simp;
-    . exact left_A!_intro efq! C!_id;
+    . exact left_A_intro efq C_id;
   case hsingle.hnil =>
-    apply E!_intro;
+    apply E_intro;
     . simp;
-    . exact left_A!_intro C!_id efq!;
+    . exact left_A_intro C_id efq;
   case hcons.hnil =>
     simp_all only [append_nil, disj₂_nil];
-    apply E!_intro;
+    apply E_intro;
     . simp;
-    . exact left_A!_intro C!_id efq!;
+    . exact left_A_intro C_id efq;
   case hnil.hcons =>
-    apply E!_intro;
+    apply E_intro;
     . simp;
-    . exact left_A!_intro efq! C!_id;
+    . exact left_A_intro efq C_id;
   case hsingle.hsingle => simp_all;
   case hsingle.hcons => simp_all;
   case hcons.hsingle φ ps hps ihp ψ =>
     simp_all only [cons_append, ne_eq, append_eq_nil_iff, cons_ne_self, and_false, not_false_eq_true,
       disj₂_cons_nonempty, disj₂_singleton];
-    apply E!_trans (by
-      apply EAA!_of_E!_right;
+    apply E_trans (by
+      apply EAA_of_E_right;
       simpa using @ihp [ψ];
-    ) EAAAA!;
+    ) EAAAA;
   case hcons.hcons φ ps hps ihp ψ qs hqs ihq =>
     simp_all only [cons_append, ne_eq, append_eq_nil_iff, reduceCtorEq, and_false, not_false_eq_true,
       disj₂_cons_nonempty];
-    exact E!_trans (by
-      apply EAA!_of_E!_right;
-      exact E!_trans (@ihp (ψ :: qs)) (by
-        apply EAA!_of_E!_right;
+    exact E_trans (by
+      apply EAA_of_E_right;
+      exact E_trans (@ihp (ψ :: qs)) (by
+        apply EAA_of_E_right;
         simp_all;
       )
-    ) EAAAA!;
+    ) EAAAA;
 
 omit [DecidableEq F] in
-lemma Disj₂Append!_iff_ADisj₂Disj₂! : 𝓢 ⊢ ⋁(Γ ++ Δ) ↔ 𝓢 ⊢ ⋁Γ ⋎ ⋁Δ := by
+lemma Disj₂Append_iff_ADisj₂Disj₂ : 𝓢 ⊢ ⋁(Γ ++ Δ) ↔ 𝓢 ⊢ ⋁Γ ⋎ ⋁Δ := by
   constructor;
-  . intro h; exact (K!_left EDisj₂AppendADisj₂Disj₂!) ⨀ h;
-  . intro h; exact (K!_right EDisj₂AppendADisj₂Disj₂!) ⨀ h;
+  . intro h; exact (K_left EDisj₂AppendADisj₂Disj₂) ⨀ h;
+  . intro h; exact (K_right EDisj₂AppendADisj₂Disj₂) ⨀ h;
 
 omit [DecidableEq F] in
-lemma CDisj₂!_iff_CADisj₂! : 𝓢 ⊢ φ 🡒 ⋁(ψ :: Γ) ↔ 𝓢 ⊢ φ 🡒 ψ ⋎ ⋁Γ := by
+lemma CDisj₂_iff_CADisj₂ : 𝓢 ⊢ φ 🡒 ⋁(ψ :: Γ) ↔ 𝓢 ⊢ φ 🡒 ψ ⋎ ⋁Γ := by
   induction Γ with
   | nil =>
     simp only [disj₂_singleton, disj₂_nil];
     constructor;
-    . intro h; exact C!_trans h or₁!;
-    . intro h; exact C!_trans h $ left_A!_intro C!_id efq!;
+    . intro h; exact C_trans h or₁;
+    . intro h; exact C_trans h $ left_A_intro C_id efq;
   | cons ψ ih => simp;
 
 @[simp]
-lemma CDisj₂ADisj₂Remove! : 𝓢 ⊢ ⋁Γ 🡒 φ ⋎ ⋁(Γ.remove φ) := by
+lemma CDisj₂ADisj₂Remove : 𝓢 ⊢ ⋁Γ 🡒 φ ⋎ ⋁(Γ.remove φ) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle ψ =>
@@ -253,15 +253,15 @@ lemma CDisj₂ADisj₂Remove! : 𝓢 ⊢ ⋁Γ 🡒 φ ⋎ ⋁(Γ.remove φ) := 
   | hcons ψ Γ h ih =>
     simp_all only [ne_eq, not_false_eq_true, disj₂_cons_nonempty];
     by_cases hpq : ψ = φ;
-    . simp_all only [List.remove_cons_self]; exact left_A!_intro or₁! ih;
+    . simp_all only [List.remove_cons_self]; exact left_A_intro or₁ ih;
     . simp_all only [(List.remove_cons_of_ne Γ hpq)];
       by_cases hqΓ : Γ.remove φ = [];
       . simp_all only [disj₂_nil, disj₂_singleton];
-        exact left_A!_intro or₂! (C!_trans ih $ CAA!_of_C!_right efq!);
+        exact left_A_intro or₂ (C_trans ih $ CAA_of_C_right efq);
       . simp_all only [ne_eq, not_false_eq_true, disj₂_cons_nonempty];
-        exact left_A!_intro (C!_trans or₁! or₂!) (C!_trans ih (CAA!_of_C!_right or₂!));
+        exact left_A_intro (C_trans or₁ or₂) (C_trans ih (CAA_of_C_right or₂));
 
-lemma left_Disj₂!_intro' (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ ⋁Γ 🡒 φ := by
+lemma left_Disj₂_intro' (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ ⋁Γ 🡒 φ := by
   induction Γ using List.induction_with_singleton with
   | hcons ψ Δ hΔ ih =>
     simp_all only [ne_eq, mem_cons, true_or, or_true, implies_true, forall_const, forall_eq_or_imp,
@@ -269,110 +269,110 @@ lemma left_Disj₂!_intro' (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ ⋁Γ 🡒 �
     have ⟨hd₁, hd₂⟩ := hd; subst hd₁;
     apply provable_iff_provable.mpr;
     apply deduct_iff.mpr;
-    exact of_C!_of_C!_of_A! (by simp) (weakening! (by simp) $ provable_iff_provable.mp $ ih) id!
+    exact of_C_of_C_of_A (by simp) (FiniteContext.weakening (by simp) $ provable_iff_provable.mp $ ih) id
   | _ => simp_all;
 
-lemma of_Disj₂!_of_mem_eq (hd : ∀ ψ ∈ Γ, ψ = φ) (h : 𝓢 ⊢ ⋁Γ) : 𝓢 ⊢ φ := (left_Disj₂!_intro' hd) ⨀ h
+lemma of_Disj₂_of_mem_eq (hd : ∀ ψ ∈ Γ, ψ = φ) (h : 𝓢 ⊢ ⋁Γ) : 𝓢 ⊢ φ := (left_Disj₂_intro' hd) ⨀ h
 
 
-@[simp] lemma CDisj₂FDisj! {Γ : Finset F} : 𝓢 ⊢ ⋁Γ.toList 🡒 Γ.disj := by
-  apply left_Disj₂!_intro;
+@[simp] lemma CDisj₂FDisj {Γ : Finset F} : 𝓢 ⊢ ⋁Γ.toList 🡒 Γ.disj := by
+  apply left_Disj₂_intro;
   intro ψ hψ;
-  apply right_Fdisj!_intro;
+  apply right_Fdisj_intro;
   simpa using hψ;
 
-@[simp] lemma CFDisjDisj₂! {Γ : Finset F} : 𝓢 ⊢ Γ.disj 🡒 ⋁Γ.toList := by
-  apply left_Fdisj!_intro;
+@[simp] lemma CFDisjDisj₂ {Γ : Finset F} : 𝓢 ⊢ Γ.disj 🡒 ⋁Γ.toList := by
+  apply left_Fdisj_intro;
   intro ψ hψ;
-  apply right_Disj₂!_intro;
+  apply right_Disj₂_intro;
   simpa;
 
-lemma CDisj₂Disj₂!_of_subset {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) : 𝓢 ⊢ ⋁Γ 🡒 ⋁Δ := by
+lemma CDisj₂Disj₂_of_subset {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) : 𝓢 ⊢ ⋁Γ 🡒 ⋁Δ := by
   match Δ with
   | [] =>
     have : Γ = [] := List.iff_nil_forall.mpr h;
     subst this;
     simp;
   | [φ] =>
-    apply left_Disj₂!_intro;
+    apply left_Disj₂_intro;
     intro ψ hψ;
     have := h ψ hψ;
     simp_all;
   | φ :: Δ =>
-    apply left_Disj₂!_intro;
+    apply left_Disj₂_intro;
     intro ψ hψ;
-    apply right_Disj₂!_intro;
+    apply right_Disj₂_intro;
     apply h;
     exact hψ;
 
-lemma CFDisjFDisj!_of_subset {Γ Δ : Finset F} (h : Γ ⊆ Δ) : 𝓢 ⊢ Γ.disj 🡒 Δ.disj := by
-  refine C!_trans (C!_trans ?_ (CDisj₂Disj₂!_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp;
+lemma CFDisjFDisj_of_subset {Γ Δ : Finset F} (h : Γ ⊆ Δ) : 𝓢 ⊢ Γ.disj 🡒 Δ.disj := by
+  refine C_trans (C_trans ?_ (CDisj₂Disj₂_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp;
 
-lemma EDisj₂FDisj! {Γ : List F} : 𝓢 ⊢ ⋁Γ 🡘 Γ.toFinset.disj := by
+lemma EDisj₂FDisj {Γ : List F} : 𝓢 ⊢ ⋁Γ 🡘 Γ.toFinset.disj := by
   match Γ with
   | [] => simp;
   | φ :: Γ =>
-    apply E!_intro;
-    . apply left_Disj₂!_intro;
+    apply E_intro;
+    . apply left_Disj₂_intro;
       simp only [List.mem_cons, List.toFinset_cons, forall_eq_or_imp];
       constructor;
-      . apply right_Fdisj!_intro;
+      . apply right_Fdisj_intro;
         simp_all;
       . intro ψ hψ;
-        apply right_Fdisj!_intro;
+        apply right_Fdisj_intro;
         simp_all;
-    . apply left_Fdisj!_intro;
+    . apply left_Fdisj_intro;
       simp only [List.toFinset_cons, Finset.mem_insert, List.mem_toFinset, forall_eq_or_imp];
       constructor;
-      . apply right_Disj₂!_intro;
+      . apply right_Disj₂_intro;
         tauto;
       . intro ψ hψ;
-        apply right_Disj₂!_intro;
+        apply right_Disj₂_intro;
         tauto;
 
-lemma EDisj₂FDisj!_doubleton : 𝓢 ⊢ ⋁[φ, ψ] 🡘 Finset.disj {φ, ψ} := by
-  convert EDisj₂FDisj! (𝓢 := 𝓢) (Γ := [φ, ψ]);
+lemma EDisj₂FDisj_doubleton : 𝓢 ⊢ ⋁[φ, ψ] 🡘 Finset.disj {φ, ψ} := by
+  convert EDisj₂FDisj (𝓢 := 𝓢) (Γ := [φ, ψ]);
   simp;
 
-lemma EConj₂FConj!_doubleton : 𝓢 ⊢ ⋁[φ, ψ] ↔ 𝓢 ⊢ Finset.disj {φ, ψ} := by
+lemma EConj₂FConj_doubleton : 𝓢 ⊢ ⋁[φ, ψ] ↔ 𝓢 ⊢ Finset.disj {φ, ψ} := by
   constructor;
-  . intro h; exact (C!_of_E!_mp $ EDisj₂FDisj!_doubleton) ⨀ h;
-  . intro h; exact (C!_of_E!_mpr $ EDisj₂FDisj!_doubleton) ⨀ h;
+  . intro h; exact (C_of_E_mp $ EDisj₂FDisj_doubleton) ⨀ h;
+  . intro h; exact (C_of_E_mpr $ EDisj₂FDisj_doubleton) ⨀ h;
 
 @[simp]
-lemma CAFDisjinsertFDisj! {Γ : Finset F} : 𝓢 ⊢ φ ⋎ Γ.disj 🡒 (insert φ Γ).disj := by
-  apply left_A!_intro;
-  . apply right_Fdisj!_intro; simp;
-  . apply CFDisjFDisj!_of_subset; simp;
+lemma CAFDisjinsertFDisj {Γ : Finset F} : 𝓢 ⊢ φ ⋎ Γ.disj 🡒 (insert φ Γ).disj := by
+  apply left_A_intro;
+  . apply right_Fdisj_intro; simp;
+  . apply CFDisjFDisj_of_subset; simp;
 
 @[simp]
-lemma CinsertFDisjAFDisj! {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).disj 🡒 φ ⋎ Γ.disj := by
-  apply left_Fdisj!_intro;
-  simp only [Finset.mem_insert, forall_eq_or_imp, or₁!, true_and];
+lemma CinsertFDisjAFDisj {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).disj 🡒 φ ⋎ Γ.disj := by
+  apply left_Fdisj_intro;
+  simp only [Finset.mem_insert, forall_eq_or_imp, or₁, true_and];
   intro ψ hψ;
-  apply right_A!_intro_right;
-  apply right_Fdisj!_intro;
+  apply right_A_intro_right;
+  apply right_Fdisj_intro;
   assumption;
 
-@[simp] lemma CAFdisjFdisjUnion! {Γ Δ : Finset F} : 𝓢 ⊢ Γ.disj ⋎ Δ.disj 🡒 (Γ ∪ Δ).disj := by
-  apply left_A!_intro <;>
-  . apply CFDisjFDisj!_of_subset;
+@[simp] lemma CAFdisjFdisjUnion {Γ Δ : Finset F} : 𝓢 ⊢ Γ.disj ⋎ Δ.disj 🡒 (Γ ∪ Δ).disj := by
+  apply left_A_intro <;>
+  . apply CFDisjFDisj_of_subset;
     simp;
 
 @[simp]
-lemma CFdisjUnionAFdisj! {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).disj 🡒 Γ.disj ⋎ Δ.disj := by
-  apply left_Fdisj!_intro;
+lemma CFdisjUnionAFdisj {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).disj 🡒 Γ.disj ⋎ Δ.disj := by
+  apply left_Fdisj_intro;
   simp only [Finset.mem_union];
   rintro ψ (hψ | hψ);
-  . apply C!_trans (ψ := Γ.disj) ?_ or₁!;
-    apply right_Fdisj!_intro;
+  . apply C_trans (ψ := Γ.disj) ?_ or₁;
+    apply right_Fdisj_intro;
     assumption;
-  . apply C!_trans (ψ := Δ.disj) ?_ or₂!;
-    apply right_Fdisj!_intro;
+  . apply C_trans (ψ := Δ.disj) ?_ or₂;
+    apply right_Fdisj_intro;
     assumption;
 
-lemma left_Fdisj!_intro' {Γ : Finset _} (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ Γ.disj 🡒 φ := by
-  apply C!_trans ?_ $ left_Disj₂!_intro' (Γ := Γ.toList) (by simpa);
+lemma left_Fdisj_intro' {Γ : Finset _} (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ Γ.disj 🡒 φ := by
+  apply C_trans ?_ $ left_Disj₂_intro' (Γ := Γ.toList) (by simpa);
   simp;
 
 end disjunction
@@ -382,19 +382,19 @@ section
 
 variable {Γ Δ : Finset F}
 
-lemma CFConjFDisj!_of_A (hφψ : φ ⋎ ψ ∈ Γ) (hφ : φ ∈ Δ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {φ, ψ});
-  . apply C!_trans (ψ := Finset.conj {φ ⋎ ψ}) ?_;
-    . apply FConj!_DT.mpr;
-      suffices ↑{φ ⋎ ψ} *⊢[𝓢] [φ, ψ].disj₂ by simpa using EConj₂FConj!_doubleton.mp this;
-      apply Context.by_axm!;
+lemma CFConjFDisj_of_A (hφψ : φ ⋎ ψ ∈ Γ) (hφ : φ ∈ Δ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+  apply C_trans (ψ := Finset.disj {φ, ψ});
+  . apply C_trans (ψ := Finset.conj {φ ⋎ ψ}) ?_;
+    . apply FConj_DT.mpr;
+      suffices ↑{φ ⋎ ψ} *⊢[𝓢] [φ, ψ].disj₂ by simpa using EConj₂FConj_doubleton.mp this;
+      apply Context.by_axm;
       simp;
-    . apply CFConjFConj!_of_subset;
+    . apply CFConjFConj_of_subset;
       simpa;
-  . apply left_Fdisj!_intro;
+  . apply left_Fdisj_intro;
     simp only [Finset.mem_insert, Finset.mem_singleton, forall_eq_or_imp, forall_eq];
     constructor <;>
-    . apply right_Fdisj!_intro;
+    . apply right_Fdisj_intro;
       assumption;
 
 end
@@ -402,48 +402,48 @@ end
 
 section
 
-/-- List version of `CNAKNN!` -/
+/-- List version of `CNAKNN` -/
 @[simp]
-lemma CNDisj₁Conj₂! : 𝓢 ⊢ ∼⋁Γ 🡒 ⋀(Γ.map (∼·)) := by
+lemma CNDisj₁Conj₂ : 𝓢 ⊢ ∼⋁Γ 🡒 ⋀(Γ.map (∼·)) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
   | hcons φ Γ hΓ ih =>
     simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
-    refine C!_trans CNAKNN! ?_;
-    apply CKK!_of_C!' ih;
+    refine C_trans CNAKNN ?_;
+    apply CKK_of_C' ih;
 
-/--- Finset version of `CNAKNN!` -/
+/--- Finset version of `CNAKNN` -/
 @[simp]
-lemma CNFdisjFconj! {Γ : Finset F} : 𝓢 ⊢ ∼Γ.disj 🡒 (Γ.image (∼·)).conj := by
-  apply C!_replace ?_ ?_ $ CNDisj₁Conj₂! (Γ := Γ.toList);
-  . apply contra!;
-    exact CDisj₂FDisj!;
-  . apply CConj₂Conj₂!_of_provable;
+lemma CNFdisjFconj {Γ : Finset F} : 𝓢 ⊢ ∼Γ.disj 🡒 (Γ.image (∼·)).conj := by
+  apply C_replace ?_ ?_ $ CNDisj₁Conj₂ (Γ := Γ.toList);
+  . apply contra;
+    exact CDisj₂FDisj;
+  . apply CConj₂Conj₂_of_provable;
     intro φ hφ;
-    apply FiniteContext.by_axm!
+    apply FiniteContext.by_axm
     simpa using hφ;
 
-/--- Finset version of `CKNNNA!` -/
+/--- Finset version of `CKNNNA` -/
 @[simp]
-lemma CConj₂NNDisj₂! : 𝓢 ⊢ ⋀Γ.map (∼·) 🡒 ∼⋁Γ := by
+lemma CConj₂NNDisj₂ : 𝓢 ⊢ ⋀Γ.map (∼·) 🡒 ∼⋁Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
   | hcons φ Γ hΓ ih =>
     simp_all only [ne_eq, not_false_eq_true, List.disj₂_cons_nonempty, List.map_cons, List.map_eq_nil_iff, List.conj₂_cons_nonempty];
-    apply C!_trans ?_ CKNNNA!;
-    apply CKK!_of_C!' ih;
+    apply C_trans ?_ CKNNNA;
+    apply CKK_of_C' ih;
 
-/--- Finset version of `CKNNNA!` -/
+/--- Finset version of `CKNNNA` -/
 @[simp]
-lemma CFconjNNFconj! {Γ : Finset F} : 𝓢 ⊢ (Γ.image (∼·)).conj 🡒 ∼Γ.disj := by
-  apply C!_replace ?_ ?_ $ CConj₂NNDisj₂! (Γ := Γ.toList);
-  . apply CConj₂Conj₂!_of_provable;
+lemma CFconjNNFconj {Γ : Finset F} : 𝓢 ⊢ (Γ.image (∼·)).conj 🡒 ∼Γ.disj := by
+  apply C_replace ?_ ?_ $ CConj₂NNDisj₂ (Γ := Γ.toList);
+  . apply CConj₂Conj₂_of_provable;
     intro φ hφ;
-    apply FiniteContext.by_axm!
+    apply FiniteContext.by_axm
     simpa using hφ;
-  . apply contra!;
+  . apply contra;
     simp;
 
 end
@@ -453,8 +453,8 @@ section consistency
 omit [DecidableEq F] in
 lemma inconsistent_of_provable_of_unprovable {φ : F}
     (hp : 𝓢 ⊢ φ) (hn : 𝓢 ⊢ ∼φ) : Inconsistent 𝓢 := by
-  have : 𝓢 ⊢ φ 🡒 ⊥ := N!_iff_CO!.mp hn
-  intro ψ; exact efq! ⨀ (this ⨀ hp)
+  have : 𝓢 ⊢ φ 🡒 ⊥ := N_iff_CO.mp hn
+  intro ψ; exact efq ⨀ (this ⨀ hp)
 
 end consistency
 

--- a/Foundation/Propositional/Entailment/Int.lean
+++ b/Foundation/Propositional/Entailment/Int.lean
@@ -101,7 +101,7 @@ def CCN : 𝓢 ⊢! φ 🡒 ∼φ 🡒 ψ := by
   apply efq_of_mem_either (φ := φ) (by simp) (by simp);
 @[simp] lemma CCN! : 𝓢 ⊢ φ 🡒 ∼φ 🡒 ψ := ⟨CCN⟩
 
-lemma C_of_N (h : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ φ 🡒 ψ := by
+lemma C!_of_N! (h : 𝓢 ⊢ ∼φ) : 𝓢 ⊢ φ 🡒 ψ := by
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
   have dnp : [φ] ⊢[𝓢] φ 🡒 ⊥ := of'! $ N!_iff_CO!.mp h;
@@ -275,19 +275,19 @@ lemma left_Disj₂!_intro' (hd : ∀ ψ ∈ Γ, ψ = φ) : 𝓢 ⊢ ⋁Γ 🡒 �
 lemma of_Disj₂!_of_mem_eq (hd : ∀ ψ ∈ Γ, ψ = φ) (h : 𝓢 ⊢ ⋁Γ) : 𝓢 ⊢ φ := (left_Disj₂!_intro' hd) ⨀ h
 
 
-@[simp] lemma CFDisjDisj₂ {Γ : Finset F} : 𝓢 ⊢ ⋁Γ.toList 🡒 Γ.disj := by
+@[simp] lemma CDisj₂FDisj! {Γ : Finset F} : 𝓢 ⊢ ⋁Γ.toList 🡒 Γ.disj := by
   apply left_Disj₂!_intro;
   intro ψ hψ;
   apply right_Fdisj!_intro;
   simpa using hψ;
 
-@[simp] lemma CDisj₂Disj {Γ : Finset F} : 𝓢 ⊢ Γ.disj 🡒 ⋁Γ.toList := by
+@[simp] lemma CFDisjDisj₂! {Γ : Finset F} : 𝓢 ⊢ Γ.disj 🡒 ⋁Γ.toList := by
   apply left_Fdisj!_intro;
   intro ψ hψ;
   apply right_Disj₂!_intro;
   simpa;
 
-lemma CDisj₂Disj₂_of_subset {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) : 𝓢 ⊢ ⋁Γ 🡒 ⋁Δ := by
+lemma CDisj₂Disj₂!_of_subset {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) : 𝓢 ⊢ ⋁Γ 🡒 ⋁Δ := by
   match Δ with
   | [] =>
     have : Γ = [] := List.iff_nil_forall.mpr h;
@@ -305,10 +305,10 @@ lemma CDisj₂Disj₂_of_subset {Γ Δ : List F} (h : ∀ φ ∈ Γ, φ ∈ Δ) 
     apply h;
     exact hψ;
 
-lemma CFDisjFDisj_of_subset {Γ Δ : Finset F} (h : Γ ⊆ Δ) : 𝓢 ⊢ Γ.disj 🡒 Δ.disj := by
-  refine C!_trans (C!_trans ?_ (CDisj₂Disj₂_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp;
+lemma CFDisjFDisj!_of_subset {Γ Δ : Finset F} (h : Γ ⊆ Δ) : 𝓢 ⊢ Γ.disj 🡒 Δ.disj := by
+  refine C!_trans (C!_trans ?_ (CDisj₂Disj₂!_of_subset (Γ := Γ.toList) (Δ := Δ.toList) (by simpa))) ?_ <;> simp;
 
-lemma EDisj₂FDisj {Γ : List F} : 𝓢 ⊢ ⋁Γ 🡘 Γ.toFinset.disj := by
+lemma EDisj₂FDisj! {Γ : List F} : 𝓢 ⊢ ⋁Γ 🡘 Γ.toFinset.disj := by
   match Γ with
   | [] => simp;
   | φ :: Γ =>
@@ -331,19 +331,19 @@ lemma EDisj₂FDisj {Γ : List F} : 𝓢 ⊢ ⋁Γ 🡘 Γ.toFinset.disj := by
         tauto;
 
 lemma EDisj₂FDisj!_doubleton : 𝓢 ⊢ ⋁[φ, ψ] 🡘 Finset.disj {φ, ψ} := by
-  convert EDisj₂FDisj (𝓢 := 𝓢) (Γ := [φ, ψ]);
+  convert EDisj₂FDisj! (𝓢 := 𝓢) (Γ := [φ, ψ]);
   simp;
 
-lemma EConj₂_FConj!_doubleton : 𝓢 ⊢ ⋁[φ, ψ] ↔ 𝓢 ⊢ Finset.disj {φ, ψ} := by
+lemma EConj₂FConj!_doubleton : 𝓢 ⊢ ⋁[φ, ψ] ↔ 𝓢 ⊢ Finset.disj {φ, ψ} := by
   constructor;
-  . intro h; exact (C_of_E_mp! $ EDisj₂FDisj!_doubleton) ⨀ h;
-  . intro h; exact (C_of_E_mpr! $ EDisj₂FDisj!_doubleton) ⨀ h;
+  . intro h; exact (C!_of_E!_mp $ EDisj₂FDisj!_doubleton) ⨀ h;
+  . intro h; exact (C!_of_E!_mpr $ EDisj₂FDisj!_doubleton) ⨀ h;
 
 @[simp]
 lemma CAFDisjinsertFDisj! {Γ : Finset F} : 𝓢 ⊢ φ ⋎ Γ.disj 🡒 (insert φ Γ).disj := by
   apply left_A!_intro;
   . apply right_Fdisj!_intro; simp;
-  . apply CFDisjFDisj_of_subset; simp;
+  . apply CFDisjFDisj!_of_subset; simp;
 
 @[simp]
 lemma CinsertFDisjAFDisj! {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).disj 🡒 φ ⋎ Γ.disj := by
@@ -354,13 +354,13 @@ lemma CinsertFDisjAFDisj! {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).disj 🡒 φ
   apply right_Fdisj!_intro;
   assumption;
 
-@[simp] lemma CAFdisjFdisjUnion {Γ Δ : Finset F} : 𝓢 ⊢ Γ.disj ⋎ Δ.disj 🡒 (Γ ∪ Δ).disj := by
+@[simp] lemma CAFdisjFdisjUnion! {Γ Δ : Finset F} : 𝓢 ⊢ Γ.disj ⋎ Δ.disj 🡒 (Γ ∪ Δ).disj := by
   apply left_A!_intro <;>
-  . apply CFDisjFDisj_of_subset;
+  . apply CFDisjFDisj!_of_subset;
     simp;
 
 @[simp]
-lemma CFdisjUnionAFdisj {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).disj 🡒 Γ.disj ⋎ Δ.disj := by
+lemma CFdisjUnionAFdisj! {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).disj 🡒 Γ.disj ⋎ Δ.disj := by
   apply left_Fdisj!_intro;
   simp only [Finset.mem_union];
   rintro ψ (hψ | hψ);
@@ -382,14 +382,14 @@ section
 
 variable {Γ Δ : Finset F}
 
-lemma CFConj_CDisj!_of_A (hφψ : φ ⋎ ψ ∈ Γ) (hφ : φ ∈ Δ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+lemma CFConjFDisj!_of_A (hφψ : φ ⋎ ψ ∈ Γ) (hφ : φ ∈ Δ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
   apply C!_trans (ψ := Finset.disj {φ, ψ});
   . apply C!_trans (ψ := Finset.conj {φ ⋎ ψ}) ?_;
-    . apply FConj_DT.mpr;
-      suffices ↑{φ ⋎ ψ} *⊢[𝓢] [φ, ψ].disj₂ by simpa using EConj₂_FConj!_doubleton.mp this;
+    . apply FConj!_DT.mpr;
+      suffices ↑{φ ⋎ ψ} *⊢[𝓢] [φ, ψ].disj₂ by simpa using EConj₂FConj!_doubleton.mp this;
       apply Context.by_axm!;
       simp;
-    . apply CFConj_FConj!_of_subset;
+    . apply CFConjFConj!_of_subset;
       simpa;
   . apply left_Fdisj!_intro;
     simp only [Finset.mem_insert, Finset.mem_singleton, forall_eq_or_imp, forall_eq];
@@ -418,7 +418,7 @@ lemma CNDisj₁Conj₂! : 𝓢 ⊢ ∼⋁Γ 🡒 ⋀(Γ.map (∼·)) := by
 lemma CNFdisjFconj! {Γ : Finset F} : 𝓢 ⊢ ∼Γ.disj 🡒 (Γ.image (∼·)).conj := by
   apply C!_replace ?_ ?_ $ CNDisj₁Conj₂! (Γ := Γ.toList);
   . apply contra!;
-    exact CFDisjDisj₂;
+    exact CDisj₂FDisj!;
   . apply CConj₂Conj₂!_of_provable;
     intro φ hφ;
     apply FiniteContext.by_axm!

--- a/Foundation/Propositional/Entailment/Minimal.lean
+++ b/Foundation/Propositional/Entailment/Minimal.lean
@@ -49,16 +49,16 @@ variable {S F : Type*} [LogicalConnective F] [Entailment S F]
 variable {𝓢 : S} {φ ψ χ : F}
 
 class ModusPonens (𝓢 : S) where
-  mdp {φ ψ : F} : 𝓢 ⊢! φ 🡒 ψ → 𝓢 ⊢! φ → 𝓢 ⊢! ψ
+  mdp! {φ ψ : F} : 𝓢 ⊢! φ 🡒 ψ → 𝓢 ⊢! φ → 𝓢 ⊢! ψ
 
-alias mdp := ModusPonens.mdp
-infixl:90 "⨀" => mdp
+alias mdp! := ModusPonens.mdp!
+infixl:90 "⨀" => mdp!
 
-lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢ φ 🡒 ψ → 𝓢 ⊢ φ → 𝓢 ⊢ ψ := by
+lemma mdp [ModusPonens 𝓢] : 𝓢 ⊢ φ 🡒 ψ → 𝓢 ⊢ φ → 𝓢 ⊢ ψ := by
   rintro ⟨hpq⟩ ⟨hp⟩;
   exact ⟨hpq ⨀ hp⟩
-infixl:90 "⨀" => mdp!
-infixl:90 "⨀!" => mdp
+infixl:90 "⨀" => mdp
+infixl:90 "⨀!" => mdp!
 
 
 
@@ -69,102 +69,102 @@ infixl:90 "⨀!" => mdp
   This is weaker asssumption than _"introducing `∼φ` as an abbreviation of `φ 🡒 ⊥`" (`NegAbbrev`)_.
 -/
 class NegationEquiv [LogicalNeutral F] (𝓢 : S) where
-  negEquiv {φ : F} : 𝓢 ⊢! Axioms.NegEquiv φ
-export NegationEquiv (negEquiv)
+  negEquiv! {φ : F} : 𝓢 ⊢! Axioms.NegEquiv φ
+export NegationEquiv (negEquiv!)
 
-@[simp] lemma neg_equiv! [LogicalNeutral F] [NegationEquiv 𝓢] : 𝓢 ⊢ ∼φ 🡘 (φ 🡒 ⊥) := ⟨negEquiv⟩
+@[simp] lemma neg_equiv [LogicalNeutral F] [NegationEquiv 𝓢] : 𝓢 ⊢ ∼φ 🡘 (φ 🡒 ⊥) := ⟨negEquiv!⟩
 
 
 class HasAxiomVerum [LogicalNeutral F] (𝓢 : S) where
-  verum : 𝓢 ⊢! Axioms.Verum
+  verum! : 𝓢 ⊢! Axioms.Verum
 
-def verum [LogicalNeutral F] [HasAxiomVerum 𝓢] : 𝓢 ⊢! ⊤ := HasAxiomVerum.verum
+def verum! [LogicalNeutral F] [HasAxiomVerum 𝓢] : 𝓢 ⊢! ⊤ := HasAxiomVerum.verum!
 
 omit [LogicalConnective F] in
-@[simp] lemma verum! [LogicalNeutral F] [HasAxiomVerum 𝓢] : 𝓢 ⊢ ⊤ := ⟨verum⟩
+@[simp] lemma verum [LogicalNeutral F] [HasAxiomVerum 𝓢] : 𝓢 ⊢ ⊤ := ⟨verum!⟩
 
 
 class HasAxiomImplyK (𝓢 : S)  where
-  implyK {φ ψ : F} : 𝓢 ⊢! Axioms.ImplyK φ ψ
-export HasAxiomImplyK (implyK)
+  implyK! {φ ψ : F} : 𝓢 ⊢! Axioms.ImplyK φ ψ
+export HasAxiomImplyK (implyK!)
 
-@[simp] lemma implyK! [HasAxiomImplyK 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 φ := ⟨implyK⟩
+@[simp] lemma implyK [HasAxiomImplyK 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 φ := ⟨implyK!⟩
 
-def C_of_conseq [ModusPonens 𝓢] [HasAxiomImplyK 𝓢] (h : 𝓢 ⊢! φ) : 𝓢 ⊢! ψ 🡒 φ := implyK ⨀ h
-alias dhyp := C_of_conseq
-
-lemma C!_of_conseq! [ModusPonens 𝓢] [HasAxiomImplyK 𝓢] (d : 𝓢 ⊢ φ) : 𝓢 ⊢ ψ 🡒 φ := ⟨C_of_conseq d.some⟩
+def C!_of_conseq! [ModusPonens 𝓢] [HasAxiomImplyK 𝓢] (h : 𝓢 ⊢! φ) : 𝓢 ⊢! ψ 🡒 φ := implyK! ⨀ h
 alias dhyp! := C!_of_conseq!
+
+lemma C_of_conseq [ModusPonens 𝓢] [HasAxiomImplyK 𝓢] (d : 𝓢 ⊢ φ) : 𝓢 ⊢ ψ 🡒 φ := ⟨C!_of_conseq! d.some⟩
+alias dhyp := C_of_conseq
 
 
 class HasAxiomImplyS (𝓢 : S)  where
-  implyS {φ ψ χ : F} : 𝓢 ⊢! Axioms.ImplyS φ ψ χ
-export HasAxiomImplyS (implyS)
+  implyS! {φ ψ χ : F} : 𝓢 ⊢! Axioms.ImplyS φ ψ χ
+export HasAxiomImplyS (implyS!)
 
-@[simp] lemma implyS! [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ) 🡒 (φ 🡒 ψ) 🡒 φ 🡒 χ := ⟨implyS⟩
+@[simp] lemma implyS [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ) 🡒 (φ 🡒 ψ) 🡒 φ 🡒 χ := ⟨implyS!⟩
 
 
 class HasAxiomAndElim (𝓢 : S)  where
-  and₁ {φ ψ : F} : 𝓢 ⊢! Axioms.AndElim₁ φ ψ
-  and₂ {φ ψ : F} : 𝓢 ⊢! Axioms.AndElim₂ φ ψ
-export HasAxiomAndElim (and₁ and₂)
+  and₁! {φ ψ : F} : 𝓢 ⊢! Axioms.AndElim₁ φ ψ
+  and₂! {φ ψ : F} : 𝓢 ⊢! Axioms.AndElim₂ φ ψ
+export HasAxiomAndElim (and₁! and₂!)
 
 
-@[simp] lemma and₁! [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 φ := ⟨and₁⟩
+@[simp] lemma and₁ [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 φ := ⟨and₁!⟩
 
-def K_left [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! φ := and₁ ⨀ d
-@[grind ->] lemma K!_left [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ φ := ⟨K_left d.some⟩
+def K!_left [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! φ := and₁! ⨀ d
+@[grind ->] lemma K_left [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ φ := ⟨K!_left d.some⟩
 
 
-@[simp] lemma and₂! [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 ψ := ⟨and₂⟩
+@[simp] lemma and₂ [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 ψ := ⟨and₂!⟩
 
-def K_right [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ψ := and₂ ⨀ d
-@[grind ->] lemma K!_right [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ψ := ⟨K_right d.some⟩
+def K!_right [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ψ := and₂! ⨀ d
+@[grind ->] lemma K_right [ModusPonens 𝓢] [HasAxiomAndElim 𝓢] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ψ := ⟨K!_right d.some⟩
 
 
 class HasAxiomAndInst (𝓢 : S) where
-  and₃ {φ ψ : F} : 𝓢 ⊢! Axioms.AndInst φ ψ
-export HasAxiomAndInst (and₃)
+  and₃! {φ ψ : F} : 𝓢 ⊢! Axioms.AndInst φ ψ
+export HasAxiomAndInst (and₃!)
 
-@[simp] lemma and₃! [HasAxiomAndInst 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 φ ⋏ ψ := ⟨and₃⟩
+@[simp] lemma and₃ [HasAxiomAndInst 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 φ ⋏ ψ := ⟨and₃!⟩
 
-def K_intro [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢! φ) (d₂: 𝓢 ⊢! ψ) : 𝓢 ⊢! φ ⋏ ψ := and₃ ⨀ d₁ ⨀ d₂
-@[grind <-] lemma K!_intro  [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢ φ) (d₂: 𝓢 ⊢ ψ) : 𝓢 ⊢ φ ⋏ ψ := ⟨K_intro d₁.some d₂.some⟩
+def K!_intro [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢! φ) (d₂: 𝓢 ⊢! ψ) : 𝓢 ⊢! φ ⋏ ψ := and₃! ⨀ d₁ ⨀ d₂
+@[grind <-] lemma K_intro  [ModusPonens 𝓢] [HasAxiomAndInst 𝓢] (d₁ : 𝓢 ⊢ φ) (d₂: 𝓢 ⊢ ψ) : 𝓢 ⊢ φ ⋏ ψ := ⟨K!_intro d₁.some d₂.some⟩
 
 
 class HasAxiomOrInst (𝓢 : S) where
-  or₁ {φ ψ : F} : 𝓢 ⊢! Axioms.OrInst₁ φ ψ
-  or₂ {φ ψ : F} : 𝓢 ⊢! Axioms.OrInst₂ φ ψ
-export HasAxiomOrInst (or₁ or₂)
+  or₁! {φ ψ : F} : 𝓢 ⊢! Axioms.OrInst₁ φ ψ
+  or₂! {φ ψ : F} : 𝓢 ⊢! Axioms.OrInst₂ φ ψ
+export HasAxiomOrInst (or₁! or₂!)
 
-@[simp] lemma or₁! [HasAxiomOrInst 𝓢] : 𝓢 ⊢ φ 🡒 φ ⋎ ψ := ⟨or₁⟩
+@[simp] lemma or₁ [HasAxiomOrInst 𝓢] : 𝓢 ⊢ φ 🡒 φ ⋎ ψ := ⟨or₁!⟩
 
-def A_intro_left [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! φ) : 𝓢 ⊢! φ ⋎ ψ := or₁ ⨀ d
-@[grind .] lemma A!_intro_left [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ φ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A_intro_left d.some⟩
+def A!_intro_left [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! φ) : 𝓢 ⊢! φ ⋎ ψ := or₁! ⨀ d
+@[grind .] lemma A_intro_left [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ φ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A!_intro_left d.some⟩
 
-@[simp] lemma or₂! [HasAxiomOrInst 𝓢] : 𝓢 ⊢ ψ 🡒 φ ⋎ ψ := ⟨or₂⟩
+@[simp] lemma or₂ [HasAxiomOrInst 𝓢] : 𝓢 ⊢ ψ 🡒 φ ⋎ ψ := ⟨or₂!⟩
 
-def A_intro_right [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! ψ) : 𝓢 ⊢! φ ⋎ ψ := or₂ ⨀ d
-@[grind .] lemma A!_intro_right [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ ψ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A_intro_right d.some⟩
+def A!_intro_right [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢! ψ) : 𝓢 ⊢! φ ⋎ ψ := or₂! ⨀ d
+@[grind .] lemma A_intro_right [HasAxiomOrInst 𝓢] [ModusPonens 𝓢] (d : 𝓢 ⊢ ψ) : 𝓢 ⊢ φ ⋎ ψ := ⟨A!_intro_right d.some⟩
 
 
 class HasAxiomOrElim (𝓢 : S) where
-  or₃ {φ ψ χ : F} : 𝓢 ⊢! Axioms.OrElim φ ψ χ
-export HasAxiomOrElim (or₃)
+  or₃! {φ ψ χ : F} : 𝓢 ⊢! Axioms.OrElim φ ψ χ
+export HasAxiomOrElim (or₃!)
 
-@[simp] lemma or₃! [HasAxiomOrElim 𝓢] : 𝓢 ⊢ (φ 🡒 χ) 🡒 (ψ 🡒 χ) 🡒 (φ ⋎ ψ) 🡒 χ := ⟨or₃⟩
+@[simp] lemma or₃ [HasAxiomOrElim 𝓢] : 𝓢 ⊢ (φ 🡒 χ) 🡒 (ψ 🡒 χ) 🡒 (φ ⋎ ψ) 🡒 χ := ⟨or₃!⟩
 
-def left_A_intro [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! φ 🡒 χ) (d₂ : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 χ := or₃ ⨀ d₁ ⨀ d₂
-alias CA_of_C_of_C := left_A_intro
-
-lemma left_A!_intro [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ φ 🡒 χ) (d₂ : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ := ⟨left_A_intro d₁.some d₂.some⟩
+def left_A!_intro [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! φ 🡒 χ) (d₂ : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 χ := or₃! ⨀ d₁ ⨀ d₂
 alias CA!_of_C!_of_C! := left_A!_intro
 
-def of_C_of_C_of_A [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! φ 🡒 χ) (d₂ : 𝓢 ⊢! ψ 🡒 χ) (d₃ : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! χ := or₃ ⨀ d₁ ⨀ d₂ ⨀ d₃
-alias A_cases := of_C_of_C_of_A
+lemma left_A_intro [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ φ 🡒 χ) (d₂ : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ := ⟨left_A!_intro d₁.some d₂.some⟩
+alias CA_of_C_of_C := left_A_intro
 
-lemma of_C!_of_C!_of_A! [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ φ 🡒 χ) (d₂ : 𝓢 ⊢ ψ 🡒 χ) (d₃ : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ χ := ⟨of_C_of_C_of_A d₁.some d₂.some d₃.some⟩
+def of_C!_of_C!_of_A! [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢! φ 🡒 χ) (d₂ : 𝓢 ⊢! ψ 🡒 χ) (d₃ : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! χ := or₃! ⨀ d₁ ⨀ d₂ ⨀ d₃
 alias A!_cases := of_C!_of_C!_of_A!
+
+lemma of_C_of_C_of_A [HasAxiomOrElim 𝓢] [ModusPonens 𝓢] (d₁ : 𝓢 ⊢ φ 🡒 χ) (d₂ : 𝓢 ⊢ ψ 🡒 χ) (d₃ : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ χ := ⟨of_C!_of_C!_of_A! d₁.some d₂.some d₃.some⟩
+alias A_cases := of_C_of_C_of_A
 
 protected class Minimal [LogicalNeutral F] (𝓢 : S) extends
               ModusPonens 𝓢,
@@ -182,134 +182,134 @@ section
 variable {S F : Type*} [LogicalConnective F] [Entailment S F]
 variable {𝓢 : S} [ModusPonens 𝓢] {φ ψ χ : F}
 
-def CO_of_N [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢! ∼φ → 𝓢 ⊢! φ 🡒 ⊥ := λ h => (K_left negEquiv) ⨀ h
-def N_of_CO [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢! φ 🡒 ⊥ → 𝓢 ⊢! ∼φ := λ h => (K_right negEquiv) ⨀ h
-@[grind =] lemma N!_iff_CO! [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢ ∼φ ↔ 𝓢 ⊢ φ 🡒 ⊥ := ⟨λ ⟨h⟩ => ⟨CO_of_N h⟩, λ ⟨h⟩ => ⟨N_of_CO h⟩⟩
+def CO!_of_N! [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢! ∼φ → 𝓢 ⊢! φ 🡒 ⊥ := λ h => (K!_left negEquiv!) ⨀ h
+def N!_of_CO! [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢! φ 🡒 ⊥ → 𝓢 ⊢! ∼φ := λ h => (K!_right negEquiv!) ⨀ h
+@[grind =] lemma N_iff_CO [LogicalNeutral F] [HasAxiomAndElim 𝓢] [NegationEquiv 𝓢] : 𝓢 ⊢ ∼φ ↔ 𝓢 ⊢ φ 🡒 ⊥ := ⟨λ ⟨h⟩ => ⟨CO!_of_N! h⟩, λ ⟨h⟩ => ⟨N!_of_CO! h⟩⟩
 
 
-def E_intro [HasAxiomAndInst 𝓢] (b₁ : 𝓢 ⊢! φ 🡒 ψ) (b₂ : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! φ 🡘 ψ := K_intro b₁ b₂
-@[grind ←] lemma E!_intro [HasAxiomAndInst 𝓢] (h₁ : 𝓢 ⊢ φ 🡒 ψ) (h₂ : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ φ 🡘 ψ := ⟨K_intro h₁.some h₂.some⟩
+def E!_intro [HasAxiomAndInst 𝓢] (b₁ : 𝓢 ⊢! φ 🡒 ψ) (b₂ : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! φ 🡘 ψ := K!_intro b₁ b₂
+@[grind ←] lemma E_intro [HasAxiomAndInst 𝓢] (h₁ : 𝓢 ⊢ φ 🡒 ψ) (h₂ : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ φ 🡘 ψ := ⟨K!_intro h₁.some h₂.some⟩
 
-@[grind =] lemma K!_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ ↔ 𝓢 ⊢ φ ∧ 𝓢 ⊢ ψ := by grind
-@[grind =] lemma E!_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ ↔ 𝓢 ⊢ φ 🡒 ψ ∧ 𝓢 ⊢ ψ 🡒 φ := ⟨fun h ↦ ⟨K!_left h, K!_right h⟩, by grind⟩
+@[grind =] lemma K_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ ⋏ ψ ↔ 𝓢 ⊢ φ ∧ 𝓢 ⊢ ψ := by grind
+@[grind =] lemma E_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ ↔ 𝓢 ⊢ φ 🡒 ψ ∧ 𝓢 ⊢ ψ 🡒 φ := ⟨fun h ↦ ⟨K_left h, K_right h⟩, by grind⟩
 
-def C_of_E_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! φ 🡒 ψ := K_left h
-@[grind →] lemma C!_of_E!_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ φ 🡒 ψ := λ ⟨d⟩ => ⟨C_of_E_mp d⟩
+def C!_of_E!_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! φ 🡒 ψ := K!_left h
+@[grind →] lemma C_of_E_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ φ 🡒 ψ := λ ⟨d⟩ => ⟨C!_of_E!_mp d⟩
 
-def C_of_E_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ψ 🡒 φ := K_right h
-@[grind →] lemma C!_of_E!_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ ψ 🡒 φ := λ ⟨d⟩ => ⟨C_of_E_mpr d⟩
+def C!_of_E!_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ψ 🡒 φ := K!_right h
+@[grind →] lemma C_of_E_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ ψ 🡒 φ := λ ⟨d⟩ => ⟨C!_of_E!_mpr d⟩
 
-@[grind →] lemma iff_of_E! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ φ ↔ 𝓢 ⊢ ψ := ⟨fun hp ↦ K!_left h ⨀ hp, fun hq ↦ K!_right h ⨀ hq⟩
+@[grind →] lemma iff_of_E [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ φ ↔ 𝓢 ⊢ ψ := ⟨fun hp ↦ K_left h ⨀ hp, fun hq ↦ K_right h ⨀ hq⟩
 
-def C_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡒 φ := implyS (φ := φ) (ψ := (φ 🡒 φ)) (χ := φ) ⨀ implyK ⨀ implyK
-@[simp] theorem C!_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡒 φ := ⟨C_id⟩
+def C!_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡒 φ := implyS! (φ := φ) (ψ := (φ 🡒 φ)) (χ := φ) ⨀ implyK! ⨀ implyK!
+@[simp] theorem C_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡒 φ := ⟨C!_id⟩
 
-def E_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡘 φ := K_intro C_id C_id
-@[simp] theorem E!_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡘 φ := ⟨E_id⟩
+def E!_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡘 φ := K!_intro C!_id C!_id
+@[simp] theorem E_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡘 φ := ⟨E!_id⟩
 
 instance [LogicalNeutral F] [NegAbbrev F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [HasAxiomAndInst 𝓢] : Entailment.NegationEquiv 𝓢 where
-  negEquiv {φ} := by
+  negEquiv! {φ} := by
     suffices 𝓢 ⊢! (φ 🡒 ⊥) 🡘 (φ 🡒 ⊥) by simpa [Axioms.NegEquiv, NegAbbrev.neg];
-    apply E_id;
+    apply E!_id;
 
 
-def NO [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! ∼⊥ := N_of_CO C_id
-@[simp] lemma NO! [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ ∼⊥ := ⟨NO⟩
+def NO! [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! ∼⊥ := N!_of_CO! C!_id
+@[simp] lemma NO [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ ∼⊥ := ⟨NO!⟩
 
 
-def mdp₁ [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) (bq : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 χ := implyS ⨀ bqr ⨀ bq
-@[grind →] lemma mdp₁! [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ) (hq : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 χ := ⟨mdp₁ hqr.some hq.some⟩
+def mdp₁! [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) (bq : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 χ := implyS! ⨀ bqr ⨀ bq
+@[grind →] lemma mdp₁ [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ) (hq : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 χ := ⟨mdp₁! hqr.some hq.some⟩
 
-infixl:90 "⨀₁" => mdp₁
 infixl:90 "⨀₁" => mdp₁!
+infixl:90 "⨀₁" => mdp₁
 
-def mdp₂ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ 🡒 s := C_of_conseq (implyS) ⨀₁ bqr ⨀₁ bq
-@[grind →] lemma mdp₂! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ 🡒 s := ⟨mdp₂ hqr.some hq.some⟩
+def mdp₂! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ 🡒 s := C!_of_conseq! (implyS!) ⨀₁ bqr ⨀₁ bq
+@[grind →] lemma mdp₂ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ 🡒 s := ⟨mdp₂! hqr.some hq.some⟩
 
-infixl:90 "⨀₂" => mdp₂
 infixl:90 "⨀₂" => mdp₂!
+infixl:90 "⨀₂" => mdp₂
 
-def mdp₃ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 t := (C_of_conseq <| C_of_conseq <| implyS) ⨀₂ bqr ⨀₂ bq
-@[grind →] lemma mdp₃! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s) : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 t := ⟨mdp₃ hqr.some hq.some⟩
+def mdp₃! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 t := (C!_of_conseq! <| C!_of_conseq! <| implyS!) ⨀₂ bqr ⨀₂ bq
+@[grind →] lemma mdp₃ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s) : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 t := ⟨mdp₃! hqr.some hq.some⟩
 
-infixl:90 "⨀₃" => mdp₃
 infixl:90 "⨀₃" => mdp₃!
+infixl:90 "⨀₃" => mdp₃
 
-def mdp₄ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t 🡒 u) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 u := (C_of_conseq <| C_of_conseq <| C_of_conseq <| implyS) ⨀₃ bqr ⨀₃ bq
-@[grind →] lemma mdp₄! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t 🡒 u) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 u := ⟨mdp₄ hqr.some hq.some⟩
-infixl:90 "⨀₄" => mdp₄
+def mdp₄! [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bqr : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t 🡒 u) (bq : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 s 🡒 u := (C!_of_conseq! <| C!_of_conseq! <| C!_of_conseq! <| implyS!) ⨀₃ bqr ⨀₃ bq
+@[grind →] lemma mdp₄ [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hqr : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t 🡒 u) (hq : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 t) : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 s 🡒 u := ⟨mdp₄! hqr.some hq.some⟩
 infixl:90 "⨀₄" => mdp₄!
+infixl:90 "⨀₄" => mdp₄
 
 
-def C_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bpq : 𝓢 ⊢! φ 🡒 ψ) (bqr : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 χ := implyS ⨀ C_of_conseq bqr ⨀ bpq
-@[grind <=] lemma C!_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hpq : 𝓢 ⊢ φ 🡒 ψ) (hqr : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ 🡒 χ := ⟨C_trans hpq.some hqr.some⟩
+def C!_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bpq : 𝓢 ⊢! φ 🡒 ψ) (bqr : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 χ := implyS! ⨀ C!_of_conseq! bqr ⨀ bpq
+@[grind <=] lemma C_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hpq : 𝓢 ⊢ φ 🡒 ψ) (hqr : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ 🡒 χ := ⟨C!_trans hpq.some hqr.some⟩
 
-def C_replace [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! ψ₁ 🡒 φ₁) (h₂ : 𝓢 ⊢! φ₂ 🡒 ψ₂) : 𝓢 ⊢! φ₁ 🡒 φ₂ → 𝓢 ⊢! ψ₁ 🡒 ψ₂ := λ h => C_trans h₁ $ C_trans h h₂
-lemma C!_replace [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢ ψ₁ 🡒 φ₁) (h₂ : 𝓢 ⊢ φ₂ 🡒 ψ₂) : 𝓢 ⊢ φ₁ 🡒 φ₂ → 𝓢 ⊢ ψ₁ 🡒 ψ₂ := λ h => ⟨C_replace h₁.some h₂.some h.some⟩
+def C!_replace [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! ψ₁ 🡒 φ₁) (h₂ : 𝓢 ⊢! φ₂ 🡒 ψ₂) : 𝓢 ⊢! φ₁ 🡒 φ₂ → 𝓢 ⊢! ψ₁ 🡒 ψ₂ := λ h => C!_trans h₁ $ C!_trans h h₂
+lemma C_replace [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢ ψ₁ 🡒 φ₁) (h₂ : 𝓢 ⊢ φ₂ 🡒 ψ₂) : 𝓢 ⊢ φ₁ 🡒 φ₂ → 𝓢 ⊢ ψ₁ 🡒 ψ₂ := λ h => ⟨C!_replace h₁.some h₂.some h.some⟩
 
-def E_replace [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! φ₁ 🡘 ψ₁) (h₂ : 𝓢 ⊢! φ₂ 🡘 ψ₂) (h₃ : 𝓢 ⊢! φ₁ 🡘 φ₂) : 𝓢 ⊢! ψ₁ 🡘 ψ₂ := by
-  apply E_intro;
-  . exact C_replace (C_of_E_mpr h₁) (C_of_E_mp h₂) (C_of_E_mp h₃);
-  . exact C_replace (C_of_E_mpr h₂) (C_of_E_mp h₁) (C_of_E_mpr h₃);
-lemma E!_replace [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ₁ 🡘 ψ₁ → 𝓢 ⊢ φ₂ 🡘 ψ₂ → 𝓢 ⊢ φ₁ 🡘 φ₂ → 𝓢 ⊢ ψ₁ 🡘 ψ₂ := λ ⟨d₁⟩ ⟨d₂⟩ ⟨d₃⟩ => ⟨E_replace d₁ d₂ d₃⟩
+def E!_replace [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! φ₁ 🡘 ψ₁) (h₂ : 𝓢 ⊢! φ₂ 🡘 ψ₂) (h₃ : 𝓢 ⊢! φ₁ 🡘 φ₂) : 𝓢 ⊢! ψ₁ 🡘 ψ₂ := by
+  apply E!_intro;
+  . exact C!_replace (C!_of_E!_mpr h₁) (C!_of_E!_mp h₂) (C!_of_E!_mp h₃);
+  . exact C!_replace (C!_of_E!_mpr h₂) (C!_of_E!_mp h₁) (C!_of_E!_mpr h₃);
+lemma E_replace [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ₁ 🡘 ψ₁ → 𝓢 ⊢ φ₂ 🡘 ψ₂ → 𝓢 ⊢ φ₁ 🡘 φ₂ → 𝓢 ⊢ ψ₁ 🡘 ψ₂ := λ ⟨d₁⟩ ⟨d₂⟩ ⟨d₃⟩ => ⟨E!_replace d₁ d₂ d₃⟩
 
-def E_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! φ 🡘 ψ) (h₂ : 𝓢 ⊢! ψ 🡘 χ) : 𝓢 ⊢! φ 🡘 χ := by
-  apply E_intro;
-  . exact C_trans (K_left h₁) (K_left h₂);
-  . exact C_trans (K_right h₂) (K_right h₁);
+def E!_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢! φ 🡘 ψ) (h₂ : 𝓢 ⊢! ψ 🡘 χ) : 𝓢 ⊢! φ 🡘 χ := by
+  apply E!_intro;
+  . exact C!_trans (K!_left h₁) (K!_left h₂);
+  . exact C!_trans (K!_right h₂) (K!_right h₁);
 @[grind <=]
-lemma E!_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢ φ 🡘 ψ) (h₂ : 𝓢 ⊢ ψ 🡘 χ) : 𝓢 ⊢ φ 🡘 χ := ⟨E_trans h₁.some h₂.some⟩
+lemma E_trans [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h₁ : 𝓢 ⊢ φ 🡘 ψ) (h₂ : 𝓢 ⊢ ψ 🡘 χ) : 𝓢 ⊢ φ 🡘 χ := ⟨E!_trans h₁.some h₂.some⟩
 
-def CCCC [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 φ := C_trans implyK implyK
+def CCCC! [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! φ 🡒 ψ 🡒 χ 🡒 φ := C!_trans implyK! implyK!
 @[grind .]
-lemma CCCC! [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 φ := ⟨CCCC⟩
+lemma CCCC [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡒 ψ 🡒 χ 🡒 φ := ⟨CCCC!⟩
 
-def CK_of_C_of_C [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bq : 𝓢 ⊢! φ 🡒 ψ) (br : 𝓢 ⊢! φ 🡒 χ)
-  : 𝓢 ⊢! φ 🡒 ψ ⋏ χ := C_of_conseq and₃ ⨀₁ bq ⨀₁ br
+def CK!_of_C!_of_C! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (bq : 𝓢 ⊢! φ 🡒 ψ) (br : 𝓢 ⊢! φ 🡒 χ)
+  : 𝓢 ⊢! φ 🡒 ψ ⋏ χ := C!_of_conseq! and₃! ⨀₁ bq ⨀₁ br
 @[grind <=]
-lemma CK!_of_C!_of_C! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hq : 𝓢 ⊢ φ 🡒 ψ) (hr : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ ⋏ χ := ⟨CK_of_C_of_C hq.some hr.some⟩
+lemma CK_of_C_of_C [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hq : 𝓢 ⊢ φ 🡒 ψ) (hr : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ ⋏ χ := ⟨CK!_of_C!_of_C! hq.some hr.some⟩
 
 
-def CKK [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! φ ⋏ ψ 🡒 ψ ⋏ φ := CK_of_C_of_C and₂ and₁
-@[simp, grind .] lemma CKK! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 ψ ⋏ φ := ⟨CKK⟩
+def CKK! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! φ ⋏ ψ 🡒 ψ ⋏ φ := CK!_of_C!_of_C! and₂! and₁!
+@[simp, grind .] lemma CKK [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ ⋏ ψ 🡒 ψ ⋏ φ := ⟨CKK!⟩
 
-def K_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ψ ⋏ φ := CKK ⨀ h
-@[grind <-] lemma K!_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ψ ⋏ φ := ⟨K_symm h.some⟩
-
-
-def CEE [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! (φ 🡘 ψ) 🡒 (ψ 🡘 φ) := CKK
-@[simp] lemma CEE! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ 🡘 ψ) 🡒 (ψ 🡘 φ) := ⟨CEE⟩
-
-def E_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ψ 🡘 φ := CEE ⨀ h
-@[grind <-] lemma E!_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ ψ 🡘 φ := ⟨E_symm h.some⟩
+def K!_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ψ ⋏ φ := CKK! ⨀ h
+@[grind <-] lemma K_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ψ ⋏ φ := ⟨K!_symm h.some⟩
 
 
-def ECKCC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! (φ ⋏ ψ 🡒 χ) 🡘 (φ 🡒 ψ 🡒 χ) := by
-  let b₁ : 𝓢 ⊢! (φ ⋏ ψ 🡒 χ) 🡒 φ 🡒 ψ 🡒 χ := CCCC ⨀₃ C_of_conseq (ψ := φ ⋏ ψ 🡒 χ) and₃
-  let b₂ : 𝓢 ⊢! (φ 🡒 ψ 🡒 χ) 🡒 φ ⋏ ψ 🡒 χ := implyK ⨀₂ (C_of_conseq (ψ := φ 🡒 ψ 🡒 χ) and₁) ⨀₂ (C_of_conseq (ψ := φ 🡒 ψ 🡒 χ) and₂);
-  exact E_intro b₁ b₂
-@[simp, grind .] lemma ECKCC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ ⋏ ψ 🡒 χ) 🡘 (φ 🡒 ψ 🡒 χ) := ⟨ECKCC⟩
+def CEE! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! (φ 🡘 ψ) 🡒 (ψ 🡘 φ) := CKK!
+@[simp] lemma CEE [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ 🡘 ψ) 🡒 (ψ 🡘 φ) := ⟨CEE!⟩
 
-def CC_of_CK [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ := (K_left $ ECKCC) ⨀ d
-def CK_of_CC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (d : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ := (K_right $ ECKCC) ⨀ d
+def E!_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ψ 🡘 φ := CEE! ⨀ h
+@[grind <-] lemma E_symm [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ ψ 🡘 φ := ⟨E!_symm h.some⟩
 
-@[grind =] lemma CK!_iff_CC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] :
-    (𝓢 ⊢ φ ⋏ ψ 🡒 χ) ↔ (𝓢 ⊢ φ 🡒 ψ 🡒 χ) := iff_of_E! ECKCC!
 
-def CV [LogicalNeutral F] [HasAxiomVerum 𝓢] [HasAxiomImplyK 𝓢] : 𝓢 ⊢! φ 🡒 ⊤ := C_of_conseq verum
-@[simp] lemma CV! [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomVerum 𝓢] : 𝓢 ⊢ φ 🡒 ⊤ := ⟨CV⟩
+def ECKCC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢! (φ ⋏ ψ 🡒 χ) 🡘 (φ 🡒 ψ 🡒 χ) := by
+  let b₁ : 𝓢 ⊢! (φ ⋏ ψ 🡒 χ) 🡒 φ 🡒 ψ 🡒 χ := CCCC! ⨀₃ C!_of_conseq! (ψ := φ ⋏ ψ 🡒 χ) and₃!
+  let b₂ : 𝓢 ⊢! (φ 🡒 ψ 🡒 χ) 🡒 φ ⋏ ψ 🡒 χ := implyK! ⨀₂ (C!_of_conseq! (ψ := φ 🡒 ψ 🡒 χ) and₁!) ⨀₂ (C!_of_conseq! (ψ := φ 🡒 ψ 🡒 χ) and₂!);
+  exact E!_intro b₁ b₂
+@[simp, grind .] lemma ECKCC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ (φ ⋏ ψ 🡒 χ) 🡘 (φ 🡒 ψ 🡒 χ) := ⟨ECKCC!⟩
+
+def CC!_of_CK! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (d : 𝓢 ⊢! φ ⋏ ψ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ 🡒 χ := (K!_left $ ECKCC!) ⨀ d
+def CK!_of_CC! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (d : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ := (K!_right $ ECKCC!) ⨀ d
+
+@[grind =] lemma CK_iff_CC [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] :
+    (𝓢 ⊢ φ ⋏ ψ 🡒 χ) ↔ (𝓢 ⊢ φ 🡒 ψ 🡒 χ) := iff_of_E ECKCC
+
+def CV! [LogicalNeutral F] [HasAxiomVerum 𝓢] [HasAxiomImplyK 𝓢] : 𝓢 ⊢! φ 🡒 ⊤ := C!_of_conseq! verum!
+@[simp] lemma CV [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomVerum 𝓢] : 𝓢 ⊢ φ 🡒 ⊤ := ⟨CV!⟩
 
 
 @[grind →]
-lemma unprovable_C!_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hpq : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊬ φ 🡒 χ → 𝓢 ⊬ ψ 🡒 χ := by
+lemma unprovable_C_trans [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (hpq : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊬ φ 🡒 χ → 𝓢 ⊬ ψ 🡒 χ := by
   contrapose!;
-  exact C!_trans hpq;
+  exact C_trans hpq;
 
 @[grind →]
-lemma uniff_of_E! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (H : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊬ φ ↔ 𝓢 ⊬ ψ := by
+lemma uniff_of_E [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] (H : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊬ φ ↔ 𝓢 ⊬ ψ := by
   constructor;
-  . intro hp hq; have := K!_right H ⨀ hq; contradiction;
-  . intro hq hp; have := K!_left H ⨀ hp; contradiction;
+  . intro hp hq; have := K_right H ⨀ hq; contradiction;
+  . intro hq hp; have := K_left H ⨀ hp; contradiction;
 
 end
 
@@ -321,61 +321,61 @@ variable {𝓢 : S} [Entailment.Minimal 𝓢] {φ ψ χ : F}
 
 variable {Γ Δ : List F}
 
-def conj₂Nth : (Γ : List F) → (n : ℕ) → (hn : n < Γ.length) → 𝓢 ⊢! ⋀Γ 🡒 Γ[n]
+def conj₂Nth! : (Γ : List F) → (n : ℕ) → (hn : n < Γ.length) → 𝓢 ⊢! ⋀Γ 🡒 Γ[n]
   |          [],     _, hn => by simp at hn
-  |         [ψ],     0, _  => C_id
-  | φ :: ψ :: Γ,     0, _  => and₁
-  | φ :: ψ :: Γ, n + 1, hn => C_trans (and₂ (φ := φ)) (conj₂Nth (ψ :: Γ) n (Nat.succ_lt_succ_iff.mp hn))
+  |         [ψ],     0, _  => C!_id
+  | φ :: ψ :: Γ,     0, _  => and₁!
+  | φ :: ψ :: Γ, n + 1, hn => C!_trans (and₂! (φ := φ)) (conj₂Nth! (ψ :: Γ) n (Nat.succ_lt_succ_iff.mp hn))
 
-theorem conj₂_nth! (Γ : List F) (n : ℕ) (hn : n < Γ.length) : 𝓢 ⊢ ⋀Γ 🡒 Γ[n] := ⟨conj₂Nth Γ n hn⟩
+theorem conj₂_nth (Γ : List F) (n : ℕ) (hn : n < Γ.length) : 𝓢 ⊢ ⋀Γ 🡒 Γ[n] := ⟨conj₂Nth! Γ n hn⟩
 
-def left_Conj_intro [DecidableEq F] {Γ : List F} {φ : F} (h : φ ∈ Γ) : 𝓢 ⊢! Γ.conj 🡒 φ :=
+def left_Conj!_intro [DecidableEq F] {Γ : List F} {φ : F} (h : φ ∈ Γ) : 𝓢 ⊢! Γ.conj 🡒 φ :=
   match Γ with
   |     [] => by simp at h
   | ψ :: Γ =>
     if e : φ = ψ
-    then e ▸ and₁
+    then e ▸ and₁!
     else
       have : φ ∈ Γ := by simpa [e] using h
-      C_trans and₂ (left_Conj_intro this)
-lemma left_Conj!_intro [DecidableEq F] (h : φ ∈ Γ) : 𝓢 ⊢ Γ.conj 🡒 φ := ⟨left_Conj_intro h⟩
+      C!_trans and₂! (left_Conj!_intro this)
+lemma left_Conj_intro [DecidableEq F] (h : φ ∈ Γ) : 𝓢 ⊢ Γ.conj 🡒 φ := ⟨left_Conj!_intro h⟩
 
-def Conj_intro (Γ : List F) (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢! φ) : 𝓢 ⊢! Γ.conj :=
+def Conj!_intro (Γ : List F) (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢! φ) : 𝓢 ⊢! Γ.conj :=
   match Γ with
-  |     [] => verum
-  | ψ :: Γ => K_intro (b ψ (by simp)) (Conj_intro Γ (fun ψ hq ↦ b ψ (by simp [hq])))
-lemma Conj!_intro {Γ : List F} (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢ φ) : 𝓢 ⊢ Γ.conj := ⟨Conj_intro Γ λ φ hφ => (b φ hφ).some⟩
+  |     [] => verum!
+  | ψ :: Γ => K!_intro (b ψ (by simp)) (Conj!_intro Γ (fun ψ hq ↦ b ψ (by simp [hq])))
+lemma Conj_intro {Γ : List F} (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢ φ) : 𝓢 ⊢ Γ.conj := ⟨Conj!_intro Γ λ φ hφ => (b φ hφ).some⟩
 
-def right_Conj_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 Γ.conj :=
+def right_Conj!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 Γ.conj :=
   match Γ with
-  |     [] => C_of_conseq verum
-  | ψ :: Γ => CK_of_C_of_C (b ψ (by simp)) (right_Conj_intro φ Γ (fun ψ hq ↦ b ψ (by simp [hq])))
-theorem right_Conj!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 Γ.conj := ⟨right_Conj_intro φ Γ fun ψ h ↦ (b ψ h).get⟩
+  |     [] => C!_of_conseq! verum!
+  | ψ :: Γ => CK!_of_C!_of_C! (b ψ (by simp)) (right_Conj!_intro φ Γ (fun ψ hq ↦ b ψ (by simp [hq])))
+theorem right_Conj_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 Γ.conj := ⟨right_Conj!_intro φ Γ fun ψ h ↦ (b ψ h).get⟩
 
-def CConjConj [DecidableEq F] (h : Δ ⊆ Γ) : 𝓢 ⊢! Γ.conj 🡒 Δ.conj := right_Conj_intro _ _ (fun _ hq ↦ left_Conj_intro (h hq))
+def CConjConj! [DecidableEq F] (h : Δ ⊆ Γ) : 𝓢 ⊢! Γ.conj 🡒 Δ.conj := right_Conj!_intro _ _ (fun _ hq ↦ left_Conj!_intro (h hq))
 
-def left_Conj₂_intro [DecidableEq F] {Γ : List F} {φ : F} (h : φ ∈ Γ) : 𝓢 ⊢! ⋀Γ 🡒 φ :=
+def left_Conj₂!_intro [DecidableEq F] {Γ : List F} {φ : F} (h : φ ∈ Γ) : 𝓢 ⊢! ⋀Γ 🡒 φ :=
   have : Γ.idxOf φ < Γ.length := List.idxOf_lt_length_of_mem h
-  cast <| conj₂Nth Γ (Γ.idxOf φ) (by assumption)
-lemma left_Conj₂!_intro [DecidableEq F] (h : φ ∈ Γ) : 𝓢 ⊢ ⋀Γ 🡒 φ := ⟨left_Conj₂_intro h⟩
+  cast <| conj₂Nth! Γ (Γ.idxOf φ) (by assumption)
+lemma left_Conj₂_intro [DecidableEq F] (h : φ ∈ Γ) : 𝓢 ⊢ ⋀Γ 🡒 φ := ⟨left_Conj₂!_intro h⟩
 
-def Conj₂_intro (Γ : List F) (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢! φ) : 𝓢 ⊢! ⋀Γ :=
+def Conj₂!_intro (Γ : List F) (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢! φ) : 𝓢 ⊢! ⋀Γ :=
   match Γ with
-  |          [] => verum
+  |          [] => verum!
   |         [ψ] => by apply b; simp;
-  | ψ :: χ :: Γ => by exact K_intro (b ψ (by simp)) (Conj₂_intro _ (by aesop))
-lemma Conj₂!_intro (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢ φ) : 𝓢 ⊢ ⋀Γ := ⟨Conj₂_intro Γ (λ φ hp => (b φ hp).some)⟩
+  | ψ :: χ :: Γ => by exact K!_intro (b ψ (by simp)) (Conj₂!_intro _ (by aesop))
+lemma Conj₂_intro (b : (φ : F) → φ ∈ Γ → 𝓢 ⊢ φ) : 𝓢 ⊢ ⋀Γ := ⟨Conj₂!_intro Γ (λ φ hp => (b φ hp).some)⟩
 
-def right_Conj₂_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 ⋀Γ :=
+def right_Conj₂!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 ⋀Γ :=
   match Γ with
-  |          [] => C_of_conseq verum
+  |          [] => C!_of_conseq! verum!
   |         [ψ] => by apply b; simp;
-  | ψ :: χ :: Γ => by apply CK_of_C_of_C (b ψ (by simp)) (right_Conj₂_intro φ _ (fun ψ hq ↦ b ψ (by simp [hq])));
-lemma right_Conj₂!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ⋀Γ := ⟨right_Conj₂_intro φ Γ (λ ψ hq => (b ψ hq).some)⟩
+  | ψ :: χ :: Γ => by apply CK!_of_C!_of_C! (b ψ (by simp)) (right_Conj₂!_intro φ _ (fun ψ hq ↦ b ψ (by simp [hq])));
+lemma right_Conj₂_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ⋀Γ := ⟨right_Conj₂!_intro φ Γ (λ ψ hq => (b ψ hq).some)⟩
 
-def CConj₂Conj₂ [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢! ⋀Γ 🡒 ⋀Δ :=
-  right_Conj₂_intro _ _ (fun _ hq ↦ left_Conj₂_intro (h hq))
-lemma CConj₂Conj₂! [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ 🡒 ⋀Δ := ⟨CConj₂Conj₂ h⟩
+def CConj₂Conj₂! [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢! ⋀Γ 🡒 ⋀Δ :=
+  right_Conj₂!_intro _ _ (fun _ hq ↦ left_Conj₂!_intro (h hq))
+lemma CConj₂Conj₂ [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ 🡒 ⋀Δ := ⟨CConj₂Conj₂! h⟩
 
 
 section
@@ -384,19 +384,19 @@ variable {G T : Type*} [Entailment T G] [LogicalConnective G] [LogicalNeutral G]
 
 abbrev Minimal.ofEquiv (𝓢 : S) [Entailment.Minimal 𝓢] (𝓣 : T)
     (f : G →ˡᶜ F) (e : (φ : G) → 𝓢 ⊢! f φ ≃ 𝓣 ⊢! φ) : Entailment.Minimal 𝓣 where
-  mdp {φ ψ dpq dp} := (e ψ) (
+  mdp! {φ ψ dpq dp} := (e ψ) (
     let d : 𝓢 ⊢! f φ 🡒 f ψ := by simpa using (e (φ 🡒 ψ)).symm dpq
     d ⨀ ((e φ).symm dp))
-  negEquiv := e _ (by simpa using negEquiv)
-  verum := e _ (by simpa using verum)
-  implyK := e _ (by simpa using implyK)
-  implyS := e _ (by simpa using implyS)
-  and₁ := e _ (by simpa using and₁)
-  and₂ := e _ (by simpa using and₂)
-  and₃ := e _ (by simpa using and₃)
-  or₁ := e _ (by simpa using or₁)
-  or₂ := e _ (by simpa using or₂)
-  or₃ := e _ (by simpa using or₃)
+  negEquiv! := e _ (by simpa using negEquiv!)
+  verum! := e _ (by simpa using verum!)
+  implyK! := e _ (by simpa using implyK!)
+  implyS! := e _ (by simpa using implyS!)
+  and₁! := e _ (by simpa using and₁!)
+  and₂! := e _ (by simpa using and₂!)
+  and₃! := e _ (by simpa using and₃!)
+  or₁! := e _ (by simpa using or₁!)
+  or₂! := e _ (by simpa using or₂!)
+  or₃! := e _ (by simpa using or₃!)
 
 end
 
@@ -465,15 +465,15 @@ notation Γ:45 " ⊢[" 𝓢 "]* " s:46 => ProvableSet 𝓢 Γ s
 
 lemma entailment_def (Γ : FiniteContext F 𝓢) (φ : F) : (Γ ⊢! φ) = (𝓢 ⊢! Γ.conj 🡒 φ) := rfl
 
-def ofDef {Γ : List F} {φ : F} (b : 𝓢 ⊢! ⋀Γ 🡒 φ) : Γ ⊢[𝓢]! φ := b
+def ofDef! {Γ : List F} {φ : F} (b : 𝓢 ⊢! ⋀Γ 🡒 φ) : Γ ⊢[𝓢]! φ := b
 
-def toDef {Γ : List F} {φ : F} (b : Γ ⊢[𝓢]! φ) : 𝓢 ⊢! ⋀Γ 🡒 φ := b
+def toDef! {Γ : List F} {φ : F} (b : Γ ⊢[𝓢]! φ) : 𝓢 ⊢! ⋀Γ 🡒 φ := b
 
-lemma toₛ! (b : Γ ⊢[𝓢] φ) : 𝓢 ⊢ ⋀Γ 🡒 φ := b
+lemma toₛ (b : Γ ⊢[𝓢] φ) : 𝓢 ⊢ ⋀Γ 🡒 φ := b
 
 lemma provable_iff {φ : F} : Γ ⊢[𝓢] φ ↔ 𝓢 ⊢ ⋀Γ 🡒 φ := iff_of_eq rfl
 
-def cast {Γ φ} (d : Γ ⊢[𝓢]! φ) (eΓ : Γ = Γ') (eφ : φ = φ') : Γ' ⊢[𝓢]! φ' := eΓ ▸ eφ ▸ d
+def cast! {Γ φ} (d : Γ ⊢[𝓢]! φ) (eΓ : Γ = Γ') (eφ : φ = φ') : Γ' ⊢[𝓢]! φ' := eΓ ▸ eφ ▸ d
 
 section
 
@@ -481,8 +481,8 @@ variable {Γ Δ E : List F}
 variable [Entailment.Minimal 𝓢]
 
 instance [DecidableEq F] : Axiomatized (FiniteContext F 𝓢) where
-  prfAxm := fun hp ↦ left_Conj₂_intro hp
-  weakening := fun H b ↦ C_trans (CConj₂Conj₂ H) b
+  prfAxm := fun hp ↦ left_Conj₂!_intro hp
+  weakening := fun H b ↦ C!_trans (CConj₂Conj₂! H) b
 
 instance : Compact (FiniteContext F 𝓢) where
   core := fun {Γ} _ _ ↦ Γ
@@ -490,96 +490,96 @@ instance : Compact (FiniteContext F 𝓢) where
   core_subset := by simp
   core_finite := by rintro ⟨Γ⟩; simp [AdjunctiveSet.Finite, AdjunctiveSet.set]
 
-def nthAxm {Γ} (n : ℕ) (h : n < Γ.length := by simp) : Γ ⊢[𝓢]! Γ[n] := conj₂Nth Γ n h
-lemma nth_axm! {Γ} (n : ℕ) (h : n < Γ.length := by simp) : Γ ⊢[𝓢] Γ[n] := ⟨nthAxm n h⟩
+def nthAxm! {Γ} (n : ℕ) (h : n < Γ.length := by simp) : Γ ⊢[𝓢]! Γ[n] := conj₂Nth! Γ n h
+lemma nth_axm {Γ} (n : ℕ) (h : n < Γ.length := by simp) : Γ ⊢[𝓢] Γ[n] := ⟨nthAxm! n h⟩
 
-def byAxm [DecidableEq F] {φ} (h : φ ∈ Γ := by simp) : Γ ⊢[𝓢]! φ := Axiomatized.prfAxm (by simpa)
+def byAxm! [DecidableEq F] {φ} (h : φ ∈ Γ := by simp) : Γ ⊢[𝓢]! φ := Axiomatized.prfAxm (by simpa)
 
-lemma by_axm! [DecidableEq F] {φ} (h : φ ∈ Γ := by simp) : Γ ⊢[𝓢] φ := Axiomatized.provable_refl _ (by simpa)
+lemma by_axm [DecidableEq F] {φ} (h : φ ∈ Γ := by simp) : Γ ⊢[𝓢] φ := Axiomatized.provable_refl _ (by simpa)
 
-def weakening [DecidableEq F] (h : Γ ⊆ Δ) {φ} : Γ ⊢[𝓢]! φ → Δ ⊢[𝓢]! φ := Axiomatized.weakening (by simpa)
+def weakening! [DecidableEq F] (h : Γ ⊆ Δ) {φ} : Γ ⊢[𝓢]! φ → Δ ⊢[𝓢]! φ := Axiomatized.weakening (by simpa)
 
-lemma weakening! [DecidableEq F] (h : Γ ⊆ Δ) {φ} : Γ ⊢[𝓢] φ → Δ ⊢[𝓢] φ := fun h ↦
+lemma weakening [DecidableEq F] (h : Γ ⊆ Δ) {φ} : Γ ⊢[𝓢] φ → Δ ⊢[𝓢] φ := fun h ↦
   (Axiomatized.le_of_subset (by simpa)).subset h
 
-def of {φ : F} (b : 𝓢 ⊢! φ) : Γ ⊢[𝓢]! φ := C_of_conseq (ψ := ⋀Γ) b
+def of! {φ : F} (b : 𝓢 ⊢! φ) : Γ ⊢[𝓢]! φ := C!_of_conseq! (ψ := ⋀Γ) b
 
-def emptyPrf {φ : F} : [] ⊢[𝓢]! φ → 𝓢 ⊢! φ := fun b ↦ b ⨀ verum
+def emptyPrf! {φ : F} : [] ⊢[𝓢]! φ → 𝓢 ⊢! φ := fun b ↦ b ⨀ verum!
 
 theorem provable_iff_provable {φ : F} : 𝓢 ⊢ φ ↔ [] ⊢[𝓢] φ :=
-  ⟨fun b ↦ ⟨of b.some⟩, fun b ↦ ⟨emptyPrf b.some⟩⟩
+  ⟨fun b ↦ ⟨of! b.some⟩, fun b ↦ ⟨emptyPrf! b.some⟩⟩
 
-lemma of'! [DecidableEq F] (h : 𝓢 ⊢ φ) : Γ ⊢[𝓢] φ := weakening! (by simp) $ provable_iff_provable.mp h
+lemma of' [DecidableEq F] (h : 𝓢 ⊢ φ) : Γ ⊢[𝓢] φ := weakening (by simp) $ provable_iff_provable.mp h
 
-def id : [φ] ⊢[𝓢]! φ := nthAxm 0
-@[simp] lemma id! : [φ] ⊢[𝓢] φ := nth_axm! 0
+def id! : [φ] ⊢[𝓢]! φ := nthAxm! 0
+@[simp] lemma id : [φ] ⊢[𝓢] φ := nth_axm 0
 
-def byAxm₀ : (φ :: Γ) ⊢[𝓢]! φ := nthAxm 0
-lemma by_axm₀! : (φ :: Γ) ⊢[𝓢] φ := nth_axm! 0
+def byAxm₀! : (φ :: Γ) ⊢[𝓢]! φ := nthAxm! 0
+lemma by_axm₀ : (φ :: Γ) ⊢[𝓢] φ := nth_axm 0
 
-def byAxm₁ : (φ :: ψ :: Γ) ⊢[𝓢]! ψ := nthAxm 1
-lemma by_axm₁! : (φ :: ψ :: Γ) ⊢[𝓢] ψ := nth_axm! 1
+def byAxm₁! : (φ :: ψ :: Γ) ⊢[𝓢]! ψ := nthAxm! 1
+lemma by_axm₁ : (φ :: ψ :: Γ) ⊢[𝓢] ψ := nth_axm 1
 
-def byAxm₂ : (φ :: ψ :: χ :: Γ) ⊢[𝓢]! χ := nthAxm 2
-lemma by_axm₂! : (φ :: ψ :: χ :: Γ) ⊢[𝓢] χ := nth_axm! 2
+def byAxm₂! : (φ :: ψ :: χ :: Γ) ⊢[𝓢]! χ := nthAxm! 2
+lemma by_axm₂ : (φ :: ψ :: χ :: Γ) ⊢[𝓢] χ := nth_axm 2
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.ModusPonens Γ := ⟨mdp₁⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.ModusPonens Γ := ⟨mdp₁!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomVerum Γ := ⟨of verum⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomVerum Γ := ⟨of! verum!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomImplyK Γ := ⟨of implyK⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomImplyK Γ := ⟨of! implyK!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomImplyS Γ := ⟨of implyS⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomImplyS Γ := ⟨of! implyS!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomAndElim Γ := ⟨of and₁, of and₂⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomAndElim Γ := ⟨of! and₁!, of! and₂!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomAndInst Γ := ⟨of and₃⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomAndInst Γ := ⟨of! and₃!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomOrInst Γ := ⟨of or₁, of or₂⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomOrInst Γ := ⟨of! or₁!, of! or₂!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomOrElim Γ := ⟨of or₃⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.HasAxiomOrElim Γ := ⟨of! or₃!⟩
 
-instance (Γ : FiniteContext F 𝓢) : Entailment.NegationEquiv Γ := ⟨of negEquiv⟩
+instance (Γ : FiniteContext F 𝓢) : Entailment.NegationEquiv Γ := ⟨of! negEquiv!⟩
 
 instance (Γ : FiniteContext F 𝓢) : Entailment.Minimal Γ where
 
 
-def mdp' [DecidableEq F] (bΓ : Γ ⊢[𝓢]! φ 🡒 ψ) (bΔ : Δ ⊢[𝓢]! φ) : (Γ ++ Δ) ⊢[𝓢]! ψ :=
+def mdp'! [DecidableEq F] (bΓ : Γ ⊢[𝓢]! φ 🡒 ψ) (bΔ : Δ ⊢[𝓢]! φ) : (Γ ++ Δ) ⊢[𝓢]! ψ :=
   wk (by simp) bΓ ⨀ wk (by simp) bΔ
 
-def deduct {φ ψ : F} : {Γ : List F} → (φ :: Γ) ⊢[𝓢]! ψ → Γ ⊢[𝓢]! φ 🡒 ψ
-  | .nil => fun b ↦ ofDef <| C_of_conseq (toDef b)
-  | .cons _ _ => fun b ↦ ofDef <| CC_of_CK (C_trans CKK (toDef b))
+def deduct! {φ ψ : F} : {Γ : List F} → (φ :: Γ) ⊢[𝓢]! ψ → Γ ⊢[𝓢]! φ 🡒 ψ
+  | .nil => fun b ↦ ofDef! <| C!_of_conseq! (toDef! b)
+  | .cons _ _ => fun b ↦ ofDef! <| CC!_of_CK! (C!_trans CKK! (toDef! b))
 
-lemma deduct! (h : (φ :: Γ) ⊢[𝓢] ψ) :  Γ ⊢[𝓢] φ 🡒 ψ  := ⟨FiniteContext.deduct h.some⟩
+lemma deduct (h : (φ :: Γ) ⊢[𝓢] ψ) :  Γ ⊢[𝓢] φ 🡒 ψ  := ⟨FiniteContext.deduct! h.some⟩
 
-def deductInv {φ ψ : F} : {Γ : List F} → Γ ⊢[𝓢]! φ 🡒 ψ → (φ :: Γ) ⊢[𝓢]! ψ
-  | .nil => λ b => ofDef <| (toDef b) ⨀ verum
-  | .cons _ _ => λ b => ofDef <| (C_trans CKK (CK_of_CC (toDef b)))
+def deductInv! {φ ψ : F} : {Γ : List F} → Γ ⊢[𝓢]! φ 🡒 ψ → (φ :: Γ) ⊢[𝓢]! ψ
+  | .nil => λ b => ofDef! <| (toDef! b) ⨀ verum!
+  | .cons _ _ => λ b => ofDef! <| (C!_trans CKK! (CK!_of_CC! (toDef! b)))
 
-lemma deductInv! (h : Γ ⊢[𝓢] φ 🡒 ψ) : (φ :: Γ) ⊢[𝓢] ψ := ⟨FiniteContext.deductInv h.some⟩
+lemma deductInv (h : Γ ⊢[𝓢] φ 🡒 ψ) : (φ :: Γ) ⊢[𝓢] ψ := ⟨FiniteContext.deductInv! h.some⟩
 
 lemma deduct_iff {φ ψ : F} {Γ : List F} : Γ ⊢[𝓢] φ 🡒 ψ ↔ (φ :: Γ) ⊢[𝓢] ψ :=
-  ⟨fun h ↦ ⟨deductInv h.some⟩, fun h ↦ ⟨deduct h.some⟩⟩
+  ⟨fun h ↦ ⟨deductInv! h.some⟩, fun h ↦ ⟨deduct! h.some⟩⟩
 
-def deduct' : [φ] ⊢[𝓢]! ψ → 𝓢 ⊢! φ 🡒 ψ := fun b ↦ emptyPrf <| deduct b
+def deduct'! : [φ] ⊢[𝓢]! ψ → 𝓢 ⊢! φ 🡒 ψ := fun b ↦ emptyPrf! <| deduct! b
 
-lemma deduct'! (h : [φ] ⊢[𝓢] ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨FiniteContext.deduct' h.some⟩
+lemma deduct' (h : [φ] ⊢[𝓢] ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨FiniteContext.deduct'! h.some⟩
 
 
-def deductInv' : 𝓢 ⊢! φ 🡒 ψ → [φ] ⊢[𝓢]! ψ := fun b ↦ deductInv <| of b
+def deductInv'! : 𝓢 ⊢! φ 🡒 ψ → [φ] ⊢[𝓢]! ψ := fun b ↦ deductInv! <| of! b
 
-lemma deductInv'! (h : 𝓢 ⊢ φ 🡒 ψ) : [φ] ⊢[𝓢] ψ := ⟨FiniteContext.deductInv' h.some⟩
+lemma deductInv' (h : 𝓢 ⊢ φ 🡒 ψ) : [φ] ⊢[𝓢] ψ := ⟨FiniteContext.deductInv'! h.some⟩
 
 
 instance deduction : Deduction (FiniteContext F 𝓢) where
-  ofInsert := deduct
-  inv := deductInv
+  ofInsert := deduct!
+  inv := deductInv!
 
 instance [DecidableEq F] : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
   ⟨fun {Γ Δ _} bΓ bΔ ↦
-    have : Γ ⊢! Δ.conj := Conj₂_intro _ (fun _ hp ↦ bΓ hp)
-    ofDef <| C_trans (toDef this) (toDef bΔ)⟩
+    have : Γ ⊢! Δ.conj := Conj₂!_intro _ (fun _ hp ↦ bΓ hp)
+    ofDef! <| C!_trans (toDef! this) (toDef! bΔ)⟩
 
 end
 
@@ -667,7 +667,7 @@ instance [DecidableEq F] : Axiomatized (Context F 𝓢) where
   prfAxm := fun {Γ φ} hp ↦ ⟨[φ], by simpa using hp, byAxm (by simp)⟩
   weakening := fun h b ↦ ⟨b.ctx, fun φ hp ↦ AdjunctiveSet.subset_iff.mp h φ (b.subset φ hp), b.prf⟩
 
-def byAxm [DecidableEq F] {Γ : Set F} {φ : F} (h : φ ∈ Γ) : Γ *⊢[𝓢]! φ := Axiomatized.prfAxm (by simpa)
+def byAxm! [DecidableEq F] {Γ : Set F} {φ : F} (h : φ ∈ Γ) : Γ *⊢[𝓢]! φ := Axiomatized.prfAxm (by simpa)
 
 instance : Compact (Context F 𝓢) where
   core := fun b ↦ AdjunctiveSet.set b.ctx
@@ -677,11 +677,11 @@ instance : Compact (Context F 𝓢) where
 
 -- lemma provable_iff' [DecidableEq F] {φ : F} : Γ *⊢[𝓢] φ ↔ ∃ Δ : Finset F, (↑Δ ⊆ Γ) ∧ Δ *⊢[𝓢] φ
 
-def deduct [DecidableEq F] {φ ψ : F} {Γ : Set F} : (insert φ Γ) *⊢[𝓢]! ψ → Γ *⊢[𝓢]! φ 🡒 ψ
+def deduct! [DecidableEq F] {φ ψ : F} {Γ : Set F} : (insert φ Γ) *⊢[𝓢]! ψ → Γ *⊢[𝓢]! φ 🡒 ψ
   | ⟨Δ, h, b⟩ =>
     have h : ∀ ψ ∈ Δ, ψ = φ ∨ ψ ∈ Γ := by simpa using h
     let b' : (φ :: Δ.filter (· ≠ φ)) ⊢[𝓢]! ψ :=
-      FiniteContext.weakening
+      FiniteContext.weakening!
         (by simp [List.subset_def, List.mem_filter]; grind)
         b
     ⟨ Δ.filter (· ≠ φ), by
@@ -691,49 +691,49 @@ def deduct [DecidableEq F] {φ ψ : F} {Γ : Set F} : (insert φ Γ) *⊢[𝓢]!
       rcases h ψ hq
       · contradiction
       · assumption,
-      FiniteContext.deduct b' ⟩
-lemma deduct! [DecidableEq F] (h : (insert φ Γ) *⊢[𝓢] ψ) : Γ *⊢[𝓢] φ 🡒 ψ := ⟨Context.deduct h.some⟩
+      FiniteContext.deduct! b' ⟩
+lemma deduct [DecidableEq F] (h : (insert φ Γ) *⊢[𝓢] ψ) : Γ *⊢[𝓢] φ 🡒 ψ := ⟨Context.deduct! h.some⟩
 
-def deductInv {φ ψ : F} {Γ : Set F} : Γ *⊢[𝓢]! φ 🡒 ψ → (insert φ Γ) *⊢[𝓢]! ψ
-  | ⟨Δ, h, b⟩ => ⟨φ :: Δ, by simpa using fun χ hr ↦ Or.inr (h χ hr), FiniteContext.deductInv b⟩
-lemma deductInv! [DecidableEq F] (h : Γ *⊢[𝓢] φ 🡒 ψ) : (insert φ Γ) *⊢[𝓢] ψ := ⟨Context.deductInv h.some⟩
+def deductInv! {φ ψ : F} {Γ : Set F} : Γ *⊢[𝓢]! φ 🡒 ψ → (insert φ Γ) *⊢[𝓢]! ψ
+  | ⟨Δ, h, b⟩ => ⟨φ :: Δ, by simpa using fun χ hr ↦ Or.inr (h χ hr), FiniteContext.deductInv! b⟩
+lemma deductInv [DecidableEq F] (h : Γ *⊢[𝓢] φ 🡒 ψ) : (insert φ Γ) *⊢[𝓢] ψ := ⟨Context.deductInv! h.some⟩
 
 instance deduction [DecidableEq F] : Deduction (Context F 𝓢) where
-  ofInsert := deduct
-  inv := deductInv
+  ofInsert := deduct!
+  inv := deductInv!
 
-def weakening [DecidableEq F] (h : Γ ⊆ Δ) {φ : F} : Γ *⊢[𝓢]! φ → Δ *⊢[𝓢]! φ := Axiomatized.weakening (by simpa)
-lemma weakening! [DecidableEq F] (h : Γ ⊆ Δ) {φ : F} : Γ *⊢[𝓢] φ → Δ *⊢[𝓢] φ := fun h ↦ (Axiomatized.le_of_subset (by simpa)).subset h
+def weakening! [DecidableEq F] (h : Γ ⊆ Δ) {φ : F} : Γ *⊢[𝓢]! φ → Δ *⊢[𝓢]! φ := Axiomatized.weakening (by simpa)
+lemma weakening [DecidableEq F] (h : Γ ⊆ Δ) {φ : F} : Γ *⊢[𝓢] φ → Δ *⊢[𝓢] φ := fun h ↦ (Axiomatized.le_of_subset (by simpa)).subset h
 
-def of {φ : F} (b : 𝓢 ⊢! φ) : Γ *⊢[𝓢]! φ := ⟨[], by simp, FiniteContext.of b⟩
+def of! {φ : F} (b : 𝓢 ⊢! φ) : Γ *⊢[𝓢]! φ := ⟨[], by simp, FiniteContext.of! b⟩
 
-lemma of! (b : 𝓢 ⊢ φ) : Γ *⊢[𝓢] φ := ⟨Context.of b.some⟩
+lemma of (b : 𝓢 ⊢ φ) : Γ *⊢[𝓢] φ := ⟨Context.of! b.some⟩
 
-def mdp [DecidableEq F] {Γ : Set F} (bpq : Γ *⊢[𝓢]! φ 🡒 ψ) (bp : Γ *⊢[𝓢]! φ) : Γ *⊢[𝓢]! ψ :=
+def mdp! [DecidableEq F] {Γ : Set F} (bpq : Γ *⊢[𝓢]! φ 🡒 ψ) (bp : Γ *⊢[𝓢]! φ) : Γ *⊢[𝓢]! ψ :=
   ⟨ bpq.ctx ++ bp.ctx, by
     simp only [List.mem_append, mem_coe_iff]
     rintro χ (hr | hr)
     · exact bpq.subset χ hr
     · exact bp.subset χ hr,
-    FiniteContext.mdp' bpq.prf bp.prf ⟩
+    FiniteContext.mdp'! bpq.prf bp.prf ⟩
 
-lemma by_axm! [DecidableEq F] (h : φ ∈ Γ) : Γ *⊢[𝓢] φ := Entailment.by_axm (by simpa)
+lemma by_axm [DecidableEq F] (h : φ ∈ Γ) : Γ *⊢[𝓢] φ := Entailment.by_axm (by simpa)
 
-def emptyPrf {φ : F} : ∅ *⊢[𝓢]! φ → 𝓢 ⊢! φ := by
+def emptyPrf! {φ : F} : ∅ *⊢[𝓢]! φ → 𝓢 ⊢! φ := by
   rintro ⟨Γ, hΓ, h⟩;
   have := List.eq_nil_iff_forall_not_mem.mpr hΓ;
   subst this;
-  exact FiniteContext.emptyPrf h;
+  exact FiniteContext.emptyPrf! h;
 
-lemma emptyPrf! {φ : F} : ∅ *⊢[𝓢] φ → 𝓢 ⊢ φ := fun h ↦ ⟨emptyPrf h.some⟩
+lemma emptyPrf {φ : F} : ∅ *⊢[𝓢] φ → 𝓢 ⊢ φ := fun h ↦ ⟨emptyPrf! h.some⟩
 
-lemma provable_iff_provable {φ : F} : 𝓢 ⊢ φ ↔ ∅ *⊢[𝓢] φ := ⟨of!, emptyPrf!⟩
+lemma provable_iff_provable {φ : F} : 𝓢 ⊢ φ ↔ ∅ *⊢[𝓢] φ := ⟨of, emptyPrf⟩
 
 lemma iff_provable_context_provable_finiteContext_toList [DecidableEq F] {Δ : Finset F} : ↑Δ *⊢[𝓢] φ ↔ Δ.toList ⊢[𝓢] φ := by
   constructor;
   . intro h;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
-    apply FiniteContext.weakening! ?_ hΓ₂;
+    apply FiniteContext.weakening ?_ hΓ₂;
     intro ψ hψ;
     simpa using hΓ₁ ψ hψ;
   . intro h;
@@ -745,17 +745,17 @@ lemma iff_provable_context_provable_finiteContext_toList [DecidableEq F] {Δ : F
     . assumption;
 
 instance minimal [DecidableEq F] (Γ : Context F 𝓢) : Entailment.Minimal Γ where
-  mdp := mdp
-  verum := of verum
-  implyK := of implyK
-  implyS := of implyS
-  and₁ := of and₁
-  and₂ := of and₂
-  and₃ := of and₃
-  or₁ := of or₁
-  or₂ := of or₂
-  or₃ := of or₃
-  negEquiv := of negEquiv
+  mdp! := mdp!
+  verum! := of! verum!
+  implyK! := of! implyK!
+  implyS! := of! implyS!
+  and₁! := of! and₁!
+  and₂! := of! and₂!
+  and₃! := of! and₃!
+  or₁! := of! or₁!
+  or₂! := of! or₂!
+  or₃! := of! or₃!
+  negEquiv! := of! negEquiv!
 
 end minimal
 
@@ -778,419 +778,419 @@ open NegationEquiv
 open FiniteContext
 open List
 
-@[simp] lemma CVNO! : 𝓢 ⊢ ⊤ 🡒 ∼⊥ := deduct'! NO!
+@[simp] lemma CVNO : 𝓢 ⊢ ⊤ 🡒 ∼⊥ := deduct' NO
 
-def innerMDP [DecidableEq F] : 𝓢 ⊢! φ ⋏ (φ 🡒 ψ) 🡒 ψ := by
-  apply deduct';
-  have hp  : [φ, φ 🡒 ψ] ⊢[𝓢]! φ := FiniteContext.byAxm;
-  have hpq : [φ, φ 🡒 ψ] ⊢[𝓢]! φ 🡒 ψ := FiniteContext.byAxm;
+def innerMDP! [DecidableEq F] : 𝓢 ⊢! φ ⋏ (φ 🡒 ψ) 🡒 ψ := by
+  apply deduct'!;
+  have hp  : [φ, φ 🡒 ψ] ⊢[𝓢]! φ := FiniteContext.byAxm!;
+  have hpq : [φ, φ 🡒 ψ] ⊢[𝓢]! φ 🡒 ψ := FiniteContext.byAxm!;
   exact hpq ⨀ hp;
-lemma inner_mdp! [DecidableEq F] : 𝓢 ⊢ φ ⋏ (φ 🡒 ψ) 🡒 ψ := ⟨innerMDP⟩
+lemma inner_mdp [DecidableEq F] : 𝓢 ⊢ φ ⋏ (φ 🡒 ψ) 🡒 ψ := ⟨innerMDP!⟩
 
-def bot_of_mem_either [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ⊥ := by
-  have hp : Γ ⊢[𝓢]! φ := FiniteContext.byAxm h₁;
-  have hnp : Γ ⊢[𝓢]! φ 🡒 ⊥ := CO_of_N $ FiniteContext.byAxm h₂;
+def bot_of_mem_either! [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢]! ⊥ := by
+  have hp : Γ ⊢[𝓢]! φ := FiniteContext.byAxm! h₁;
+  have hnp : Γ ⊢[𝓢]! φ 🡒 ⊥ := CO!_of_N! $ FiniteContext.byAxm! h₂;
   exact hnp ⨀ hp
-lemma bot_of_mem_either! [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
+lemma bot_of_mem_either [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ⊥ := ⟨bot_of_mem_either! h₁ h₂⟩
 
-def negMDP (hnp : 𝓢 ⊢! ∼φ) (hn : 𝓢 ⊢! φ) : 𝓢 ⊢! ⊥ := (CO_of_N hnp) ⨀ hn
-lemma neg_mdp! (hnp : 𝓢 ⊢ ∼φ) (hn : 𝓢 ⊢ φ) : 𝓢 ⊢ ⊥ := ⟨negMDP hnp.some hn.some⟩
-
-
-def right_A_intro_left (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ 🡒 (χ ⋎ ψ) := by
-  apply deduct';
-  apply A_intro_left;
-  apply deductInv;
-  exact of h;
-lemma right_A!_intro_left (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 (χ ⋎ ψ) := ⟨right_A_intro_left h.some⟩
-
-def right_A_intro_right (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! ψ 🡒 (φ ⋎ χ) := by
-  apply deduct';
-  apply A_intro_right;
-  apply deductInv;
-  exact of h;
-lemma right_A!_intro_right (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ ψ 🡒 (φ ⋎ χ) := ⟨right_A_intro_right h.some⟩
+def negMDP! (hnp : 𝓢 ⊢! ∼φ) (hn : 𝓢 ⊢! φ) : 𝓢 ⊢! ⊥ := (CO!_of_N! hnp) ⨀ hn
+lemma neg_mdp (hnp : 𝓢 ⊢ ∼φ) (hn : 𝓢 ⊢ φ) : 𝓢 ⊢ ⊥ := ⟨negMDP! hnp.some hn.some⟩
 
 
-def right_K_intro [DecidableEq F] (hq : 𝓢 ⊢! φ 🡒 ψ) (hr : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ ⋏ χ := by
-  apply deduct';
-  replace hq : [] ⊢[𝓢]! φ 🡒 ψ := of hq;
-  replace hr : [] ⊢[𝓢]! φ 🡒 χ := of hr;
-  exact K_intro (mdp' hq FiniteContext.id) (mdp' hr FiniteContext.id)
-lemma right_K!_intro [DecidableEq F] (hq : 𝓢 ⊢ φ 🡒 ψ) (hr : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ ⋏ χ := ⟨right_K_intro hq.some hr.some⟩
-
-lemma left_K!_symm (d : 𝓢 ⊢ φ ⋏ ψ 🡒 χ) : 𝓢 ⊢ ψ ⋏ φ 🡒 χ := C!_trans CKK! d
-
-
-lemma left_K!_intro_right [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ (ψ ⋏ φ) 🡒 χ := by
-  apply CK!_iff_CC!.mpr;
+def right_A!_intro_left (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ 🡒 (χ ⋎ ψ) := by
   apply deduct'!;
-  exact FiniteContext.of'! (Γ := [ψ]) h;
+  apply A!_intro_left;
+  apply deductInv!;
+  exact of! h;
+lemma right_A_intro_left (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 (χ ⋎ ψ) := ⟨right_A!_intro_left h.some⟩
 
-
-lemma left_K!_intro_left [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ (φ ⋏ ψ) 🡒 χ := C!_trans CKK! (left_K!_intro_right h)
-
-
-lemma cut! [DecidableEq F] (d₁ : 𝓢 ⊢ φ₁ ⋏ c 🡒 ψ₁) (d₂ : 𝓢 ⊢ φ₂ 🡒 c ⋎ ψ₂) : 𝓢 ⊢ φ₁ ⋏ φ₂ 🡒 ψ₁ ⋎ ψ₂ := by
+def right_A!_intro_right (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! ψ 🡒 (φ ⋎ χ) := by
   apply deduct'!;
-  exact of_C!_of_C!_of_A! (right_A!_intro_left $ of'! (CK!_iff_CC!.mp d₁) ⨀ (K!_left id!)) or₂! (of'! d₂ ⨀ K!_right id!);
+  apply A!_intro_right;
+  apply deductInv!;
+  exact of! h;
+lemma right_A_intro_right (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ ψ 🡒 (φ ⋎ χ) := ⟨right_A!_intro_right h.some⟩
 
 
-def CAA : 𝓢 ⊢! φ ⋎ ψ 🡒 ψ ⋎ φ := by
+def right_K!_intro [DecidableEq F] (hq : 𝓢 ⊢! φ 🡒 ψ) (hr : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ 🡒 ψ ⋏ χ := by
+  apply deduct'!;
+  replace hq : [] ⊢[𝓢]! φ 🡒 ψ := of! hq;
+  replace hr : [] ⊢[𝓢]! φ 🡒 χ := of! hr;
+  exact K!_intro (mdp'! hq FiniteContext.id!) (mdp'! hr FiniteContext.id!)
+lemma right_K_intro [DecidableEq F] (hq : 𝓢 ⊢ φ 🡒 ψ) (hr : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ 🡒 ψ ⋏ χ := ⟨right_K!_intro hq.some hr.some⟩
+
+lemma left_K_symm (d : 𝓢 ⊢ φ ⋏ ψ 🡒 χ) : 𝓢 ⊢ ψ ⋏ φ 🡒 χ := C_trans CKK d
+
+
+lemma left_K_intro_right [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ (ψ ⋏ φ) 🡒 χ := by
+  apply CK_iff_CC.mpr;
   apply deduct';
-  exact of_C_of_C_of_A or₂ or₁ $ FiniteContext.id
-lemma CAA! : 𝓢 ⊢ φ ⋎ ψ 🡒 ψ ⋎ φ := ⟨CAA⟩
-
-def A_symm (h : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ψ ⋎ φ := CAA ⨀ h
-lemma A!_symm (h : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ψ ⋎ φ := ⟨A_symm h.some⟩
+  exact FiniteContext.of' (Γ := [ψ]) h;
 
 
+lemma left_K_intro_left [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ (φ ⋏ ψ) 🡒 χ := C_trans CKK (left_K_intro_right h)
 
-lemma A!_assoc : 𝓢 ⊢ φ ⋎ (ψ ⋎ χ) ↔ 𝓢 ⊢ (φ ⋎ ψ) ⋎ χ := by
+
+lemma cut [DecidableEq F] (d₁ : 𝓢 ⊢ φ₁ ⋏ c 🡒 ψ₁) (d₂ : 𝓢 ⊢ φ₂ 🡒 c ⋎ ψ₂) : 𝓢 ⊢ φ₁ ⋏ φ₂ 🡒 ψ₁ ⋎ ψ₂ := by
+  apply deduct';
+  exact of_C_of_C_of_A (right_A_intro_left $ of' (CK_iff_CC.mp d₁) ⨀ (K_left id)) or₂ (of' d₂ ⨀ K_right id);
+
+
+def CAA! : 𝓢 ⊢! φ ⋎ ψ 🡒 ψ ⋎ φ := by
+  apply deduct'!;
+  exact of_C!_of_C!_of_A! or₂! or₁! $ FiniteContext.id!
+lemma CAA : 𝓢 ⊢ φ ⋎ ψ 🡒 ψ ⋎ φ := ⟨CAA!⟩
+
+def A!_symm (h : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ψ ⋎ φ := CAA! ⨀ h
+lemma A_symm (h : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ψ ⋎ φ := ⟨A!_symm h.some⟩
+
+
+
+lemma A_assoc : 𝓢 ⊢ φ ⋎ (ψ ⋎ χ) ↔ 𝓢 ⊢ (φ ⋎ ψ) ⋎ χ := by
   constructor;
   . intro h;
-    exact of_C!_of_C!_of_A!
-      (right_A!_intro_left $ right_A!_intro_left C!_id)
+    exact of_C_of_C_of_A
+      (right_A_intro_left $ right_A_intro_left C_id)
       (by
         apply provable_iff_provable.mpr;
         apply deduct_iff.mpr;
-        exact of_C!_of_C!_of_A! (right_A!_intro_left $ right_A!_intro_right C!_id) (right_A!_intro_right C!_id) id!;
+        exact of_C_of_C_of_A (right_A_intro_left $ right_A_intro_right C_id) (right_A_intro_right C_id) id;
       )
       h;
   . intro h;
-    exact of_C!_of_C!_of_A!
+    exact of_C_of_C_of_A
       (by
         apply provable_iff_provable.mpr;
         apply deduct_iff.mpr;
-        exact of_C!_of_C!_of_A! (right_A!_intro_left C!_id) (right_A!_intro_right $ right_A!_intro_left C!_id) id!;
+        exact of_C_of_C_of_A (right_A_intro_left C_id) (right_A_intro_right $ right_A_intro_left C_id) id;
       )
-      (right_A!_intro_right $ right_A!_intro_right C!_id)
+      (right_A_intro_right $ right_A_intro_right C_id)
       h;
 
 
 
-lemma K!_assoc : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ 🡘 φ ⋏ (ψ ⋏ χ) := by
-  apply E!_intro;
-  . apply FiniteContext.deduct'!;
-    have hp : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] φ := K!_left $ K!_left id!;
-    have hq : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] ψ := K!_right $ K!_left id!;
-    have hr : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] χ := K!_right id!;
-    exact K!_intro hp (K!_intro hq hr);
-  . apply FiniteContext.deduct'!;
-    have hp : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] φ := K!_left id!;
-    have hq : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] ψ := K!_left $ K!_right id!;
-    have hr : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] χ := K!_right $ K!_right id!;
-    apply K!_intro;
-    . exact K!_intro hp hq;
+lemma K_assoc : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ 🡘 φ ⋏ (ψ ⋏ χ) := by
+  apply E_intro;
+  . apply FiniteContext.deduct';
+    have hp : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] φ := K_left $ K_left id;
+    have hq : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] ψ := K_right $ K_left id;
+    have hr : [(φ ⋏ ψ) ⋏ χ] ⊢[𝓢] χ := K_right id;
+    exact K_intro hp (K_intro hq hr);
+  . apply FiniteContext.deduct';
+    have hp : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] φ := K_left id;
+    have hq : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] ψ := K_left $ K_right id;
+    have hr : [φ ⋏ (ψ ⋏ χ)] ⊢[𝓢] χ := K_right $ K_right id;
+    apply K_intro;
+    . exact K_intro hp hq;
     . exact hr;
 
-lemma K!_assoc_mp (h : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ) : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ) := C!_of_E!_mp K!_assoc ⨀ h
-lemma K!_assoc_mpr (h : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ)) : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ := C!_of_E!_mpr K!_assoc ⨀ h
+lemma K_assoc_mp (h : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ) : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ) := C_of_E_mp K_assoc ⨀ h
+lemma K_assoc_mpr (h : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ)) : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ := C_of_E_mpr K_assoc ⨀ h
 
-def K_replace_left (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! χ ⋏ ψ := K_intro (h ⨀ K_left hc) (K_right hc)
-lemma K!_replace_left (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ χ ⋏ ψ := ⟨K_replace_left hc.some h.some⟩
-
-
-def CKK_of_C (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ ⋏ ψ := by
-  apply deduct';
-  exact K_replace_left FiniteContext.id (of h)
-lemma CKK!_of_C! (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋏ ψ 🡒 χ ⋏ ψ := ⟨CKK_of_C h.some⟩
+def K!_replace_left (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! χ ⋏ ψ := K!_intro (h ⨀ K!_left hc) (K!_right hc)
+lemma K_replace_left (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ χ ⋏ ψ := ⟨K!_replace_left hc.some h.some⟩
 
 
-def K_replace_right (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ χ := K_intro (K_left hc) (h ⨀ K_right hc)
-lemma K!_replace_right (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋏ χ := ⟨K_replace_right hc.some h.some⟩
-
-def CKK_of_C' (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 φ ⋏ χ := by
-  apply deduct';
-  exact K_replace_right (FiniteContext.id) (of h)
-lemma CKK!_of_C!' (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋏ ψ 🡒 φ ⋏ χ := ⟨CKK_of_C' h.some⟩
-
-def K_replace (hc : 𝓢 ⊢! φ ⋏ ψ) (h₁ : 𝓢 ⊢! φ 🡒 χ) (h₂ : 𝓢 ⊢! ψ 🡒 ξ) : 𝓢 ⊢! χ ⋏ ξ := K_replace_right (K_replace_left hc h₁) h₂
-lemma K!_replace (hc : 𝓢 ⊢ φ ⋏ ψ) (h₁ : 𝓢 ⊢ φ 🡒 χ) (h₂ : 𝓢 ⊢ ψ 🡒 ξ) : 𝓢 ⊢ χ ⋏ ξ := ⟨K_replace hc.some h₁.some h₂.some⟩
-
-def CKK_of_C_of_C (h₁ : 𝓢 ⊢! φ 🡒 χ) (h₂ : 𝓢 ⊢! ψ 🡒 ξ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ ⋏ ξ := by
-  apply deduct';
-  exact K_replace FiniteContext.id (of h₁) (of h₂)
-lemma CKK!_of_C!_of_C! (h₁ : 𝓢 ⊢ φ 🡒 χ) (h₂ : 𝓢 ⊢ ψ 🡒 ξ) : 𝓢 ⊢ φ ⋏ ψ 🡒 χ ⋏ ξ := ⟨CKK_of_C_of_C h₁.some h₂.some⟩
-
-def A_replace_left (hc : 𝓢 ⊢! φ ⋎ ψ) (hp : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! χ ⋎ ψ := of_C_of_C_of_A (C_trans hp or₁) (or₂) hc
-lemma A!_replace_left (hc : 𝓢 ⊢ φ ⋎ ψ) (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ χ ⋎ ψ := ⟨A_replace_left hc.some hp.some⟩
-
-def CAA_of_C_left (hp : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 χ ⋎ ψ := by
-  apply deduct';
-  exact A_replace_left FiniteContext.id (of hp)
-lemma CAA!_of_C!_left (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ ⋎ ψ := ⟨CAA_of_C_left hp.some⟩
-
-def A_replace_right (hc : 𝓢 ⊢! φ ⋎ ψ) (hq : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ χ := of_C_of_C_of_A (or₁) (C_trans hq or₂) hc
-lemma A!_replace_right (hc : 𝓢 ⊢ φ ⋎ ψ) (hq : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ χ := ⟨A_replace_right hc.some hq.some⟩
-
-def CAA_of_C_right (hq : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 φ ⋎ χ := by
-  apply deduct';
-  exact A_replace_right FiniteContext.id (of hq)
-lemma CAA!_of_C!_right (hq : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 φ ⋎ χ := ⟨CAA_of_C_right hq.some⟩
-
-def A_replace (h : 𝓢 ⊢! φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢! φ₁ 🡒 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡒 ψ₂) : 𝓢 ⊢! φ₂ ⋎ ψ₂ := A_replace_right (A_replace_left h hp) hq
-lemma A!_replace (h : 𝓢 ⊢ φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢ φ₁ 🡒 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡒 ψ₂) : 𝓢 ⊢ φ₂ ⋎ ψ₂ := ⟨A_replace h.some hp.some hq.some⟩
-
-def CAA_of_C_of_C (hp : 𝓢 ⊢! φ₁ 🡒 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡒 ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ 🡒 φ₂ ⋎ ψ₂ := by
-  apply deduct';
-  exact A_replace FiniteContext.id (of hp) (of hq) ;
-lemma CAA!_of_C!_of_C! (hp : 𝓢 ⊢ φ₁ 🡒 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡒 ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ 🡒 φ₂ ⋎ ψ₂ := ⟨CAA_of_C_of_C hp.some hq.some⟩
-
-def EAA_of_E_of_E (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ 🡘 φ₂ ⋎ ψ₂ := by
-  apply E_intro;
-  . exact CAA_of_C_of_C (K_left hp) (K_left hq);
-  . exact CAA_of_C_of_C (K_right hp) (K_right hq);
-lemma EAA!_of_E!_of_E! (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ 🡘 φ₂ ⋎ ψ₂ := ⟨EAA_of_E_of_E hp.some hq.some⟩
+def CKK!_of_C! (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ ⋏ ψ := by
+  apply deduct'!;
+  exact K!_replace_left FiniteContext.id! (of! h)
+lemma CKK_of_C (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋏ ψ 🡒 χ ⋏ ψ := ⟨CKK!_of_C! h.some⟩
 
 
-lemma EAAAA! : 𝓢 ⊢ φ ⋎ (ψ ⋎ χ) 🡘 (φ ⋎ ψ) ⋎ χ := by
+def K!_replace_right (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ χ := K!_intro (K!_left hc) (h ⨀ K!_right hc)
+lemma K_replace_right (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋏ χ := ⟨K!_replace_right hc.some h.some⟩
+
+def CKK!_of_C!' (h : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋏ ψ 🡒 φ ⋏ χ := by
+  apply deduct'!;
+  exact K!_replace_right (FiniteContext.id!) (of! h)
+lemma CKK_of_C' (h : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋏ ψ 🡒 φ ⋏ χ := ⟨CKK!_of_C!' h.some⟩
+
+def K!_replace (hc : 𝓢 ⊢! φ ⋏ ψ) (h₁ : 𝓢 ⊢! φ 🡒 χ) (h₂ : 𝓢 ⊢! ψ 🡒 ξ) : 𝓢 ⊢! χ ⋏ ξ := K!_replace_right (K!_replace_left hc h₁) h₂
+lemma K_replace (hc : 𝓢 ⊢ φ ⋏ ψ) (h₁ : 𝓢 ⊢ φ 🡒 χ) (h₂ : 𝓢 ⊢ ψ 🡒 ξ) : 𝓢 ⊢ χ ⋏ ξ := ⟨K!_replace hc.some h₁.some h₂.some⟩
+
+def CKK!_of_C!_of_C! (h₁ : 𝓢 ⊢! φ 🡒 χ) (h₂ : 𝓢 ⊢! ψ 🡒 ξ) : 𝓢 ⊢! φ ⋏ ψ 🡒 χ ⋏ ξ := by
+  apply deduct'!;
+  exact K!_replace FiniteContext.id! (of! h₁) (of! h₂)
+lemma CKK_of_C_of_C (h₁ : 𝓢 ⊢ φ 🡒 χ) (h₂ : 𝓢 ⊢ ψ 🡒 ξ) : 𝓢 ⊢ φ ⋏ ψ 🡒 χ ⋏ ξ := ⟨CKK!_of_C!_of_C! h₁.some h₂.some⟩
+
+def A!_replace_left (hc : 𝓢 ⊢! φ ⋎ ψ) (hp : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! χ ⋎ ψ := of_C!_of_C!_of_A! (C!_trans hp or₁!) (or₂!) hc
+lemma A_replace_left (hc : 𝓢 ⊢ φ ⋎ ψ) (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ χ ⋎ ψ := ⟨A!_replace_left hc.some hp.some⟩
+
+def CAA!_of_C!_left (hp : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 χ ⋎ ψ := by
+  apply deduct'!;
+  exact A!_replace_left FiniteContext.id! (of! hp)
+lemma CAA_of_C_left (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ ⋎ ψ := ⟨CAA!_of_C!_left hp.some⟩
+
+def A!_replace_right (hc : 𝓢 ⊢! φ ⋎ ψ) (hq : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ χ := of_C!_of_C!_of_A! (or₁!) (C!_trans hq or₂!) hc
+lemma A_replace_right (hc : 𝓢 ⊢ φ ⋎ ψ) (hq : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ χ := ⟨A!_replace_right hc.some hq.some⟩
+
+def CAA!_of_C!_right (hq : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 φ ⋎ χ := by
+  apply deduct'!;
+  exact A!_replace_right FiniteContext.id! (of! hq)
+lemma CAA_of_C_right (hq : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 φ ⋎ χ := ⟨CAA!_of_C!_right hq.some⟩
+
+def A!_replace (h : 𝓢 ⊢! φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢! φ₁ 🡒 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡒 ψ₂) : 𝓢 ⊢! φ₂ ⋎ ψ₂ := A!_replace_right (A!_replace_left h hp) hq
+lemma A_replace (h : 𝓢 ⊢ φ₁ ⋎ ψ₁) (hp : 𝓢 ⊢ φ₁ 🡒 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡒 ψ₂) : 𝓢 ⊢ φ₂ ⋎ ψ₂ := ⟨A!_replace h.some hp.some hq.some⟩
+
+def CAA!_of_C!_of_C! (hp : 𝓢 ⊢! φ₁ 🡒 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡒 ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ 🡒 φ₂ ⋎ ψ₂ := by
+  apply deduct'!;
+  exact A!_replace FiniteContext.id! (of! hp) (of! hq) ;
+lemma CAA_of_C_of_C (hp : 𝓢 ⊢ φ₁ 🡒 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡒 ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ 🡒 φ₂ ⋎ ψ₂ := ⟨CAA!_of_C!_of_C! hp.some hq.some⟩
+
+def EAA!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! φ₁ ⋎ ψ₁ 🡘 φ₂ ⋎ ψ₂ := by
   apply E!_intro;
-  . exact deduct'! $ A!_assoc.mp id!;
-  . exact deduct'! $ A!_assoc.mpr id!;
+  . exact CAA!_of_C!_of_C! (K!_left hp) (K!_left hq);
+  . exact CAA!_of_C!_of_C! (K!_right hp) (K!_right hq);
+lemma EAA_of_E_of_E (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ ⋎ ψ₁ 🡘 φ₂ ⋎ ψ₂ := ⟨EAA!_of_E!_of_E! hp.some hq.some⟩
 
 
-lemma EAA!_of_E!_right (d : 𝓢 ⊢ ψ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 φ ⋎ χ := by
-  apply E!_intro;
-  . apply CAA!_of_C!_right; exact K!_left d;
-  . apply CAA!_of_C!_right; exact K!_right d;
-
-
-lemma EAA!_of_E!_left (d : 𝓢 ⊢ φ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 χ ⋎ ψ := by
-  apply E!_intro;
-  . apply CAA!_of_C!_left; exact K!_left d;
-  . apply CAA!_of_C!_left; exact K!_right d;
-
-
-def EKK_of_E_of_E (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! φ₁ ⋏ ψ₁ 🡘 φ₂ ⋏ ψ₂ := by
+lemma EAAAA : 𝓢 ⊢ φ ⋎ (ψ ⋎ χ) 🡘 (φ ⋎ ψ) ⋎ χ := by
   apply E_intro;
-  . exact CKK_of_C_of_C (K_left hp) (K_left hq);
-  . exact CKK_of_C_of_C (K_right hp) (K_right hq);
-lemma EKK!_of_E!_of_E! (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ ⋏ ψ₁ 🡘 φ₂ ⋏ ψ₂ := ⟨EKK_of_E_of_E hp.some hq.some⟩
+  . exact deduct' $ A_assoc.mp id;
+  . exact deduct' $ A_assoc.mpr id;
 
-def ECC_of_E_of_E (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! (φ₁ 🡒 ψ₁) 🡘 (φ₂ 🡒 ψ₂) := by
+
+lemma EAA_of_E_right (d : 𝓢 ⊢ ψ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 φ ⋎ χ := by
   apply E_intro;
-  . apply deduct'; exact C_trans (of $ K_right hp) $ C_trans (FiniteContext.id) (of $ K_left hq);
-  . apply deduct'; exact C_trans (of $ K_left hp) $ C_trans (FiniteContext.id) (of $ K_right hq);
-lemma ECC!_of_E!_of_E! (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ (φ₁ 🡒 ψ₁) 🡘 (φ₂ 🡒 ψ₂) := ⟨ECC_of_E_of_E hp.some hq.some⟩
+  . apply CAA_of_C_right; exact K_left d;
+  . apply CAA_of_C_right; exact K_right d;
 
 
-lemma C!_iff_C!_of_E!_of_E! [DecidableEq F] (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ 🡒 ψ₁ ↔ 𝓢 ⊢ φ₂ 🡒 ψ₂ :=
-  iff_of_E! (ECC!_of_E!_of_E! hp hq)
+lemma EAA_of_E_left (d : 𝓢 ⊢ φ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 χ ⋎ ψ := by
+  apply E_intro;
+  . apply CAA_of_C_left; exact K_left d;
+  . apply CAA_of_C_left; exact K_right d;
 
-def dni [DecidableEq F] : 𝓢 ⊢! φ 🡒 ∼∼φ := by
-  apply deduct';
-  apply N_of_CO;
-  apply deduct;
-  exact bot_of_mem_either (φ := φ) (by simp) (by simp);
-@[simp] lemma dni! [DecidableEq F] : 𝓢 ⊢ φ 🡒 ∼∼φ := ⟨dni⟩
 
-def dni' [DecidableEq F] (b : 𝓢 ⊢! φ) : 𝓢 ⊢! ∼∼φ := dni ⨀ b
-lemma dni'! [DecidableEq F] (b : 𝓢 ⊢ φ) : 𝓢 ⊢ ∼∼φ := ⟨dni' b.some⟩
+def EKK!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! φ₁ ⋏ ψ₁ 🡘 φ₂ ⋏ ψ₂ := by
+  apply E!_intro;
+  . exact CKK!_of_C!_of_C! (K!_left hp) (K!_left hq);
+  . exact CKK!_of_C!_of_C! (K!_right hp) (K!_right hq);
+lemma EKK_of_E_of_E (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ ⋏ ψ₁ 🡘 φ₂ ⋏ ψ₂ := ⟨EKK!_of_E!_of_E! hp.some hq.some⟩
 
-def ANNNN_of_A [DecidableEq F] (d : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ∼∼φ ⋎ ∼∼ψ := of_C_of_C_of_A (C_trans dni or₁) (C_trans dni or₂) d
-lemma ANNNN!_of_A! [DecidableEq F] (d : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ∼∼φ ⋎ ∼∼ψ := ⟨ANNNN_of_A d.some⟩
+def ECC!_of_E!_of_E! (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! (φ₁ 🡒 ψ₁) 🡘 (φ₂ 🡒 ψ₂) := by
+  apply E!_intro;
+  . apply deduct'!; exact C!_trans (of! $ K!_right hp) $ C!_trans (FiniteContext.id!) (of! $ K!_left hq);
+  . apply deduct'!; exact C!_trans (of! $ K!_left hp) $ C!_trans (FiniteContext.id!) (of! $ K!_right hq);
+lemma ECC_of_E_of_E (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ (φ₁ 🡒 ψ₁) 🡘 (φ₂ 🡒 ψ₂) := ⟨ECC!_of_E!_of_E! hp.some hq.some⟩
 
-def KNNNN_of_K [DecidableEq F] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ∼∼φ ⋏ ∼∼ψ := K_intro (dni' $ K_left d) (dni' $ K_right d)
-lemma KNNNN!_of_K! [DecidableEq F] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ∼∼φ ⋏ ∼∼ψ := ⟨KNNNN_of_K d.some⟩
 
-def CNNOO : 𝓢 ⊢! ∼∼⊥ 🡒 ⊥ := by
-  apply deduct'
-  have d₁ : [∼∼⊥] ⊢[𝓢]! ∼⊥ 🡒 ⊥ := CO_of_N byAxm₀
-  have d₂ : [∼∼⊥] ⊢[𝓢]! ∼⊥ := N_of_CO C_id
+lemma C_iff_C_of_E_of_E [DecidableEq F] (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ 🡒 ψ₁ ↔ 𝓢 ⊢ φ₂ 🡒 ψ₂ :=
+  iff_of_E (ECC_of_E_of_E hp hq)
+
+def dni! [DecidableEq F] : 𝓢 ⊢! φ 🡒 ∼∼φ := by
+  apply deduct'!;
+  apply N!_of_CO!;
+  apply deduct!;
+  exact bot_of_mem_either! (φ := φ) (by simp) (by simp);
+@[simp] lemma dni [DecidableEq F] : 𝓢 ⊢ φ 🡒 ∼∼φ := ⟨dni!⟩
+
+def dni'! [DecidableEq F] (b : 𝓢 ⊢! φ) : 𝓢 ⊢! ∼∼φ := dni! ⨀ b
+lemma dni' [DecidableEq F] (b : 𝓢 ⊢ φ) : 𝓢 ⊢ ∼∼φ := ⟨dni'! b.some⟩
+
+def ANNNN!_of_A! [DecidableEq F] (d : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ∼∼φ ⋎ ∼∼ψ := of_C!_of_C!_of_A! (C!_trans dni! or₁!) (C!_trans dni! or₂!) d
+lemma ANNNN_of_A [DecidableEq F] (d : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ∼∼φ ⋎ ∼∼ψ := ⟨ANNNN!_of_A! d.some⟩
+
+def KNNNN!_of_K! [DecidableEq F] (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! ∼∼φ ⋏ ∼∼ψ := K!_intro (dni'! $ K!_left d) (dni'! $ K!_right d)
+lemma KNNNN_of_K [DecidableEq F] (d : 𝓢 ⊢ φ ⋏ ψ) : 𝓢 ⊢ ∼∼φ ⋏ ∼∼ψ := ⟨KNNNN!_of_K! d.some⟩
+
+def CNNOO! : 𝓢 ⊢! ∼∼⊥ 🡒 ⊥ := by
+  apply deduct'!
+  have d₁ : [∼∼⊥] ⊢[𝓢]! ∼⊥ 🡒 ⊥ := CO!_of_N! byAxm₀!
+  have d₂ : [∼∼⊥] ⊢[𝓢]! ∼⊥ := N!_of_CO! C!_id
   exact d₁ ⨀ d₂
 
-def ENNOO [DecidableEq F] : 𝓢 ⊢! ∼∼⊥ 🡘 ⊥ := K_intro CNNOO dni
+def ENNOO! [DecidableEq F] : 𝓢 ⊢! ∼∼⊥ 🡘 ⊥ := K!_intro CNNOO! dni!
 
 
-def CCCNN [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼ψ 🡒 ∼φ) := by
-  apply deduct';
-  apply deduct;
-  apply N_of_CO;
-  apply deduct;
-  have dp  : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! φ := FiniteContext.byAxm;
-  have dpq : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! φ 🡒 ψ := FiniteContext.byAxm;
+def CCCNN! [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼ψ 🡒 ∼φ) := by
+  apply deduct'!;
+  apply deduct!;
+  apply N!_of_CO!;
+  apply deduct!;
+  have dp  : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! φ := FiniteContext.byAxm!;
+  have dpq : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! φ 🡒 ψ := FiniteContext.byAxm!;
   have dq  : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! ψ := dpq ⨀ dp;
-  have dnq : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! ψ 🡒 ⊥ := CO_of_N $ FiniteContext.byAxm;
+  have dnq : [φ, ∼ψ, φ 🡒 ψ] ⊢[𝓢]! ψ 🡒 ⊥ := CO!_of_N! $ FiniteContext.byAxm!;
   exact dnq ⨀ dq;
-@[simp] theorem CCCNN! [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ) 🡒 (∼ψ 🡒 ∼φ) := ⟨CCCNN⟩
+@[simp] theorem CCCNN [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ) 🡒 (∼ψ 🡒 ∼φ) := ⟨CCCNN!⟩
 
-@[deprecated "use `CCCNN`" (since := "2026-07-20")] alias contra₀ := CCCNN
 @[deprecated "use `CCCNN!`" (since := "2026-07-20")] alias contra₀! := CCCNN!
+@[deprecated "use `CCCNN`" (since := "2026-07-20")] alias contra₀ := CCCNN
 
-def contra [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼ψ 🡒 ∼φ := CCCNN ⨀ b
-lemma contra! [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼ψ 🡒 ∼φ := ⟨contra b.some⟩
+def contra! [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼ψ 🡒 ∼φ := CCCNN! ⨀ b
+lemma contra [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼ψ 🡒 ∼φ := ⟨contra! b.some⟩
 
-@[deprecated "use `contra`" (since := "2026-07-20")] alias contra₀' := contra
 @[deprecated "use `contra!`" (since := "2026-07-20")] alias contra₀'! := contra!
+@[deprecated "use `contra`" (since := "2026-07-20")] alias contra₀' := contra
 
-def CNNNN_of_C [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ := contra $ contra b
-@[grind <=] lemma CNNNN!_of_C! [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ := ⟨CNNNN_of_C b.some⟩
+def CNNNN!_of_C! [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ := contra! $ contra! b
+@[grind <=] lemma CNNNN_of_C [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ := ⟨CNNNN!_of_C! b.some⟩
 
-def CCCNNNN [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := deduct' $ CNNNN_of_C FiniteContext.id
-@[simp] lemma CCCNNNN! [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := ⟨CCCNNNN⟩
+def CCCNNNN! [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := deduct'! $ CNNNN!_of_C! FiniteContext.id!
+@[simp] lemma CCCNNNN [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := ⟨CCCNNNN!⟩
 
 
-def CN_of_CN_right [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ∼ψ) : 𝓢 ⊢! ψ 🡒 ∼φ := C_trans dni (contra b)
-lemma CN!_of_CN!_right [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ∼ψ) : 𝓢 ⊢ ψ 🡒 ∼φ := ⟨CN_of_CN_right b.some⟩
+def CN!_of_CN!_right [DecidableEq F] (b : 𝓢 ⊢! φ 🡒 ∼ψ) : 𝓢 ⊢! ψ 🡒 ∼φ := C!_trans dni! (contra! b)
+lemma CN_of_CN_right [DecidableEq F] (b : 𝓢 ⊢ φ 🡒 ∼ψ) : 𝓢 ⊢ ψ 🡒 ∼φ := ⟨CN!_of_CN!_right b.some⟩
 
-def CCNCN [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ∼ψ) 🡒 (ψ 🡒 ∼φ) := deduct' $ CN_of_CN_right FiniteContext.id
-lemma CCNCN! [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ∼ψ) 🡒 (ψ 🡒 ∼φ) := ⟨CCNCN⟩
+def CCNCN! [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ∼ψ) 🡒 (ψ 🡒 ∼φ) := deduct'! $ CN!_of_CN!_right FiniteContext.id!
+lemma CCNCN [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ∼ψ) 🡒 (ψ 🡒 ∼φ) := ⟨CCNCN!⟩
 
-def ENN_of_E [DecidableEq F] (b : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ∼φ 🡘 ∼ψ := E_intro (contra $ K_right b) (contra $ K_left b)
-lemma ENN!_of_E! [DecidableEq F] (b : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ ∼φ 🡘 ∼ψ := ⟨ENN_of_E b.some⟩
+def ENN!_of_E! [DecidableEq F] (b : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ∼φ 🡘 ∼ψ := E!_intro (contra! $ K!_right b) (contra! $ K!_left b)
+lemma ENN_of_E [DecidableEq F] (b : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ ∼φ 🡘 ∼ψ := ⟨ENN!_of_E! b.some⟩
 
 
 section NegationEquiv
 
-def ENNCCOO [DecidableEq F] : 𝓢 ⊢! ∼∼φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := by
-  apply E_intro;
-  . exact C_trans (by apply contra; exact K_right negEquiv) (K_left negEquiv)
-  . exact C_trans (K_right negEquiv) (by apply contra; exact K_left negEquiv)
-@[simp] lemma ENNCCOO! [DecidableEq F] : 𝓢 ⊢ ∼∼φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := ⟨ENNCCOO⟩
+def ENNCCOO! [DecidableEq F] : 𝓢 ⊢! ∼∼φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := by
+  apply E!_intro;
+  . exact C!_trans (by apply contra!; exact K!_right negEquiv!) (K!_left negEquiv!)
+  . exact C!_trans (K!_right negEquiv!) (by apply contra!; exact K!_left negEquiv!)
+@[simp] lemma ENNCCOO [DecidableEq F] : 𝓢 ⊢ ∼∼φ 🡘 ((φ 🡒 ⊥) 🡒 ⊥) := ⟨ENNCCOO!⟩
 
 end NegationEquiv
 
 
-def tne [DecidableEq F] : 𝓢 ⊢! ∼(∼∼φ) 🡒 ∼φ := contra dni
-@[simp] lemma tne! [DecidableEq F] : 𝓢 ⊢ ∼(∼∼φ) 🡒 ∼φ := ⟨tne⟩
+def tne! [DecidableEq F] : 𝓢 ⊢! ∼(∼∼φ) 🡒 ∼φ := contra! dni!
+@[simp] lemma tne [DecidableEq F] : 𝓢 ⊢ ∼(∼∼φ) 🡒 ∼φ := ⟨tne!⟩
 
-def tne' [DecidableEq F] (b : 𝓢 ⊢! ∼(∼∼φ)) : 𝓢 ⊢! ∼φ := tne ⨀ b
-lemma tne'! [DecidableEq F] (b : 𝓢 ⊢ ∼(∼∼φ)) : 𝓢 ⊢ ∼φ := ⟨tne' b.some⟩
+def tne'! [DecidableEq F] (b : 𝓢 ⊢! ∼(∼∼φ)) : 𝓢 ⊢! ∼φ := tne! ⨀ b
+lemma tne' [DecidableEq F] (b : 𝓢 ⊢ ∼(∼∼φ)) : 𝓢 ⊢ ∼φ := ⟨tne'! b.some⟩
 
-def tneIff [DecidableEq F] : 𝓢 ⊢! ∼∼∼φ 🡘 ∼φ := K_intro tne dni
+def tneIff! [DecidableEq F] : 𝓢 ⊢! ∼∼∼φ 🡘 ∼φ := K!_intro tne! dni!
 
-def CCC_of_C_left (h : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! (φ 🡒 χ) 🡒 (ψ 🡒 χ) := by
-  apply deduct';
-  exact C_trans (of h) id;
-lemma CCC!_of_C!_left (h : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ (φ 🡒 χ) 🡒 (ψ 🡒 χ) := ⟨CCC_of_C_left h.some⟩
+def CCC!_of_C!_left (h : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! (φ 🡒 χ) 🡒 (ψ 🡒 χ) := by
+  apply deduct'!;
+  exact C!_trans (of! h) id!;
+lemma CCC_of_C_left (h : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ (φ 🡒 χ) 🡒 (ψ 🡒 χ) := ⟨CCC!_of_C!_left h.some⟩
 
-@[deprecated "use `CCC_of_C_left`" (since := "2026-07-20")] alias rev_dhyp_imp' := CCC_of_C_left
 @[deprecated "use `CCC!_of_C!_left`" (since := "2026-07-20")] alias rev_dhyp_imp'! := CCC!_of_C!_left
+@[deprecated "use `CCC_of_C_left`" (since := "2026-07-20")] alias rev_dhyp_imp' := CCC_of_C_left
 
-lemma C!_iff_C!_of_iff_left (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ φ 🡒 χ ↔ 𝓢 ⊢ ψ 🡒 χ := by
+lemma C_iff_C_of_iff_left (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ φ 🡒 χ ↔ 𝓢 ⊢ ψ 🡒 χ := by
   constructor;
-  . exact C!_trans $ K!_right h;
-  . exact C!_trans $ K!_left h;
+  . exact C_trans $ K_right h;
+  . exact C_trans $ K_left h;
 
-lemma C!_iff_C!_of_iff_right (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ χ 🡒 φ ↔ 𝓢 ⊢ χ 🡒 ψ := by
+lemma C_iff_C_of_iff_right (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ χ 🡒 φ ↔ 𝓢 ⊢ χ 🡒 ψ := by
   constructor;
-  . intro hrp; exact C!_trans hrp $ K!_left h;
-  . intro hrq; exact C!_trans hrq $ K!_right h;
+  . intro hrp; exact C_trans hrp $ K_left h;
+  . intro hrq; exact C_trans hrq $ K_right h;
 
-def C_swap [DecidableEq F] (h : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! ψ 🡒 φ 🡒 χ := by
-  apply deduct';
-  apply deduct;
-  exact (of (Γ := [φ, ψ]) h) ⨀ FiniteContext.byAxm ⨀ FiniteContext.byAxm;
-lemma C!_swap [DecidableEq F] (h : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ)) : 𝓢 ⊢ (ψ 🡒 φ 🡒 χ) := ⟨C_swap h.some⟩
+def C!_swap [DecidableEq F] (h : 𝓢 ⊢! φ 🡒 ψ 🡒 χ) : 𝓢 ⊢! ψ 🡒 φ 🡒 χ := by
+  apply deduct'!;
+  apply deduct!;
+  exact (of! (Γ := [φ, ψ]) h) ⨀ FiniteContext.byAxm! ⨀ FiniteContext.byAxm!;
+lemma C_swap [DecidableEq F] (h : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ)) : 𝓢 ⊢ (ψ 🡒 φ 🡒 χ) := ⟨C!_swap h.some⟩
 
-def CCCCC [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ 🡒 χ) 🡒 (ψ 🡒 φ 🡒 χ) := deduct' $ C_swap FiniteContext.id
-@[simp] lemma CCCCC! [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ) 🡒 (ψ 🡒 φ 🡒 χ) := ⟨CCCCC⟩
+def CCCCC! [DecidableEq F] : 𝓢 ⊢! (φ 🡒 ψ 🡒 χ) 🡒 (ψ 🡒 φ 🡒 χ) := deduct'! $ C!_swap FiniteContext.id!
+@[simp] lemma CCCCC [DecidableEq F] : 𝓢 ⊢ (φ 🡒 ψ 🡒 χ) 🡒 (ψ 🡒 φ 🡒 χ) := ⟨CCCCC!⟩
 
-def C_of_CC [DecidableEq F] (h : 𝓢 ⊢! φ 🡒 φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 ψ := by
-  apply deduct';
-  have := of (Γ := [φ]) h;
-  exact this ⨀ (FiniteContext.byAxm) ⨀ (FiniteContext.byAxm);
-lemma C!_of_CC! [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨C_of_CC h.some⟩
+def C!_of_CC! [DecidableEq F] (h : 𝓢 ⊢! φ 🡒 φ 🡒 ψ) : 𝓢 ⊢! φ 🡒 ψ := by
+  apply deduct'!;
+  have := of! (Γ := [φ]) h;
+  exact this ⨀ (FiniteContext.byAxm!) ⨀ (FiniteContext.byAxm!);
+lemma C_of_CC [DecidableEq F] (h : 𝓢 ⊢ φ 🡒 φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ψ := ⟨C!_of_CC! h.some⟩
 
-def CCC [DecidableEq F] : 𝓢 ⊢! φ 🡒 (φ 🡒 ψ) 🡒 ψ := C_swap $ C_id
-lemma CCC! [DecidableEq F] : 𝓢 ⊢ φ 🡒 (φ 🡒 ψ) 🡒 ψ := ⟨CCC⟩
+def CCC! [DecidableEq F] : 𝓢 ⊢! φ 🡒 (φ 🡒 ψ) 🡒 ψ := C!_swap $ C!_id
+lemma CCC [DecidableEq F] : 𝓢 ⊢ φ 🡒 (φ 🡒 ψ) 🡒 ψ := ⟨CCC!⟩
 
-def CCC_of_C_right (h : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! (χ 🡒 φ) 🡒 (χ 🡒 ψ) := implyS ⨀ (C_of_conseq h)
-lemma CCC!_of_C!_right (h : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ (χ 🡒 φ) 🡒 (χ 🡒 ψ) := ⟨CCC_of_C_right h.some⟩
+def CCC!_of_C!_right (h : 𝓢 ⊢! φ 🡒 ψ) : 𝓢 ⊢! (χ 🡒 φ) 🡒 (χ 🡒 ψ) := implyS! ⨀ (C!_of_conseq! h)
+lemma CCC_of_C_right (h : 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ (χ 🡒 φ) 🡒 (χ 🡒 ψ) := ⟨CCC!_of_C!_right h.some⟩
 
-def CNNCCNNNN [DecidableEq F] : 𝓢 ⊢! ∼∼(φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := by
-  apply C_swap;
-  apply deduct';
-  exact C_trans (CNNNN_of_C $ deductInv $ of $ C_swap $ CCCNNNN) tne;
-@[simp] lemma CNNCCNNNN! [DecidableEq F] : 𝓢 ⊢ ∼∼(φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := ⟨CNNCCNNNN⟩
+def CNNCCNNNN! [DecidableEq F] : 𝓢 ⊢! ∼∼(φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := by
+  apply C!_swap;
+  apply deduct'!;
+  exact C!_trans (CNNNN!_of_C! $ deductInv! $ of! $ C!_swap $ CCCNNNN!) tne!;
+@[simp] lemma CNNCCNNNN [DecidableEq F] : 𝓢 ⊢ ∼∼(φ 🡒 ψ) 🡒 (∼∼φ 🡒 ∼∼ψ) := ⟨CNNCCNNNN!⟩
 
-def CNNNN_of_NNC [DecidableEq F] (b : 𝓢 ⊢! ∼∼(φ 🡒 ψ)) : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ := CNNCCNNNN ⨀ b
-lemma CNNNN!_of_NNC! [DecidableEq F] (b : 𝓢 ⊢ ∼∼(φ 🡒 ψ)) : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ := ⟨CNNNN_of_NNC b.some⟩
+def CNNNN!_of_NNC! [DecidableEq F] (b : 𝓢 ⊢! ∼∼(φ 🡒 ψ)) : 𝓢 ⊢! ∼∼φ 🡒 ∼∼ψ := CNNCCNNNN! ⨀ b
+lemma CNNNN_of_NNC [DecidableEq F] (b : 𝓢 ⊢ ∼∼(φ 🡒 ψ)) : 𝓢 ⊢ ∼∼φ 🡒 ∼∼ψ := ⟨CNNNN!_of_NNC! b.some⟩
 
-def O_intro_of_KN (h : 𝓢 ⊢! φ ⋏ ∼φ) : 𝓢 ⊢! ⊥ := (CO_of_N $ K_right h) ⨀ (K_left h)
-lemma O!_intro_of_KN! (h : 𝓢 ⊢ φ ⋏ ∼φ) : 𝓢 ⊢ ⊥ := ⟨O_intro_of_KN h.some⟩
+def O!_intro_of_KN! (h : 𝓢 ⊢! φ ⋏ ∼φ) : 𝓢 ⊢! ⊥ := (CO!_of_N! $ K!_right h) ⨀ (K!_left h)
+lemma O_intro_of_KN (h : 𝓢 ⊢ φ ⋏ ∼φ) : 𝓢 ⊢ ⊥ := ⟨O!_intro_of_KN! h.some⟩
 /-- Law of contradiction -/
-alias lac'! := O!_intro_of_KN!
+alias lac' := O_intro_of_KN
 
-def CKNO : 𝓢 ⊢! φ ⋏ ∼φ 🡒 ⊥ := by
-  apply deduct';
-  exact O_intro_of_KN (φ := φ) $ FiniteContext.id
-@[simp] lemma CKNO! : 𝓢 ⊢ φ ⋏ ∼φ 🡒 ⊥ := ⟨CKNO⟩
+def CKNO! : 𝓢 ⊢! φ ⋏ ∼φ 🡒 ⊥ := by
+  apply deduct'!;
+  exact O!_intro_of_KN! (φ := φ) $ FiniteContext.id!
+@[simp] lemma CKNO : 𝓢 ⊢ φ ⋏ ∼φ 🡒 ⊥ := ⟨CKNO!⟩
 /-- Law of contradiction -/
-alias lac! := CKNO!
+alias lac := CKNO
 
-def CANNNK [DecidableEq F] : 𝓢 ⊢! (∼φ ⋎ ∼ψ) 🡒 ∼(φ ⋏ ψ) := left_A_intro (contra and₁) (contra and₂)
-@[simp] lemma CANNNK! [DecidableEq F] : 𝓢 ⊢ (∼φ ⋎ ∼ψ) 🡒 ∼(φ ⋏ ψ) := ⟨CANNNK⟩
+def CANNNK! [DecidableEq F] : 𝓢 ⊢! (∼φ ⋎ ∼ψ) 🡒 ∼(φ ⋏ ψ) := left_A!_intro (contra! and₁!) (contra! and₂!)
+@[simp] lemma CANNNK [DecidableEq F] : 𝓢 ⊢ (∼φ ⋎ ∼ψ) 🡒 ∼(φ ⋏ ψ) := ⟨CANNNK!⟩
 
-def NK_of_ANN [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋎ ∼ψ) : 𝓢 ⊢! ∼(φ ⋏ ψ)  := CANNNK ⨀ d
-lemma NK!_of_ANN! [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋎ ∼ψ) : 𝓢 ⊢ ∼(φ ⋏ ψ) := ⟨NK_of_ANN d.some⟩
+def NK!_of_ANN! [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋎ ∼ψ) : 𝓢 ⊢! ∼(φ ⋏ ψ)  := CANNNK! ⨀ d
+lemma NK_of_ANN [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋎ ∼ψ) : 𝓢 ⊢ ∼(φ ⋏ ψ) := ⟨NK!_of_ANN! d.some⟩
 
-def CKNNNA [DecidableEq F] : 𝓢 ⊢! (∼φ ⋏ ∼ψ) 🡒 ∼(φ ⋎ ψ) := by
-  apply CK_of_CC;
-  apply deduct';
-  apply deduct;
-  apply N_of_CO;
-  apply deduct;
-  exact of_C_of_C_of_A (CO_of_N FiniteContext.byAxm) (CO_of_N FiniteContext.byAxm) (FiniteContext.byAxm (φ := φ ⋎ ψ));
-@[simp] lemma CKNNNA! [DecidableEq F] : 𝓢 ⊢ ∼φ ⋏ ∼ψ 🡒 ∼(φ ⋎ ψ) := ⟨CKNNNA⟩
+def CKNNNA! [DecidableEq F] : 𝓢 ⊢! (∼φ ⋏ ∼ψ) 🡒 ∼(φ ⋎ ψ) := by
+  apply CK!_of_CC!;
+  apply deduct'!;
+  apply deduct!;
+  apply N!_of_CO!;
+  apply deduct!;
+  exact of_C!_of_C!_of_A! (CO!_of_N! FiniteContext.byAxm!) (CO!_of_N! FiniteContext.byAxm!) (FiniteContext.byAxm! (φ := φ ⋎ ψ));
+@[simp] lemma CKNNNA [DecidableEq F] : 𝓢 ⊢ ∼φ ⋏ ∼ψ 🡒 ∼(φ ⋎ ψ) := ⟨CKNNNA!⟩
 
-def NA_of_KNN [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋏ ∼ψ) : 𝓢 ⊢! ∼(φ ⋎ ψ) := CKNNNA ⨀ d
-lemma NA!_of_KNN! [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋏ ∼ψ) : 𝓢 ⊢ ∼(φ ⋎ ψ) := ⟨NA_of_KNN d.some⟩
+def NA!_of_KNN! [DecidableEq F] (d : 𝓢 ⊢! ∼φ ⋏ ∼ψ) : 𝓢 ⊢! ∼(φ ⋎ ψ) := CKNNNA! ⨀ d
+lemma NA_of_KNN [DecidableEq F] (d : 𝓢 ⊢ ∼φ ⋏ ∼ψ) : 𝓢 ⊢ ∼(φ ⋎ ψ) := ⟨NA!_of_KNN! d.some⟩
 
 
-def CNAKNN [DecidableEq F] : 𝓢 ⊢! ∼(φ ⋎ ψ) 🡒 (∼φ ⋏ ∼ψ) := by
-  apply deduct';
-  exact K_intro (deductInv $ contra $ or₁) (deductInv $ contra $ or₂)
-@[simp] lemma CNAKNN! [DecidableEq F] : 𝓢 ⊢ ∼(φ ⋎ ψ) 🡒 (∼φ ⋏ ∼ψ) := ⟨CNAKNN⟩
+def CNAKNN! [DecidableEq F] : 𝓢 ⊢! ∼(φ ⋎ ψ) 🡒 (∼φ ⋏ ∼ψ) := by
+  apply deduct'!;
+  exact K!_intro (deductInv! $ contra! $ or₁!) (deductInv! $ contra! $ or₂!)
+@[simp] lemma CNAKNN [DecidableEq F] : 𝓢 ⊢ ∼(φ ⋎ ψ) 🡒 (∼φ ⋏ ∼ψ) := ⟨CNAKNN!⟩
 
-def KNN_of_NA [DecidableEq F] (b : 𝓢 ⊢! ∼(φ ⋎ ψ)) : 𝓢 ⊢! ∼φ ⋏ ∼ψ := CNAKNN ⨀ b
-lemma KNN!_of_NA! [DecidableEq F] (b : 𝓢 ⊢ ∼(φ ⋎ ψ)) : 𝓢 ⊢ ∼φ ⋏ ∼ψ := ⟨KNN_of_NA b.some⟩
+def KNN!_of_NA! [DecidableEq F] (b : 𝓢 ⊢! ∼(φ ⋎ ψ)) : 𝓢 ⊢! ∼φ ⋏ ∼ψ := CNAKNN! ⨀ b
+lemma KNN_of_NA [DecidableEq F] (b : 𝓢 ⊢ ∼(φ ⋎ ψ)) : 𝓢 ⊢ ∼φ ⋏ ∼ψ := ⟨KNN!_of_NA! b.some⟩
 
 
 
 
 section Conjunction
 
-def EConj₂Conj : (Γ : List F) → 𝓢 ⊢! ⋀Γ 🡘 Γ.conj
-  | []          => E_id
-  | [_]         => E_intro (deduct' <| K_intro FiniteContext.id verum) and₁
-  | _ :: ψ :: Γ => EKK_of_E_of_E (E_id) (EConj₂Conj (ψ :: Γ))
-@[simp] lemma EConj₂Conj! : 𝓢 ⊢ ⋀Γ 🡘 Γ.conj := ⟨EConj₂Conj Γ⟩
+def EConj₂Conj! : (Γ : List F) → 𝓢 ⊢! ⋀Γ 🡘 Γ.conj
+  | []          => E!_id
+  | [_]         => E!_intro (deduct'! <| K!_intro FiniteContext.id! verum!) and₁!
+  | _ :: ψ :: Γ => EKK!_of_E!_of_E! (E!_id) (EConj₂Conj! (ψ :: Γ))
+@[simp] lemma EConj₂Conj : 𝓢 ⊢ ⋀Γ 🡘 Γ.conj := ⟨EConj₂Conj! Γ⟩
 
-lemma CConj!_iff_CConj₂! : 𝓢 ⊢ Γ.conj 🡒 φ ↔ 𝓢 ⊢ ⋀Γ 🡒 φ := C!_iff_C!_of_iff_left $ E!_symm EConj₂Conj!
+lemma CConj_iff_CConj₂ : 𝓢 ⊢ Γ.conj 🡒 φ ↔ 𝓢 ⊢ ⋀Γ 🡒 φ := C_iff_C_of_iff_left $ E_symm EConj₂Conj
 
 /--! note: It may be easier to handle define `List.conj` based on `List.conj' (?)`  -/
-def right_Conj'_intro [DecidableEq F] (φ : F) (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢! φ 🡒 ψ i) : 𝓢 ⊢! φ 🡒 l.conj' ψ :=
-  right_Conj₂_intro φ (l.map ψ) fun χ h ↦
+def right_Conj'!_intro [DecidableEq F] (φ : F) (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢! φ 🡒 ψ i) : 𝓢 ⊢! φ 🡒 l.conj' ψ :=
+  right_Conj₂!_intro φ (l.map ψ) fun χ h ↦
     let ⟨i, hi, e⟩ := l.chooseX (fun i ↦ ψ i = χ) (by simpa using h)
     e ▸ (b i hi)
-lemma right_Conj'!_intro [DecidableEq F] (φ : F) (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢ φ 🡒 ψ i) : 𝓢 ⊢ φ 🡒 l.conj' ψ :=
-  ⟨right_Conj'_intro φ l ψ fun i hi ↦ (b i hi).get⟩
+lemma right_Conj'_intro [DecidableEq F] (φ : F) (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢ φ 🡒 ψ i) : 𝓢 ⊢ φ 🡒 l.conj' ψ :=
+  ⟨right_Conj'!_intro φ l ψ fun i hi ↦ (b i hi).get⟩
 
-def left_Conj'_intro [DecidableEq F] {l : List ι} (h : i ∈ l) (φ : ι → F) : 𝓢 ⊢! l.conj' φ 🡒 φ i :=
-  left_Conj₂_intro (by simp only [mem_map]; use i)
-lemma left_Conj'!_intro [DecidableEq F] {l : List ι} (h : i ∈ l) (φ : ι → F) : 𝓢 ⊢ l.conj' φ 🡒 φ i := ⟨left_Conj'_intro h φ⟩
-
-
-lemma right_Fconj!_intro (φ : F) (s : Finset F) (b : (ψ : F) → ψ ∈ s → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 s.conj :=
-  right_Conj₂!_intro φ s.toList fun ψ hψ ↦ b ψ (by simpa using hψ)
-
-lemma left_Fconj!_intro [DecidableEq F] {s : Finset F} (h : φ ∈ s) : 𝓢 ⊢ s.conj 🡒 φ := left_Conj₂!_intro <| by simp [h]
-
-lemma right_Fconj'!_intro [DecidableEq F] (φ : F) (s : Finset ι) (ψ : ι → F) (b : ∀ i ∈ s, 𝓢 ⊢ φ 🡒 ψ i) :
-    𝓢 ⊢ φ 🡒 ⩕ i ∈ s, ψ i := right_Conj'!_intro φ s.toList ψ (by simpa)
-
-lemma left_Fconj'!_intro [DecidableEq F] {s : Finset ι} (φ : ι → F) {i} (hi : i ∈ s) : 𝓢 ⊢ (⩕ i ∈ s, φ i) 🡒 φ i :=
-  left_Conj'!_intro (by simpa) φ
-
-lemma right_Uconj!_intro [DecidableEq F] [Fintype ι] (φ : F) (ψ : ι → F) (b : (i : ι) → 𝓢 ⊢ φ 🡒 ψ i) :
-    𝓢 ⊢ φ 🡒 ⩕ i, ψ i := right_Fconj'!_intro φ Finset.univ ψ (by simpa using b)
-
-lemma left_Uconj!_intro [DecidableEq F] [Fintype ι] (φ : ι → F) (i) : 𝓢 ⊢ (⩕ i, φ i) 🡒 φ i := left_Fconj'!_intro _ <| by simp
+def left_Conj'!_intro [DecidableEq F] {l : List ι} (h : i ∈ l) (φ : ι → F) : 𝓢 ⊢! l.conj' φ 🡒 φ i :=
+  left_Conj₂!_intro (by simp only [mem_map]; use i)
+lemma left_Conj'_intro [DecidableEq F] {l : List ι} (h : i ∈ l) (φ : ι → F) : 𝓢 ⊢ l.conj' φ 🡒 φ i := ⟨left_Conj'!_intro h φ⟩
 
 
-lemma Conj₂!_iff_forall_provable [DecidableEq F] {Γ : List F} : (𝓢 ⊢ ⋀Γ) ↔ (∀ φ ∈ Γ, 𝓢 ⊢ φ) := by
+lemma right_Fconj_intro (φ : F) (s : Finset F) (b : (ψ : F) → ψ ∈ s → 𝓢 ⊢ φ 🡒 ψ) : 𝓢 ⊢ φ 🡒 s.conj :=
+  right_Conj₂_intro φ s.toList fun ψ hψ ↦ b ψ (by simpa using hψ)
+
+lemma left_Fconj_intro [DecidableEq F] {s : Finset F} (h : φ ∈ s) : 𝓢 ⊢ s.conj 🡒 φ := left_Conj₂_intro <| by simp [h]
+
+lemma right_Fconj'_intro [DecidableEq F] (φ : F) (s : Finset ι) (ψ : ι → F) (b : ∀ i ∈ s, 𝓢 ⊢ φ 🡒 ψ i) :
+    𝓢 ⊢ φ 🡒 ⩕ i ∈ s, ψ i := right_Conj'_intro φ s.toList ψ (by simpa)
+
+lemma left_Fconj'_intro [DecidableEq F] {s : Finset ι} (φ : ι → F) {i} (hi : i ∈ s) : 𝓢 ⊢ (⩕ i ∈ s, φ i) 🡒 φ i :=
+  left_Conj'_intro (by simpa) φ
+
+lemma right_Uconj_intro [DecidableEq F] [Fintype ι] (φ : F) (ψ : ι → F) (b : (i : ι) → 𝓢 ⊢ φ 🡒 ψ i) :
+    𝓢 ⊢ φ 🡒 ⩕ i, ψ i := right_Fconj'_intro φ Finset.univ ψ (by simpa using b)
+
+lemma left_Uconj_intro [DecidableEq F] [Fintype ι] (φ : ι → F) (i) : 𝓢 ⊢ (⩕ i, φ i) 🡒 φ i := left_Fconj'_intro _ <| by simp
+
+
+lemma Conj₂_iff_forall_provable [DecidableEq F] {Γ : List F} : (𝓢 ⊢ ⋀Γ) ↔ (∀ φ ∈ Γ, 𝓢 ⊢ φ) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
@@ -1199,125 +1199,125 @@ lemma Conj₂!_iff_forall_provable [DecidableEq F] {Γ : List F} : (𝓢 ⊢ ⋀
     constructor;
     . intro h;
       constructor;
-      . exact K!_left h;
-      . exact ih.mp (K!_right h);
+      . exact K_left h;
+      . exact ih.mp (K_right h);
     . rintro ⟨h₁, h₂⟩;
-      exact K!_intro h₁ (ih.mpr h₂);
+      exact K_intro h₁ (ih.mpr h₂);
 
-lemma CConj₂Conj₂!_of_subset [DecidableEq F] (h : ∀ φ, φ ∈ Γ → φ ∈ Δ) : 𝓢 ⊢ ⋀Δ 🡒 ⋀Γ := by
+lemma CConj₂Conj₂_of_subset [DecidableEq F] (h : ∀ φ, φ ∈ Γ → φ ∈ Δ) : 𝓢 ⊢ ⋀Δ 🡒 ⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
-  | hsingle => simp_all only [mem_cons, not_mem_nil, or_false, forall_eq, conj₂_singleton]; exact left_Conj₂!_intro h;
+  | hsingle => simp_all only [mem_cons, not_mem_nil, or_false, forall_eq, conj₂_singleton]; exact left_Conj₂_intro h;
   | hcons φ Γ hne ih =>
     simp_all only [ne_eq, mem_cons, or_true, implies_true, forall_const, forall_eq_or_imp, not_false_eq_true,
       conj₂_cons_nonempty];
-    exact right_K!_intro (left_Conj₂!_intro h.1) ih;
+    exact right_K_intro (left_Conj₂_intro h.1) ih;
 
-lemma CConj₂Conj₂!_of_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢] φ) : 𝓢 ⊢ ⋀Δ 🡒 ⋀Γ :=
+lemma CConj₂Conj₂_of_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢] φ) : 𝓢 ⊢ ⋀Δ 🡒 ⋀Γ :=
   by induction Γ using List.induction_with_singleton with
-  | hnil => exact C!_of_conseq! verum!;
+  | hnil => exact C_of_conseq verum;
   | hsingle => simp_all only [mem_cons, not_mem_nil, or_false, forall_eq, conj₂_singleton]; exact provable_iff.mp h;
   | hcons φ Γ hne ih =>
     simp_all only [ne_eq, mem_cons, or_true, implies_true, forall_const, forall_eq_or_imp, not_false_eq_true,
       conj₂_cons_nonempty];
-    exact right_K!_intro (provable_iff.mp h.1) ih;
+    exact right_K_intro (provable_iff.mp h.1) ih;
 
-lemma CConj₂!_of_forall_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢] φ) : Δ ⊢[𝓢] ⋀Γ := provable_iff.mpr $ CConj₂Conj₂!_of_provable h
+lemma CConj₂_of_forall_provable [DecidableEq F] (h : ∀ φ, φ ∈ Γ → Δ ⊢[𝓢] φ) : Δ ⊢[𝓢] ⋀Γ := provable_iff.mpr $ CConj₂Conj₂_of_provable h
 
-lemma CConj₂!_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) : 𝓢 ⊢ φ 🡒 ⋀Γ := by
+lemma CConj₂_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) : 𝓢 ⊢ φ 🡒 ⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hcons χ Γ h ih =>
     simp_all only [ne_eq, mem_cons, true_or, or_true, implies_true, forall_const, forall_eq_or_imp,
       not_false_eq_true, conj₂_cons_nonempty];
     have ⟨he₁, he₂⟩ := he; subst he₁;
-    exact right_K!_intro C!_id ih;
+    exact right_K_intro C_id ih;
   | _ => simp_all;
 
-lemma C!_of_CConj₂!_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) (hd : 𝓢 ⊢ ⋀Γ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ψ := C!_trans (CConj₂!_of_unique he) hd
+lemma C_of_CConj₂_of_unique [DecidableEq F] (he : ∀ g ∈ Γ, g = φ) (hd : 𝓢 ⊢ ⋀Γ 🡒 ψ) : 𝓢 ⊢ φ 🡒 ψ := C_trans (CConj₂_of_unique he) hd
 
-lemma CConj₂!_iff_CKConj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(φ :: Γ) 🡒 ψ ↔ 𝓢 ⊢ φ ⋏ ⋀Γ 🡒 ψ := by
+lemma CConj₂_iff_CKConj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(φ :: Γ) 🡒 ψ ↔ 𝓢 ⊢ φ ⋏ ⋀Γ 🡒 ψ := by
   induction Γ with
   | nil =>
-    simp only [conj₂_singleton, conj₂_nil, CK!_iff_CC!];
+    simp only [conj₂_singleton, conj₂_nil, CK_iff_CC];
     constructor;
-    . intro h; apply C!_swap; exact C!_of_conseq! h;
-    . intro h; exact C!_swap h ⨀ verum!;
+    . intro h; apply C_swap; exact C_of_conseq h;
+    . intro h; exact C_swap h ⨀ verum;
   | cons ψ ih => simp;
 
 
-@[simp] lemma CConj₂AppendKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡒 ⋀Γ ⋏ ⋀Δ := by
-  apply FiniteContext.deduct'!;
-  have : [⋀(Γ ++ Δ)] ⊢[𝓢] ⋀(Γ ++ Δ) := id!;
-  have d := Conj₂!_iff_forall_provable.mp this;
-  apply K!_intro;
-  . apply Conj₂!_iff_forall_provable.mpr;
+@[simp] lemma CConj₂AppendKConj₂Conj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡒 ⋀Γ ⋏ ⋀Δ := by
+  apply FiniteContext.deduct';
+  have : [⋀(Γ ++ Δ)] ⊢[𝓢] ⋀(Γ ++ Δ) := id;
+  have d := Conj₂_iff_forall_provable.mp this;
+  apply K_intro;
+  . apply Conj₂_iff_forall_provable.mpr;
     intro φ hp;
     exact d φ (by simp only [mem_append]; left; exact hp);
-  . apply Conj₂!_iff_forall_provable.mpr;
+  . apply Conj₂_iff_forall_provable.mpr;
     intro φ hp;
     exact d φ (by simp only [mem_append]; right; exact hp);
 
 @[simp]
-lemma CKConj₂RemoveConj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ.remove φ) ⋏ φ 🡒 ⋀Γ := by
-  apply deduct'!;
-  apply Conj₂!_iff_forall_provable.mpr;
+lemma CKConj₂RemoveConj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(Γ.remove φ) ⋏ φ 🡒 ⋀Γ := by
+  apply deduct';
+  apply Conj₂_iff_forall_provable.mpr;
   intro ψ hq;
   by_cases e : ψ = φ;
-  . subst e; exact K!_right id!;
-  . exact Conj₂!_iff_forall_provable.mp (K!_left id!) ψ (by apply List.mem_remove_iff.mpr; simp_all);
+  . subst e; exact K_right id;
+  . exact Conj₂_iff_forall_provable.mp (K_left id) ψ (by apply List.mem_remove_iff.mpr; simp_all);
 
-lemma CKConj₂Remove!_of_CConj₂! [DecidableEq F] (b : 𝓢 ⊢ ⋀Γ 🡒 ψ) : 𝓢 ⊢ ⋀(Γ.remove φ) ⋏ φ 🡒 ψ := C!_trans CKConj₂RemoveConj₂! b
+lemma CKConj₂Remove_of_CConj₂ [DecidableEq F] (b : 𝓢 ⊢ ⋀Γ 🡒 ψ) : 𝓢 ⊢ ⋀(Γ.remove φ) ⋏ φ 🡒 ψ := C_trans CKConj₂RemoveConj₂ b
 
 
-lemma Conj₂Append!_iff_KConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) ↔ 𝓢 ⊢ ⋀Γ ⋏ ⋀Δ := by
+lemma Conj₂Append_iff_KConj₂Conj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) ↔ 𝓢 ⊢ ⋀Γ ⋏ ⋀Δ := by
   constructor;
   . intro h;
-    replace h := Conj₂!_iff_forall_provable.mp h;
-    apply K!_intro;
-    . apply Conj₂!_iff_forall_provable.mpr;
+    replace h := Conj₂_iff_forall_provable.mp h;
+    apply K_intro;
+    . apply Conj₂_iff_forall_provable.mpr;
       intro φ hp; exact h φ (by simp only [List.mem_append]; left; simpa);
-    . apply Conj₂!_iff_forall_provable.mpr;
+    . apply Conj₂_iff_forall_provable.mpr;
       intro φ hp; exact h φ (by simp only [List.mem_append]; right; simpa);
   . intro h;
-    apply Conj₂!_iff_forall_provable.mpr;
+    apply Conj₂_iff_forall_provable.mpr;
     simp only [List.mem_append];
     rintro φ (hp₁ | hp₂);
-    . exact (Conj₂!_iff_forall_provable.mp $ K!_left h) φ hp₁;
-    . exact (Conj₂!_iff_forall_provable.mp $ K!_right h) φ hp₂;
+    . exact (Conj₂_iff_forall_provable.mp $ K_left h) φ hp₁;
+    . exact (Conj₂_iff_forall_provable.mp $ K_right h) φ hp₂;
 
 
-@[simp] lemma EConj₂AppendKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡘 ⋀Γ ⋏ ⋀Δ := by
-  apply E!_intro;
-  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mp; exact id!;
-  . apply deduct'!; apply Conj₂Append!_iff_KConj₂Conj₂!.mpr; exact id!;
+@[simp] lemma EConj₂AppendKConj₂Conj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡘 ⋀Γ ⋏ ⋀Δ := by
+  apply E_intro;
+  . apply deduct'; apply Conj₂Append_iff_KConj₂Conj₂.mp; exact id;
+  . apply deduct'; apply Conj₂Append_iff_KConj₂Conj₂.mpr; exact id;
 
 
-lemma CConj₂Append!_iff_CKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡒 φ ↔ 𝓢 ⊢ (⋀Γ ⋏ ⋀Δ) 🡒 φ := by
+lemma CConj₂Append_iff_CKConj₂Conj₂ [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++ Δ) 🡒 φ ↔ 𝓢 ⊢ (⋀Γ ⋏ ⋀Δ) 🡒 φ := by
   constructor;
-  . intro h; exact C!_trans (K!_right EConj₂AppendKConj₂Conj₂!) h;
-  . intro h; exact C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) h;
+  . intro h; exact C_trans (K_right EConj₂AppendKConj₂Conj₂) h;
+  . intro h; exact C_trans (K_left EConj₂AppendKConj₂Conj₂) h;
 
-@[simp] lemma CConj₂FConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ ⋀Γ.toList 🡒 Γ.conj := by
-  apply CConj₂Conj₂!_of_provable;
-  apply FiniteContext.by_axm!;
+@[simp] lemma CConj₂FConj [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ ⋀Γ.toList 🡒 Γ.conj := by
+  apply CConj₂Conj₂_of_provable;
+  apply FiniteContext.by_axm;
 
-@[simp] lemma CConj₂FConj!_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ ⋀Γ 🡒 Γ.toFinset.conj := by
-  apply C!_trans ?_ CConj₂FConj!;
-  apply CConj₂Conj₂!_of_subset;
+@[simp] lemma CConj₂FConj_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ ⋀Γ 🡒 Γ.toFinset.conj := by
+  apply C_trans ?_ CConj₂FConj;
+  apply CConj₂Conj₂_of_subset;
   simp;
 
-@[simp] lemma CFConjConj₂! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 ⋀Γ.toList := by
-  apply right_Conj₂!_intro;
+@[simp] lemma CFConjConj₂ [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 ⋀Γ.toList := by
+  apply right_Conj₂_intro;
   intro φ hφ;
-  apply left_Fconj!_intro;
+  apply left_Fconj_intro;
   simpa using hφ;
 
-@[simp] lemma CFConjConj₂!_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ Γ.toFinset.conj 🡒 ⋀Γ := by
-  apply C!_trans $ CFConjConj₂!;
-  apply CConj₂Conj₂!_of_subset;
+@[simp] lemma CFConjConj₂_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ Γ.toFinset.conj 🡒 ⋀Γ := by
+  apply C_trans $ CFConjConj₂;
+  apply CConj₂Conj₂_of_subset;
   simp;
 
-lemma FConj!_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 φ ↔ Γ *⊢[𝓢] φ := by
+lemma FConj_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 φ ↔ Γ *⊢[𝓢] φ := by
   constructor;
   . intro h;
     apply Context.provable_iff.mpr;
@@ -1325,65 +1325,65 @@ lemma FConj!_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 φ ↔ �
     constructor;
     . simp;
     . apply FiniteContext.provable_iff.mpr;
-      exact C!_trans (by simp) h;
+      exact C_trans (by simp) h;
   . intro h;
     obtain ⟨Δ, hΔ₁, hΔ₂⟩ := Context.provable_iff.mp h;
-    replace hΔ₂ : 𝓢 ⊢ ⋀Γ.toList 🡒 φ := C!_trans (CConj₂Conj₂!_of_subset (by simpa)) $ FiniteContext.provable_iff.mp hΔ₂
-    exact C!_trans (by simp) hΔ₂;
+    replace hΔ₂ : 𝓢 ⊢ ⋀Γ.toList 🡒 φ := C_trans (CConj₂Conj₂_of_subset (by simpa)) $ FiniteContext.provable_iff.mp hΔ₂
+    exact C_trans (by simp) hΔ₂;
 
-lemma FConj!_iff_forall_provable [DecidableEq F] {Γ : Finset F} : (𝓢 ⊢ Γ.conj) ↔ (∀ φ ∈ Γ, 𝓢 ⊢ φ) := by
-  apply Iff.trans Conj₂!_iff_forall_provable;
+lemma FConj_iff_forall_provable [DecidableEq F] {Γ : Finset F} : (𝓢 ⊢ Γ.conj) ↔ (∀ φ ∈ Γ, 𝓢 ⊢ φ) := by
+  apply Iff.trans Conj₂_iff_forall_provable;
   constructor <;> simp_all;
 
-lemma FConj!_of_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) (hΓ : 𝓢 ⊢ Γ.conj) : 𝓢 ⊢ Δ.conj := by
-  rw [FConj!_iff_forall_provable] at hΓ ⊢;
+lemma FConj_of_FConj_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) (hΓ : 𝓢 ⊢ Γ.conj) : 𝓢 ⊢ Δ.conj := by
+  rw [FConj_iff_forall_provable] at hΓ ⊢;
   intro φ hφ;
   apply hΓ;
   apply h hφ;
 
-lemma CFConjFConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj 🡒 Δ.conj := by
-  apply FConj!_DT.mpr;
-  apply FConj!_of_FConj!_of_subset h;
-  apply FConj!_DT.mp;
+lemma CFConjFConj_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj 🡒 Δ.conj := by
+  apply FConj_DT.mpr;
+  apply FConj_of_FConj_of_subset h;
+  apply FConj_DT.mp;
   simp;
 
-@[simp] lemma CFconjUnionKFconj! [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).conj 🡒 Γ.conj ⋏ Δ.conj := by
-  apply FConj!_DT.mpr;
-  apply K!_intro <;>
-  . apply FConj!_DT.mp;
-    apply CFConjFConj!_of_subset;
+@[simp] lemma CFconjUnionKFconj [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).conj 🡒 Γ.conj ⋏ Δ.conj := by
+  apply FConj_DT.mpr;
+  apply K_intro <;>
+  . apply FConj_DT.mp;
+    apply CFConjFConj_of_subset;
     simp;
 
-@[simp] lemma CinsertFConjKFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).conj 🡒 φ ⋏ Γ.conj := by
+@[simp] lemma CinsertFConjKFConj [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).conj 🡒 φ ⋏ Γ.conj := by
   suffices 𝓢 ⊢ ({φ} ∪ Γ).conj 🡒 (Finset.conj {φ}) ⋏ Γ.conj by simpa using this;
-  apply CFconjUnionKFconj!;
+  apply CFconjUnionKFconj;
 
-@[simp] lemma CKFconjFconjUnion! [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢ Γ.conj ⋏ Δ.conj 🡒 (Γ ∪ Δ).conj := by
-  apply right_Fconj!_intro;
+@[simp] lemma CKFconjFconjUnion [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢ Γ.conj ⋏ Δ.conj 🡒 (Γ ∪ Δ).conj := by
+  apply right_Fconj_intro;
   simp only [Finset.mem_union];
   rintro φ (hφ | hφ);
-  . apply left_K!_intro_left
-    apply left_Fconj!_intro hφ;
-  . apply left_K!_intro_right;
-    apply left_Fconj!_intro hφ;
+  . apply left_K_intro_left
+    apply left_Fconj_intro hφ;
+  . apply left_K_intro_right;
+    apply left_Fconj_intro hφ;
 
 @[simp]
-lemma CKFConjinsertFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ φ ⋏ Γ.conj 🡒 (insert φ Γ).conj := by
+lemma CKFConjinsertFConj [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ φ ⋏ Γ.conj 🡒 (insert φ Γ).conj := by
   suffices 𝓢 ⊢ (Finset.conj {φ}) ⋏ Γ.conj 🡒 ({φ} ∪ Γ).conj by simpa using this;
-  apply CKFconjFconjUnion!;
+  apply CKFconjFconjUnion;
 
-lemma FConj!_DT' [DecidableEq F] {Γ Δ : Finset F} : Γ *⊢[𝓢] Δ.conj 🡒 φ ↔ ↑(Γ ∪ Δ) *⊢[𝓢] φ := by
+lemma FConj_DT' [DecidableEq F] {Γ Δ : Finset F} : Γ *⊢[𝓢] Δ.conj 🡒 φ ↔ ↑(Γ ∪ Δ) *⊢[𝓢] φ := by
   constructor;
-  . intro h; exact FConj!_DT.mp $ C!_trans CFconjUnionKFconj! $ CK!_iff_CC!.mpr $ FConj!_DT.mpr h;
-  . intro h; exact FConj!_DT.mp $ CK!_iff_CC!.mp $ C!_trans CKFconjFconjUnion! $ FConj!_DT.mpr h;
+  . intro h; exact FConj_DT.mp $ C_trans CFconjUnionKFconj $ CK_iff_CC.mpr $ FConj_DT.mpr h;
+  . intro h; exact FConj_DT.mp $ CK_iff_CC.mp $ C_trans CKFconjFconjUnion $ FConj_DT.mpr h;
 
-lemma CFconjFconj!_of_provable [DecidableEq F] {Γ Δ : Finset _} (h : ∀ φ, φ ∈ Γ → Δ *⊢[𝓢] φ) : 𝓢 ⊢ Δ.conj 🡒 Γ.conj := by
-  have : 𝓢 ⊢ ⋀(Δ.toList) 🡒 ⋀(Γ.toList) := CConj₂Conj₂!_of_provable $ by
+lemma CFconjFconj_of_provable [DecidableEq F] {Γ Δ : Finset _} (h : ∀ φ, φ ∈ Γ → Δ *⊢[𝓢] φ) : 𝓢 ⊢ Δ.conj 🡒 Γ.conj := by
+  have : 𝓢 ⊢ ⋀(Δ.toList) 🡒 ⋀(Γ.toList) := CConj₂Conj₂_of_provable $ by
     intro φ hφ;
     apply Context.iff_provable_context_provable_finiteContext_toList.mp
     apply h φ;
     simpa using hφ;
-  refine C!_replace ?_ ?_ this;
+  refine C_replace ?_ ?_ this;
   . simp;
   . simp;
 
@@ -1392,41 +1392,41 @@ end Conjunction
 
 section disjunction
 
-def right_Disj_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢! φ 🡒 Γ.disj :=
+def right_Disj!_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢! φ 🡒 Γ.disj :=
   match Γ with
   |     [] => by simp at h
   | ψ :: Γ =>
-    if e : φ = ψ then cast (or₁ : 𝓢 ⊢! φ 🡒 φ ⋎ Γ.disj) (by simp [e])
+    if e : φ = ψ then cast (or₁! : 𝓢 ⊢! φ 🡒 φ ⋎ Γ.disj) (by simp [e])
     else
       have : φ ∈ Γ := by simpa [e] using h
-      C_trans (right_Disj_intro Γ this) or₂
-theorem right_Disj!_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢ φ 🡒 Γ.disj := ⟨right_Disj_intro Γ h⟩
+      C!_trans (right_Disj!_intro Γ this) or₂!
+theorem right_Disj_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢ φ 🡒 Γ.disj := ⟨right_Disj!_intro Γ h⟩
 
-def right_Disj_intro' [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) (hψ : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! ψ 🡒 Γ.disj :=
-  C_trans hψ (right_Disj_intro Γ h)
-theorem right_Disj!_intro' [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) (hψ : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ ψ 🡒 Γ.disj := ⟨right_Disj_intro' Γ h hψ.get⟩
+def right_Disj!_intro' [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) (hψ : 𝓢 ⊢! ψ 🡒 φ) : 𝓢 ⊢! ψ 🡒 Γ.disj :=
+  C!_trans hψ (right_Disj!_intro Γ h)
+theorem right_Disj_intro' [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) (hψ : 𝓢 ⊢ ψ 🡒 φ) : 𝓢 ⊢ ψ 🡒 Γ.disj := ⟨right_Disj!_intro' Γ h hψ.get⟩
 
-def right_Disj₂_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢! φ 🡒 ⋁Γ :=
+def right_Disj₂!_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢! φ 🡒 ⋁Γ :=
   match Γ with
   |     [] => by simp at h
-  |    [ψ] => (show ⋁[ψ] = φ by simp_all) ▸ C_id
+  |    [ψ] => (show ⋁[ψ] = φ by simp_all) ▸ C!_id
   | ψ :: χ :: Γ =>
-    if e : φ = ψ then cast (or₁ : 𝓢 ⊢! φ 🡒 φ ⋎ ⋁(χ :: Γ)) (by simp [e])
+    if e : φ = ψ then cast (or₁! : 𝓢 ⊢! φ 🡒 φ ⋎ ⋁(χ :: Γ)) (by simp [e])
     else
       have : φ ∈ χ :: Γ := by simpa [e] using h
-      C_trans (right_Disj₂_intro _ this) or₂
-theorem right_Disj₂!_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢ φ 🡒 ⋁Γ := ⟨right_Disj₂_intro Γ h⟩
+      C!_trans (right_Disj₂!_intro _ this) or₂!
+theorem right_Disj₂_intro [DecidableEq F] (Γ : List F) (h : φ ∈ Γ) : 𝓢 ⊢ φ 🡒 ⋁Γ := ⟨right_Disj₂!_intro Γ h⟩
 
-def right_Disj'_intro [DecidableEq F] (φ : ι → F) (l : List ι) (h : i ∈ l) : 𝓢 ⊢! φ i 🡒 l.disj' φ :=
-  right_Disj₂_intro (l.map φ) (by simpa using ⟨i, h, rfl⟩)
-lemma right_Disj'!_intro [DecidableEq F] (φ : ι → F) (l : List ι) (h : i ∈ l) : 𝓢 ⊢ φ i 🡒 l.disj' φ := ⟨right_Disj'_intro φ l h⟩
+def right_Disj'!_intro [DecidableEq F] (φ : ι → F) (l : List ι) (h : i ∈ l) : 𝓢 ⊢! φ i 🡒 l.disj' φ :=
+  right_Disj₂!_intro (l.map φ) (by simpa using ⟨i, h, rfl⟩)
+lemma right_Disj'_intro [DecidableEq F] (φ : ι → F) (l : List ι) (h : i ∈ l) : 𝓢 ⊢ φ i 🡒 l.disj' φ := ⟨right_Disj'!_intro φ l h⟩
 
-lemma right_Fdisj!_intro [DecidableEq F] (s : Finset F) (h : φ ∈ s) : 𝓢 ⊢ φ 🡒 s.disj := right_Disj₂!_intro _ (by simp [h])
+lemma right_Fdisj_intro [DecidableEq F] (s : Finset F) (h : φ ∈ s) : 𝓢 ⊢ φ 🡒 s.disj := right_Disj₂_intro _ (by simp [h])
 
-lemma right_Fdisj'!_intro [DecidableEq F] (s : Finset ι) (φ : ι → F) {i} (hi : i ∈ s) : 𝓢 ⊢ φ i 🡒 ⩖ j ∈ s, φ j :=
-  right_Disj'!_intro _ _ (by simp [hi])
+lemma right_Fdisj'_intro [DecidableEq F] (s : Finset ι) (φ : ι → F) {i} (hi : i ∈ s) : 𝓢 ⊢ φ i 🡒 ⩖ j ∈ s, φ j :=
+  right_Disj'_intro _ _ (by simp [hi])
 
-lemma right_Udisj!_intro [DecidableEq F] [Fintype ι] (φ : ι → F) : 𝓢 ⊢ φ i 🡒 ⩖ j, φ j := right_Fdisj'!_intro _ _ (by simp)
+lemma right_Udisj_intro [DecidableEq F] [Fintype ι] (φ : ι → F) : 𝓢 ⊢ φ i 🡒 ⩖ j, φ j := right_Fdisj'_intro _ _ (by simp)
 
 end disjunction
 
@@ -1435,44 +1435,44 @@ section
 
 variable {Γ Δ : Finset F}
 
-lemma CFConjFDisj!_of_K_intro [DecidableEq F] (hp : φ ∈ Γ) (hpq : ψ ∈ Γ) (hψ : φ ⋏ ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {φ ⋏ ψ});
-  . apply C!_trans (ψ := Finset.conj {φ, ψ}) ?_;
-    . apply FConj!_DT.mpr;
+lemma CFConjFDisj_of_K_intro [DecidableEq F] (hp : φ ∈ Γ) (hpq : ψ ∈ Γ) (hψ : φ ⋏ ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+  apply C_trans (ψ := Finset.disj {φ ⋏ ψ});
+  . apply C_trans (ψ := Finset.conj {φ, ψ}) ?_;
+    . apply FConj_DT.mpr;
       simp only [Finset.coe_insert, Finset.coe_singleton, Finset.disj_singleton];
-      apply K!_intro <;> exact Context.by_axm! $ by simp;
-    . apply CFConjFConj!_of_subset;
+      apply K_intro <;> exact Context.by_axm $ by simp;
+    . apply CFConjFConj_of_subset;
       apply Finset.doubleton_subset.mpr;
       tauto;
   . simp only [Finset.disj_singleton];
-    apply right_Fdisj!_intro _ hψ;
+    apply right_Fdisj_intro _ hψ;
 
-lemma CFConjFDisj!_of_innerMDP [DecidableEq F] (hp : φ ∈ Γ) (hpq : φ 🡒 ψ ∈ Γ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
-  apply C!_trans (ψ := Finset.disj {ψ});
-  . apply C!_trans (ψ := Finset.conj {φ, φ 🡒 ψ}) ?_;
-    . apply FConj!_DT.mpr;
-      have h₁ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ 🡒 ψ := Context.by_axm! $ by simp;
-      have h₂ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ := Context.by_axm! $ by simp;
+lemma CFConjFDisj_of_innerMDP [DecidableEq F] (hp : φ ∈ Γ) (hpq : φ 🡒 ψ ∈ Γ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+  apply C_trans (ψ := Finset.disj {ψ});
+  . apply C_trans (ψ := Finset.conj {φ, φ 🡒 ψ}) ?_;
+    . apply FConj_DT.mpr;
+      have h₁ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ 🡒 ψ := Context.by_axm $ by simp;
+      have h₂ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ := Context.by_axm $ by simp;
       simpa using h₁ ⨀ h₂;
-    . apply CFConjFConj!_of_subset;
+    . apply CFConjFConj_of_subset;
       apply Finset.doubleton_subset.mpr;
       tauto;
   . simp only [Finset.disj_singleton];
-    apply right_Fdisj!_intro _ hψ;
+    apply right_Fdisj_intro _ hψ;
 
 lemma iff_FiniteContext_Context [DecidableEq F] {Γ : List F} : Γ ⊢[𝓢] φ ↔ ↑Γ.toFinset *⊢[𝓢] φ := by
   constructor;
   . intro h;
     replace h := FiniteContext.provable_iff.mp h;
-    apply FConj!_DT.mp;
-    exact C!_trans (by simp) h;
+    apply FConj_DT.mp;
+    exact C_trans (by simp) h;
   . intro h;
-    replace h := FConj!_DT.mpr h;
+    replace h := FConj_DT.mpr h;
     apply FiniteContext.provable_iff.mpr;
-    exact C!_trans (by simp) h;
+    exact C_trans (by simp) h;
 
-lemma FConj'!_iff_forall_provable [DecidableEq F] {s : Finset α} {ι : α → F} : (𝓢 ⊢ ⩕ i ∈ s, ι i) ↔ (∀ i ∈ s, 𝓢 ⊢ ι i) := by
-  have : 𝓢 ⊢ ⋀(s.toList.map ι) ↔ ∀ i ∈ s, 𝓢 ⊢ ι i := by simpa using Conj₂!_iff_forall_provable (Γ := s.toList.map ι);
+lemma FConj'_iff_forall_provable [DecidableEq F] {s : Finset α} {ι : α → F} : (𝓢 ⊢ ⩕ i ∈ s, ι i) ↔ (∀ i ∈ s, 𝓢 ⊢ ι i) := by
+  have : 𝓢 ⊢ ⋀(s.toList.map ι) ↔ ∀ i ∈ s, 𝓢 ⊢ ι i := by simpa using Conj₂_iff_forall_provable (Γ := s.toList.map ι);
   apply Iff.trans ?_ this;
   simp [Finset.conj', List.conj'];
 
@@ -1496,12 +1496,12 @@ lemma provable_iff_finset [DecidableEq F] {Γ : Set F} {φ : F} : Γ *⊢[𝓢] 
     constructor;
     . simpa;
     . apply FiniteContext.provable_iff.mpr;
-      refine C!_trans ?_ (FConj!_DT.mpr hΔ₂);
+      refine C_trans ?_ (FConj_DT.mpr hΔ₂);
       simp;
 
-lemma bot_of_mem_neg! [DecidableEq F] {Γ : Set F}  (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ *⊢[𝓢] ⊥ := by
-  replace h₁ : Γ *⊢[𝓢] φ := by_axm! h₁;
-  replace h₂ : Γ *⊢[𝓢] φ 🡒 ⊥ := N!_iff_CO!.mp $ by_axm! h₂;
+lemma bot_of_mem_neg [DecidableEq F] {Γ : Set F}  (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ *⊢[𝓢] ⊥ := by
+  replace h₁ : Γ *⊢[𝓢] φ := by_axm h₁;
+  replace h₂ : Γ *⊢[𝓢] φ 🡒 ⊥ := N_iff_CO.mp $ by_axm h₂;
   exact h₂ ⨀ h₁;
 
 end Context

--- a/Foundation/Propositional/Entailment/Minimal.lean
+++ b/Foundation/Propositional/Entailment/Minimal.lean
@@ -194,23 +194,23 @@ def E_intro [HasAxiomAndInst 𝓢] (b₁ : 𝓢 ⊢! φ 🡒 ψ) (b₂ : 𝓢 �
 @[grind =] lemma E!_intro_iff [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ ↔ 𝓢 ⊢ φ 🡒 ψ ∧ 𝓢 ⊢ ψ 🡒 φ := ⟨fun h ↦ ⟨K!_left h, K!_right h⟩, by grind⟩
 
 def C_of_E_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! φ 🡒 ψ := K_left h
-@[grind →] lemma C_of_E_mp! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ φ 🡒 ψ := λ ⟨d⟩ => ⟨C_of_E_mp d⟩
+@[grind →] lemma C!_of_E!_mp [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ φ 🡒 ψ := λ ⟨d⟩ => ⟨C_of_E_mp d⟩
 
 def C_of_E_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢! φ 🡘 ψ) : 𝓢 ⊢! ψ 🡒 φ := K_right h
-@[grind →] lemma C_of_E_mpr! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ ψ 🡒 φ := λ ⟨d⟩ => ⟨C_of_E_mpr d⟩
+@[grind →] lemma C!_of_E!_mpr [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢ φ 🡘 ψ → 𝓢 ⊢ ψ 🡒 φ := λ ⟨d⟩ => ⟨C_of_E_mpr d⟩
 
 @[grind →] lemma iff_of_E! [HasAxiomAndInst 𝓢] [HasAxiomAndElim 𝓢] (h : 𝓢 ⊢ φ 🡘 ψ) : 𝓢 ⊢ φ ↔ 𝓢 ⊢ ψ := ⟨fun hp ↦ K!_left h ⨀ hp, fun hq ↦ K!_right h ⨀ hq⟩
 
 def C_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡒 φ := implyS (φ := φ) (ψ := (φ 🡒 φ)) (χ := φ) ⨀ implyK ⨀ implyK
 @[simp] theorem C!_id [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡒 φ := ⟨C_id⟩
 
-def E_Id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡘 φ := K_intro C_id C_id
-@[simp] theorem E!_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡘 φ := ⟨E_Id⟩
+def E_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] {φ : F} : 𝓢 ⊢! φ 🡘 φ := K_intro C_id C_id
+@[simp] theorem E!_id [HasAxiomAndInst 𝓢] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] : 𝓢 ⊢ φ 🡘 φ := ⟨E_id⟩
 
 instance [LogicalNeutral F] [NegAbbrev F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [HasAxiomAndInst 𝓢] : Entailment.NegationEquiv 𝓢 where
   negEquiv {φ} := by
     suffices 𝓢 ⊢! (φ 🡒 ⊥) 🡘 (φ 🡒 ⊥) by simpa [Axioms.NegEquiv, NegAbbrev.neg];
-    apply E_Id;
+    apply E_id;
 
 
 def NO [LogicalNeutral F] [HasAxiomImplyK 𝓢] [HasAxiomImplyS 𝓢] [NegationEquiv 𝓢] [HasAxiomAndElim 𝓢] : 𝓢 ⊢! ∼⊥ := N_of_CO C_id
@@ -375,7 +375,7 @@ lemma right_Conj₂!_intro (φ : F) (Γ : List F) (b : (ψ : F) → ψ ∈ Γ �
 
 def CConj₂Conj₂ [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢! ⋀Γ 🡒 ⋀Δ :=
   right_Conj₂_intro _ _ (fun _ hq ↦ left_Conj₂_intro (h hq))
-lemma CConj₂_Conj₂! [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ 🡒 ⋀Δ := ⟨CConj₂Conj₂ h⟩
+lemma CConj₂Conj₂! [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ 🡒 ⋀Δ := ⟨CConj₂Conj₂ h⟩
 
 
 section
@@ -669,8 +669,6 @@ instance [DecidableEq F] : Axiomatized (Context F 𝓢) where
 
 def byAxm [DecidableEq F] {Γ : Set F} {φ : F} (h : φ ∈ Γ) : Γ *⊢[𝓢]! φ := Axiomatized.prfAxm (by simpa)
 
-lemma by_axm [DecidableEq F] {Γ : Set F} {φ : F} (h : φ ∈ Γ) : Γ *⊢[𝓢] φ := Axiomatized.provable_refl _ (by simpa)
-
 instance : Compact (Context F 𝓢) where
   core := fun b ↦ AdjunctiveSet.set b.ctx
   corePrf := fun b ↦ ⟨b.ctx, by simp [AdjunctiveSet.set], b.prf⟩
@@ -780,7 +778,7 @@ open NegationEquiv
 open FiniteContext
 open List
 
-@[simp] lemma CONV! : 𝓢 ⊢ ⊤ 🡒 ∼⊥ := deduct'! NO!
+@[simp] lemma CVNO! : 𝓢 ⊢ ⊤ 🡒 ∼⊥ := deduct'! NO!
 
 def innerMDP [DecidableEq F] : 𝓢 ⊢! φ ⋏ (φ 🡒 ψ) 🡒 ψ := by
   apply deduct';
@@ -796,7 +794,7 @@ def bot_of_mem_either [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) :
 lemma bot_of_mem_either! [DecidableEq F] (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ ⊢[𝓢] ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
 
 def negMDP (hnp : 𝓢 ⊢! ∼φ) (hn : 𝓢 ⊢! φ) : 𝓢 ⊢! ⊥ := (CO_of_N hnp) ⨀ hn
-lemma neg_mdp (hnp : 𝓢 ⊢ ∼φ) (hn : 𝓢 ⊢ φ) : 𝓢 ⊢ ⊥ := ⟨negMDP hnp.some hn.some⟩
+lemma neg_mdp! (hnp : 𝓢 ⊢ ∼φ) (hn : 𝓢 ⊢ φ) : 𝓢 ⊢ ⊥ := ⟨negMDP hnp.some hn.some⟩
 
 
 def right_A_intro_left (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ 🡒 (χ ⋎ ψ) := by
@@ -838,13 +836,13 @@ lemma cut! [DecidableEq F] (d₁ : 𝓢 ⊢ φ₁ ⋏ c 🡒 ψ₁) (d₂ : 𝓢
   exact of_C!_of_C!_of_A! (right_A!_intro_left $ of'! (CK!_iff_CC!.mp d₁) ⨀ (K!_left id!)) or₂! (of'! d₂ ⨀ K!_right id!);
 
 
-def inner_A_symm : 𝓢 ⊢! φ ⋎ ψ 🡒 ψ ⋎ φ := by
+def CAA : 𝓢 ⊢! φ ⋎ ψ 🡒 ψ ⋎ φ := by
   apply deduct';
   exact of_C_of_C_of_A or₂ or₁ $ FiniteContext.id
-lemma or_comm! : 𝓢 ⊢ φ ⋎ ψ 🡒 ψ ⋎ φ := ⟨inner_A_symm⟩
+lemma CAA! : 𝓢 ⊢ φ ⋎ ψ 🡒 ψ ⋎ φ := ⟨CAA⟩
 
-def A_symm (h : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ψ ⋎ φ := inner_A_symm ⨀ h
-lemma or_comm'! (h : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ψ ⋎ φ := ⟨A_symm h.some⟩
+def A_symm (h : 𝓢 ⊢! φ ⋎ ψ) : 𝓢 ⊢! ψ ⋎ φ := CAA ⨀ h
+lemma A!_symm (h : 𝓢 ⊢ φ ⋎ ψ) : 𝓢 ⊢ ψ ⋎ φ := ⟨A_symm h.some⟩
 
 
 
@@ -886,8 +884,8 @@ lemma K!_assoc : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ 🡘 φ ⋏ (ψ ⋏ χ) := by
     . exact K!_intro hp hq;
     . exact hr;
 
-lemma K!_assoc_mp (h : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ) : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ) := C_of_E_mp! K!_assoc ⨀ h
-lemma K!_assoc_mpr (h : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ)) : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ := C_of_E_mpr! K!_assoc ⨀ h
+lemma K!_assoc_mp (h : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ) : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ) := C!_of_E!_mp K!_assoc ⨀ h
+lemma K!_assoc_mpr (h : 𝓢 ⊢ φ ⋏ (ψ ⋏ χ)) : 𝓢 ⊢ (φ ⋏ ψ) ⋏ χ := C!_of_E!_mpr K!_assoc ⨀ h
 
 def K_replace_left (hc : 𝓢 ⊢! φ ⋏ ψ) (h : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! χ ⋏ ψ := K_intro (h ⨀ K_left hc) (K_right hc)
 lemma K!_replace_left (hc : 𝓢 ⊢ φ ⋏ ψ) (h : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ χ ⋏ ψ := ⟨K_replace_left hc.some h.some⟩
@@ -921,7 +919,7 @@ lemma A!_replace_left (hc : 𝓢 ⊢ φ ⋎ ψ) (hp : 𝓢 ⊢ φ 🡒 χ) : �
 def CAA_of_C_left (hp : 𝓢 ⊢! φ 🡒 χ) : 𝓢 ⊢! φ ⋎ ψ 🡒 χ ⋎ ψ := by
   apply deduct';
   exact A_replace_left FiniteContext.id (of hp)
-lemma A_replace_left! (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ ⋎ ψ := ⟨CAA_of_C_left hp.some⟩
+lemma CAA!_of_C!_left (hp : 𝓢 ⊢ φ 🡒 χ) : 𝓢 ⊢ φ ⋎ ψ 🡒 χ ⋎ ψ := ⟨CAA_of_C_left hp.some⟩
 
 def A_replace_right (hc : 𝓢 ⊢! φ ⋎ ψ) (hq : 𝓢 ⊢! ψ 🡒 χ) : 𝓢 ⊢! φ ⋎ χ := of_C_of_C_of_A (or₁) (C_trans hq or₂) hc
 lemma A!_replace_right (hc : 𝓢 ⊢ φ ⋎ ψ) (hq : 𝓢 ⊢ ψ 🡒 χ) : 𝓢 ⊢ φ ⋎ χ := ⟨A_replace_right hc.some hq.some⟩
@@ -960,8 +958,8 @@ lemma EAA!_of_E!_right (d : 𝓢 ⊢ ψ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 φ �
 
 lemma EAA!_of_E!_left (d : 𝓢 ⊢ φ 🡘 χ) : 𝓢 ⊢ φ ⋎ ψ 🡘 χ ⋎ ψ := by
   apply E!_intro;
-  . apply A_replace_left!; exact K!_left d;
-  . apply A_replace_left!; exact K!_right d;
+  . apply CAA!_of_C!_left; exact K!_left d;
+  . apply CAA!_of_C!_left; exact K!_right d;
 
 
 def EKK_of_E_of_E (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 ψ₂) : 𝓢 ⊢! φ₁ ⋏ ψ₁ 🡘 φ₂ ⋏ ψ₂ := by
@@ -977,7 +975,7 @@ def ECC_of_E_of_E (hp : 𝓢 ⊢! φ₁ 🡘 φ₂) (hq : 𝓢 ⊢! ψ₁ 🡘 �
 lemma ECC!_of_E!_of_E! (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ (φ₁ 🡒 ψ₁) 🡘 (φ₂ 🡒 ψ₂) := ⟨ECC_of_E_of_E hp.some hq.some⟩
 
 
-lemma C!_repalce [DecidableEq F] (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ 🡒 ψ₁ ↔ 𝓢 ⊢ φ₂ 🡒 ψ₂ :=
+lemma C!_iff_C!_of_E!_of_E! [DecidableEq F] (hp : 𝓢 ⊢ φ₁ 🡘 φ₂) (hq : 𝓢 ⊢ ψ₁ 🡘 ψ₂) : 𝓢 ⊢ φ₁ 🡒 ψ₁ ↔ 𝓢 ⊢ φ₂ 🡒 ψ₂ :=
   iff_of_E! (ECC!_of_E!_of_E! hp hq)
 
 def dni [DecidableEq F] : 𝓢 ⊢! φ 🡒 ∼∼φ := by
@@ -1155,12 +1153,12 @@ lemma KNN!_of_NA! [DecidableEq F] (b : 𝓢 ⊢ ∼(φ ⋎ ψ)) : 𝓢 ⊢ ∼φ
 section Conjunction
 
 def EConj₂Conj : (Γ : List F) → 𝓢 ⊢! ⋀Γ 🡘 Γ.conj
-  | []          => E_Id
+  | []          => E_id
   | [_]         => E_intro (deduct' <| K_intro FiniteContext.id verum) and₁
-  | _ :: ψ :: Γ => EKK_of_E_of_E (E_Id) (EConj₂Conj (ψ :: Γ))
+  | _ :: ψ :: Γ => EKK_of_E_of_E (E_id) (EConj₂Conj (ψ :: Γ))
 @[simp] lemma EConj₂Conj! : 𝓢 ⊢ ⋀Γ 🡘 Γ.conj := ⟨EConj₂Conj Γ⟩
 
-lemma CConj!_iff_CConj₂ : 𝓢 ⊢ Γ.conj 🡒 φ ↔ 𝓢 ⊢ ⋀Γ 🡒 φ := C!_iff_C!_of_iff_left $ E!_symm EConj₂Conj!
+lemma CConj!_iff_CConj₂! : 𝓢 ⊢ Γ.conj 🡒 φ ↔ 𝓢 ⊢ ⋀Γ 🡒 φ := C!_iff_C!_of_iff_left $ E!_symm EConj₂Conj!
 
 /--! note: It may be easier to handle define `List.conj` based on `List.conj' (?)`  -/
 def right_Conj'_intro [DecidableEq F] (φ : F) (l : List ι) (ψ : ι → F) (b : ∀ i ∈ l, 𝓢 ⊢! φ 🡒 ψ i) : 𝓢 ⊢! φ 🡒 l.conj' ψ :=
@@ -1299,27 +1297,27 @@ lemma CConj₂Append!_iff_CKConj₂Conj₂! [DecidableEq F] : 𝓢 ⊢ ⋀(Γ ++
   . intro h; exact C!_trans (K!_right EConj₂AppendKConj₂Conj₂!) h;
   . intro h; exact C!_trans (K!_left EConj₂AppendKConj₂Conj₂!) h;
 
-@[simp] lemma CFConjConj₂ [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ ⋀Γ.toList 🡒 Γ.conj := by
+@[simp] lemma CConj₂FConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ ⋀Γ.toList 🡒 Γ.conj := by
   apply CConj₂Conj₂!_of_provable;
   apply FiniteContext.by_axm!;
 
-@[simp] lemma CConj₂Conj_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ ⋀Γ 🡒 Γ.toFinset.conj := by
-  apply C!_trans ?_ CFConjConj₂;
+@[simp] lemma CConj₂FConj!_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ ⋀Γ 🡒 Γ.toFinset.conj := by
+  apply C!_trans ?_ CConj₂FConj!;
   apply CConj₂Conj₂!_of_subset;
   simp;
 
-@[simp] lemma CConj₂FConj [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 ⋀Γ.toList := by
+@[simp] lemma CFConjConj₂! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 ⋀Γ.toList := by
   apply right_Conj₂!_intro;
   intro φ hφ;
   apply left_Fconj!_intro;
   simpa using hφ;
 
-@[simp] lemma CConj₂FConj_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ Γ.toFinset.conj 🡒 ⋀Γ := by
-  apply C!_trans $ CConj₂FConj;
+@[simp] lemma CFConjConj₂!_list [DecidableEq F] {Γ : List F} : 𝓢 ⊢ Γ.toFinset.conj 🡒 ⋀Γ := by
+  apply C!_trans $ CFConjConj₂!;
   apply CConj₂Conj₂!_of_subset;
   simp;
 
-lemma FConj_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 φ ↔ Γ *⊢[𝓢] φ := by
+lemma FConj!_DT [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ Γ.conj 🡒 φ ↔ Γ *⊢[𝓢] φ := by
   constructor;
   . intro h;
     apply Context.provable_iff.mpr;
@@ -1337,23 +1335,23 @@ lemma FConj!_iff_forall_provable [DecidableEq F] {Γ : Finset F} : (𝓢 ⊢ Γ.
   apply Iff.trans Conj₂!_iff_forall_provable;
   constructor <;> simp_all;
 
-lemma FConj_of_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) (hΓ : 𝓢 ⊢ Γ.conj) : 𝓢 ⊢ Δ.conj := by
+lemma FConj!_of_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) (hΓ : 𝓢 ⊢ Γ.conj) : 𝓢 ⊢ Δ.conj := by
   rw [FConj!_iff_forall_provable] at hΓ ⊢;
   intro φ hφ;
   apply hΓ;
   apply h hφ;
 
-lemma CFConj_FConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj 🡒 Δ.conj := by
-  apply FConj_DT.mpr;
-  apply FConj_of_FConj!_of_subset h;
-  apply FConj_DT.mp;
+lemma CFConjFConj!_of_subset [DecidableEq F] {Γ Δ : Finset F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj 🡒 Δ.conj := by
+  apply FConj!_DT.mpr;
+  apply FConj!_of_FConj!_of_subset h;
+  apply FConj!_DT.mp;
   simp;
 
 @[simp] lemma CFconjUnionKFconj! [DecidableEq F] {Γ Δ : Finset F} : 𝓢 ⊢ (Γ ∪ Δ).conj 🡒 Γ.conj ⋏ Δ.conj := by
-  apply FConj_DT.mpr;
+  apply FConj!_DT.mpr;
   apply K!_intro <;>
-  . apply FConj_DT.mp;
-    apply CFConj_FConj!_of_subset;
+  . apply FConj!_DT.mp;
+    apply CFConjFConj!_of_subset;
     simp;
 
 @[simp] lemma CinsertFConjKFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ (insert φ Γ).conj 🡒 φ ⋏ Γ.conj := by
@@ -1374,10 +1372,10 @@ lemma CKFConjinsertFConj! [DecidableEq F] {Γ : Finset F} : 𝓢 ⊢ φ ⋏ Γ.c
   suffices 𝓢 ⊢ (Finset.conj {φ}) ⋏ Γ.conj 🡒 ({φ} ∪ Γ).conj by simpa using this;
   apply CKFconjFconjUnion!;
 
-lemma FConj_DT' [DecidableEq F] {Γ Δ : Finset F} : Γ *⊢[𝓢] Δ.conj 🡒 φ ↔ ↑(Γ ∪ Δ) *⊢[𝓢] φ := by
+lemma FConj!_DT' [DecidableEq F] {Γ Δ : Finset F} : Γ *⊢[𝓢] Δ.conj 🡒 φ ↔ ↑(Γ ∪ Δ) *⊢[𝓢] φ := by
   constructor;
-  . intro h; exact FConj_DT.mp $ C!_trans CFconjUnionKFconj! $ CK!_iff_CC!.mpr $ FConj_DT.mpr h;
-  . intro h; exact FConj_DT.mp $ CK!_iff_CC!.mp $ C!_trans CKFconjFconjUnion! $ FConj_DT.mpr h;
+  . intro h; exact FConj!_DT.mp $ C!_trans CFconjUnionKFconj! $ CK!_iff_CC!.mpr $ FConj!_DT.mpr h;
+  . intro h; exact FConj!_DT.mp $ CK!_iff_CC!.mp $ C!_trans CKFconjFconjUnion! $ FConj!_DT.mpr h;
 
 lemma CFconjFconj!_of_provable [DecidableEq F] {Γ Δ : Finset _} (h : ∀ φ, φ ∈ Γ → Δ *⊢[𝓢] φ) : 𝓢 ⊢ Δ.conj 🡒 Γ.conj := by
   have : 𝓢 ⊢ ⋀(Δ.toList) 🡒 ⋀(Γ.toList) := CConj₂Conj₂!_of_provable $ by
@@ -1437,26 +1435,26 @@ section
 
 variable {Γ Δ : Finset F}
 
-lemma CFConj_CDisj!_of_K_intro [DecidableEq F] (hp : φ ∈ Γ) (hpq : ψ ∈ Γ) (hψ : φ ⋏ ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+lemma CFConjFDisj!_of_K_intro [DecidableEq F] (hp : φ ∈ Γ) (hpq : ψ ∈ Γ) (hψ : φ ⋏ ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
   apply C!_trans (ψ := Finset.disj {φ ⋏ ψ});
   . apply C!_trans (ψ := Finset.conj {φ, ψ}) ?_;
-    . apply FConj_DT.mpr;
+    . apply FConj!_DT.mpr;
       simp only [Finset.coe_insert, Finset.coe_singleton, Finset.disj_singleton];
       apply K!_intro <;> exact Context.by_axm! $ by simp;
-    . apply CFConj_FConj!_of_subset;
+    . apply CFConjFConj!_of_subset;
       apply Finset.doubleton_subset.mpr;
       tauto;
   . simp only [Finset.disj_singleton];
     apply right_Fdisj!_intro _ hψ;
 
-lemma CFConj_CDisj!_of_innerMDP [DecidableEq F] (hp : φ ∈ Γ) (hpq : φ 🡒 ψ ∈ Γ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
+lemma CFConjFDisj!_of_innerMDP [DecidableEq F] (hp : φ ∈ Γ) (hpq : φ 🡒 ψ ∈ Γ) (hψ : ψ ∈ Δ) : 𝓢 ⊢ Γ.conj 🡒 Δ.disj := by
   apply C!_trans (ψ := Finset.disj {ψ});
   . apply C!_trans (ψ := Finset.conj {φ, φ 🡒 ψ}) ?_;
-    . apply FConj_DT.mpr;
+    . apply FConj!_DT.mpr;
       have h₁ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ 🡒 ψ := Context.by_axm! $ by simp;
       have h₂ : ({φ, φ 🡒 ψ}) *⊢[𝓢] φ := Context.by_axm! $ by simp;
       simpa using h₁ ⨀ h₂;
-    . apply CFConj_FConj!_of_subset;
+    . apply CFConjFConj!_of_subset;
       apply Finset.doubleton_subset.mpr;
       tauto;
   . simp only [Finset.disj_singleton];
@@ -1466,14 +1464,14 @@ lemma iff_FiniteContext_Context [DecidableEq F] {Γ : List F} : Γ ⊢[𝓢] φ 
   constructor;
   . intro h;
     replace h := FiniteContext.provable_iff.mp h;
-    apply FConj_DT.mp;
+    apply FConj!_DT.mp;
     exact C!_trans (by simp) h;
   . intro h;
-    replace h := FConj_DT.mpr h;
+    replace h := FConj!_DT.mpr h;
     apply FiniteContext.provable_iff.mpr;
     exact C!_trans (by simp) h;
 
-lemma FConj'_iff_forall_provable [DecidableEq F] {s : Finset α} {ι : α → F} : (𝓢 ⊢ ⩕ i ∈ s, ι i) ↔ (∀ i ∈ s, 𝓢 ⊢ ι i) := by
+lemma FConj'!_iff_forall_provable [DecidableEq F] {s : Finset α} {ι : α → F} : (𝓢 ⊢ ⩕ i ∈ s, ι i) ↔ (∀ i ∈ s, 𝓢 ⊢ ι i) := by
   have : 𝓢 ⊢ ⋀(s.toList.map ι) ↔ ∀ i ∈ s, 𝓢 ⊢ ι i := by simpa using Conj₂!_iff_forall_provable (Γ := s.toList.map ι);
   apply Iff.trans ?_ this;
   simp [Finset.conj', List.conj'];
@@ -1498,10 +1496,10 @@ lemma provable_iff_finset [DecidableEq F] {Γ : Set F} {φ : F} : Γ *⊢[𝓢] 
     constructor;
     . simpa;
     . apply FiniteContext.provable_iff.mpr;
-      refine C!_trans ?_ (FConj_DT.mpr hΔ₂);
+      refine C!_trans ?_ (FConj!_DT.mpr hΔ₂);
       simp;
 
-lemma bot_of_mem_neg [DecidableEq F] {Γ : Set F}  (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ *⊢[𝓢] ⊥ := by
+lemma bot_of_mem_neg! [DecidableEq F] {Γ : Set F}  (h₁ : φ ∈ Γ) (h₂ : ∼φ ∈ Γ) : Γ *⊢[𝓢] ⊥ := by
   replace h₁ : Γ *⊢[𝓢] φ := by_axm! h₁;
   replace h₂ : Γ *⊢[𝓢] φ 🡒 ⊥ := N!_iff_CO!.mp $ by_axm! h₂;
   exact h₂ ⨀ h₁;

--- a/Foundation/Propositional/Hilbert/Basic.lean
+++ b/Foundation/Propositional/Hilbert/Basic.lean
@@ -58,12 +58,12 @@ instance : Entailment.HasAxiomImplyK H := ⟨implyK⟩
 instance : Entailment.HasAxiomImplyS H := ⟨implyS⟩
 instance : Entailment.HasAxiomAndInst H := ⟨andIntro⟩
 instance : Entailment.Minimal H where
-  verum := verum
-  and₁ := andElimL
-  and₂ := andElimR
-  or₁ := orIntroL
-  or₂ := orIntroR
-  or₃ := orElim
+  verum! := verum
+  and₁! := andElimL
+  and₂! := andElimR
+  or₁! := orIntroL
+  or₂! := orIntroR
+  or₃! := orElim
 
 variable {H} {H₁ H₂ : Hilbert α}
 
@@ -123,7 +123,7 @@ lemma weakerThan_of_provable_schema (h : H₂ ⊢* H₁.schema) : H₁ ⪯ H₂ 
 section
 
 instance : Entailment.Int (Hilbert.Int : Hilbert α) where
-  efq := axm $ by tauto
+  efq! := axm $ by tauto
 
 instance : Entailment.HasAxiomEFQ (Hilbert.Cl : Hilbert α) := ⟨axm $ by tauto⟩
 instance : Entailment.HasAxiomLEM (Hilbert.Cl : Hilbert α) := ⟨axm $ by tauto⟩
@@ -140,7 +140,7 @@ namespace Hilbert
 abbrev logic (H : Hilbert α) : Logic α where
   logic := Entailment.theory H
   subst s {_} := Hilbert.subst s
-  mdp := Entailment.mdp!;
+  mdp := Entailment.mdp;
 
 variable {H : Hilbert α}
 


### PR DESCRIPTION
## Motivation

The naming convention for formalized proofs, introduced in #288, is:

> 1. Convert the formula to Łukasiewicz's notation (`ECKφψχCφCψχ`).
> 2. Remove meta variables (`ECKCC`).
> 3. Postfix `!` if it is a proposition (`ECKCC!`).
> 4. Use snake_case even if it is definition.

At that time `𝓢 ⊢! φ` was the proposition and `𝓢 ⊢ φ` was the proof term, so the `!`
in a name and the `!` in the notation agreed. #566 swapped the two turnstiles but left
the names alone, and since then every pair under `Foundation/Propositional/Entailment/`
has read backwards: the `def` returning `𝓢 ⊢! φ` carried no `!`, while the `lemma`
about `𝓢 ⊢ φ` did.

On top of that, a number of names had drifted from the convention in other ways.

## Changes

**1. Fix names that were simply wrong (`166fa175`)**

- `!` missing on provable statements: `neg_mdp`, `C_of_N`, `FConj_DT`, `EDisj₂FDisj`,
  `CDisj₂Disj₂_of_subset`, `CFDisjFDisj_of_subset`, `CAFdisjFdisjUnion`,
  `CFdisjUnionAFdisj`, `bot_of_mem_neg`, …
- `!` attached to the wrong token: `C_of_E_mp!`, `C_of_E_mpr!`, `CConj!_iff_CConj₂`,
  `FConj_of_FConj!_of_subset`, `A_replace_left!`, `of_a!_of_n!`, …
- Names contradicting the statement: `CFConjConj₂` and `CConj₂FConj` (and their `_list`
  variants) were swapped; `CONV!` is `⊤ 🡒 ∼⊥`, i.e. `CVNO`; `CFConj_CDisj!_of_*`
  conclude in `FDisj`, not `CDisj`.
- Leftover meta-connective names: `or_comm!`, `or_comm'!`, `not_imply_prem''!`, `ofAOfN`.
- Typo `C!_repalce`, spelling `E_Id`, stray `_` inside formula tokens.
- `Context.by_axm` was dropped: it duplicated `Context.by_axm!` and had no references.

**2. Swap the `!` decoration so it matches the notation (`8bfcf403`)**

```lean
-- before
def   K_left  (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! φ
lemma K!_left (d : 𝓢 ⊢  φ ⋏ ψ) : 𝓢 ⊢  φ

-- after
def   K!_left (d : 𝓢 ⊢! φ ⋏ ψ) : 𝓢 ⊢! φ
lemma K_left  (d : 𝓢 ⊢  φ ⋏ ψ) : 𝓢 ⊢  φ
```

This covers all 428 affected names in `Minimal.lean`, `Int.lean` and `Cl.lean`, with the
call sites updated across the repository. The axiom class fields are included
(`ModusPonens.mdp!`, `NegationEquiv.negEquiv!`, `HasAxiomAndElim.and₁!`,
`HasAxiomDNE.dne!`, …): they are `export`ed into the namespace, so leaving them alone
would collide with the renamed provability lemmas.

Two bare references had to be qualified, because the un-decorated names now clash with
`Foundation/Logic/Entailment.lean`: `FiniteContext.weakening` (vs `Entailment.weakening`)
and `FiniteContext.by_axm` (vs `Entailment.by_axm`).

## Out of scope

- `Foundation/Logic/Entailment.lean` still uses the pre-#566 convention
  (`Axiomatized.weakening` is `⊢!` without `!`; `Axiomatized.weakening!`, `adjoin!`,
  `cast!`, `wk!` are `⊢` with `!`). Aligning it is a natural follow-up.
- Type synonyms and instance builders (`Prf`, `Provable`, `PrfSet`, `ProvableSet`,
  `entailment_def`, `Minimal.ofEquiv`, `Cl.ofEquiv`) are not part of the `!` convention.
- Purely descriptive meta lemmas without a Łukasiewicz token (`provable_iff`,
  `deduct_iff`, `inconsistent_of_provable_of_unprovable`, …) keep their names, matching
  how `Foundation/Logic/Entailment.lean` names such statements.
- `dni` / `dne` are left as they are: both would become `CNN` under the convention, so
  the abbreviations still earn their place.

No mathematical content changes; this is a rename only.

## Checks

- `lake build`: 1331 jobs, no errors and no warnings.
- `just axiom-audit`: 22215 declarations, all within the allowlist.
- `lake exe mk_all --module`: no update necessary.

An AI coding agent (Claude) produced these changes; the commits carry the co-author trailer.