### PR TITLE
add(FirstOrder/Incompleteness): `𝗣𝗔` and `𝗜𝚺₁` are Δ₁

### DIFF
--- a/Foundation/FirstOrder/Incompleteness/Definability.lean
+++ b/Foundation/FirstOrder/Incompleteness/Definability.lean
@@ -1063,4 +1063,12 @@ instance : 𝗣𝗔.RE := Theory.RE.add (Theory.RE.ofFinite PeanoMinus.finite) i
 
 instance : 𝗜𝚺₁.RE := Theory.RE.add (Theory.RE.ofFinite PeanoMinus.finite) inferInstance
 
+/-! ## `𝗣𝗔` and `𝗜𝚺₁` are `Δ₁`
+
+TODO: remove. Not mathematically essential — `RE` above already suffices. -/
+
+noncomputable instance : 𝗣𝗔.Δ₁ := Theory.Δ₁.add PeanoMinus.delta1 InductionScheme.delta1_univ
+
+noncomputable instance : 𝗜𝚺₁.Δ₁ := Theory.Δ₁.add PeanoMinus.delta1 InductionScheme.delta1_sigma1
+
 end FFL.FirstOrder.Arithmetic


### PR DESCRIPTION
`𝗣𝗔` and `𝗜𝚺₁` are shown `Δ₁`, by combining the existing `PeanoMinus.delta1` instance with the `Δ₁` recognizers already proved for the induction schemata (`InductionScheme.delta1_univ`, `InductionScheme.delta1_sigma1`) via `Theory.Δ₁.add`.

Marked `TODO: remove`, since this is not mathematically essential — `𝗣𝗔.RE`/`𝗜𝚺₁.RE`, already present, suffice for downstream results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)