### PR TITLE
add(Arithmetic): Strong representation of computable predicates and drop Σ₁-soundness from Church's theorem

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -292,7 +292,12 @@ noncomputable def charFnPart (p : ℕ → Prop) : List.Vector ℕ 1 →. ℕ :=
 noncomputable def codeOfComputablePred (p : ℕ → Prop) : ArithmeticSemisentence 1 :=
   (codeOfPartrec' (charFnPart p))/[‘1’, #0]
 
-lemma ComputablePred.partrec'_charFn {p : ℕ → Prop} (hp : ComputablePred p) :
+@[simp] lemma codeOfComputablePred_sigma1 (p : ℕ → Prop) : Hierarchy 𝚺 1 (codeOfComputablePred p) := by
+  simp [codeOfComputablePred, codeOfPartrec']
+
+variable {p : ℕ → Prop}
+
+lemma ComputablePred.partrec'_charFn (hp : ComputablePred p) :
     Nat.Partrec' (charFnPart p) := by
   obtain ⟨f, hf, rfl⟩ := ComputablePred.computable_iff.mp hp
   have hc : Computable fun v : List.Vector ℕ 1 ↦ f (v.get 0) :=
@@ -302,14 +307,11 @@ lemma ComputablePred.partrec'_charFn {p : ℕ → Prop} (hp : ComputablePred p) 
       cases f (v.get 0) <;> simp
   exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp [charFnPart])
 
-@[simp] lemma codeOfComputablePred_sigma1 (p : ℕ → Prop) : Hierarchy 𝚺 1 (codeOfComputablePred p) := by
-  simp [codeOfComputablePred, codeOfPartrec']
-
-lemma codeOfComputablePred_val_spec {p : ℕ → Prop} (hp : ComputablePred p) (x y : ℕ) :
+lemma codeOfComputablePred_val_spec (hp : ComputablePred p) (x y : ℕ) :
     (codeOfPartrec' (charFnPart p)).Evalb (y :> ![x]) ↔ y = if p x then 1 else 0 := by
   simpa [charFnPart] using codeOfPartrec'_spec (ComputablePred.partrec'_charFn hp) (y := y) (v := ![x])
 
-lemma codeOfComputablePred_spec {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} :
+lemma codeOfComputablePred_spec (hp : ComputablePred p) {x : ℕ} :
     (codeOfComputablePred p).Evalb ![x] ↔ p x := by
   simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfComputablePred_val_spec hp x 1).trans (by by_cases h : p x <;> simp [h])
@@ -318,7 +320,7 @@ section model
 
 variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
 
-lemma codeOfComputablePred_not_eval {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
+lemma codeOfComputablePred_not_eval (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
     ¬(codeOfComputablePred p).Evalb (M := M) ![ORingStructure.numeral x] := by
   intro hM
   have : M↓[ℒₒᵣ] ⊧* 𝗥₀ := ModelsTheory.of_provably_subtheory M 𝗥₀ 𝗣𝗔⁻ inferInstance
@@ -334,18 +336,18 @@ lemma codeOfComputablePred_not_eval {p : ℕ → Prop} (hp : ComputablePred p) {
 
 end model
 
-variable {T : ArithmeticTheory}
+variable {T : ArithmeticTheory} {x : ℕ}
 
 /-- Positive representation of a computable predicate. -/
-theorem codeOfComputablePred_provable [𝗥₀ ⪯ T] {p : ℕ → Prop} (hp : ComputablePred p)
-    {x : ℕ} (h : p x) : T ⊢ (codeOfComputablePred p)/[↑x] :=
+theorem codeOfComputablePred_provable [𝗥₀ ⪯ T] (hp : ComputablePred p) (h : p x) :
+    T ⊢ (codeOfComputablePred p)/[↑x] :=
   sigma_one_completeness (by simp) (by
     simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
       using (codeOfComputablePred_spec hp (x := x)).mpr h)
 
 /-- Negative representation of a computable predicate. -/
-theorem codeOfComputablePred_provable_neg [𝗣𝗔⁻ ⪯ T] {p : ℕ → Prop} (hp : ComputablePred p)
-    {x : ℕ} (h : ¬p x) : T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
+theorem codeOfComputablePred_provable_neg [𝗣𝗔⁻ ⪯ T] (hp : ComputablePred p) (h : ¬p x) :
+    T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
   have : 𝗘𝗤 _ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗣𝗔⁻) inferInstance inferInstance
   refine complete.{0} T _ fun M _ _ ↦ ?_
   have : M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := ModelsTheory.of_provably_subtheory M 𝗣𝗔⁻ T inferInstance

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -1,6 +1,7 @@
 module
 
 public import Foundation.FirstOrder.Arithmetic.Definability.Definable
+public import Foundation.FirstOrder.Arithmetic.PeanoMinus.Basic
 public import Foundation.FirstOrder.Arithmetic.R0.Basic
 public import Foundation.Vorspiel.Arithmetic
 public import Foundation.Vorspiel.Computability
@@ -113,54 +114,64 @@ def codeAux {k : ℕ} : Nat.ArithPart₁.Code k → ArithmeticFormula (Fin (k + 
 
 def code (c : Code k) : ArithmeticSemisentence (k + 1) := (Rew.bind (L := ℒₒᵣ) (ξ₁ := Fin (k + 1)) ![] (#0 :> (#·.succ))) ▹ (codeAux c)
 
-/-
 section model
 
-open LO.Arithmetic
+open PeanoMinus
 
-variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗥₀]
+variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
 
+-- Each case below rewrites hypotheses with `simp [...] at h h'` and then destructures the
+-- normalized hypotheses; the flexible-tactic linter cannot see that the later tactics only
+-- depend on the (already fully simplified) shape of `h`/`h'`, not on the exact simp set used.
+set_option linter.flexible false in
 private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
-    Semiformula.Evalfm M (z :> v) (codeAux c) → Semiformula.Evalfm M (z' :> v) (codeAux c) → z = z' := by
-  induction c generalizing z z' <;> simp [code, codeAux]
-  case zero => rintro rfl rfl; rfl
-  case one  => rintro rfl rfl; rfl
-  case add  => rintro rfl rfl; rfl
-  case mul  => rintro rfl rfl; rfl
-  case proj => rintro rfl rfl; rfl
-  case equal i j =>
-    by_cases hv : v i = v j <;> simp [hv]
-    · rintro rfl rfl; rfl
-    · rintro rfl rfl; rfl
-  case lt i j =>
-    by_cases hv : v i < v j <;> simp [hv, -not_lt, ←not_lt]
-    · rintro rfl rfl; rfl
-    · rintro rfl rfl; rfl
-  case comp m n c d ihc ihd =>
-    simp [Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq, Matrix.comp_vecCons']
-    intro w₁ hc₁ hd₁ w₂ hc₂ hd₂;
+    (codeAux c).Evalf (M := M) (z :> v) → (codeAux c).Evalf (M := M) (z' :> v) → z = z' := by
+  induction c generalizing z z' with
+  | zero _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | one _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | add i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | mul i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | proj i => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | equal i j =>
+    intro h h'
+    by_cases hv : v i = v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+  | lt i j =>
+    intro h h'
+    by_cases hv : v i < v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+  | comp c d ihc ihd =>
+    intro h h'
+    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+      Matrix.comp_vecCons'] at h h'
+    obtain ⟨w₁, hc₁, hd₁⟩ := h
+    obtain ⟨w₂, hc₂, hd₂⟩ := h'
     have : w₁ = w₂ := funext fun i => ihd i (hd₁ i) (hd₂ i)
     rcases this with rfl
     exact ihc hc₁ hc₂
-  case rfind c ih =>
-    simp [Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq, Matrix.comp_vecCons']
-    intro h₁ hm₁ h₂ hm₂
+  | rfind c ih =>
+    intro H₁ H₂
+    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+      Matrix.comp_vecCons'] at H₁ H₂
+    obtain ⟨h₁, hm₁⟩ := H₁
+    obtain ⟨h₂, hm₂⟩ := H₂
     by_contra hz
     wlog h : z < z' with Hz
     case inr =>
       have : z' < z := lt_of_le_of_ne (not_lt.mp h) (Ne.symm hz)
       exact Hz (k := k) c ih h₂ hm₂ h₁ hm₁ (Ne.symm hz) this
-    have : ∃ x, x ≠ 0 ∧ (Semiformula.Evalfm M (x :> z :> fun i => v i)) (codeAux c) := hm₂ z h
+    have : ∃ x, x ≠ 0 ∧ (codeAux c).Evalf (M := M) (x :> z :> fun i => v i) := hm₂ z h
     rcases this with ⟨x, xz, hx⟩
     exact xz (ih hx h₁)
 
+-- `simp ... at h h'` normalizes the two hypotheses to the `codeAux_uniq` shape before
+-- `exact`; the flexible-tactic linter cannot see that `exact` only depends on that final shape.
+set_option linter.flexible false in
 lemma code_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
-    Semiformula.Evalbm M (z :> v) (code c) → Semiformula.Evalbm M (z' :> v) (code c) → z = z' := by
-  simp [code, Semiformula.eval_rew, Matrix.empty_eq, Function.comp_def, Matrix.comp_vecCons']
-  exact codeAux_uniq
+    (code c).Evalb (M := M) (z :> v) → (code c).Evalb (M := M) (z' :> v) → z = z' := by
+  intro h h'
+  simp [code, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq] at h h'
+  exact codeAux_uniq h h'
 
 end model
--/
 
 private lemma codeAux_sigma_one {k} (c : Nat.ArithPart₁.Code k) : Hierarchy 𝚺 1 (codeAux c) := by
   induction c

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -268,26 +268,30 @@ lemma codeOfREPred_spec {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
   simpa [Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfPartrec'_spec (Nat.Partrec'.of_part this) (v := ![x]) (y := 0)).trans (by simp [f])
 
+/-- The `0`/`1`-valued characteristic function of `p`, packaged as a one-variable partial
+function for `codeOfPartrec'`. -/
+noncomputable def charFnPart (p : ℕ → Prop) : List.Vector ℕ 1 →. ℕ :=
+  fun v ↦ Part.some (if p (v.get 0) then 1 else 0)
+
 noncomputable def codeOfComputablePred (p : ℕ → Prop) : ArithmeticSemisentence 1 :=
-  (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ Part.some (if p (v.get 0) then 1 else 0))/[‘1’, #0]
+  (codeOfPartrec' (charFnPart p))/[‘1’, #0]
 
 lemma ComputablePred.partrec'_charFn {p : ℕ → Prop} (hp : ComputablePred p) :
-    Nat.Partrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ) := by
+    Nat.Partrec' (charFnPart p) := by
   obtain ⟨f, hf, rfl⟩ := ComputablePred.computable_iff.mp hp
   have hc : Computable fun v : List.Vector ℕ 1 ↦ f (v.get 0) :=
     hf.comp (Primrec.to_comp <| Primrec.vector_get.comp .id (.const 0))
   have : Computable fun v : List.Vector ℕ 1 ↦ if (f (v.get 0) : Prop) then (1 : ℕ) else 0 :=
     (Computable.cond hc (Computable.const 1) (Computable.const 0)).of_eq fun v ↦ by
       cases f (v.get 0) <;> simp
-  exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp)
+  exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp [charFnPart])
 
 @[simp] lemma codeOfComputablePred_sigma1 (p : ℕ → Prop) : Hierarchy 𝚺 1 (codeOfComputablePred p) := by
   simp [codeOfComputablePred, codeOfPartrec']
 
 lemma codeOfComputablePred_val_spec {p : ℕ → Prop} (hp : ComputablePred p) (x y : ℕ) :
-    (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb (y :> ![x])
-      ↔ y = if p x then 1 else 0 := by
-  simpa using codeOfPartrec'_spec (ComputablePred.partrec'_charFn hp) (y := y) (v := ![x])
+    (codeOfPartrec' (charFnPart p)).Evalb (y :> ![x]) ↔ y = if p x then 1 else 0 := by
+  simpa [charFnPart] using codeOfPartrec'_spec (ComputablePred.partrec'_charFn hp) (y := y) (v := ![x])
 
 lemma codeOfComputablePred_spec {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} :
     (codeOfComputablePred p).Evalb ![x] ↔ p x := by
@@ -302,43 +306,36 @@ lemma codeOfComputablePred_not_eval {p : ℕ → Prop} (hp : ComputablePred p) {
     ¬(codeOfComputablePred p).Evalb (M := M) ![ORingStructure.numeral x] := by
   intro hM
   have : M↓[ℒₒᵣ] ⊧* 𝗥₀ := ModelsTheory.of_provably_subtheory M 𝗥₀ 𝗣𝗔⁻ inferInstance
-  have h0 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
-      (M := ℕ) (0 :> ![x]) :=
+  have h0 : (codeOfPartrec' (charFnPart p)).Evalb (M := ℕ) (0 :> ![x]) :=
     (codeOfComputablePred_val_spec hp x 0).mpr (by simp [h])
-  have h1 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
-      (M := M) ((0 : M) :> ![ORingStructure.numeral x]) := by
-    simpa using bold_sigma_one_completeness' (M := M)
-      (σ := codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ))
+  have h1 : (codeOfPartrec' (charFnPart p)).Evalb (M := M) ((0 : M) :> ![ORingStructure.numeral x]) := by
+    simpa using bold_sigma_one_completeness' (M := M) (σ := codeOfPartrec' (charFnPart p))
       (by simp [codeOfPartrec']) h0
-  have h2 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
-      (M := M) ((1 : M) :> ![ORingStructure.numeral x]) := by
+  have h2 : (codeOfPartrec' (charFnPart p)).Evalb (M := M) ((1 : M) :> ![ORingStructure.numeral x]) := by
     simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
       using hM
   exact absurd (code_uniq h1 h2) (ne_of_lt zero_lt_one)
 
 end model
 
-variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
+section
 
-/-- Weak representation of a r.e. predicate -/
-theorem rePred_weak_representation {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
-    p x ↔ T ⊢ (codeOfREPred p)/[x] := Iff.trans
-  (by simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using (codeOfREPred_spec hp (x := x)).symm)
-  (sigma_one_completeness_iff <| by simp [codeOfREPred, codeOfPartrec'])
+variable {T : ArithmeticTheory} [𝗥₀ ⪯ T]
 
--- `T.SoundOnHierarchy 𝚺 1` is not needed here: only `sigma_one_completeness` (which
--- requires `𝗥₀ ⪯ T` alone) is used, not the `Iff` version.
-omit [T.SoundOnHierarchy 𝚺 1] in
+/-- Positive representation of a computable predicate. -/
 theorem codeOfComputablePred_provable {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : p x) :
     T ⊢ (codeOfComputablePred p)/[↑x] :=
   sigma_one_completeness (by simp) (by
     simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
       using (codeOfComputablePred_spec hp (x := x)).mpr h)
 
+end
+
 section
 
 variable {T : ArithmeticTheory} [𝗣𝗔⁻ ⪯ T]
 
+/-- Negative representation of a computable predicate. -/
 theorem codeOfComputablePred_provable_neg {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
     T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
   have : 𝗘𝗤 _ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗣𝗔⁻) inferInstance inferInstance
@@ -348,6 +345,14 @@ theorem codeOfComputablePred_provable_neg {p : ℕ → Prop} (hp : ComputablePre
     using codeOfComputablePred_not_eval hp h
 
 end
+
+variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
+
+/-- Weak representation of a r.e. predicate -/
+theorem rePred_weak_representation {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
+    p x ↔ T ⊢ (codeOfREPred p)/[x] := Iff.trans
+  (by simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using (codeOfREPred_spec hp (x := x)).symm)
+  (sigma_one_completeness_iff <| by simp [codeOfREPred, codeOfPartrec'])
 
 theorem rePred_iff_sigma1 {p : ℕ → Prop} : REPred p ↔ 𝚺₁-Predicate p := by
   constructor

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -302,6 +302,15 @@ theorem rePred_weak_representation {p : ℕ → Prop} (hp : REPred p) {x : ℕ} 
   (by simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using (codeOfREPred_spec hp (x := x)).symm)
   (sigma_one_completeness_iff <| by simp [codeOfREPred, codeOfPartrec'])
 
+-- `T.SoundOnHierarchy 𝚺 1` is not needed here: only `sigma_one_completeness` (which
+-- requires `𝗥₀ ⪯ T` alone) is used, not the `Iff` version.
+omit [T.SoundOnHierarchy 𝚺 1] in
+theorem codeOfComputablePred_provable {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : p x) :
+    T ⊢ (codeOfComputablePred p)/[↑x] :=
+  sigma_one_completeness (by simp) (by
+    simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
+      using (codeOfComputablePred_spec hp (x := x)).mpr h)
+
 theorem rePred_iff_sigma1 {p : ℕ → Prop} : REPred p ↔ 𝚺₁-Predicate p := by
   constructor
   · intro h

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -294,6 +294,30 @@ lemma codeOfComputablePred_spec {p : ℕ → Prop} (hp : ComputablePred p) {x : 
   simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfComputablePred_val_spec hp x 1).trans (by by_cases h : p x <;> simp [h])
 
+section model
+
+variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
+
+lemma codeOfComputablePred_not_eval {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
+    ¬(codeOfComputablePred p).Evalb (M := M) ![ORingStructure.numeral x] := by
+  intro hM
+  have : M↓[ℒₒᵣ] ⊧* 𝗥₀ := ModelsTheory.of_provably_subtheory M 𝗥₀ 𝗣𝗔⁻ inferInstance
+  have h0 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
+      (M := ℕ) (0 :> ![x]) :=
+    (codeOfComputablePred_val_spec hp x 0).mpr (by simp [h])
+  have h1 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
+      (M := M) ((0 : M) :> ![ORingStructure.numeral x]) := by
+    simpa using bold_sigma_one_completeness' (M := M)
+      (σ := codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ))
+      (by simp [codeOfPartrec']) h0
+  have h2 : (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb
+      (M := M) ((1 : M) :> ![ORingStructure.numeral x]) := by
+    simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
+      using hM
+  exact absurd (code_uniq h1 h2) (ne_of_lt zero_lt_one)
+
+end model
+
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
 /-- Weak representation of a r.e. predicate -/
@@ -310,6 +334,20 @@ theorem codeOfComputablePred_provable {p : ℕ → Prop} (hp : ComputablePred p)
   sigma_one_completeness (by simp) (by
     simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
       using (codeOfComputablePred_spec hp (x := x)).mpr h)
+
+section
+
+variable {T : ArithmeticTheory} [𝗣𝗔⁻ ⪯ T]
+
+theorem codeOfComputablePred_provable_neg {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
+    T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
+  have : 𝗘𝗤 _ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗣𝗔⁻) inferInstance inferInstance
+  refine complete.{0} T _ fun M _ _ ↦ ?_
+  have : M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := ModelsTheory.of_provably_subtheory M 𝗣𝗔⁻ T inferInstance
+  simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
+    using codeOfComputablePred_not_eval hp h
+
+end
 
 theorem rePred_iff_sigma1 {p : ℕ → Prop} : REPred p ↔ 𝚺₁-Predicate p := by
   constructor

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -95,6 +95,8 @@ lemma sigma1_re (ε : ξ → ℕ) {k} {φ : ArithmeticSemiformula ξ k} (hp : Hi
 
 end
 
+section code
+
 open Nat.ArithPart₁
 
 def codeAux {k : ℕ} : Nat.ArithPart₁.Code k → ArithmeticFormula (Fin (k + 1))
@@ -113,65 +115,6 @@ def codeAux {k : ℕ} : Nat.ArithPart₁.Code k → ArithmeticFormula (Fin (k + 
     (∀¹[“z. z < &0”] ∃¹ “z. z ≠ 0” ⋏ ((Rew.bind (L := ℒₒᵣ) (ξ₁ := Fin (k + 1 + 1)) ![] (#0 :> #1 :> (&·.succ)) ▹ codeAux c)))
 
 def code (c : Code k) : ArithmeticSemisentence (k + 1) := (Rew.bind (L := ℒₒᵣ) (ξ₁ := Fin (k + 1)) ![] (#0 :> (#·.succ))) ▹ (codeAux c)
-
-section model
-
-open PeanoMinus
-
-variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
-
--- Each case below rewrites hypotheses with `simp [...] at h h'` and then destructures the
--- normalized hypotheses; the flexible-tactic linter cannot see that the later tactics only
--- depend on the (already fully simplified) shape of `h`/`h'`, not on the exact simp set used.
-set_option linter.flexible false in
-private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
-    (codeAux c).Evalf (M := M) (z :> v) → (codeAux c).Evalf (M := M) (z' :> v) → z = z' := by
-  induction c generalizing z z' with
-  | zero _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | one _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | add i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | mul i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | proj i => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | equal i j =>
-    intro h h'
-    by_cases hv : v i = v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
-  | lt i j =>
-    intro h h'
-    by_cases hv : v i < v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
-  | comp c d ihc ihd =>
-    intro h h'
-    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
-      Matrix.comp_vecCons'] at h h'
-    obtain ⟨w₁, hc₁, hd₁⟩ := h
-    obtain ⟨w₂, hc₂, hd₂⟩ := h'
-    have : w₁ = w₂ := funext fun i => ihd i (hd₁ i) (hd₂ i)
-    rcases this with rfl
-    exact ihc hc₁ hc₂
-  | rfind c ih =>
-    intro H₁ H₂
-    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
-      Matrix.comp_vecCons'] at H₁ H₂
-    obtain ⟨h₁, hm₁⟩ := H₁
-    obtain ⟨h₂, hm₂⟩ := H₂
-    by_contra hz
-    wlog h : z < z' with Hz
-    case inr =>
-      have : z' < z := lt_of_le_of_ne (not_lt.mp h) (Ne.symm hz)
-      exact Hz (k := k) c ih h₂ hm₂ h₁ hm₁ (Ne.symm hz) this
-    have : ∃ x, x ≠ 0 ∧ (codeAux c).Evalf (M := M) (x :> z :> fun i => v i) := hm₂ z h
-    rcases this with ⟨x, xz, hx⟩
-    exact xz (ih hx h₁)
-
--- `simp ... at h h'` normalizes the two hypotheses to the `codeAux_uniq` shape before
--- `exact`; the flexible-tactic linter cannot see that `exact` only depends on that final shape.
-set_option linter.flexible false in
-lemma code_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
-    (code c).Evalb (M := M) (z :> v) → (code c).Evalb (M := M) (z' :> v) → z = z' := by
-  intro h h'
-  simp [code, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq] at h h'
-  exact codeAux_uniq h h'
-
-end model
 
 private lemma codeAux_sigma_one {k} (c : Nat.ArithPart₁.Code k) : Hierarchy 𝚺 1 (codeAux c) := by
   induction c
@@ -253,7 +196,66 @@ lemma codeOfPartrec'_spec {k} {f : List.Vector ℕ k →. ℕ} (hf : Nat.Partrec
     exact ⟨c, models_code hc⟩
   exact Classical.epsilon_spec this y v
 
-open Classical
+section model
+
+variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
+
+-- Each case below rewrites hypotheses with `simp [...] at h h'` and then destructures the
+-- normalized hypotheses; the flexible-tactic linter cannot see that the later tactics only
+-- depend on the (already fully simplified) shape of `h`/`h'`, not on the exact simp set used.
+set_option linter.flexible false in
+private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
+    (codeAux c).Evalf (M := M) (z :> v) → (codeAux c).Evalf (M := M) (z' :> v) → z = z' := by
+  induction c generalizing z z' with
+  | zero _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | one _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | add i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | mul i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | proj i => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | equal i j =>
+    intro h h'
+    by_cases hv : v i = v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+  | lt i j =>
+    intro h h'
+    by_cases hv : v i < v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+  | comp c d ihc ihd =>
+    intro h h'
+    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+      Matrix.comp_vecCons'] at h h'
+    obtain ⟨w₁, hc₁, hd₁⟩ := h
+    obtain ⟨w₂, hc₂, hd₂⟩ := h'
+    have : w₁ = w₂ := funext fun i => ihd i (hd₁ i) (hd₂ i)
+    rcases this with rfl
+    exact ihc hc₁ hc₂
+  | rfind c ih =>
+    intro H₁ H₂
+    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+      Matrix.comp_vecCons'] at H₁ H₂
+    obtain ⟨h₁, hm₁⟩ := H₁
+    obtain ⟨h₂, hm₂⟩ := H₂
+    by_contra hz
+    wlog h : z < z' with Hz
+    case inr =>
+      have : z' < z := lt_of_le_of_ne (not_lt.mp h) (Ne.symm hz)
+      exact Hz (k := k) c ih h₂ hm₂ h₁ hm₁ (Ne.symm hz) this
+    have : ∃ x, x ≠ 0 ∧ (codeAux c).Evalf (M := M) (x :> z :> fun i => v i) := hm₂ z h
+    rcases this with ⟨x, xz, hx⟩
+    exact xz (ih hx h₁)
+
+-- `simp ... at h h'` normalizes the two hypotheses to the `codeAux_uniq` shape before
+-- `exact`; the flexible-tactic linter cannot see that `exact` only depends on that final shape.
+set_option linter.flexible false in
+lemma code_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
+    (code c).Evalb (M := M) (z :> v) → (code c).Evalb (M := M) (z' :> v) → z = z' := by
+  intro h h'
+  simp [code, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq] at h h'
+  exact codeAux_uniq h h'
+
+end model
+
+end code
+
+section codeOfREPred
 
 noncomputable def codeOfREPred (p : ℕ → Prop) : ArithmeticSemisentence 1 :=
   let f : ℕ →. Unit := fun a ↦ Part.assert (p a) fun _ ↦ Part.some ()
@@ -267,6 +269,20 @@ lemma codeOfREPred_spec {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
     refine Partrec.map (Partrec.comp hp (Primrec.to_comp <| Primrec.vector_get.comp .id (.const 0))) (Computable.const 0).to₂
   simpa [Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfPartrec'_spec (Nat.Partrec'.of_part this) (v := ![x]) (y := 0)).trans (by simp [f])
+
+variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
+
+/-- Weak representation of a r.e. predicate -/
+theorem rePred_weak_representation {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
+    p x ↔ T ⊢ (codeOfREPred p)/[x] := Iff.trans
+  (by simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using (codeOfREPred_spec hp (x := x)).symm)
+  (sigma_one_completeness_iff <| by simp [codeOfREPred, codeOfPartrec'])
+
+end codeOfREPred
+
+section codeOfComputablePred
+
+open Classical
 
 /-- The `0`/`1`-valued characteristic function of `p`, packaged as a one-variable partial
 function for `codeOfPartrec'`. -/
@@ -318,41 +334,27 @@ lemma codeOfComputablePred_not_eval {p : ℕ → Prop} (hp : ComputablePred p) {
 
 end model
 
-section
-
-variable {T : ArithmeticTheory} [𝗥₀ ⪯ T]
+variable {T : ArithmeticTheory}
 
 /-- Positive representation of a computable predicate. -/
-theorem codeOfComputablePred_provable {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : p x) :
-    T ⊢ (codeOfComputablePred p)/[↑x] :=
+theorem codeOfComputablePred_provable [𝗥₀ ⪯ T] {p : ℕ → Prop} (hp : ComputablePred p)
+    {x : ℕ} (h : p x) : T ⊢ (codeOfComputablePred p)/[↑x] :=
   sigma_one_completeness (by simp) (by
     simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
       using (codeOfComputablePred_spec hp (x := x)).mpr h)
 
-end
-
-section
-
-variable {T : ArithmeticTheory} [𝗣𝗔⁻ ⪯ T]
-
 /-- Negative representation of a computable predicate. -/
-theorem codeOfComputablePred_provable_neg {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
-    T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
+theorem codeOfComputablePred_provable_neg [𝗣𝗔⁻ ⪯ T] {p : ℕ → Prop} (hp : ComputablePred p)
+    {x : ℕ} (h : ¬p x) : T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
   have : 𝗘𝗤 _ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗣𝗔⁻) inferInstance inferInstance
   refine complete.{0} T _ fun M _ _ ↦ ?_
   have : M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := ModelsTheory.of_provably_subtheory M 𝗣𝗔⁻ T inferInstance
   simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
     using codeOfComputablePred_not_eval hp h
 
-end
+end codeOfComputablePred
 
-variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
-
-/-- Weak representation of a r.e. predicate -/
-theorem rePred_weak_representation {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
-    p x ↔ T ⊢ (codeOfREPred p)/[x] := Iff.trans
-  (by simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using (codeOfREPred_spec hp (x := x)).symm)
-  (sigma_one_completeness_iff <| by simp [codeOfREPred, codeOfPartrec'])
+section
 
 theorem rePred_iff_sigma1 {p : ℕ → Prop} : REPred p ↔ 𝚺₁-Predicate p := by
   constructor
@@ -427,5 +429,7 @@ theorem computable₂_iff_sigma1 {f : ℕ → ℕ → ℕ} : Computable₂ f ↔
     exact ComputablePred.of_graph_rePred <| hRe.of_eq <| by
       intro p
       simpa [List.Vector.cons_get] using hφ ![p.2, p.1.1, p.1.2]
+
+end
 
 end LO.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -268,6 +268,32 @@ lemma codeOfREPred_spec {p : ℕ → Prop} (hp : REPred p) {x : ℕ} :
   simpa [Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
     using (codeOfPartrec'_spec (Nat.Partrec'.of_part this) (v := ![x]) (y := 0)).trans (by simp [f])
 
+noncomputable def codeOfComputablePred (p : ℕ → Prop) : ArithmeticSemisentence 1 :=
+  (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ Part.some (if p (v.get 0) then 1 else 0))/[‘1’, #0]
+
+lemma ComputablePred.partrec'_charFn {p : ℕ → Prop} (hp : ComputablePred p) :
+    Nat.Partrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ) := by
+  obtain ⟨f, hf, rfl⟩ := ComputablePred.computable_iff.mp hp
+  have hc : Computable fun v : List.Vector ℕ 1 ↦ f (v.get 0) :=
+    hf.comp (Primrec.to_comp <| Primrec.vector_get.comp .id (.const 0))
+  have : Computable fun v : List.Vector ℕ 1 ↦ if (f (v.get 0) : Prop) then (1 : ℕ) else 0 :=
+    (Computable.cond hc (Computable.const 1) (Computable.const 0)).of_eq fun v ↦ by
+      cases f (v.get 0) <;> simp
+  exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp)
+
+@[simp] lemma codeOfComputablePred_sigma1 (p : ℕ → Prop) : Hierarchy 𝚺 1 (codeOfComputablePred p) := by
+  simp [codeOfComputablePred, codeOfPartrec']
+
+lemma codeOfComputablePred_val_spec {p : ℕ → Prop} (hp : ComputablePred p) (x y : ℕ) :
+    (codeOfPartrec' fun v : List.Vector ℕ 1 ↦ (Part.some (if p (v.get 0) then 1 else 0) : Part ℕ)).Evalb (y :> ![x])
+      ↔ y = if p x then 1 else 0 := by
+  simpa using codeOfPartrec'_spec (ComputablePred.partrec'_charFn hp) (y := y) (v := ![x])
+
+lemma codeOfComputablePred_spec {p : ℕ → Prop} (hp : ComputablePred p) {x : ℕ} :
+    (codeOfComputablePred p).Evalb ![x] ↔ p x := by
+  simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
+    using (codeOfComputablePred_val_spec hp x 1).trans (by by_cases h : p x <;> simp [h])
+
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
 /-- Weak representation of a r.e. predicate -/

--- a/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
+++ b/Foundation/FirstOrder/Arithmetic/R0/Representation.lean
@@ -200,39 +200,48 @@ section model
 
 variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
 
--- Each case below rewrites hypotheses with `simp [...] at h h'` and then destructures the
--- normalized hypotheses; the flexible-tactic linter cannot see that the later tactics only
--- depend on the (already fully simplified) shape of `h`/`h'`, not on the exact simp set used.
-set_option linter.flexible false in
 private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
     (codeAux c).Evalf (M := M) (z :> v) → (codeAux c).Evalf (M := M) (z' :> v) → z = z' := by
   induction c generalizing z z' with
-  | zero _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | one _ => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | add i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | mul i j => intro h h'; simp [codeAux] at h h'; rw [h, h']
-  | proj i => intro h h'; simp [codeAux] at h h'; rw [h, h']
+  | zero _ => intro h h'; simp_all [codeAux]
+  | one _ => intro h h'; simp_all [codeAux]
+  | add i j => intro h h'; simp_all [codeAux]
+  | mul i j => intro h h'; simp_all [codeAux]
+  | proj i => intro h h'; simp_all [codeAux]
   | equal i j =>
     intro h h'
-    by_cases hv : v i = v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+    by_cases hv : v i = v j <;> simp_all [codeAux]
   | lt i j =>
     intro h h'
-    by_cases hv : v i < v j <;> simp [codeAux, hv] at h h' <;> rw [h, h']
+    by_cases hv : v i < v j <;> simp_all [codeAux]
   | comp c d ihc ihd =>
     intro h h'
-    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
-      Matrix.comp_vecCons'] at h h'
-    obtain ⟨w₁, hc₁, hd₁⟩ := h
-    obtain ⟨w₂, hc₂, hd₂⟩ := h'
+    obtain ⟨w₁, hc₁, hd₁⟩ :
+        ∃ e', (codeAux c).Evalf (M := M) (z :> e') ∧
+          ∀ i, (codeAux (d i)).Evalf (M := M) (e' i :> v) := by
+      simpa [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+        Matrix.comp_vecCons'] using h
+    obtain ⟨w₂, hc₂, hd₂⟩ :
+        ∃ e', (codeAux c).Evalf (M := M) (z' :> e') ∧
+          ∀ i, (codeAux (d i)).Evalf (M := M) (e' i :> v) := by
+      simpa [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+        Matrix.comp_vecCons'] using h'
     have : w₁ = w₂ := funext fun i => ihd i (hd₁ i) (hd₂ i)
     rcases this with rfl
     exact ihc hc₁ hc₂
   | rfind c ih =>
     intro H₁ H₂
-    simp [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
-      Matrix.comp_vecCons'] at H₁ H₂
-    obtain ⟨h₁, hm₁⟩ := H₁
-    obtain ⟨h₂, hm₂⟩ := H₂
+    obtain ⟨h₁, hm₁⟩ :
+        (codeAux c).Evalf (M := M) (0 :> z :> v) ∧
+          ∀ x < z, ∃ y, y ≠ 0 ∧ (codeAux c).Evalf (M := M) (y :> x :> v) := by
+      simpa [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+        Matrix.comp_vecCons'] using H₁
+    obtain ⟨h₂, hm₂⟩ :
+        (codeAux c).Evalf (M := M) (0 :> z' :> v) ∧
+          ∀ x < z', ∃ y, y ≠ 0 ∧ (codeAux c).Evalf (M := M) (y :> x :> v) := by
+      simpa [codeAux, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq,
+        Matrix.comp_vecCons'] using H₂
+    clear H₁ H₂
     by_contra hz
     wlog h : z < z' with Hz
     case inr =>
@@ -242,14 +251,12 @@ private lemma codeAux_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
     rcases this with ⟨x, xz, hx⟩
     exact xz (ih hx h₁)
 
--- `simp ... at h h'` normalizes the two hypotheses to the `codeAux_uniq` shape before
--- `exact`; the flexible-tactic linter cannot see that `exact` only depends on that final shape.
-set_option linter.flexible false in
 lemma code_uniq {k} {c : Code k} {v : Fin k → M} {z z' : M} :
     (code c).Evalb (M := M) (z :> v) → (code c).Evalb (M := M) (z' :> v) → z = z' := by
   intro h h'
-  simp [code, Semiformula.eval_rew, Function.comp_def, Matrix.empty_eq] at h h'
-  exact codeAux_uniq h h'
+  exact codeAux_uniq
+    (by simpa [code, Semiformula.eval_rew, Matrix.empty_eq, Function.comp_def] using h)
+    (by simpa [code, Semiformula.eval_rew, Matrix.empty_eq, Function.comp_def] using h')
 
 end model
 
@@ -284,57 +291,27 @@ section codeOfComputablePred
 
 open Classical
 
-/-- The `0`/`1`-valued characteristic function of `p`, packaged as a one-variable partial
-function for `codeOfPartrec'`. -/
-noncomputable def charFnPart (p : ℕ → Prop) : List.Vector ℕ 1 →. ℕ :=
-  fun v ↦ Part.some (if p (v.get 0) then 1 else 0)
-
 noncomputable def codeOfComputablePred (p : ℕ → Prop) : ArithmeticSemisentence 1 :=
-  (codeOfPartrec' (charFnPart p))/[‘1’, #0]
+  (codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0)))/[‘1’, #0]
 
 @[simp] lemma codeOfComputablePred_sigma1 (p : ℕ → Prop) : Hierarchy 𝚺 1 (codeOfComputablePred p) := by
   simp [codeOfComputablePred, codeOfPartrec']
 
 variable {p : ℕ → Prop}
 
-lemma ComputablePred.partrec'_charFn (hp : ComputablePred p) :
-    Nat.Partrec' (charFnPart p) := by
-  obtain ⟨f, hf, rfl⟩ := ComputablePred.computable_iff.mp hp
-  have hc : Computable fun v : List.Vector ℕ 1 ↦ f (v.get 0) :=
-    hf.comp (Primrec.to_comp <| Primrec.vector_get.comp .id (.const 0))
-  have : Computable fun v : List.Vector ℕ 1 ↦ if (f (v.get 0) : Prop) then (1 : ℕ) else 0 :=
-    (Computable.cond hc (Computable.const 1) (Computable.const 0)).of_eq fun v ↦ by
-      cases f (v.get 0) <;> simp
-  exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp [charFnPart])
-
-lemma codeOfComputablePred_val_spec (hp : ComputablePred p) (x y : ℕ) :
-    (codeOfPartrec' (charFnPart p)).Evalb (y :> ![x]) ↔ y = if p x then 1 else 0 := by
-  simpa [charFnPart] using codeOfPartrec'_spec (ComputablePred.partrec'_charFn hp) (y := y) (v := ![x])
-
-lemma codeOfComputablePred_spec (hp : ComputablePred p) {x : ℕ} :
-    (codeOfComputablePred p).Evalb ![x] ↔ p x := by
-  simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
-    using (codeOfComputablePred_val_spec hp x 1).trans (by by_cases h : p x <;> simp [h])
-
-section model
-
-variable {M : Type*} [ORingStructure M] [M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻]
-
-lemma codeOfComputablePred_not_eval (hp : ComputablePred p) {x : ℕ} (h : ¬p x) :
-    ¬(codeOfComputablePred p).Evalb (M := M) ![ORingStructure.numeral x] := by
-  intro hM
-  have : M↓[ℒₒᵣ] ⊧* 𝗥₀ := ModelsTheory.of_provably_subtheory M 𝗥₀ 𝗣𝗔⁻ inferInstance
-  have h0 : (codeOfPartrec' (charFnPart p)).Evalb (M := ℕ) (0 :> ![x]) :=
-    (codeOfComputablePred_val_spec hp x 0).mpr (by simp [h])
-  have h1 : (codeOfPartrec' (charFnPart p)).Evalb (M := M) ((0 : M) :> ![ORingStructure.numeral x]) := by
-    simpa using bold_sigma_one_completeness' (M := M) (σ := codeOfPartrec' (charFnPart p))
-      (by simp [codeOfPartrec']) h0
-  have h2 : (codeOfPartrec' (charFnPart p)).Evalb (M := M) ((1 : M) :> ![ORingStructure.numeral x]) := by
-    simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons', Matrix.constant_eq_singleton]
-      using hM
-  exact absurd (code_uniq h1 h2) (ne_of_lt zero_lt_one)
-
-end model
+private lemma codeOfComputablePred_val_spec (hp : ComputablePred p) (x y : ℕ) :
+    (codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0))).Evalb (y :> ![x]) ↔
+      y = if p x then 1 else 0 := by
+  have hpart :
+      Nat.Partrec' (fun v : List.Vector ℕ 1 ↦ Part.some (if p (v.get 0) then 1 else 0)) := by
+    obtain ⟨f, hf, rfl⟩ := ComputablePred.computable_iff.mp hp
+    have hc : Computable fun v : List.Vector ℕ 1 ↦ f (v.get 0) :=
+      hf.comp (Primrec.to_comp <| Primrec.vector_get.comp .id (.const 0))
+    have : Computable fun v : List.Vector ℕ 1 ↦ if (f (v.get 0) : Prop) then (1 : ℕ) else 0 :=
+      (Computable.cond hc (Computable.const 1) (Computable.const 0)).of_eq fun v ↦ by
+        cases f (v.get 0) <;> simp
+    exact Nat.Partrec'.of_part (this.partrec.of_eq fun v ↦ by simp)
+  simpa using codeOfPartrec'_spec hpart (y := y) (v := ![x])
 
 variable {T : ArithmeticTheory} {x : ℕ}
 
@@ -342,17 +319,36 @@ variable {T : ArithmeticTheory} {x : ℕ}
 theorem codeOfComputablePred_provable [𝗥₀ ⪯ T] (hp : ComputablePred p) (h : p x) :
     T ⊢ (codeOfComputablePred p)/[↑x] :=
   sigma_one_completeness (by simp) (by
-    simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
-      using (codeOfComputablePred_spec hp (x := x)).mpr h)
+    have : (codeOfComputablePred p).Evalb ![x] ↔ p x := by
+      simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons',
+        Matrix.constant_eq_singleton]
+        using (codeOfComputablePred_val_spec hp x 1).trans (by by_cases hx : p x <;> simp [hx])
+    simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using this.mpr h)
 
 /-- Negative representation of a computable predicate. -/
 theorem codeOfComputablePred_provable_neg [𝗣𝗔⁻ ⪯ T] (hp : ComputablePred p) (h : ¬p x) :
     T ⊢ ∼((codeOfComputablePred p)/[↑x]) := by
   have : 𝗘𝗤 _ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗣𝗔⁻) inferInstance inferInstance
   refine complete.{0} T _ fun M _ _ ↦ ?_
-  have : M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := ModelsTheory.of_provably_subtheory M 𝗣𝗔⁻ T inferInstance
-  simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton]
-    using codeOfComputablePred_not_eval hp h
+  have hPA : M↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := ModelsTheory.of_provably_subtheory M 𝗣𝗔⁻ T inferInstance
+  have hNotEval : ¬(codeOfComputablePred p).Evalb (M := M) ![ORingStructure.numeral x] := by
+    intro hM
+    have hR0 : M↓[ℒₒᵣ] ⊧* 𝗥₀ := ModelsTheory.of_provably_subtheory M 𝗥₀ 𝗣𝗔⁻ inferInstance
+    have h0 : (codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0))).Evalb
+        (M := ℕ) (0 :> ![x]) :=
+      (codeOfComputablePred_val_spec hp x 0).mpr (by simp [h])
+    have h1 : (codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0))).Evalb (M := M)
+        ((0 : M) :> ![ORingStructure.numeral x]) := by
+      simpa using bold_sigma_one_completeness' (M := M)
+        (σ := codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0)))
+        (by simp [codeOfPartrec']) h0
+    have h2 : (codeOfPartrec' (fun v ↦ Part.some (if p (v.get 0) then 1 else 0))).Evalb (M := M)
+        ((1 : M) :> ![ORingStructure.numeral x]) := by
+      simpa [codeOfComputablePred, Semiformula.eval_substs, Matrix.comp_vecCons',
+        Matrix.constant_eq_singleton]
+        using hM
+    exact absurd (code_uniq h1 h2) (ne_of_lt zero_lt_one)
+  simpa [models_iff, Semiformula.eval_substs, Matrix.constant_eq_singleton] using hNotEval
 
 end codeOfComputablePred
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -5,6 +5,7 @@ public import Foundation.FirstOrder.Basic.PrimrecCoding
 public import Foundation.FirstOrder.Incompleteness.RosserProvability
 public import Foundation.FirstOrder.Arithmetic.R0.Representation
 public import Foundation.FirstOrder.Incompleteness.Halting
+public import Foundation.Meta.ClProver
 public import Mathlib.Computability.Reduce
 
 /-!
@@ -68,6 +69,32 @@ theorem uncomputable_theory_of_sigma1Sound : ¬ComputablePred T.theory := by
   tauto
 
 end Diagonalization
+
+section ConsistencyOnly
+
+variable {T : ArithmeticTheory} [𝗜𝚺₁ ⪯ T] [Entailment.Consistent T]
+
+theorem uncomputable_theory_of_consistent : ¬ComputablePred T.theory := by
+  by_contra hC
+  have : 𝗣𝗔⁻ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗜𝚺₁) inferInstance inferInstance
+  let p : ℕ → Prop := fun n ↦ (Encodable.decode (α := ArithmeticSentence) n).elim False (fun σ ↦ T ⊢ σ)
+  have hp : ComputablePred p := ComputablePred.iff_decoded_pred.mp hC
+  let ψ : ArithmeticSemisentence 1 := codeOfComputablePred p
+  let δ : ArithmeticSentence := fixedpoint (∼ψ)
+  have hδ : T ⊢ δ 🡘 ∼(ψ/[⌜δ⌝]) := by simpa using diagonal (T := T) (∼ψ)
+  have hp_iff : p (Encodable.encode δ) ↔ T ⊢ δ := by simp [p, Encodable.encodek]
+  by_cases h : T ⊢ δ
+  · have hψ : T ⊢ ψ/[⌜δ⌝] := by
+      simpa [Arithmetic.gödelNumber'_eq_coe_encode] using
+        codeOfComputablePred_provable hp (hp_iff.mpr h)
+    apply Entailment.Consistent.not_bot (𝓢 := T)
+    cl_prover [hδ, h, hψ]
+  · have hnψ : T ⊢ ∼(ψ/[⌜δ⌝]) := by
+      simpa [Arithmetic.gödelNumber'_eq_coe_encode] using
+        codeOfComputablePred_provable_neg hp (hp_iff.not.mpr h)
+    exact h (by cl_prover [hδ, hnψ])
+
+end ConsistencyOnly
 
 section PeanoMinusReduction
 

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -11,8 +11,10 @@ public import Mathlib.Computability.Reduce
 /-!
 # Church's undecidability theorem
 
-Neither the set of sentences provable in an arithmetic theory `T ⊇ 𝗥₀` that is sound on `𝚺₁`
-sentences, nor the set of sentences provable in pure first-order logic, is computable.
+The set of sentences provable in an arithmetic theory `T ⊇ 𝗥₀` is not computable, whether `T` is
+sound on `𝚺₁` sentences (`uncomputable_theory_of_sigma1Sound`) or merely consistent and extends
+`𝗜𝚺₁` (`uncomputable_theory_of_consistent`). Provability in pure first-order logic is likewise
+undecidable (`undecidability_first_order_logic`).
 -/
 
 @[expose] public section

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -10,14 +10,8 @@ public import Mathlib.Computability.Reduce
 /-!
 # Church's undecidability theorem
 
-`church_theorem_general` shows that for every arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences,
-the set of `T`-provable sentences is not computable, by a direct diagonalization on the
-self-applied substitution `σ ↦ σ/[⌜σ⌝]` (no fixed-point/Gödel-numbering machinery beyond weak
-representability of r.e. predicates, `rePred_weak_representation`, is needed, unlike Gödel's first incompleteness
-theorem). `undecidability_first_order_logic` specializes this to `T = ∅`: since `𝗣𝗔⁻` is finitely axiomatizable,
-`𝗣𝗔⁻`-provability computably many-one reduces to `∅`-provability, so undecidability transfers
-from `church_theorem_general` without needing the `𝗥₀ ⪯ T` and soundness hypotheses required
-there.
+Neither the set of sentences provable in an arithmetic theory `T ⊇ 𝗥₀` that is sound on `𝚺₁`
+sentences, nor the set of sentences provable in pure first-order logic, is computable.
 -/
 
 @[expose] public section
@@ -51,9 +45,7 @@ lemma computable₂_iff_sigma1_simulate {α β γ : Type*} [Primcodable α] [Pri
 
 variable {T : ArithmeticTheory} [𝗥₀ ⪯ T] [T.SoundOnHierarchy 𝚺 1]
 
-/-- Church's theorem, for an arbitrary arithmetic theory `T ⊇ 𝗥₀` sound on `𝚺₁` sentences: the set
-of `T`-provable sentences is not computable. -/
-theorem church_theorem_general : ¬ComputablePred T.theory := by
+theorem uncomputable_theory_of_sigma1Sound : ¬ComputablePred T.theory := by
   by_contra hC
   have hQuoteSubst :
       Computable₂ fun σ π : ArithmeticSemisentence 1 ↦ (σ/[⌜π⌝] : ArithmeticSentence) :=
@@ -79,8 +71,8 @@ end Diagonalization
 
 section PeanoMinusReduction
 
-/-- Church's theorem: the set of (purely logically, i.e. `∅`-)provable sentences is not
-computable. -/
+/-- Provability in pure first-order logic, i.e. provability from the empty theory, is
+undecidable. -/
 theorem undecidability_first_order_logic : ¬ComputablePred ((∅ : ArithmeticTheory).theory) := by
   have hDeduction (σ : ArithmeticSentence) :
       𝗣𝗔⁻ ⊢ σ ↔ (∅ : ArithmeticTheory) ⊢ PeanoMinus.finite.toFinset.conj 🡒 σ := by
@@ -94,7 +86,7 @@ theorem undecidability_first_order_logic : ¬ComputablePred ((∅ : ArithmeticTh
       fun σ ↦ by
       simp [nat_pair_eq, c, Semiformula.imp_eq, Semiformula.encode_or,
         ← Semiformula.encode_eq_toNat, ← Semiformula.encode_eq_toNat]
-  apply church_theorem_general (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC)
+  apply uncomputable_theory_of_sigma1Sound (T := 𝗣𝗔⁻) (ComputablePred.computable_of_manyOneReducible ?_ hC)
   refine ⟨fun σ ↦ PeanoMinus.finite.toFinset.conj 🡒 σ, ?_, ?_⟩
   . exact hImpIntro
   . exact hDeduction

--- a/Foundation/FirstOrder/Incompleteness/Church.lean
+++ b/Foundation/FirstOrder/Incompleteness/Church.lean
@@ -78,7 +78,6 @@ variable {T : ArithmeticTheory} [𝗜𝚺₁ ⪯ T] [Entailment.Consistent T]
 
 theorem uncomputable_theory_of_consistent : ¬ComputablePred T.theory := by
   by_contra hC
-  have : 𝗣𝗔⁻ ⪯ T := Entailment.WeakerThan.trans (𝓣 := 𝗜𝚺₁) inferInstance inferInstance
   let p : ℕ → Prop := fun n ↦ (Encodable.decode (α := ArithmeticSentence) n).elim False (fun σ ↦ T ⊢ σ)
   have hp : ComputablePred p := ComputablePred.iff_decoded_pred.mp hC
   let ψ : ArithmeticSemisentence 1 := codeOfComputablePred p


### PR DESCRIPTION
Adds a strong representation of computable predicates in `Arithmetic/R0/Representation.lean`:

- `code_uniq`, revived from a commented-out proof, with its base strengthened from `𝗥₀` to `𝗣𝗔⁻` (the `rfind` case needs totality of the order).
- `codeOfComputablePred p`, the `𝚺₁` formula saying that the arithmetized characteristic function of `p` takes value 1, with `codeOfComputablePred_provable` (`p x → T ⊢ ψ/[x]`, for `T ⊇ 𝗥₀`) and `codeOfComputablePred_provable_neg` (`¬p x → T ⊢ ∼ψ/[x]`, for `T ⊇ 𝗣𝗔⁻`). Unlike `rePred_weak_representation`, neither needs `𝚺₁`-soundness.

This gives Church's theorem under consistency alone:

```lean
theorem uncomputable_theory_of_consistent {T : ArithmeticTheory}
    [𝗜𝚺₁ ⪯ T] [Entailment.Consistent T] : ¬ComputablePred T.theory
```

Its hypotheses are incomparable with those of the existing variant, which is kept and renamed `church_theorem_general` → `uncomputable_theory_of_sigma1Sound`.

Produced with an AI agent (Claude); every commit carries a co-author trailer.