### PR TITLE
add(Zoo): Horizontal layout of the arithmetic theory zoo

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,8 +22,8 @@ zoo:
     mkdir -p pages/zoo
     typst compile --input dir=TB Zoo/arithmetic.typ pages/zoo/arithmetic_v.png
     typst compile --input dir=TB Zoo/arithmetic.typ pages/zoo/arithmetic_v.pdf
-    typst compile --input dir=LR Zoo/arithmetic.typ pages/zoo/arithmetic_h.png
-    typst compile --input dir=LR Zoo/arithmetic.typ pages/zoo/arithmetic_h.pdf
+    typst compile --input dir=RL Zoo/arithmetic.typ pages/zoo/arithmetic_h.png
+    typst compile --input dir=RL Zoo/arithmetic.typ pages/zoo/arithmetic_h.pdf
 
 # Regenerate Foundation.lean to include all modules (run after adding/removing files).
 # Restricted to the Foundation library: Zoo has no aggregator, its modules are executable roots.

--- a/Justfile
+++ b/Justfile
@@ -15,13 +15,15 @@ import-graph:
 cloc:
     cloc --include-lang=Lean Foundation/
 
-# Generate the zoo diagrams as pages/zoo/*.{png,pdf} (requires typst)
+# Generate the zoo diagrams as pages/zoo/*.{png,pdf}, vertical and horizontal (requires typst)
 zoo:
     lake build zoo_arithmetic
     lake exe zoo_arithmetic Zoo/arithmetic.json
     mkdir -p pages/zoo
-    typst compile Zoo/arithmetic.typ pages/zoo/arithmetic.png
-    typst compile Zoo/arithmetic.typ pages/zoo/arithmetic.pdf
+    typst compile --input dir=TB Zoo/arithmetic.typ pages/zoo/arithmetic_v.png
+    typst compile --input dir=TB Zoo/arithmetic.typ pages/zoo/arithmetic_v.pdf
+    typst compile --input dir=LR Zoo/arithmetic.typ pages/zoo/arithmetic_h.png
+    typst compile --input dir=LR Zoo/arithmetic.typ pages/zoo/arithmetic_h.pdf
 
 # Regenerate Foundation.lean to include all modules (run after adding/removing files).
 # Restricted to the Foundation library: Zoo has no aggregator, its modules are executable roots.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ regenerate them locally.
 
 #### Arithmetic Theory Zoo
 
-![Arithmetic Theory Zoo](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic.png)
+![Arithmetic Theory Zoo](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic_h.png)
+
+Also available [stacked vertically](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic_v.png), and as PDF ([horizontal](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic_h.pdf), [vertical](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic_v.pdf)).
 
 ## Contributing
 

--- a/Zoo/arithmetic.typ
+++ b/Zoo/arithmetic.typ
@@ -8,7 +8,7 @@
 #let ISigma0 = $Theory(I)Sigma_0$
 #let ISigma1 = $Theory(I)Sigma_1$
 
-// Orientation, chosen with `typst compile --input dir=LR`; see `zoo` in template.typ.
+// Orientation, chosen with `typst compile --input dir=RL`; see `zoo` in template.typ.
 #let dir = sys.inputs.at("dir", default: "TB")
 
 // Keys are the theories as pretty-printed by `lake exe zoo_arithmetic`; a theory with no entry

--- a/Zoo/arithmetic.typ
+++ b/Zoo/arithmetic.typ
@@ -8,6 +8,9 @@
 #let ISigma0 = $Theory(I)Sigma_0$
 #let ISigma1 = $Theory(I)Sigma_1$
 
+// Orientation, chosen with `typst compile --input dir=LR`; see `zoo` in template.typ.
+#let dir = sys.inputs.at("dir", default: "TB")
+
 // Keys are the theories as pretty-printed by `lake exe zoo_arithmetic`; a theory with no entry
 // here is drawn under its pretty-printed name.
 #figure(caption: [Arithmetic Theory Zoo], numbering: none)[
@@ -33,5 +36,6 @@
     ),
     // `𝗣𝗔⁻` is finitely axiomatizable; its single axiom does not deserve a vertex of its own.
     omit: ("{FFL.FirstOrder.Arithmetic.PeanoMinus.finite.toFinset.conj}",),
+    dir: dir,
   )
 ]

--- a/Zoo/template.typ
+++ b/Zoo/template.typ
@@ -9,7 +9,10 @@
 // to `a`: solid for `⪱`, dashed for `⪯`, and as an undirected double line for `≊`.
 //
 // Theories listed in `omit` are dropped along with every edge touching them.
-#let zoo(path, labels: (:), omit: (), width: 640pt) = {
+//
+// `dir` is the Graphviz `rankdir`: "TB" stacks the theories vertically, strongest at the top,
+// "LR" lays them out horizontally, strongest on the left.
+#let zoo(path, labels: (:), omit: (), dir: "TB", width: 640pt) = {
   let edges = json(path).filter(((from, to, ..)) => {
     not omit.contains(from) and not omit.contains(to)
   }).map(((from, to, type)) => {
@@ -25,7 +28,7 @@
   raw-render(
     raw(
       "digraph Zoo {
-        rankdir = TB;
+        rankdir = " + dir + ";
 
         node [
           shape = none

--- a/Zoo/template.typ
+++ b/Zoo/template.typ
@@ -11,7 +11,7 @@
 // Theories listed in `omit` are dropped along with every edge touching them.
 //
 // `dir` is the Graphviz `rankdir`: "TB" stacks the theories vertically, strongest at the top,
-// "LR" lays them out horizontally, strongest on the left.
+// "RL" lays them out horizontally, strongest on the right.
 #let zoo(path, labels: (:), omit: (), dir: "TB", width: 640pt) = {
   let edges = json(path).filter(((from, to, ..)) => {
     not omit.contains(from) and not omit.contains(to)


### PR DESCRIPTION
The vertical zoo added in #912 is too tall to read in the README.

`zoo` now takes the Graphviz `rankdir` as a `dir` argument, chosen per run with `typst compile --input dir=…`, and `just zoo` renders both orientations: `arithmetic_v` stacks the theories vertically, `arithmetic_h` lays them out horizontally. The README shows the horizontal one and links the other renderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
