### PR TITLE
ci: Regenerate documentation HTML on every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: just axiom-audit
 
       - name: Build docs
-        run: lake build Foundation:docs
+        run: just docs
 
       - name: Generate zoo
         run: just zoo

--- a/Justfile
+++ b/Justfile
@@ -36,13 +36,15 @@ shake:
 axiom-audit:
     lake exe axiom-audit --root Foundation
 
-# doc-gen4 records that the HTML pass ran by touching an empty marker file, and Lake traces that
-# marker by its (always identical) contents. Once the marker is in the restored build cache the
-# HTML pass is replayed forever, so the published documentation freezes at whatever commit last
-# missed the cache. Dropping the marker and the stale output forces a regeneration; the expensive
-# per-module database pass behind it stays incremental.
+# doc-gen4 records that its HTML pass ran by touching an empty marker file, and Lake traces that
+# marker by its own -- always identical -- contents. `lake pack` carries the marker into the build
+# cache, so every run that restores the cache replays the pass and the generated HTML is never
+# rewritten. Clearing the output and the two markers that guard it forces a regeneration:
+# `doc/references.bib` comes from the bib prepass, keyed on `doc-data/references.json`, and the rest
+# of `doc/` from the HTML pass. The per-module database pass behind them stays incremental.
 #
 # Generate the API documentation into .lake/build/doc (requires `lake build Foundation` first)
 docs:
-    rm -rf .lake/build/doc .lake/build/doc-data/*.docs_built
+    rm -rf .lake/build/doc
+    rm -f .lake/build/doc-data/references.json .lake/build/doc-data/*.docs_built
     lake build Foundation:docs

--- a/Justfile
+++ b/Justfile
@@ -35,3 +35,14 @@ shake:
 # Audit Foundation for sorry/native_decide/unauthorized axioms (requires `lake build Foundation` first)
 axiom-audit:
     lake exe axiom-audit --root Foundation
+
+# doc-gen4 records that the HTML pass ran by touching an empty marker file, and Lake traces that
+# marker by its (always identical) contents. Once the marker is in the restored build cache the
+# HTML pass is replayed forever, so the published documentation freezes at whatever commit last
+# missed the cache. Dropping the marker and the stale output forces a regeneration; the expensive
+# per-module database pass behind it stays incremental.
+#
+# Generate the API documentation into .lake/build/doc (requires `lake build Foundation` first)
+docs:
+    rm -rf .lake/build/doc .lake/build/doc-data/*.docs_built
+    lake build Foundation:docs

--- a/Justfile
+++ b/Justfile
@@ -36,12 +36,8 @@ shake:
 axiom-audit:
     lake exe axiom-audit --root Foundation
 
-# doc-gen4 records that its HTML pass ran by touching an empty marker file, and Lake traces that
-# marker by its own -- always identical -- contents. `lake pack` carries the marker into the build
-# cache, so every run that restores the cache replays the pass and the generated HTML is never
-# rewritten. Clearing the output and the two markers that guard it forces a regeneration:
-# `doc/references.bib` comes from the bib prepass, keyed on `doc-data/references.json`, and the rest
-# of `doc/` from the HTML pass. The per-module database pass behind them stays incremental.
+# doc-gen4 guards its output with empty marker files whose Lake trace never changes, so a restored
+# build cache would otherwise leave the generated documentation frozen forever.
 #
 # Generate the API documentation into .lake/build/doc (requires `lake build Foundation` first)
 docs:


### PR DESCRIPTION
close #923

The published documentation has been frozen since #898: it still carries the pre-#909 `LO`
namespace and none of the declarations added afterwards, even though every CI run is green.

doc-gen4 marks its HTML generation pass as done by touching an empty marker file under
`.lake/build/doc-data`, and Lake traces that marker by its own — always identical — contents.
`lake pack` carries the marker into the build cache, so from the first run that restores the cache
onwards `Foundation:docs` is replayed and the HTML is never rewritten; only a cache key change
(a toolchain or manifest bump, as in #898) brings the site back up to date. The declaration
database behind it is updated correctly all along.

A new `just docs` recipe clears the output and the two markers that guard it — `doc/references.bib`
comes from the bib prepass, the rest of `doc/` from the HTML pass — so both run again. The
per-module database pass and the core documentation pass stay incremental; the HTML pass took 54s
on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)