### PR TITLE
fix(Zoo): Cap the height of the zoo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ regenerate them locally.
 
 #### Arithmetic Theory Zoo
 
-![Arithmetic Theory Zoo](https://formalizedformallogic.github.io/Foundation/zoo/arithmetic.png)
+<a href="https://formalizedformallogic.github.io/Foundation/zoo/arithmetic.png"><img alt="Arithmetic Theory Zoo" src="https://formalizedformallogic.github.io/Foundation/zoo/arithmetic.png" height="600"></a>
 
 ## Contributing
 

--- a/Zoo/template.typ
+++ b/Zoo/template.typ
@@ -27,6 +27,11 @@
       "digraph Zoo {
         rankdir = TB;
 
+        // Tighter than the Graphviz defaults, so that the diagram stays legible once the README
+        // scales it down to fit.
+        ranksep = 0.28;
+        nodesep = 0.18;
+
         node [
           shape = none
           margin = 0.05


### PR DESCRIPTION
The zoo added in #912 is 1376x2618, too tall to sit in the README at full size.

Tightening `ranksep` and `nodesep` takes it to 1376x1890, and the README caps it at 600px tall and links the full-size image. Without the tighter spacing, that cap leaves the diagram 315px wide and its labels unreadable.

The remaining height is structural: `IΣ₁ → IΣ₀ + Ω₁ → IΣ₀ → IOpen → PA⁻ → Q → R₀ → EQ` is a chain of eight ranks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
