### PR TITLE
refactor(FirstOrder/Arithmetic): Deduplicate `Hierarchy.exsItr/allItr`

### DIFF
--- a/Foundation/FirstOrder/Arithmetic/Basic/Hierarchy.lean
+++ b/Foundation/FirstOrder/Arithmetic/Basic/Hierarchy.lean
@@ -399,18 +399,6 @@ lemma remove_exists {φ : Semiformula L ξ (n + 1)} : Hierarchy b s (∃¹ φ) �
 @[simp] lemma finset_udisj_iff {Γ s n} [Fintype ι] {φ : ι → Semiformula L ξ n} :
     Hierarchy Γ s (Finset.udisj φ) ↔ ∀ i, Hierarchy Γ s (φ i) := by simp [Finset.udisj]
 
-@[simp] lemma exsItr {n k} {φ : Semiformula L ξ (n + k)} :
-    Hierarchy 𝚺 (s + 1) (∃¹^[k] φ) ↔ Hierarchy 𝚺 (s + 1) φ := by
-  match k with
-  |     0 => simp
-  | k + 1 => simp [LO.FirstOrder.exsItr_succ, exsItr]
-
-@[simp] lemma allItr {n k} {φ : Semiformula L ξ (n + k)} :
-    Hierarchy 𝚷 (s + 1) (∀¹^[k] φ) ↔ Hierarchy 𝚷 (s + 1) φ := by
-  match k with
-  |     0 => simp
-  | k + 1 => simp [LO.FirstOrder.allItr_succ, allItr]
-
 end Hierarchy
 
 section LOR


### PR DESCRIPTION
`Hierarchy.exsItr` and `Hierarchy.allItr` state exactly what `Hierarchy.exsItr_iff` and `Hierarchy.allItr_iff` already state, and all four carry `@[simp]`, so the simp set held each fact twice.

The `_iff` names are kept, in line with `all_iff` / `sigma_iff` / `rew_iff` / `padding_iff` in the same file. The removed pair additionally shadowed the quantifier-iteration definitions `LO.FirstOrder.exsItr` / `allItr` inside `namespace Hierarchy`, which is why their own proofs had to write `LO.FirstOrder.exsItr_succ` fully qualified.

No declaration referred to the removed names.
