### PR TITLE
add(FirstOrder/Arithmetic): Least number principle

### DIFF
--- a/Foundation.lean
+++ b/Foundation.lean
@@ -11,6 +11,7 @@ public import Foundation.FirstOrder.Arithmetic.Definability.Absoluteness
 public import Foundation.FirstOrder.Arithmetic.Definability.BoundedDefinable
 public import Foundation.FirstOrder.Arithmetic.Definability.Definable
 public import Foundation.FirstOrder.Arithmetic.Definability.Hierarchy
+public import Foundation.FirstOrder.Arithmetic.Examples
 public import Foundation.FirstOrder.Arithmetic.Exponential
 public import Foundation.FirstOrder.Arithmetic.Exponential.Bit
 public import Foundation.FirstOrder.Arithmetic.Exponential.Exp

--- a/Foundation.lean
+++ b/Foundation.lean
@@ -28,6 +28,7 @@ public import Foundation.FirstOrder.Arithmetic.HFS.Vec
 public import Foundation.FirstOrder.Arithmetic.IOpen.Basic
 public import Foundation.FirstOrder.Arithmetic.ISigma1.Prenex
 public import Foundation.FirstOrder.Arithmetic.Induction
+public import Foundation.FirstOrder.Arithmetic.LeastNumber.Basic
 public import Foundation.FirstOrder.Arithmetic.Omega1.Basic
 public import Foundation.FirstOrder.Arithmetic.Omega1.Nuon
 public import Foundation.FirstOrder.Arithmetic.PA.Prenex

--- a/Foundation/FirstOrder/Arithmetic/Basic/Model.lean
+++ b/Foundation/FirstOrder/Arithmetic/Basic/Model.lean
@@ -104,6 +104,11 @@ lemma weakerThan_of_models (T S : ArithmeticTheory) [𝗘𝗤 ℒₒᵣ ⪯ S]
            M↓[ℒₒᵣ] ⊧* T) : T ⪯ S :=
   Entailment.weakerThan_iff.mpr fun h ↦ complete _ _ fun M _ _ ↦ Theory.Proof.sound h (H M)
 
+lemma equiv_of_models {T S : ArithmeticTheory} [𝗘𝗤 ℒₒᵣ ⪯ S] [𝗘𝗤 ℒₒᵣ ⪯ T]
+    (hTS : ∀ (M : Type*) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* S], M↓[ℒₒᵣ] ⊧* T)
+    (hST : ∀ (M : Type*) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* T], M↓[ℒₒᵣ] ⊧* S) : T ≊ S :=
+  Entailment.Equiv.antisymm ⟨weakerThan_of_models T S hTS, weakerThan_of_models S T hST⟩
+
 end Arithmetic
 
 class ArithmeticTheory.SoundOn (T : ArithmeticTheory) (F : ArithmeticSentence → Prop) where

--- a/Foundation/FirstOrder/Arithmetic/Definability/Definable.lean
+++ b/Foundation/FirstOrder/Arithmetic/Definability/Definable.lean
@@ -3,7 +3,9 @@ module
 public import Foundation.FirstOrder.Arithmetic.Definability.Hierarchy
 
 @[expose] public section
-namespace FFL.FirstOrder.Arithmetic.HierarchySymbol
+namespace FFL.FirstOrder.Arithmetic
+
+namespace HierarchySymbol
 
 variable (ξ : Type*) (n : ℕ)
 
@@ -915,9 +917,7 @@ instance [𝚫-[2].DefinableFunction f] : 𝚫-[0+1+1].DefinableFunction f := in
 
 end
 
-end FFL.FirstOrder.Arithmetic.HierarchySymbol
-
-namespace FFL.FirstOrder.Arithmetic
+end HierarchySymbol
 
 variable {V : Type*} [ORingStructure V] {Γ : Polarity} {s k : ℕ}
 

--- a/Foundation/FirstOrder/Arithmetic/Definability/Definable.lean
+++ b/Foundation/FirstOrder/Arithmetic/Definability/Definable.lean
@@ -916,3 +916,19 @@ instance [𝚫-[2].DefinableFunction f] : 𝚫-[0+1+1].DefinableFunction f := in
 end
 
 end FFL.FirstOrder.Arithmetic.HierarchySymbol
+
+namespace FFL.FirstOrder.Arithmetic
+
+variable {V : Type*} [ORingStructure V] {Γ : Polarity} {s k : ℕ}
+
+lemma definable_of_hierarchy {φ : ArithmeticSemiformula ℕ k} (hφ : Hierarchy Γ s φ) (e : ℕ → V) :
+    Γ-[s].Definable fun v ↦ φ.Eval v e :=
+  .mkPolarity (Rew.rewriteMap e ▹ φ) (hφ.rew _) fun _ ↦ by simp [Semiformula.eval_rewriteMap]
+
+lemma definablePred_of_hierarchy {φ : ArithmeticSemiformula ℕ 1} (hφ : Hierarchy Γ s φ)
+    (e : ℕ → V) : Γ-[s].DefinablePred fun x ↦ φ.Eval ![x] e :=
+  (definable_of_hierarchy hφ e).of_iff fun v ↦ by
+    have h : ![v 0] = v := (Matrix.fun_eq_vec_one v).symm
+    simp [h]
+
+end FFL.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Arithmetic/Examples.lean
+++ b/Foundation/FirstOrder/Arithmetic/Examples.lean
@@ -1,0 +1,29 @@
+module
+
+public import Foundation.FirstOrder.Arithmetic.LeastNumber.Basic
+
+/-!
+# Relations between fragments at concrete indices
+
+The relations between the fragments are stated for every index, which leaves the theory zoo —
+whose vertices are closed theories — with nothing to draw. These are their instances at the first
+few indices.
+-/
+
+@[expose] public section
+
+namespace FFL.FirstOrder.Arithmetic
+
+instance : 𝗜𝚺 1 ≊ 𝗜𝚷 1 := ISigma_equiv_IPi 1
+
+instance : 𝗜𝚺 2 ≊ 𝗜𝚷 2 := ISigma_equiv_IPi 2
+
+instance : 𝗟𝚺 1 ≊ 𝗜𝚺 1 := LSigma_equiv_ISigma 1
+
+instance : 𝗟𝚷 1 ≊ 𝗜𝚺 1 := LPi_equiv_ISigma 1
+
+instance : 𝗟𝚺 2 ≊ 𝗜𝚺 2 := LSigma_equiv_ISigma 2
+
+instance : 𝗜𝚺 2 ⪯ 𝗣𝗔 := inferInstance
+
+end FFL.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
+++ b/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
@@ -130,7 +130,7 @@ lemma models_alt : V↓[ℒₒᵣ] ⊧* 𝗜𝗡𝗗 Γ.alt m := by
   suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy Γ.alt m) by
     simpa [InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
   simp only [InductionScheme];
-  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  apply Semantics.ModelsSet.setOf_iff.mpr;
   rintro _ ⟨φ, hφ, rfl⟩;
   suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
       ∀ x, φ.Eval ![x] v by
@@ -143,13 +143,13 @@ end LeastNumberOnHierarchy
 
 variable (n : ℕ)
 
-lemma models_LOnHierarchy_of_ISigma (Γ : Polarity) (n : ℕ) [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] :
+lemma models_LeastNumberOnHierarchy_of_ISigma (Γ : Polarity) (n : ℕ) [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] :
     V↓[ℒₒᵣ] ⊧* 𝗟 Γ n := by
   have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n›;
   suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy Γ n) by
     simpa [LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
   simp only [LeastNumberScheme];
-  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  apply Semantics.ModelsSet.setOf_iff.mpr;
   rintro _ ⟨φ, hφ, rfl⟩;
   suffices ∀ v : ℕ → V, (∃ x, φ.Eval ![x] v) → ∃ z, φ.Eval ![z] v ∧ ∀ x < z, ¬φ.Eval ![x] v by
     simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
@@ -158,10 +158,10 @@ lemma models_LOnHierarchy_of_ISigma (Γ : Polarity) (n : ℕ) [V↓[ℒₒᵣ] �
   exact InductionOnHierarchy.least_number Γ n (definablePred_of_hierarchy hφ v) hx;
 
 instance models_LSigma_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n :=
-  models_LOnHierarchy_of_ISigma 𝚺 n
+  models_LeastNumberOnHierarchy_of_ISigma 𝚺 n
 
 instance models_LPi_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n :=
-  models_LOnHierarchy_of_ISigma 𝚷 n
+  models_LeastNumberOnHierarchy_of_ISigma 𝚷 n
 
 instance models_IPi_of_LSigma [V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚷 n :=
   LeastNumberOnHierarchy.models_alt 𝚺 n
@@ -173,19 +173,14 @@ end models
 
 section theorems
 
-private lemma antisymm_of_models {T S : ArithmeticTheory} [𝗘𝗤 ℒₒᵣ ⪯ S] [𝗘𝗤 ℒₒᵣ ⪯ T]
-    (hTS : ∀ (M : Type) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* S], M↓[ℒₒᵣ] ⊧* T)
-    (hST : ∀ (M : Type) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* T], M↓[ℒₒᵣ] ⊧* S) : T ≊ S :=
-  Equiv.antisymm ⟨weakerThan_of_models.{0} T S hTS, weakerThan_of_models.{0} S T hST⟩
-
 theorem ISigma_equiv_IPi (n : ℕ) : 𝗜𝚺 n ≊ 𝗜𝚷 n :=
-  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
+  equiv_of_models.{0, 0} (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
 
 theorem LSigma_equiv_ISigma (n : ℕ) : 𝗟𝚺 n ≊ 𝗜𝚺 n :=
-  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
+  equiv_of_models.{0, 0} (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
 
 theorem LPi_equiv_ISigma (n : ℕ) : 𝗟𝚷 n ≊ 𝗜𝚺 n :=
-  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
+  equiv_of_models.{0, 0} (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
 
 end theorems
 

--- a/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
+++ b/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
@@ -18,6 +18,11 @@ open _root_.FFL.Entailment
 
 section axioms
 
+variable {L : Language} [L.ORing] {ξ : Type*}
+
+def leastNumber {ξ} (φ : Semiformula L ξ 1) : Formula L ξ :=
+  “(∃ x, !φ x) → ∃ z, !φ z ∧ ∀ x < z, ¬!φ x”
+
 def LeastNumberScheme (Γ : ArithmeticSemiformula ℕ 1 → Prop) : ArithmeticTheory :=
   { ψ | ∃ φ : ArithmeticSemiformula ℕ 1, Γ φ ∧ ψ = .univCl (leastNumber φ) }
 
@@ -120,14 +125,29 @@ lemma succ_induction {P : V → Prop} (hP : Γ.alt-[m].DefinablePred P)
   apply lt_succ_iff_le.mpr;
   apply le_rfl;
 
+lemma models_alt : V↓[ℒₒᵣ] ⊧* 𝗜𝗡𝗗 Γ.alt m := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟 Γ m›;
+  suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy Γ.alt m) by
+    simpa [InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  simp only [InductionScheme];
+  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  rintro _ ⟨φ, hφ, rfl⟩;
+  suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
+      ∀ x, φ.Eval ![x] v by
+    simpa [models_iff, Semiformula.eval_univCl, succInd, Semiformula.eval_substs,
+      Matrix.constant_eq_singleton] using this;
+  intro v;
+  exact succ_induction Γ m (definablePred_of_hierarchy hφ v);
+
 end LeastNumberOnHierarchy
 
 variable (n : ℕ)
 
-instance models_LSigma_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n := by
+lemma models_LOnHierarchy_of_ISigma (Γ : Polarity) (n : ℕ) [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] :
+    V↓[ℒₒᵣ] ⊧* 𝗟 Γ n := by
   have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n›;
-  suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy 𝚺 n) by
-    simpa [LSigma, LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy Γ n) by
+    simpa [LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
   simp only [LeastNumberScheme];
   refine Semantics.ModelsSet.setOf_iff.mpr ?_;
   rintro _ ⟨φ, hφ, rfl⟩;
@@ -135,67 +155,37 @@ instance models_LSigma_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒ
     simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
       Matrix.constant_eq_singleton] using this;
   intro v ⟨x, hx⟩;
-  exact InductionOnHierarchy.least_number 𝚺 n (definablePred_of_hierarchy hφ v) hx;
+  exact InductionOnHierarchy.least_number Γ n (definablePred_of_hierarchy hφ v) hx;
 
-instance models_LPi_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n := by
-  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n›;
-  suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy 𝚷 n) by
-    simpa [LPi, LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
-  simp only [LeastNumberScheme];
-  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
-  rintro _ ⟨φ, hφ, rfl⟩;
-  suffices ∀ v : ℕ → V, (∃ x, φ.Eval ![x] v) → ∃ z, φ.Eval ![z] v ∧ ∀ x < z, ¬φ.Eval ![x] v by
-    simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
-      Matrix.constant_eq_singleton] using this;
-  intro v ⟨x, hx⟩;
-  exact InductionOnHierarchy.least_number 𝚷 n (definablePred_of_hierarchy hφ v) hx;
+instance models_LSigma_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n :=
+  models_LOnHierarchy_of_ISigma 𝚺 n
 
-instance models_IPi_of_LSigma [V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚷 n := by
-  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n›;
-  suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy 𝚷 n) by
-    simpa [IPi, InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
-  simp only [InductionScheme];
-  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
-  rintro _ ⟨φ, hφ, rfl⟩;
-  suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
-      ∀ x, φ.Eval ![x] v by
-    simpa [models_iff, Semiformula.eval_univCl, succInd, Semiformula.eval_substs,
-      Matrix.constant_eq_singleton] using this;
-  intro v;
-  exact LeastNumberOnHierarchy.succ_induction 𝚺 n (definablePred_of_hierarchy hφ v);
+instance models_LPi_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n :=
+  models_LOnHierarchy_of_ISigma 𝚷 n
 
-instance models_ISigma_of_LPi [V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n := by
-  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n›;
-  suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy 𝚺 n) by
-    simpa [ISigma, InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
-  simp only [InductionScheme];
-  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
-  rintro _ ⟨φ, hφ, rfl⟩;
-  suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
-      ∀ x, φ.Eval ![x] v by
-    simpa [models_iff, Semiformula.eval_univCl, succInd, Semiformula.eval_substs,
-      Matrix.constant_eq_singleton] using this;
-  intro v;
-  exact LeastNumberOnHierarchy.succ_induction 𝚷 n (definablePred_of_hierarchy hφ v);
+instance models_IPi_of_LSigma [V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚷 n :=
+  LeastNumberOnHierarchy.models_alt 𝚺 n
+
+instance models_ISigma_of_LPi [V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n :=
+  LeastNumberOnHierarchy.models_alt 𝚷 n
 
 end models
 
 section theorems
 
-theorem ISigma_equiv_IPi (n : ℕ) : 𝗜𝚺 n ≊ 𝗜𝚷 n := Equiv.antisymm_iff.mpr ⟨
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
-⟩
+private lemma antisymm_of_models {T S : ArithmeticTheory} [𝗘𝗤 ℒₒᵣ ⪯ S] [𝗘𝗤 ℒₒᵣ ⪯ T]
+    (hTS : ∀ (M : Type) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* S], M↓[ℒₒᵣ] ⊧* T)
+    (hST : ∀ (M : Type) [ORingStructure M] [M↓[ℒₒᵣ] ⊧* T], M↓[ℒₒᵣ] ⊧* S) : T ≊ S :=
+  Equiv.antisymm ⟨weakerThan_of_models.{0} T S hTS, weakerThan_of_models.{0} S T hST⟩
 
-theorem LSigma_equiv_ISigma (n : ℕ) : 𝗟𝚺 n ≊ 𝗜𝚺 n := Equiv.antisymm_iff.mpr ⟨
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
-⟩
+theorem ISigma_equiv_IPi (n : ℕ) : 𝗜𝚺 n ≊ 𝗜𝚷 n :=
+  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
 
-theorem LPi_equiv_ISigma (n : ℕ) : 𝗟𝚷 n ≊ 𝗜𝚺 n := Equiv.antisymm_iff.mpr ⟨
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
-  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
-⟩
+theorem LSigma_equiv_ISigma (n : ℕ) : 𝗟𝚺 n ≊ 𝗜𝚺 n :=
+  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
+
+theorem LPi_equiv_ISigma (n : ℕ) : 𝗟𝚷 n ≊ 𝗜𝚺 n :=
+  antisymm_of_models (fun _ _ _ ↦ inferInstance) (fun _ _ _ ↦ inferInstance)
 
 end theorems
 

--- a/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
+++ b/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
@@ -3,11 +3,11 @@ module
 public import Foundation.FirstOrder.Arithmetic.Schemata
 
 /-!
-# The least number schemes `𝗟𝚺` and `𝗟𝚷`
+# Equivalence of the least number schemes `𝗟𝚺`, `𝗟𝚷` with `𝗜𝚺`
 
 ## References
 
-- [HP98, §I.2(a), I.2.3, Theorem I.2.4, Lemma I.2.8, Lemma I.2.12]
+- [HP98, Theorem I.2.4, Lemma I.2.8, Lemma I.2.12]
 -/
 
 @[expose] public section
@@ -15,51 +15,6 @@ public import Foundation.FirstOrder.Arithmetic.Schemata
 namespace FFL.FirstOrder.Arithmetic
 
 open _root_.FFL.Entailment
-
-section axioms
-
-variable {L : Language} [L.ORing] {ξ : Type*}
-
-def leastNumber {ξ} (φ : Semiformula L ξ 1) : Formula L ξ :=
-  “(∃ x, !φ x) → ∃ z, !φ z ∧ ∀ x < z, ¬!φ x”
-
-def LeastNumberScheme (Γ : ArithmeticSemiformula ℕ 1 → Prop) : ArithmeticTheory :=
-  { ψ | ∃ φ : ArithmeticSemiformula ℕ 1, Γ φ ∧ ψ = .univCl (leastNumber φ) }
-
-abbrev LeastNumberOnHierarchy (Γ : Polarity) (n : ℕ) : ArithmeticTheory :=
-  𝗣𝗔⁻ ∪ LeastNumberScheme (Arithmetic.Hierarchy Γ n)
-
-prefix:max "𝗟 " => LeastNumberOnHierarchy
-
-abbrev LSigma (n : ℕ) : ArithmeticTheory := 𝗟 𝚺 n
-
-prefix:max "𝗟𝚺" => LSigma
-
-abbrev LPi (n : ℕ) : ArithmeticTheory := 𝗟 𝚷 n
-
-prefix:max "𝗟𝚷" => LPi
-
-variable {C C' : ArithmeticSemiformula ℕ 1 → Prop} {Γ : Polarity}
-
-lemma LeastNumberScheme_subset (h : ∀ {φ : ArithmeticSemiformula ℕ 1}, C φ → C' φ) :
-    LeastNumberScheme C ⊆ LeastNumberScheme C' := by
-  rintro _ ⟨φ, hφ, rfl⟩; exact ⟨φ, h hφ, rfl⟩;
-
-lemma mem_LeastNumberScheme_of_mem {φ : ArithmeticSemiformula ℕ 1} (hφ : C φ) :
-    .univCl (leastNumber φ) ∈ LeastNumberScheme C := ⟨φ, hφ, rfl⟩
-
-lemma LeastNumberOnHierarchy_subset_mono {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⊆ 𝗟 Γ n₂ :=
-  Set.union_subset_union_right _ (LeastNumberScheme_subset (fun H ↦ H.mono h))
-
-lemma LeastNumberOnHierarchy_weakerThan_of_le {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⪯ 𝗟 Γ n₂ :=
-  WeakerThan.ofSubset (LeastNumberOnHierarchy_subset_mono h)
-
-instance (Γ : Polarity) (n : ℕ) : 𝗣𝗔⁻ ⪯ 𝗟 Γ n := WeakerThan.ofSubset Set.subset_union_left
-
-instance (Γ : Polarity) (n : ℕ) : 𝗘𝗤 ℒₒᵣ ⪯ 𝗟 Γ n :=
-  WeakerThan.trans (inferInstance : 𝗘𝗤 ℒₒᵣ ⪯ 𝗣𝗔⁻) inferInstance
-
-end axioms
 
 section models
 

--- a/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
+++ b/Foundation/FirstOrder/Arithmetic/LeastNumber/Basic.lean
@@ -1,0 +1,202 @@
+module
+
+public import Foundation.FirstOrder.Arithmetic.Schemata
+
+/-!
+# The least number schemes `𝗟𝚺` and `𝗟𝚷`
+
+## References
+
+- [HP98, §I.2(a), I.2.3, Theorem I.2.4, Lemma I.2.8, Lemma I.2.12]
+-/
+
+@[expose] public section
+
+namespace FFL.FirstOrder.Arithmetic
+
+open _root_.FFL.Entailment
+
+section axioms
+
+def LeastNumberScheme (Γ : ArithmeticSemiformula ℕ 1 → Prop) : ArithmeticTheory :=
+  { ψ | ∃ φ : ArithmeticSemiformula ℕ 1, Γ φ ∧ ψ = .univCl (leastNumber φ) }
+
+abbrev LeastNumberOnHierarchy (Γ : Polarity) (n : ℕ) : ArithmeticTheory :=
+  𝗣𝗔⁻ ∪ LeastNumberScheme (Arithmetic.Hierarchy Γ n)
+
+prefix:max "𝗟 " => LeastNumberOnHierarchy
+
+abbrev LSigma (n : ℕ) : ArithmeticTheory := 𝗟 𝚺 n
+
+prefix:max "𝗟𝚺" => LSigma
+
+abbrev LPi (n : ℕ) : ArithmeticTheory := 𝗟 𝚷 n
+
+prefix:max "𝗟𝚷" => LPi
+
+variable {C C' : ArithmeticSemiformula ℕ 1 → Prop} {Γ : Polarity}
+
+lemma LeastNumberScheme_subset (h : ∀ {φ : ArithmeticSemiformula ℕ 1}, C φ → C' φ) :
+    LeastNumberScheme C ⊆ LeastNumberScheme C' := by
+  rintro _ ⟨φ, hφ, rfl⟩; exact ⟨φ, h hφ, rfl⟩;
+
+lemma mem_LeastNumberScheme_of_mem {φ : ArithmeticSemiformula ℕ 1} (hφ : C φ) :
+    .univCl (leastNumber φ) ∈ LeastNumberScheme C := ⟨φ, hφ, rfl⟩
+
+lemma LeastNumberOnHierarchy_subset_mono {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⊆ 𝗟 Γ n₂ :=
+  Set.union_subset_union_right _ (LeastNumberScheme_subset (fun H ↦ H.mono h))
+
+lemma LeastNumberOnHierarchy_weakerThan_of_le {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⪯ 𝗟 Γ n₂ :=
+  WeakerThan.ofSubset (LeastNumberOnHierarchy_subset_mono h)
+
+instance (Γ : Polarity) (n : ℕ) : 𝗣𝗔⁻ ⪯ 𝗟 Γ n := WeakerThan.ofSubset Set.subset_union_left
+
+instance (Γ : Polarity) (n : ℕ) : 𝗘𝗤 ℒₒᵣ ⪯ 𝗟 Γ n :=
+  WeakerThan.trans (inferInstance : 𝗘𝗤 ℒₒᵣ ⪯ 𝗣𝗔⁻) inferInstance
+
+end axioms
+
+section models
+
+variable {V : Type*} [ORingStructure V]
+
+namespace LeastNumberScheme
+
+variable {C : ArithmeticSemiformula ℕ 1 → Prop} [V↓[ℒₒᵣ] ⊧* LeastNumberScheme C]
+
+private lemma leastNumber_eval {φ : ArithmeticSemiformula ℕ 1} (hφ : C φ) (v : ℕ → V) :
+    (∃ x, φ.Eval ![x] v) → ∃ z, φ.Eval ![z] v ∧ ∀ x < z, ¬φ.Eval ![x] v := by
+  have : V↓[ℒₒᵣ] ⊧ .univCl (leastNumber φ) :=
+    Theory.models (T := LeastNumberScheme C) V (by simpa using mem_LeastNumberScheme_of_mem hφ);
+  revert v;
+  simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
+    Matrix.constant_eq_singleton] using this;
+
+lemma least_number {P : V → Prop}
+    (hP : ∃ e : ℕ → V, ∃ φ : ArithmeticSemiformula ℕ 1, C φ ∧ ∀ x, P x ↔ φ.Eval ![x] e)
+    {x} (h : P x) : ∃ y, P y ∧ ∀ z < y, ¬P z := by
+  rcases hP with ⟨e, φ, Cφ, hφ⟩;
+  simpa [← hφ] using leastNumber_eval (V := V) Cφ e ⟨x, (hφ x).mp h⟩;
+
+end LeastNumberScheme
+
+namespace LeastNumberOnHierarchy
+
+variable (Γ : Polarity) (m : ℕ) [V↓[ℒₒᵣ] ⊧* 𝗟 Γ m]
+
+instance : V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy Γ m) := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟 Γ m›
+
+lemma least_number {P : V → Prop} (hP : Γ-[m].DefinablePred P) {x} (h : P x) :
+    ∃ y, P y ∧ ∀ z < y, ¬P z :=
+  LeastNumberScheme.least_number (P := P) (C := Hierarchy Γ m) (by
+    classical
+    rcases hP with ⟨φ, hp⟩;
+    have : Inhabited V := Classical.inhabited_of_nonempty';
+    use φ.val.enumerateFVar, (Rew.rewriteMap φ.val.idxOfFVar) ▹ φ.val;
+    and_intros;
+    . simp;
+    . intro x;
+      simp [Semiformula.eval_rewriteMap, hp.df.iff]
+  ) h
+
+lemma succ_induction {P : V → Prop} (hP : Γ.alt-[m].DefinablePred P)
+    (zero : P 0) (succ : ∀ x, P x → P (x + 1)) : ∀ x, P x := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟 Γ m›;
+  have : V↓[ℒₒᵣ] ⊧* 𝗤 := models_of_subtheory this;
+  by_contra! hcon;
+  obtain ⟨a, ha⟩ := hcon;
+  obtain ⟨y, hy, hmin⟩ := least_number Γ m (P := fun x ↦ ¬P x) (by
+    apply Arithmetic.HierarchySymbol.Definable.not;
+    simpa [SigmaPiDelta.alt_coe];
+  ) ha;
+  push Not at hmin;
+  obtain ⟨z, rfl⟩ := Arithmetic.exists_succ_of_ne_zero $
+    show y ≠ 0 by
+    rintro rfl;
+    contradiction;
+  apply hy;
+  apply succ;
+  apply hmin;
+  apply lt_succ_iff_le.mpr;
+  apply le_rfl;
+
+end LeastNumberOnHierarchy
+
+variable (n : ℕ)
+
+instance models_LSigma_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n›;
+  suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy 𝚺 n) by
+    simpa [LSigma, LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  simp only [LeastNumberScheme];
+  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  rintro _ ⟨φ, hφ, rfl⟩;
+  suffices ∀ v : ℕ → V, (∃ x, φ.Eval ![x] v) → ∃ z, φ.Eval ![z] v ∧ ∀ x < z, ¬φ.Eval ![x] v by
+    simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
+      Matrix.constant_eq_singleton] using this;
+  intro v ⟨x, hx⟩;
+  exact InductionOnHierarchy.least_number 𝚺 n (definablePred_of_hierarchy hφ v) hx;
+
+instance models_LPi_of_ISigma [V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n›;
+  suffices V↓[ℒₒᵣ] ⊧* LeastNumberScheme (Hierarchy 𝚷 n) by
+    simpa [LPi, LeastNumberOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  simp only [LeastNumberScheme];
+  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  rintro _ ⟨φ, hφ, rfl⟩;
+  suffices ∀ v : ℕ → V, (∃ x, φ.Eval ![x] v) → ∃ z, φ.Eval ![z] v ∧ ∀ x < z, ¬φ.Eval ![x] v by
+    simpa [models_iff, Semiformula.eval_univCl, leastNumber, Semiformula.eval_substs,
+      Matrix.constant_eq_singleton] using this;
+  intro v ⟨x, hx⟩;
+  exact InductionOnHierarchy.least_number 𝚷 n (definablePred_of_hierarchy hφ v) hx;
+
+instance models_IPi_of_LSigma [V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚷 n := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟𝚺 n›;
+  suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy 𝚷 n) by
+    simpa [IPi, InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  simp only [InductionScheme];
+  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  rintro _ ⟨φ, hφ, rfl⟩;
+  suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
+      ∀ x, φ.Eval ![x] v by
+    simpa [models_iff, Semiformula.eval_univCl, succInd, Semiformula.eval_substs,
+      Matrix.constant_eq_singleton] using this;
+  intro v;
+  exact LeastNumberOnHierarchy.succ_induction 𝚺 n (definablePred_of_hierarchy hφ v);
+
+instance models_ISigma_of_LPi [V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n] : V↓[ℒₒᵣ] ⊧* 𝗜𝚺 n := by
+  have : V↓[ℒₒᵣ] ⊧* 𝗣𝗔⁻ := models_of_subtheory ‹V↓[ℒₒᵣ] ⊧* 𝗟𝚷 n›;
+  suffices V↓[ℒₒᵣ] ⊧* InductionScheme ℒₒᵣ (Hierarchy 𝚺 n) by
+    simpa [ISigma, InductionOnHierarchy, Semantics.ModelsSet.union_iff] using ⟨‹_›, this⟩;
+  simp only [InductionScheme];
+  refine Semantics.ModelsSet.setOf_iff.mpr ?_;
+  rintro _ ⟨φ, hφ, rfl⟩;
+  suffices ∀ v : ℕ → V, φ.Eval ![0] v → (∀ x, φ.Eval ![x] v → φ.Eval ![x + 1] v) →
+      ∀ x, φ.Eval ![x] v by
+    simpa [models_iff, Semiformula.eval_univCl, succInd, Semiformula.eval_substs,
+      Matrix.constant_eq_singleton] using this;
+  intro v;
+  exact LeastNumberOnHierarchy.succ_induction 𝚷 n (definablePred_of_hierarchy hφ v);
+
+end models
+
+section theorems
+
+theorem ISigma_equiv_IPi (n : ℕ) : 𝗜𝚺 n ≊ 𝗜𝚷 n := Equiv.antisymm_iff.mpr ⟨
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
+⟩
+
+theorem LSigma_equiv_ISigma (n : ℕ) : 𝗟𝚺 n ≊ 𝗜𝚺 n := Equiv.antisymm_iff.mpr ⟨
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
+⟩
+
+theorem LPi_equiv_ISigma (n : ℕ) : 𝗟𝚷 n ≊ 𝗜𝚺 n := Equiv.antisymm_iff.mpr ⟨
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance,
+  weakerThan_of_models.{0} _ _ fun _ _ _ ↦ inferInstance
+⟩
+
+end theorems
+
+end FFL.FirstOrder.Arithmetic

--- a/Foundation/FirstOrder/Arithmetic/Schemata.lean
+++ b/Foundation/FirstOrder/Arithmetic/Schemata.lean
@@ -3,11 +3,15 @@ module
 public import Foundation.FirstOrder.Arithmetic.PeanoMinus.Functions
 public import Foundation.FirstOrder.Arithmetic.TA.Basic
 
-@[expose] public section
-
 /-!
-# Induction schemata of Arithmetic
+# Induction and least number schemata of Arithmetic
+
+## References
+
+- [HP98, §I.2(a), I.2.3]
 -/
+
+@[expose] public section
 
 namespace FFL.FirstOrder.Arithmetic
 
@@ -18,6 +22,9 @@ variable {L : Language} [L.ORing] {ξ : Type*} [DecidableEq ξ]
 def succInd {ξ} (φ : Semiformula L ξ 1) : Formula L ξ := “!φ 0 → (∀ x, !φ x → !φ (x + 1)) → ∀ x, !φ x”
 
 def orderInd {ξ} (φ : Semiformula L ξ 1) : Formula L ξ := “(∀ x, (∀ y < x, !φ y) → !φ x) → ∀ x, !φ x”
+
+def leastNumber {ξ} (φ : Semiformula L ξ 1) : Formula L ξ :=
+  “(∃ x, !φ x) → ∃ z, !φ z ∧ ∀ x < z, ¬!φ x”
 
 variable (L)
 
@@ -51,6 +58,22 @@ notation "𝗜𝚷₁" => IPi 1
 abbrev Peano : ArithmeticTheory := 𝗣𝗔⁻ ∪ InductionScheme ℒₒᵣ Set.univ
 
 notation "𝗣𝗔" => Peano
+
+def LeastNumberScheme (Γ : ArithmeticSemiformula ℕ 1 → Prop) : ArithmeticTheory :=
+  { ψ | ∃ φ : ArithmeticSemiformula ℕ 1, Γ φ ∧ ψ = .univCl (leastNumber φ) }
+
+abbrev LeastNumberOnHierarchy (Γ : Polarity) (n : ℕ) : ArithmeticTheory :=
+  𝗣𝗔⁻ ∪ LeastNumberScheme (Arithmetic.Hierarchy Γ n)
+
+prefix:max "𝗟 " => LeastNumberOnHierarchy
+
+abbrev LSigma (n : ℕ) : ArithmeticTheory := 𝗟 𝚺 n
+
+prefix:max "𝗟𝚺" => LSigma
+
+abbrev LPi (n : ℕ) : ArithmeticTheory := 𝗟 𝚷 n
+
+prefix:max "𝗟𝚷" => LPi
 
 variable {L}
 
@@ -88,6 +111,25 @@ instance : 𝗜𝚺i ⪯ 𝗣𝗔 :=
 lemma mem_InductionScheme_of_mem {φ : ArithmeticSemiformula ℕ 1} (hp : C φ) :
     .univCl (succInd φ) ∈ InductionScheme ℒₒᵣ C := by
   simpa [InductionScheme] using ⟨φ, hp, rfl⟩
+
+lemma LeastNumberScheme_subset (h : ∀ {φ : ArithmeticSemiformula ℕ 1}, C φ → C' φ) :
+    LeastNumberScheme C ⊆ LeastNumberScheme C' := by
+  rintro _ ⟨φ, hφ, rfl⟩; exact ⟨φ, h hφ, rfl⟩;
+
+lemma mem_LeastNumberScheme_of_mem {φ : ArithmeticSemiformula ℕ 1} (hφ : C φ) :
+    .univCl (leastNumber φ) ∈ LeastNumberScheme C := ⟨φ, hφ, rfl⟩
+
+lemma LeastNumberOnHierarchy_subset_mono {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⊆ 𝗟 Γ n₂ :=
+  Set.union_subset_union_right _ (LeastNumberScheme_subset (fun H ↦ H.mono h))
+
+lemma LeastNumberOnHierarchy_weakerThan_of_le {n₁ n₂} (h : n₁ ≤ n₂) : 𝗟 Γ n₁ ⪯ 𝗟 Γ n₂ :=
+  Entailment.WeakerThan.ofSubset (LeastNumberOnHierarchy_subset_mono h)
+
+instance (Γ : Polarity) (n : ℕ) : 𝗣𝗔⁻ ⪯ 𝗟 Γ n :=
+  Entailment.WeakerThan.ofSubset Set.subset_union_left
+
+instance (Γ : Polarity) (n : ℕ) : 𝗘𝗤 ℒₒᵣ ⪯ 𝗟 Γ n :=
+  Entailment.WeakerThan.trans (inferInstance : 𝗘𝗤 ℒₒᵣ ⪯ 𝗣𝗔⁻) inferInstance
 
 lemma mem_IOpen_of_qfree {φ : ArithmeticSemiformula ℕ 1} (hp : φ.Open) :
     .univCl (succInd φ) ∈ InductionScheme ℒₒᵣ Semiformula.Open := by

--- a/Foundation/FirstOrder/Arithmetic/Schemata.lean
+++ b/Foundation/FirstOrder/Arithmetic/Schemata.lean
@@ -19,8 +19,6 @@ def succInd {ξ} (φ : Semiformula L ξ 1) : Formula L ξ := “!φ 0 → (∀ x
 
 def orderInd {ξ} (φ : Semiformula L ξ 1) : Formula L ξ := “(∀ x, (∀ y < x, !φ y) → !φ x) → ∀ x, !φ x”
 
-def leastNumber {ξ} (φ : Semiformula L ξ 1) : Formula L ξ := “(∃ x, !φ x) → ∃ z, !φ z ∧ ∀ x < z, ¬!φ x”
-
 variable (L)
 
 def InductionScheme (Γ : Semiformula L ℕ 1 → Prop) : Theory L :=


### PR DESCRIPTION
Ported from [AlphaCentauri](https://github.com/FormalizedFormalLogic/AlphaCentauri).

`𝗟𝚺 n` and `𝗟𝚷 n` are `𝗣𝗔⁻` together with the least number scheme for `𝚺-[n]` resp. `𝚷-[n]` formulas. Both are equivalent to `𝗜𝚺 n`, which in turn is equivalent to `𝗜𝚷 n`. `Foundation/FirstOrder/Arithmetic/Examples.lean` states these at the first few indices so the theory zoo, whose vertices are closed theories, can draw them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)