### PR TITLE
change(SecondOrder, FirstOrder, Propositional): explicit contraction and weakening

### DIFF
--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -66,8 +66,7 @@ inductive Derivation : Sequent L → Type _
 | weakening : Derivation Γ → Derivation (Γ + ⦃φ⦄)
 | verum : Derivation ⦃⊤⦄
 | or : Derivation (Γ + ⦃φ, ψ⦄) → Derivation (Γ + ⦃φ ⋎ ψ⦄)
-| and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) →
-    Derivation (Γ + ⦃φ ⋏ ψ⦄)
+| and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) → Derivation (Γ + ⦃φ ⋏ ψ⦄)
 | all : Derivation (Γ⁺ + ⦃φ.free⦄) → Derivation (Γ + ⦃∀¹ φ⦄)
 | exs : Derivation (Γ + ⦃φ/[t]⦄) → Derivation (Γ + ⦃∃¹ φ⦄)
 
@@ -80,15 +79,15 @@ open Rewriting LawfulSyntacticRewriting
 variable {Γ Δ : Sequent L}
 
 def height {Δ : Sequent L} : ⊢ᴸᴷ¹ Δ → ℕ
-  |    identity _ _ => 0
-  |       cut dp dn => max dp.height dn.height + 1
+  |  identity _ _ => 0
+  |     cut dp dn => max dp.height dn.height + 1
   | contraction d => d.height + 1
-  | weakening d => d.height + 1
-  |           verum => 0
-  |            or d => d.height + 1
-  |       and dp dq => max (height dp) (height dq) + 1
-  |           all d => d.height + 1
-  |           exs d => d.height + 1
+  |   weakening d => d.height + 1
+  |         verum => 0
+  |          or d => d.height + 1
+  |     and dp dq => max (height dp) (height dq) + 1
+  |         all d => d.height + 1
+  |         exs d => d.height + 1
 
 section height
 
@@ -131,20 +130,20 @@ instance : Structural (Derivation (L := L)) where
 
 /-- Enumerates the end sequent by recursion on the local inference rules.
 This is a routine syntactic construction. -/
-def traversal [L.DecidableEq] : {Γ : Sequent L} → (⊢ᴸᴷ¹ Γ) → Γ.Traversal
-  | _, identity r v =>
+def traversal [L.DecidableEq] {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → Γ.Traversal
+  | identity r v =>
       (Multiset.Traversal.atom (Semiformula.rel r v)).succ (Semiformula.nrel r v)
-  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
-  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
-  | _, weakening (φ := φ) d => d.traversal.succ φ
-  | _, verum => .atom ⊤
-  | _, or (φ := φ) (ψ := ψ) d =>
+  | cut d dn => d.traversal.remove.add dn.traversal.remove
+  | contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | weakening (φ := φ) d => d.traversal.succ φ
+  | verum => .atom ⊤
+  | or (φ := φ) (ψ := ψ) d =>
       ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
-  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
-  | _, all (Γ := Γ) (φ := φ) d =>
+  | and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
+  | all (Γ := Γ) (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
         simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∀¹ φ)
-  | _, exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+  | exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
 
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
 def contra [L.DecidableEq] (d : ⊢ᴸᴷ¹ Δ) (t : Γ.Traversal)

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -62,7 +62,8 @@ end Sequent
 inductive Derivation : Sequent L → Type _
 | identity (r : L.Rel k) (v) : Derivation ⦃.rel r v, .nrel r v⦄
 | cut : Derivation (Γ + ⦃φ⦄) → Derivation (Δ + ⦃∼φ⦄) → Derivation (Γ + Δ)
-| contraction : Derivation Δ → Δ ⊆ Γ → Derivation Γ
+| contraction : Derivation (Γ + ⦃φ, φ⦄) → Derivation (Γ + ⦃φ⦄)
+| weakening : Derivation Γ → Derivation (Γ + ⦃φ⦄)
 | verum : Derivation ⦃⊤⦄
 | or : Derivation (Γ + ⦃φ, ψ⦄) → Derivation (Γ + ⦃φ ⋎ ψ⦄)
 | and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) →
@@ -79,7 +80,8 @@ open Rewriting LawfulSyntacticRewriting
 def height {Δ : Sequent L} : ⊢ᴸᴷ¹ Δ → ℕ
   |    identity _ _ => 0
   |       cut dp dn => max dp.height dn.height + 1
-  | contraction d _ => d.height + 1
+  | contraction d => d.height + 1
+  | weakening d => d.height + 1
   |           verum => 0
   |            or d => d.height + 1
   |       and dp dq => max (height dp) (height dq) + 1
@@ -94,8 +96,11 @@ section height
 @[simp] lemma height_cut {φ} (dp : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (dn : ⊢ᴸᴷ¹ Δ + ⦃∼φ⦄) :
   height (cut dp dn) = (max (height dp) (height dn)).succ := rfl
 
-@[simp] lemma height_contraction (d : ⊢ᴸᴷ¹ Δ) (h : Δ ⊆ Γ) :
-    height (contraction d h) = d.height.succ := rfl
+@[simp] lemma height_contraction (d : ⊢ᴸᴷ¹ Γ + ⦃φ, φ⦄) :
+    height (contraction d) = d.height.succ := rfl
+
+@[simp] lemma height_weakening (d : ⊢ᴸᴷ¹ Γ) :
+    height (weakening (φ := φ) d) = d.height.succ := rfl
 
 @[simp] lemma height_verum : height (verum : ⊢ᴸᴷ¹ (⦃⊤⦄ : Sequent L)) = 0 := rfl
 
@@ -118,33 +123,68 @@ abbrev cast (d : ⊢ᴸᴷ¹ Δ) (e : Δ = Γ := by abel) : ⊢ᴸᴷ¹ Γ := e 
 @[simp] lemma height_cast (d : ⊢ᴸᴷ¹ Δ) (e : Δ = Γ) :
     height (Derivation.cast d e) = height d := by rcases e with rfl; simp [Derivation.cast]
 
-def contra (d : ⊢ᴸᴷ¹ Δ) (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ¹ Γ := contraction d h
+instance : Structural (Derivation (L := L)) where
+  weakening d := d.weakening
+  contraction d := d.contraction
 
-def top (h : ⊤ ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ := verum.contraction (by simpa using h)
+private lemma unshift_shift (φ : Proposition L) :
+    Rew.rewriteMap Nat.pred ▹ Rewriting.shift φ = φ := by
+  change Rew.rewriteMap Nat.pred ▹ (Rew.rewriteMap Nat.succ ▹ φ) = φ;
+  rw [← TransitiveRewriting.comp_app, Rew.rewriteMap_comp_rewriteMap];
+  change Rew.rewriteMap id ▹ φ = φ;
+  simp;
 
-def identity' (r : L.Rel k) (v) (hpos : Semiformula.rel r v ∈ Δ := by simp)
+/-- Enumerates the end sequent by recursion on the local inference rules.
+This is a routine syntactic construction. -/
+def traversal [L.DecidableEq] : {Γ : Sequent L} → (⊢ᴸᴷ¹ Γ) → Γ.Traversal
+  | _, identity r v => (.atom (.rel r v)).succ (.nrel r v)
+  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
+  | _, contraction d => (d.traversal.cast (by abel)).remove
+  | _, weakening (φ := φ) d => d.traversal.succ φ
+  | _, verum => .atom ⊤
+  | _, or (φ := φ) (ψ := ψ) d =>
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove |>.succ (φ ⋎ ψ)
+  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
+  | _, all (Γ := Γ) (φ := φ) d =>
+      ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
+        simp [Rewriting.shifts, Multiset.map_map, Function.comp_def, unshift_shift])).succ (∀¹ φ)
+  | _, exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+
+/-- Applies structural rules along supplied traversals (a routine derived rule). -/
+def contra [L.DecidableEq] (d : ⊢ᴸᴷ¹ Δ) (t : Γ.Traversal)
+    (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ¹ Γ :=
+  Structural.ofSubset d.traversal t d h
+
+def top [L.DecidableEq] (t : Δ.Traversal) (h : ⊤ ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
+  verum.contra t (by simpa using h)
+
+def identity' [L.DecidableEq] (r : L.Rel k) (v) (t : Δ.Traversal)
+    (hpos : Semiformula.rel r v ∈ Δ := by simp)
     (hneg : Semiformula.nrel r v ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  (identity r v).contraction <| by
+  (identity r v).contra t <| by
     intro φ hφ
     rcases Multiset.mem_add.mp hφ with hφ | hφ <;> simp_all
 
-def tensor {φ ψ} (dφ : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (dψ : ⊢ᴸᴷ¹ Δ + ⦃ψ⦄) :
+def tensor {φ ψ} (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
+    (dφ : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (dψ : ⊢ᴸᴷ¹ Δ + ⦃ψ⦄) :
     ⊢ᴸᴷ¹ Γ + Δ + ⦃φ ⋏ ψ⦄ :=
   and
-    (dφ.contra <| by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all)
-    (dψ.contra <| by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all)
+    (Structural.weakenMany tΔ dφ |>.cast)
+    (Structural.weakenMany tΓ dψ |>.cast)
 
 def eta : (φ : Proposition L) → ⊢ᴸᴷ¹ ⦃φ, ∼φ⦄
-  | .rel R v | .nrel R v => identity' R v
-  | ⊤ | ⊥ => top
+  | .rel R v => identity R v
+  | .nrel R v => (identity R v).cast (by simp [add_comm])
+  | ⊤ => verum.weakening
+  | ⊥ => verum.weakening.cast (by simp [add_comm])
   | φ ⋏ ψ =>
     (or (Γ := ⦃φ ⋏ ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
       (tensor (Γ := ⦃∼φ⦄) (Δ := ⦃∼ψ⦄) (φ := φ) (ψ := ψ)
-        (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
+        (.atom _) (.atom _) (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
   | φ ⋎ ψ =>
     (or (Γ := ⦃∼φ ⋏ ∼ψ⦄) (φ := φ) (ψ := ψ)
       (tensor (Γ := ⦃φ⦄) (Δ := ⦃ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
-        (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
+        (.atom _) (.atom _) (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
   | ∀¹ φ =>
     (all (Γ := ⦃∃¹ ∼φ⦄) (φ := φ)
       ((exs (Γ := ⦃φ.free⦄) (φ := ∼φ.shift) (t := &0)
@@ -161,15 +201,20 @@ instance : OneSidedLK (Derivation (L := L)) where
   verum := verum
   and d₁ d₂ := d₁.and d₂
   or d := d.or
-  contraction d ss := d.contraction ss
+  weakening d := d.weakening
+  contraction d := d.contraction
   identity φ := eta φ
 
 instance : OneSidedLK.Cut (Derivation (L := L)) where
   cut dp dn := cut dp dn
 
 lemma of_isClosed {Γ : Sequent L} (h : Γ.IsClosed) : Nonempty (⊢ᴸᴷ¹ Γ) := by
-  rcases h with ⟨φ, hp, hn⟩
-  exact ⟨OneSidedLK.close φ hp hn⟩
+  classical
+  rcases h with ⟨φ, hp, hn⟩;
+  exact ⟨(eta φ).contra default (by
+    intro ψ hψ;
+    simp only [Multiset.mem_add, Multiset.mem_atom_iff] at hψ;
+    rcases hψ with rfl | rfl <;> assumption)⟩;
 
 def rewrite {Γ} (f : ℕ → SyntacticTerm L) :
     ⊢ᴸᴷ¹ Γ → ⊢ᴸᴷ¹ Γ.map (Rew.rewrite f ▹ ·)
@@ -178,7 +223,11 @@ def rewrite {Γ} (f : ℕ → SyntacticTerm L) :
     (cut (Γ := Γ.map (Rew.rewrite f ▹ ·))
       (Δ := Δ.map (Rew.rewrite f ▹ ·)) (φ := Rew.rewrite f ▹ φ)
       ((d₁.rewrite f).cast (by simp)) ((d₂.rewrite f).cast (by simp))).cast (by simp)
-  | contraction d ss => d.rewrite f |>.contraction (Multiset.map_subset_map ss)
+  | contraction (Γ := Γ) (φ := φ) d =>
+      (contraction (Γ := Γ.map (Rew.rewrite f ▹ ·)) (φ := Rew.rewrite f ▹ φ)
+        ((d.rewrite f).cast (by simp))).cast (by simp)
+  | weakening (Γ := Γ) (φ := φ) d =>
+      (weakening (φ := Rew.rewrite f ▹ φ) (d.rewrite f)).cast (by simp)
   | verum => verum
   | or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
     (or (Γ := Γ.map (Rew.rewrite f ▹ ·))
@@ -223,7 +272,11 @@ def lMap (Φ : L₁ →ᵥ L₂) {Γ} : ⊢ᴸᴷ¹ Γ → ⊢ᴸᴷ¹ Γ.map (.
     (cut (Γ := Γ.map (.lMap Φ)) (Δ := Δ.map (.lMap Φ))
       (φ := .lMap Φ φ) (Derivation.cast (lMap Φ d) (by simp))
       (Derivation.cast (lMap Φ dn) (by simp))).cast (by simp)
-  | contraction (Δ := Δ) (Γ := Γ) d ss => (lMap Φ d).contraction (Multiset.map_subset_map ss)
+  | contraction (Γ := Γ) (φ := φ) d =>
+      (contraction (Γ := Γ.map (.lMap Φ)) (φ := .lMap Φ φ)
+        ((lMap Φ d).cast (by simp))).cast (by simp)
+  | weakening (φ := φ) d =>
+      (weakening (φ := .lMap Φ φ) (lMap Φ d)).cast (by simp)
   | verum => by simpa using verum
   | or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
     (or (Γ := Γ.map (.lMap Φ)) (φ := .lMap Φ φ) (ψ := .lMap Φ ψ)
@@ -269,7 +322,7 @@ def generalizeByNewVar {φ : Semiproposition L 1} (hp : ¬φ.FVar? m)
 def exOfInstances (v : List (SyntacticTerm L)) (φ : Semiproposition L 1)
     (h : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + Γ) : ⊢ᴸᴷ¹ Γ + ⦃∃¹ φ⦄ := by
   induction' v with t v ih generalizing Γ
-  · exact contra h (by intro ψ hψ; simp_all)
+  · exact (h.cast (by simp)).weakening
   · have d : ⊢ᴸᴷ¹ ((v.map (φ/[·]) : Multiset _) + Γ) + ⦃∃¹ φ⦄ :=
       exs (t := t) (h.cast (by
         change (φ/[t] ::ₘ (v.map (φ/[·]) : Multiset _)) + Γ =
@@ -278,24 +331,20 @@ def exOfInstances (v : List (SyntacticTerm L)) (φ : Semiproposition L 1)
         abel))
     have d : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + (Γ + ⦃∃¹ φ⦄) :=
       d.cast (by simp [add_assoc, add_left_comm, add_comm])
-    exact (ih d).contraction (by intro ψ hψ; simp_all)
+    exact ((ih d).cast (by abel)).contraction
 
 def exOfInstances' (v : List (SyntacticTerm L)) (φ : Semiproposition L 1)
     (h : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + Γ + ⦃∃¹ φ⦄) :
     ⊢ᴸᴷ¹ Γ + ⦃∃¹ φ⦄ :=
-  (exOfInstances (Γ := Γ + ⦃∃¹ φ⦄) v φ (h.cast (by simp [add_assoc]))).contraction
-    (by intro ψ hψ; simp_all)
+  ((exOfInstances (Γ := Γ + ⦃∃¹ φ⦄) v φ
+    (h.cast (by simp [add_assoc]))).cast (by abel)).contraction
 
-def allNvar {Δ : Sequent L} {φ} (h : ∀¹ φ ∈ Δ) :
+def allNvar [L.DecidableEq] {Δ : Sequent L} {φ} (h : ∀¹ φ ∈ Δ) :
     ⊢ᴸᴷ¹ Δ + ⦃φ/[&Δ.newVar]⦄ → ⊢ᴸᴷ¹ Δ := fun b ↦
   let b : ⊢ᴸᴷ¹ Δ + ⦃∀¹ φ⦄ :=
     b.generalizeByNewVar (by simpa [Semiformula.FVar?] using Sequent.not_fvar?_newVar h)
       (fun _ ↦ Sequent.not_fvar?_newVar)
-  b.contraction (by
-    intro ψ hψ
-    rcases Multiset.mem_add.mp hψ with hψ | hψ
-    · exact hψ
-    · exact Multiset.mem_singleton.mp hψ ▸ h)
+  Structural.absorb b h
 
 end Derivation
 
@@ -423,7 +472,8 @@ instance : Entailment.DeductiveExplosion (Theory L) where
     refine ⟨b.axioms, b.axioms_mem, ?_⟩
     have db : ⊢ᴸᴷ¹ (∼Sequent.embed b.axioms) + ⦃Rewriting.emb (⊥ : Sentence L)⦄ :=
       Derivation.cast b.derivation (by simp [Sequent.embed, add_comm])
-    exact (OneSidedLK.removeBot db).contraction (by intro ψ hψ; simp_all [Sequent.embed])
+    exact (OneSidedLK.removeBot db).weakening.cast (by
+      simp [OneSidedLK.Pullback, Sequent.embed, add_comm])
 
 lemma weakerThan_of_le {T U : Theory L} (h : T ⊆ U) : T ⪯ U :=
   Entailment.Axiomatized.weakerThanOfSubset h
@@ -452,7 +502,7 @@ lemma inconsistent_iff :
       d.cast (by rw [add_comm])
     exact ⟨Γ, hΓ, ⟨OneSidedLK.removeBot db⟩⟩
   · rintro ⟨Γ, hΓ, ⟨d⟩⟩
-    exact ⟨Γ, hΓ, ⟨d.contraction (by intro ψ hψ; simp_all)⟩⟩
+    exact ⟨Γ, hΓ, ⟨d.weakening.cast (by simp [add_comm])⟩⟩
 
 open Entailment Derivation
 
@@ -502,9 +552,10 @@ noncomputable instance : Entailment.Deduction (Theory L) where
       simpa [hnχ] using b.axioms_mem χ hχ
     · exact Derivation.cast (Derivation.or (Γ := (∼Γ).map Rewriting.emb)
         (φ := Rewriting.emb (∼φ)) (ψ := Rewriting.emb ψ)
-        (b.derivation.contraction
+        (b.derivation.contra
           (Γ := (∼Γ).map Rewriting.emb +
             ⦃Rewriting.emb (∼φ), Rewriting.emb ψ⦄)
+          default
           (by simpa [OneSidedLK.Pullback, Multiset.tilde_def, Γ, add_assoc] using
             Multiset.map_subset_map (f := Rewriting.emb) <|
               Multiset.add_map_subset_map_filter_add_atom

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -77,6 +77,8 @@ namespace Derivation
 
 open Rewriting LawfulSyntacticRewriting
 
+variable {Γ Δ : Sequent L}
+
 def height {Δ : Sequent L} : ⊢ᴸᴷ¹ Δ → ℕ
   |    identity _ _ => 0
   |       cut dp dn => max dp.height dn.height + 1
@@ -137,31 +139,33 @@ private lemma unshift_shift (φ : Proposition L) :
 /-- Enumerates the end sequent by recursion on the local inference rules.
 This is a routine syntactic construction. -/
 def traversal [L.DecidableEq] : {Γ : Sequent L} → (⊢ᴸᴷ¹ Γ) → Γ.Traversal
-  | _, identity r v => (.atom (.rel r v)).succ (.nrel r v)
+  | _, identity r v =>
+      (Multiset.Traversal.atom (Semiformula.rel r v)).succ (Semiformula.nrel r v)
   | _, cut d dn => d.traversal.remove.add dn.traversal.remove
-  | _, contraction d => (d.traversal.cast (by abel)).remove
+  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
   | _, weakening (φ := φ) d => d.traversal.succ φ
   | _, verum => .atom ⊤
   | _, or (φ := φ) (ψ := ψ) d =>
-      ((d.traversal.cast (by abel)).remove (a := ψ)).remove |>.succ (φ ⋎ ψ)
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
   | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
   | _, all (Γ := Γ) (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
-        simp [Rewriting.shifts, Multiset.map_map, Function.comp_def, unshift_shift])).succ (∀¹ φ)
+        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])).succ (∀¹ φ)
   | _, exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
 
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
 def contra [L.DecidableEq] (d : ⊢ᴸᴷ¹ Δ) (t : Γ.Traversal)
     (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ¹ Γ :=
-  Structural.ofSubset d.traversal t d h
+  Structural.ofSubset (F := Proposition L) (𝔇 := Derivation (L := L))
+    (Γ := Δ) (Δ := Γ) (traversal (L := L) d) t d h
 
 def top [L.DecidableEq] (t : Δ.Traversal) (h : ⊤ ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  verum.contra t (by simpa using h)
+  contra (L := L) verum t (by simpa using h)
 
 def identity' [L.DecidableEq] (r : L.Rel k) (v) (t : Δ.Traversal)
     (hpos : Semiformula.rel r v ∈ Δ := by simp)
     (hneg : Semiformula.nrel r v ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  (identity r v).contra t <| by
+  contra (L := L) (identity r v) t <| by
     intro φ hφ
     rcases Multiset.mem_add.mp hφ with hφ | hφ <;> simp_all
 
@@ -176,15 +180,15 @@ def eta : (φ : Proposition L) → ⊢ᴸᴷ¹ ⦃φ, ∼φ⦄
   | .rel R v => identity R v
   | .nrel R v => (identity R v).cast (by simp [add_comm])
   | ⊤ => verum.weakening
-  | ⊥ => verum.weakening.cast (by simp [add_comm])
+  | ⊥ => (verum.weakening (φ := ⊥)).cast (by simp [add_comm])
   | φ ⋏ ψ =>
     (or (Γ := ⦃φ ⋏ ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
       (tensor (Γ := ⦃∼φ⦄) (Δ := ⦃∼ψ⦄) (φ := φ) (ψ := ψ)
-        (.atom _) (.atom _) (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
+        (Multiset.Traversal.atom _) (Multiset.Traversal.atom _) (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
   | φ ⋎ ψ =>
     (or (Γ := ⦃∼φ ⋏ ∼ψ⦄) (φ := φ) (ψ := ψ)
       (tensor (Γ := ⦃φ⦄) (Δ := ⦃ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
-        (.atom _) (.atom _) (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
+        (Multiset.Traversal.atom _) (Multiset.Traversal.atom _) (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
   | ∀¹ φ =>
     (all (Γ := ⦃∃¹ ∼φ⦄) (φ := φ)
       ((exs (Γ := ⦃φ.free⦄) (φ := ∼φ.shift) (t := &0)
@@ -211,7 +215,7 @@ instance : OneSidedLK.Cut (Derivation (L := L)) where
 lemma of_isClosed {Γ : Sequent L} (h : Γ.IsClosed) : Nonempty (⊢ᴸᴷ¹ Γ) := by
   classical
   rcases h with ⟨φ, hp, hn⟩;
-  exact ⟨(eta φ).contra default (by
+  exact ⟨contra (L := L) (eta φ) (default : Γ.Traversal) (by
     intro ψ hψ;
     simp only [Multiset.mem_add, Multiset.mem_atom_iff] at hψ;
     rcases hψ with rfl | rfl <;> assumption)⟩;
@@ -472,8 +476,8 @@ instance : Entailment.DeductiveExplosion (Theory L) where
     refine ⟨b.axioms, b.axioms_mem, ?_⟩
     have db : ⊢ᴸᴷ¹ (∼Sequent.embed b.axioms) + ⦃Rewriting.emb (⊥ : Sentence L)⦄ :=
       Derivation.cast b.derivation (by simp [Sequent.embed, add_comm])
-    exact (OneSidedLK.removeBot db).weakening.cast (by
-      simp [OneSidedLK.Pullback, Sequent.embed, add_comm])
+    exact ((OneSidedLK.removeBot db).weakening (φ := Rewriting.emb φ)).cast (by
+      simp [Sequent.embed, add_comm])
 
 lemma weakerThan_of_le {T U : Theory L} (h : T ⊆ U) : T ⪯ U :=
   Entailment.Axiomatized.weakerThanOfSubset h
@@ -502,7 +506,8 @@ lemma inconsistent_iff :
       d.cast (by rw [add_comm])
     exact ⟨Γ, hΓ, ⟨OneSidedLK.removeBot db⟩⟩
   · rintro ⟨Γ, hΓ, ⟨d⟩⟩
-    exact ⟨Γ, hΓ, ⟨d.weakening.cast (by simp [add_comm])⟩⟩
+    exact ⟨Γ, hΓ, ⟨(d.weakening (φ := Rewriting.emb (⊥ : Sentence L))).cast
+      (by simp [add_comm])⟩⟩
 
 open Entailment Derivation
 
@@ -552,10 +557,11 @@ noncomputable instance : Entailment.Deduction (Theory L) where
       simpa [hnχ] using b.axioms_mem χ hχ
     · exact Derivation.cast (Derivation.or (Γ := (∼Γ).map Rewriting.emb)
         (φ := Rewriting.emb (∼φ)) (ψ := Rewriting.emb ψ)
-        (b.derivation.contra
+        (contra (L := L) b.derivation
           (Γ := (∼Γ).map Rewriting.emb +
             ⦃Rewriting.emb (∼φ), Rewriting.emb ψ⦄)
-          default
+          (default : ((∼Γ).map Rewriting.emb +
+            ⦃Rewriting.emb (∼φ), Rewriting.emb ψ⦄).Traversal)
           (by simpa [OneSidedLK.Pullback, Multiset.tilde_def, Γ, add_assoc] using
             Multiset.map_subset_map (f := Rewriting.emb) <|
               Multiset.add_map_subset_map_filter_add_atom

--- a/Foundation/FirstOrder/Basic/Calculus.lean
+++ b/Foundation/FirstOrder/Basic/Calculus.lean
@@ -129,13 +129,6 @@ instance : Structural (Derivation (L := L)) where
   weakening d := d.weakening
   contraction d := d.contraction
 
-private lemma unshift_shift (φ : Proposition L) :
-    Rew.rewriteMap Nat.pred ▹ Rewriting.shift φ = φ := by
-  change Rew.rewriteMap Nat.pred ▹ (Rew.rewriteMap Nat.succ ▹ φ) = φ;
-  rw [← TransitiveRewriting.comp_app, Rew.rewriteMap_comp_rewriteMap];
-  change Rew.rewriteMap id ▹ φ = φ;
-  simp;
-
 /-- Enumerates the end sequent by recursion on the local inference rules.
 This is a routine syntactic construction. -/
 def traversal [L.DecidableEq] : {Γ : Sequent L} → (⊢ᴸᴷ¹ Γ) → Γ.Traversal
@@ -150,7 +143,7 @@ def traversal [L.DecidableEq] : {Γ : Sequent L} → (⊢ᴸᴷ¹ Γ) → Γ.Tra
   | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
   | _, all (Γ := Γ) (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
-        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])).succ (∀¹ φ)
+        simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∀¹ φ)
   | _, exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
 
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
@@ -158,16 +151,6 @@ def contra [L.DecidableEq] (d : ⊢ᴸᴷ¹ Δ) (t : Γ.Traversal)
     (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ¹ Γ :=
   Structural.ofSubset (F := Proposition L) (𝔇 := Derivation (L := L))
     (Γ := Δ) (Δ := Γ) (traversal (L := L) d) t d h
-
-def top [L.DecidableEq] (t : Δ.Traversal) (h : ⊤ ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  contra (L := L) verum t (by simpa using h)
-
-def identity' [L.DecidableEq] (r : L.Rel k) (v) (t : Δ.Traversal)
-    (hpos : Semiformula.rel r v ∈ Δ := by simp)
-    (hneg : Semiformula.nrel r v ∈ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  contra (L := L) (identity r v) t <| by
-    intro φ hφ
-    rcases Multiset.mem_add.mp hφ with hφ | hφ <;> simp_all
 
 def tensor {φ ψ} (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
     (dφ : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (dψ : ⊢ᴸᴷ¹ Δ + ⦃ψ⦄) :
@@ -322,33 +305,6 @@ def generalizeByNewVar {φ : Semiproposition L 1} (hp : ¬φ.FVar? m)
     Derivation.cast (Derivation.map d (fun x ↦ if x = m then 0 else x + 1))
     (by simp [map_subst_eq_free φ hp, map_rewriteMap_eq_shifts Δ hΔ])
   exact all this
-
-def exOfInstances (v : List (SyntacticTerm L)) (φ : Semiproposition L 1)
-    (h : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + Γ) : ⊢ᴸᴷ¹ Γ + ⦃∃¹ φ⦄ := by
-  induction' v with t v ih generalizing Γ
-  · exact (h.cast (by simp)).weakening
-  · have d : ⊢ᴸᴷ¹ ((v.map (φ/[·]) : Multiset _) + Γ) + ⦃∃¹ φ⦄ :=
-      exs (t := t) (h.cast (by
-        change (φ/[t] ::ₘ (v.map (φ/[·]) : Multiset _)) + Γ =
-          ((v.map (φ/[·]) : Multiset _) + Γ) + ⦃φ/[t]⦄
-        rw [← Multiset.add_atom_eq_cons]
-        abel))
-    have d : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + (Γ + ⦃∃¹ φ⦄) :=
-      d.cast (by simp [add_assoc, add_left_comm, add_comm])
-    exact ((ih d).cast (by abel)).contraction
-
-def exOfInstances' (v : List (SyntacticTerm L)) (φ : Semiproposition L 1)
-    (h : ⊢ᴸᴷ¹ (v.map (φ/[·]) : Multiset _) + Γ + ⦃∃¹ φ⦄) :
-    ⊢ᴸᴷ¹ Γ + ⦃∃¹ φ⦄ :=
-  ((exOfInstances (Γ := Γ + ⦃∃¹ φ⦄) v φ
-    (h.cast (by simp [add_assoc]))).cast (by abel)).contraction
-
-def allNvar [L.DecidableEq] {Δ : Sequent L} {φ} (h : ∀¹ φ ∈ Δ) :
-    ⊢ᴸᴷ¹ Δ + ⦃φ/[&Δ.newVar]⦄ → ⊢ᴸᴷ¹ Δ := fun b ↦
-  let b : ⊢ᴸᴷ¹ Δ + ⦃∀¹ φ⦄ :=
-    b.generalizeByNewVar (by simpa [Semiformula.FVar?] using Sequent.not_fvar?_newVar h)
-      (fun _ ↦ Sequent.not_fvar?_newVar)
-  Structural.absorb b h
 
 end Derivation
 

--- a/Foundation/FirstOrder/Basic/Calculus2.lean
+++ b/Foundation/FirstOrder/Basic/Calculus2.lean
@@ -32,7 +32,7 @@ abbrev _root_.FFL.FirstOrder.Theory.Proof2 (T : Theory L) (φ : Proposition L) :
 
 scoped infix: 45 " ⊢₂! " => Theory.Proof2
 
-variable {T : Theory L}
+variable {T : Theory L} {Γ : Sequent L} {φ : Proposition L}
 
 lemma shifts_toFinset_eq_image_shift (Γ : Sequent L) :
     Γ⁺.toFinset = Γ.toFinset.image Rewriting.shift := by ext φ; simp [Rewriting.shifts]
@@ -70,7 +70,8 @@ def Derivation.toDerivation2 (T) {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → T ⟹₂ 
 /-- Contracts a principal formula already present in the side context.
 This is a routine structural derivation. -/
 def Derivation.absorb (d : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (h : φ ∈ Γ) : ⊢ᴸᴷ¹ Γ :=
-  Structural.absorb d h
+  Structural.absorb (F := Proposition L) (𝔇 := Derivation (L := L))
+    (Γ := Γ) (φ := φ) d h
 
 namespace Derivation2
 

--- a/Foundation/FirstOrder/Basic/Calculus2.lean
+++ b/Foundation/FirstOrder/Basic/Calculus2.lean
@@ -19,7 +19,7 @@ inductive Derivation2 (T : Theory L) : Finset (Proposition L) → Type _
 | all {Γ} {φ : Semiproposition L 1} : ∀¹ φ ∈ Γ → Derivation2 T (insert (Rewriting.free φ) (Γ.image Rewriting.shift)) → Derivation2 T Γ
 | exs {Γ} {φ : Semiproposition L 1} : ∃¹ φ ∈ Γ → (t : SyntacticTerm L) → Derivation2 T (insert (φ/[t]) Γ) → Derivation2 T Γ
 | wk {Δ Γ} : Derivation2 T Δ → Δ ⊆ Γ → Derivation2 T Γ
-| shift {Γ}   : Derivation2 T Γ → Derivation2 T (Γ.image Rewriting.shift)
+| shift {Γ} : Derivation2 T Γ → Derivation2 T (Γ.image Rewriting.shift)
 | cut {Γ φ} : Derivation2 T (insert φ Γ) → Derivation2 T (insert (∼φ) Γ) → Derivation2 T Γ
 
 scoped infix:45 " ⟹₂" => Derivation2
@@ -105,20 +105,20 @@ omit [L.DecidableEq] in
         go l (by simp_all) c
   go A.toList (by simpa using hA) <| Derivation2.cast d (by ext x; simp)
 
-noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ →
+noncomputable def toProofData {Γ : Finset (Proposition L)} : T ⟹₂ Γ →
     ProofData T Γ
-  | Γ, closed _ φ hp hn =>
+  | closed _ φ hp hn =>
       ⟨0, by simp, (Derivation.eta φ).contra default (by
         intro x hx
         rcases Multiset.mem_add.mp hx with hx | hx <;> simp_all)⟩
-  | Γ, axm φ hT hΓ =>
+  | axm φ hT hΓ =>
       ⟨⦃φ⦄, by simp [hT],
         (Derivation.eta (φ : Proposition L)).contra default (by
           intro x hx
           rcases Multiset.mem_add.mp hx with hx | hx <;> simp_all)⟩
-  | Γ, verum h =>
+  | verum h =>
       ⟨0, by simp, Derivation.verum.contra default (by intro x hx; simp_all)⟩
-  | Γ, and (φ := φ) (ψ := ψ) h dφ dψ => by
+  | and (φ := φ) (ψ := ψ) h dφ dψ => by
       rcases toProofData dφ with ⟨A, hA, bφ⟩
       rcases toProofData dψ with ⟨B, hB, bψ⟩
       refine ⟨A + B, by simp; grind, ?_⟩
@@ -127,13 +127,13 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
       have bψ' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃ψ⦄ :=
         bψ.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       exact Structural.absorb (Derivation.and bφ' bψ') (Multiset.mem_add.mpr <| Or.inl h)
-  | Γ, or (φ := φ) (ψ := ψ) h d => by
+  | or (φ := φ) (ψ := ψ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ, ψ⦄ :=
         b.contra default (by intro x hx; simp_all; aesop)
       exact Structural.absorb (Derivation.or b') (Multiset.mem_add.mpr <| Or.inl h)
-  | Γ, all (φ := φ) h d => by
+  | all (φ := φ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A)⁺ + ⦃Rewriting.free φ⦄ :=
@@ -143,22 +143,22 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
           simp [Rewriting.shifts] at hx ⊢
           aesop)
       exact Structural.absorb (Derivation.all b') (Multiset.mem_add.mpr <| Or.inl h)
-  | Γ, exs (φ := φ) h t d => by
+  | exs (φ := φ) h t d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ/[t]⦄ :=
         b.contra default (by intro x hx; simp_all; aesop)
       exact Structural.absorb (Derivation.exs (t := t) b') (Multiset.mem_add.mpr <| Or.inl h)
-  | Γ, wk d h => by
+  | wk d h => by
       rcases toProofData d with ⟨A, hA, b⟩
       exact ⟨A, hA, b.contra default (by intro x hx; simp_all; aesop)⟩
-  | _, shift (Γ := Γ) d => by
+  | shift (Γ := Γ) d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, b.shift.contra default ?_⟩
       rw [Rewriting.shifts_add, shifts_tilde_embed]
       intro x hx
       simpa [Rewriting.shifts] using hx
-  | Γ, cut (φ := φ) d dn => by
+  | cut (φ := φ) d dn => by
       rcases toProofData d with ⟨A, hA, b⟩
       rcases toProofData dn with ⟨B, hB, bn⟩
       refine ⟨A + B, by simp; grind, ?_⟩

--- a/Foundation/FirstOrder/Basic/Calculus2.lean
+++ b/Foundation/FirstOrder/Basic/Calculus2.lean
@@ -67,12 +67,6 @@ def Derivation.toDerivation2 (T) {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → T ⟹₂ 
       (Derivation2.wk (Derivation.toDerivation2 T d₁) (by intro x hx; simp_all; tauto))
       (Derivation2.wk (Derivation.toDerivation2 T d₂) (by intro x hx; simp_all; tauto))
 
-/-- Contracts a principal formula already present in the side context.
-This is a routine structural derivation. -/
-def Derivation.absorb (d : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (h : φ ∈ Γ) : ⊢ᴸᴷ¹ Γ :=
-  Structural.absorb (F := Proposition L) (𝔇 := Derivation (L := L))
-    (Γ := Γ) (φ := φ) d h
-
 namespace Derivation2
 
 structure ProofData (T : Theory L) (Γ : Finset (Proposition L)) where
@@ -132,13 +126,13 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
         bφ.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       have bψ' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃ψ⦄ :=
         bψ.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
-      exact (Derivation.and bφ' bψ').absorb (Multiset.mem_add.mpr <| Or.inl h)
+      exact Structural.absorb (Derivation.and bφ' bψ') (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, or (φ := φ) (ψ := ψ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ, ψ⦄ :=
         b.contra default (by intro x hx; simp_all; aesop)
-      exact (Derivation.or b').absorb (Multiset.mem_add.mpr <| Or.inl h)
+      exact Structural.absorb (Derivation.or b') (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, all (φ := φ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
@@ -148,13 +142,13 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
           intro x hx
           simp [Rewriting.shifts] at hx ⊢
           aesop)
-      exact (Derivation.all b').absorb (Multiset.mem_add.mpr <| Or.inl h)
+      exact Structural.absorb (Derivation.all b') (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, exs (φ := φ) h t d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ/[t]⦄ :=
         b.contra default (by intro x hx; simp_all; aesop)
-      exact (Derivation.exs (t := t) b').absorb (Multiset.mem_add.mpr <| Or.inl h)
+      exact Structural.absorb (Derivation.exs (t := t) b') (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, wk d h => by
       rcases toProofData d with ⟨A, hA, b⟩
       exact ⟨A, hA, b.contra default (by intro x hx; simp_all; aesop)⟩

--- a/Foundation/FirstOrder/Basic/Calculus2.lean
+++ b/Foundation/FirstOrder/Basic/Calculus2.lean
@@ -58,8 +58,10 @@ def Derivation.toDerivation2 (T) {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → T ⟹₂ 
   | Derivation.exs (Γ := Γ) (φ := φ) (t := t) dp =>
     Derivation2.exs (φ := φ) (by simp) t
       (Derivation2.wk (Derivation.toDerivation2 T dp) (by intro x hx; simp_all; tauto))
-  | Derivation.contraction d h =>
-    Derivation2.wk (Derivation.toDerivation2 T d) (Multiset.toFinset_subset.mpr h)
+  | Derivation.contraction d =>
+    Derivation2.wk (Derivation.toDerivation2 T d) (by intro x hx; simpa using hx)
+  | Derivation.weakening d =>
+    Derivation2.wk (Derivation.toDerivation2 T d) (by intro x hx; simp_all)
   | Derivation.cut (Γ := Γ) (Δ := Δ) (φ := φ) d₁ d₂ =>
     Derivation2.cut (φ := φ)
       (Derivation2.wk (Derivation.toDerivation2 T d₁) (by intro x hx; simp_all; tauto))
@@ -68,9 +70,7 @@ def Derivation.toDerivation2 (T) {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → T ⟹₂ 
 /-- Contracts a principal formula already present in the side context.
 This is a routine structural derivation. -/
 def Derivation.absorb (d : ⊢ᴸᴷ¹ Γ + ⦃φ⦄) (h : φ ∈ Γ) : ⊢ᴸᴷ¹ Γ :=
-  d.contra <| by
-    intro ψ hψ
-    rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all
+  Structural.absorb d h
 
 namespace Derivation2
 
@@ -113,36 +113,36 @@ omit [L.DecidableEq] in
 noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ →
     ProofData T Γ
   | Γ, closed _ φ hp hn =>
-      ⟨0, by simp, (Derivation.eta φ).contra (by
+      ⟨0, by simp, (Derivation.eta φ).contra default (by
         intro x hx
         rcases Multiset.mem_add.mp hx with hx | hx <;> simp_all)⟩
   | Γ, axm φ hT hΓ =>
       ⟨⦃φ⦄, by simp [hT],
-        (Derivation.eta (φ : Proposition L)).contra (by
+        (Derivation.eta (φ : Proposition L)).contra default (by
           intro x hx
           rcases Multiset.mem_add.mp hx with hx | hx <;> simp_all)⟩
   | Γ, verum h =>
-      ⟨0, by simp, Derivation.verum.contra (by intro x hx; simp_all)⟩
+      ⟨0, by simp, Derivation.verum.contra default (by intro x hx; simp_all)⟩
   | Γ, and (φ := φ) (ψ := ψ) h dφ dψ => by
       rcases toProofData dφ with ⟨A, hA, bφ⟩
       rcases toProofData dψ with ⟨B, hB, bψ⟩
       refine ⟨A + B, by simp; grind, ?_⟩
       have bφ' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃φ⦄ :=
-        bφ.contra (by intro x hx; simp_all [Sequent.embed]; aesop)
+        bφ.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       have bψ' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃ψ⦄ :=
-        bψ.contra (by intro x hx; simp_all [Sequent.embed]; aesop)
+        bψ.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       exact (Derivation.and bφ' bψ').absorb (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, or (φ := φ) (ψ := ψ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ, ψ⦄ :=
-        b.contra (by intro x hx; simp_all; aesop)
+        b.contra default (by intro x hx; simp_all; aesop)
       exact (Derivation.or b').absorb (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, all (φ := φ) h d => by
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A)⁺ + ⦃Rewriting.free φ⦄ :=
-        b.contra (by
+        b.contra default (by
           rw [Rewriting.shifts_add, shifts_tilde_embed]
           intro x hx
           simp [Rewriting.shifts] at hx ⊢
@@ -152,14 +152,14 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
       rcases toProofData d with ⟨A, hA, b⟩
       refine ⟨A, hA, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed A) + ⦃φ/[t]⦄ :=
-        b.contra (by intro x hx; simp_all; aesop)
+        b.contra default (by intro x hx; simp_all; aesop)
       exact (Derivation.exs (t := t) b').absorb (Multiset.mem_add.mpr <| Or.inl h)
   | Γ, wk d h => by
       rcases toProofData d with ⟨A, hA, b⟩
-      exact ⟨A, hA, b.contra (by intro x hx; simp_all; aesop)⟩
+      exact ⟨A, hA, b.contra default (by intro x hx; simp_all; aesop)⟩
   | _, shift (Γ := Γ) d => by
       rcases toProofData d with ⟨A, hA, b⟩
-      refine ⟨A, hA, b.shift.contra ?_⟩
+      refine ⟨A, hA, b.shift.contra default ?_⟩
       rw [Rewriting.shifts_add, shifts_tilde_embed]
       intro x hx
       simpa [Rewriting.shifts] using hx
@@ -168,11 +168,11 @@ noncomputable def toProofData : {Γ : Finset (Proposition L)} → T ⟹₂ Γ �
       rcases toProofData dn with ⟨B, hB, bn⟩
       refine ⟨A + B, by simp; grind, ?_⟩
       have b' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃φ⦄ :=
-        b.contra (by intro x hx; simp_all [Sequent.embed]; aesop)
+        b.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       have bn' : ⊢ᴸᴷ¹ (Γ.1 + ∼Sequent.embed (A + B)) + ⦃∼φ⦄ :=
-        bn.contra (by intro x hx; simp_all [Sequent.embed]; aesop)
+        bn.contra default (by intro x hx; simp_all [Sequent.embed]; aesop)
       exact (Derivation.cut (Γ := Γ.1 + ∼Sequent.embed (A + B))
-        (Δ := Γ.1 + ∼Sequent.embed (A + B)) (φ := φ) b' bn').contra
+        (Δ := Γ.1 + ∼Sequent.embed (A + B)) (φ := φ) b' bn').contra default
         (by intro x hx; simp_all)
 
 end Derivation2

--- a/Foundation/FirstOrder/Basic/CutFree.lean
+++ b/Foundation/FirstOrder/Basic/CutFree.lean
@@ -23,7 +23,8 @@ inductive IsCutFree : {Γ : Sequent L} → ⊢ᴸᴷ¹ Γ → Prop
       IsCutFree dφ → IsCutFree dψ → IsCutFree (dφ.and dψ)
   | all {d : ⊢ᴸᴷ¹ Γ⁺ + ⦃Rewriting.free φ⦄} : IsCutFree d → IsCutFree d.all
   | exs (t) {d : ⊢ᴸᴷ¹ Γ + ⦃φ/[t]⦄} : IsCutFree d → IsCutFree d.exs
-  | contraction {d : ⊢ᴸᴷ¹ Δ} (ss : Δ ⊆ Γ) : IsCutFree d → IsCutFree (d.contraction ss)
+  | contraction {d : ⊢ᴸᴷ¹ Γ + ⦃φ, φ⦄} : IsCutFree d → IsCutFree d.contraction
+  | weakening {d : ⊢ᴸᴷ¹ Γ} : IsCutFree d → IsCutFree (d.weakening (φ := φ))
 
 attribute [simp] IsCutFree.identity IsCutFree.verum
 
@@ -35,7 +36,7 @@ variable {Γ Δ : Sequent L}
   · intro h
     refine h.rec
       (motive := fun {_} d _ ↦ match d with | .or d => IsCutFree d | _ => True)
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     all_goals simp_all
   · exact .or
 
@@ -46,7 +47,7 @@ variable {Γ Δ : Sequent L}
     refine h.rec
       (motive := fun {_} d _ ↦
         match d with | .and dφ dψ => IsCutFree dφ ∧ IsCutFree dψ | _ => True)
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     all_goals simp_all
   · rintro ⟨hφ, hψ⟩
     exact hφ.and hψ
@@ -56,7 +57,7 @@ variable {Γ Δ : Sequent L}
   constructor
   · intro h
     refine h.rec (motive := fun {_} d _ ↦ match d with | .all d => IsCutFree d | _ => True)
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     all_goals simp_all
   · exact .all
 
@@ -65,19 +66,27 @@ variable {Γ Δ : Sequent L}
   constructor
   · intro h
     refine h.rec (motive := fun {_} d _ ↦ match d with | .exs d => IsCutFree d | _ => True)
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     all_goals simp_all
   · exact .exs t
 
-@[simp] lemma isCutFree_contraction_iff {d : ⊢ᴸᴷ¹ Δ} {ss : Δ ⊆ Γ} :
-    IsCutFree (d.contraction ss) ↔ IsCutFree d := by
+@[simp] lemma isCutFree_contraction_iff {d : ⊢ᴸᴷ¹ Γ + ⦃φ, φ⦄} :
+    IsCutFree d.contraction ↔ IsCutFree d := by
   constructor
   · intro h
     refine h.rec
-      (motive := fun {_} d _ ↦ match d with | .contraction d _ => IsCutFree d | _ => True)
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
+      (motive := fun {_} d _ ↦ match d with | .contraction d => IsCutFree d | _ => True)
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     all_goals simp_all
-  · exact .contraction _
+  · exact .contraction
+
+@[simp] lemma isCutFree_weakening_iff {d : ⊢ᴸᴷ¹ Γ} :
+    IsCutFree (d.weakening (φ := φ)) ↔ IsCutFree d := by
+  constructor;
+  . intro h;
+    cases h with
+    | weakening h => exact h;
+  . exact .weakening;
 
 @[simp] lemma IsCutFree.cast {d : ⊢ᴸᴷ¹ Γ} {e : Γ = Δ} :
     IsCutFree (.cast d e) ↔ IsCutFree d := by rcases e; rfl
@@ -87,7 +96,7 @@ variable {Γ Δ : Sequent L}
   intro h
   refine h.rec
     (motive := fun {_} d _ ↦ match d with | .cut _ _ => False | _ => True)
-    ?_ ?_ ?_ ?_ ?_ ?_ ?_
+    ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
   all_goals simp
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Foundation/FirstOrder/Basic/CutFree.lean
+++ b/Foundation/FirstOrder/Basic/CutFree.lean
@@ -84,8 +84,10 @@ variable {Γ Δ : Sequent L}
     IsCutFree (d.weakening (φ := φ)) ↔ IsCutFree d := by
   constructor;
   . intro h;
-    cases h with
-    | weakening h => exact h;
+    refine h.rec
+      (motive := fun {_} d _ ↦ match d with | .weakening d => IsCutFree d | _ => True)
+      ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_;
+    all_goals simp_all;
   . exact .weakening;
 
 @[simp] lemma IsCutFree.cast {d : ⊢ᴸᴷ¹ Γ} {e : Γ = Δ} :

--- a/Foundation/FirstOrder/Basic/Soundness.lean
+++ b/Foundation/FirstOrder/Basic/Soundness.lean
@@ -52,10 +52,10 @@ lemma sound {M : Type*} [s : Structure L M] [Nonempty M] (f : ℕ → M) {Γ : S
     rcases this with (⟨ψ, hq, hhq⟩ | hp)
     · exact ⟨ψ, by simp [hq], hhq⟩
     · exact ⟨∃¹ φ, by simp, t.val ![] f, hp⟩
-  | contraction (Δ := Δ) (Γ := Γ) d ss => by
-    have : ∃ φ ∈ Δ, Evalf f φ := sound f d
-    rcases this with ⟨φ, hp, h⟩
-    exact ⟨φ, ss hp, h⟩
+  | contraction d => by simpa using sound f d
+  | weakening d => by
+    obtain ⟨φ, hp, h⟩ := sound f d;
+    exact ⟨φ, Multiset.mem_add.mpr (.inl hp), h⟩;
   | cut (Γ := Γ) (Δ := Δ) (φ := φ) d dn => by
     have h : (∃ ψ ∈ Γ, Evalf f ψ) ∨ Evalf f φ := by simpa using sound f d
     have hn : (∃ ψ ∈ Δ, Evalf f ψ) ∨ ¬Evalf f φ := by simpa using sound f dn

--- a/Foundation/FirstOrder/Completeness/CanonicalModel.lean
+++ b/Foundation/FirstOrder/Completeness/CanonicalModel.lean
@@ -29,7 +29,7 @@ namespace ConsistentSequent
 
 instance : Preorder ℙ where
   le q p := Nonempty (q.val ≼ p.val)
-  le_refl p := ⟨StrongerThan.refl p.val default⟩
+  le_refl p := ⟨StrongerThan.refl p.val⟩
   le_trans _ _ _ hqp hrq := ⟨hqp.some.trans hrq.some⟩
 
 def nil : ℙ := ⟨0, by simp⟩

--- a/Foundation/FirstOrder/Completeness/CanonicalModel.lean
+++ b/Foundation/FirstOrder/Completeness/CanonicalModel.lean
@@ -15,6 +15,8 @@ namespace FFL.FirstOrder.Derivation.Canonical
 
 variable {L : Language}
 
+open Classical
+
 variable (L)
 
 def ConsistentSequent := {Γ : Sequent L // IsEmpty (⊢ᴸᴷ¹ ∼Γ)}
@@ -27,7 +29,7 @@ namespace ConsistentSequent
 
 instance : Preorder ℙ where
   le q p := Nonempty (q.val ≼ p.val)
-  le_refl p := ⟨StrongerThan.refl p.val⟩
+  le_refl p := ⟨StrongerThan.refl p.val default⟩
   le_trans _ _ _ hqp hrq := ⟨hqp.some.trans hrq.some⟩
 
 def nil : ℙ := ⟨0, by simp⟩
@@ -36,7 +38,7 @@ instance : OrderTop ℙ where
   top := nil
   le_top := by
     rintro ⟨Γ, hΓ⟩
-    exact ⟨StrongerThan.ofSubset <| by simp [nil]⟩
+    exact ⟨StrongerThan.ofSubset default default <| by simp [nil]⟩
 
 def ofUnprovable (φ : Proposition L) (h : 𝐋𝐊¹ ⊬ ∼φ) : ℙ := ⟨⦃φ⦄, by simpa [LK.Proof.unprovable_def] using h⟩
 
@@ -47,8 +49,6 @@ abbrev IsForced (p : ℙ) (φ : Propositionᵢ L) := Nonempty (Forces p.val φ)
 instance : ForcingRelation ℙ (Propositionᵢ L) := ⟨IsForced⟩
 
 instance : WeakForcingRelation ℙ (Proposition L) := ⟨fun p φ ↦ p ⊩ φᴺ⟩
-
-open Classical
 
 namespace IsForced
 
@@ -127,7 +127,7 @@ instance : ForcingRelation.IntKripke ℙ (· ≥ ·) where
   monotone hφ _ hpq := hφ.monotone hpq
 
 lemma sound [L.DecidableEq] {φ : Propositionᵢ L} : 𝐋𝐉¹ ⊢ φ → ℙ ∀⊩ φ := by
-  rintro ⟨d⟩ p; exact ⟨Forces.ljSound d p.val⟩
+  rintro ⟨d⟩ p; exact ⟨Forces.ljSound d p.val default⟩
 
 end IsForced
 
@@ -142,9 +142,9 @@ lemma dn_neg_iff {φ : Proposition L} {p : ℙ} : p ⊩ᶜ ∼φ ↔ p ⊩ ∼φ
   have e := LJ.Derivation.negDoubleNegation φ
   constructor
   · rintro ⟨h⟩
-    exact ⟨Forces.sound e.2 p.val fun ψ hψ ↦ h.cast (Multiset.mem_atom_iff.mp hψ).symm⟩
+    exact ⟨Forces.sound e.2 p.val default fun ψ hψ ↦ h.cast (Multiset.mem_atom_iff.mp hψ).symm⟩
   · rintro ⟨h⟩
-    exact ⟨Forces.sound e.1 p.val fun ψ hψ ↦ h.cast (Multiset.mem_atom_iff.mp hψ).symm⟩
+    exact ⟨Forces.sound e.1 p.val default fun ψ hψ ↦ h.cast (Multiset.mem_atom_iff.mp hψ).symm⟩
 
 @[simp] lemma verum (p : ℙ) : p ⊩ᶜ ⊤ := by simp [iff_isForced, IsForced.not]
 

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -22,55 +22,72 @@ inductive Positive (Ξ : Sequent L) : Sequent L → Type _
 | or : Positive Ξ (Γ + ⦃φ, ψ⦄) → Positive Ξ (Γ + ⦃φ ⋎ ψ⦄)
 | exs : Positive Ξ (Γ + ⦃φ/[t]⦄) → Positive Ξ (Γ + ⦃∃¹ φ⦄)
 
-/--/
-inductive Positive (Ξ : Sequent L) : Sequent L → Type _
-| or : Positive Ξ (Γ + ⦃φ, ψ⦄) → Positive Ξ (Γ + ⦃φ ⋎ ψ⦄)
-| exs : Positive Ξ (Γ + ⦃φ/[t]⦄) → Positive Ξ (Γ + ⦃∃¹ φ⦄)
-| contraction : Positive Ξ Δ → Δ ⊆ Γ → Positive Ξ Γ
-| protected id : Positive Ξ Ξ
-
 infix:45 " ⟶⁺ " => Positive
 
 namespace Positive
 
 variable {Ξ Γ Δ : Sequent L}
 
-def ofSubset (ss : Ξ ⊆ Γ) : Ξ ⟶⁺ Γ := contraction .id ss
+/-- Recovers the traversal stored at the source of a positive derivation. -/
+def sourceTraversal : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Ξ.Traversal
+  | _, .refl t => t
+  | _, .weakening d | _, .contraction d | _, .or d | _, .exs d => d.sourceTraversal
+
+/-- Enumerates the target of a positive derivation. -/
+def traversal [L.DecidableEq] : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Γ.Traversal
+  | _, .refl t => t
+  | _, .weakening (φ := φ) d => d.traversal.succ φ
+  | _, .contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | _, .or (φ := φ) (ψ := ψ) d =>
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
+  | _, .exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+
+instance : Structural (Positive Ξ) where
+  weakening d := d.weakening
+  contraction d := d.contraction
+
+def ofSubset [L.DecidableEq] (tΞ : Ξ.Traversal) (tΓ : Γ.Traversal)
+    (ss : Ξ ⊆ Γ) : Ξ ⟶⁺ Γ :=
+  Structural.ofSubset (F := Proposition L) (𝔇 := Positive Ξ)
+    (Γ := Ξ) (Δ := Γ) tΞ tΓ (.refl tΞ) ss
 
 def trans {Ξ Γ Δ : Sequent L} : Ξ ⟶⁺ Γ → Γ ⟶⁺ Δ → Ξ ⟶⁺ Δ
   | b,    or d => or (b.trans d)
   | b,   exs d => exs (b.trans d)
-  | b,  contraction d h => contraction (b.trans d) h
-  | b,     .id => b
+  | b, weakening d => weakening (b.trans d)
+  | b, contraction d => contraction (b.trans d)
+  | b, .refl _ => b
 
 def cast {Ξ Γ Ξ' Γ' : Sequent L} (d : Ξ ⟶⁺ Γ)
     (hΞ : Ξ = Ξ' := by abel) (hΓ : Γ = Γ' := by abel) : Ξ' ⟶⁺ Γ' :=
   hΞ ▸ hΓ ▸ d
 
-def addLeft (Δ : Sequent L) : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
+def addLeft [L.DecidableEq] (tΔ : Δ.Traversal) : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
   | _, or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
       cast (.or (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (ψ := ψ)
-        (cast (addLeft Δ d)))
+        (cast (addLeft tΔ d)))
   | _, exs (Γ := Γ) (φ := φ) (t := t) d =>
       cast (.exs (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (t := t)
-        (cast (addLeft Δ d)))
-  | _, contraction d h => contraction (addLeft Δ d) <| by
-      intro φ hφ
-      simp only [Multiset.mem_add] at *
-      tauto
-  | _, .id => .id
+        (cast (addLeft tΔ d)))
+  | _, weakening (φ := φ) d => cast (.weakening (φ := φ) (addLeft tΔ d))
+  | _, contraction (Γ := Γ) (φ := φ) d =>
+      cast (.contraction (Γ := Δ + Γ) (φ := φ)
+        (cast (addLeft tΔ d) (hΞ := rfl) (hΓ := by abel)))
+  | _, .refl t => .refl (tΔ.add t)
 
-def cons (φ) (d : Ξ ⟶⁺ Γ) : Ξ + ⦃φ⦄ ⟶⁺ Γ + ⦃φ⦄ :=
-  cast (addLeft ⦃φ⦄ d)
+def cons [L.DecidableEq] (φ) (d : Ξ ⟶⁺ Γ) : Ξ + ⦃φ⦄ ⟶⁺ Γ + ⦃φ⦄ :=
+  cast (addLeft (.atom φ) d)
 
-def add {Γ Δ Ξ Θ : Sequent L} (d : Γ ⟶⁺ Δ) (b : Ξ ⟶⁺ Θ) : Γ + Ξ ⟶⁺ Δ + Θ :=
-  (addLeft Γ b).trans (cast (addLeft Θ d))
+def add [L.DecidableEq] {Γ Δ Ξ Θ : Sequent L} (d : Γ ⟶⁺ Δ) (b : Ξ ⟶⁺ Θ) :
+    Γ + Ξ ⟶⁺ Δ + Θ :=
+  (addLeft d.sourceTraversal b).trans (cast (addLeft b.traversal d))
 
 def graft {Ξ Γ : Sequent L} (b : ⊢ᴸᴷ¹ Ξ) : Ξ ⟶⁺ Γ → ⊢ᴸᴷ¹ Γ
   |    or d => .or (d.graft b)
   |   exs d => .exs (d.graft b)
-  |  contraction d h => .contraction (d.graft b) h
-  |     .id => b
+  | weakening d => .weakening (d.graft b)
+  | contraction d => .contraction (d.graft b)
+  | .refl _ => b
 
 lemma graft_isCutFree_of_isCutFree {b : ⊢ᴸᴷ¹ Ξ} {d : Ξ ⟶⁺ Γ} (hb : Derivation.IsCutFree b) : Derivation.IsCutFree (d.graft b) := by
   induction d <;> simp [graft, *]
@@ -81,6 +98,8 @@ namespace Canonical
 
 open Semiformulaᵢ
 
+variable [L.DecidableEq]
+
 structure StrongerThan (q p : Sequent L) where
   val : ∼p ⟶⁺ ∼q
 
@@ -88,47 +107,66 @@ scoped infix:60 " ≼ " => StrongerThan
 
 scoped instance : Min (Sequent L) := ⟨fun p q ↦ p + q⟩
 
+omit [L.DecidableEq] in
 lemma inf_def (p q : Sequent L) : p ⊓ q = p + q := rfl
 
+omit [L.DecidableEq] in
 @[simp] lemma neg_inf_p_eq (p q : Sequent L) : ∼(p ⊓ q) = ∼p ⊓ ∼q := Multiset.map_add _ _ _
 
 namespace StrongerThan
 
-protected def refl (p : Sequent L) : p ≼ p := ⟨.id⟩
+protected def refl (p : Sequent L) (t : (∼p).Traversal) : p ≼ p := ⟨.refl t⟩
 
 def trans {r q p : Sequent L} (srq : r ≼ q) (sqp : q ≼ p) : r ≼ p := ⟨sqp.val.trans srq.val⟩
 
-def ofSubset {q p : Sequent L} (h : q ⊇ p) : q ≼ p := ⟨.ofSubset <| Multiset.map_subset_map h⟩
+def ofSubset {q p : Sequent L} (tp : (∼p).Traversal) (tq : (∼q).Traversal)
+    (h : q ⊇ p) : q ≼ p :=
+  ⟨.ofSubset tp tq <| Multiset.map_subset_map h⟩
 
-def and {p : Sequent L} (φ ψ : Proposition L) : p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ, ψ⦄ := by
-  let d : ∼p + ⦃∼φ, ∼ψ⦄ ⟶⁺ ∼p + ⦃∼φ ⋎ ∼ψ⦄ := .or .id
+def and {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
+    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ, ψ⦄ := by
+  let t := (tp.succ (∼φ)).succ (∼ψ)
+  let d : ∼p + ⦃∼φ, ∼ψ⦄ ⟶⁺ ∼p + ⦃∼φ ⋎ ∼ψ⦄ :=
+    .or (.refl (t.cast (by abel)))
   exact ⟨d.cast (by simp) (by simp)⟩
 
-def K_left {p : Sequent L} (φ ψ : Proposition L) : p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ⦄ :=
-  trans (and φ ψ) (ofSubset <| by
+def K_left {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
+    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ⦄ :=
+  trans (and tp φ ψ) (ofSubset ((tp.succ (∼φ)).cast (by simp))
+    (((tp.succ (∼φ)).succ (∼ψ)).cast (by simp; abel)) <| by
     intro θ hθ
     simp only [Multiset.mem_add] at *
     tauto)
 
-def K_right {p : Sequent L} (φ ψ : Proposition L) : p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃ψ⦄ :=
-  trans (and φ ψ) (ofSubset <| by
+def K_right {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
+    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃ψ⦄ :=
+  trans (and tp φ ψ) (ofSubset ((tp.succ (∼ψ)).cast (by simp))
+    (((tp.succ (∼φ)).succ (∼ψ)).cast (by simp; abel)) <| by
     intro θ hθ
     simp only [Multiset.mem_add] at *
     tauto)
 
-def all {p : Sequent L} (φ : Semiproposition L 1) (t) : p + ⦃∀¹ φ⦄ ≼ p + ⦃φ/[t]⦄ := by
-  let d : ∼p + ⦃(∼φ)/[t]⦄ ⟶⁺ ∼p + ⦃∃¹ ∼φ⦄ := .exs .id
+def all {p : Sequent L} (tp : (∼p).Traversal) (φ : Semiproposition L 1) (t) :
+    p + ⦃∀¹ φ⦄ ≼ p + ⦃φ/[t]⦄ := by
+  let d : ∼p + ⦃(∼φ)/[t]⦄ ⟶⁺ ∼p + ⦃∃¹ ∼φ⦄ := .exs (.refl (tp.succ _))
   exact ⟨d.cast (by simp) (by simp)⟩
 
-def minLeLeft (p q : Sequent L) : p ⊓ q ≼ p := ofSubset (by intro φ hφ; simp_all [inf_def])
+def minLeLeft (p q : Sequent L) (tp : (∼p).Traversal) (tq : (∼q).Traversal) :
+    p ⊓ q ≼ p :=
+  ofSubset tp (by simpa [inf_def] using tp.add tq) (by intro φ hφ; simp_all [inf_def])
 
-def minLeRight (p q : Sequent L) : p ⊓ q ≼ q := ofSubset (by intro φ hφ; simp_all [inf_def])
+def minLeRight (p q : Sequent L) (tp : (∼p).Traversal) (tq : (∼q).Traversal) :
+    p ⊓ q ≼ q :=
+  ofSubset tq (by simpa [inf_def] using tp.add tq) (by intro φ hφ; simp_all [inf_def])
 
-def leMinOfle (srp : r ≼ p) (srq : r ≼ q) : r ≼ p ⊓ q := ⟨
-  let d : ∼p + ∼q ⟶⁺ ∼r := .contraction (srp.val.add srq.val) (by intro φ hφ; simp_all)
+def leMinOfle {r p q : Sequent L} (srp : r ≼ p) (srq : r ≼ q) : r ≼ p ⊓ q := ⟨
+  let d : ∼p + ∼q ⟶⁺ ∼r := Positive.cast
+    (Structural.contractMany (F := Proposition L) (𝔇 := Positive (∼p + ∼q))
+      (Δ := 0) srp.val.traversal (Positive.cast (srp.val.add srq.val)))
   neg_inf_p_eq _ _ ▸ d⟩
 
-def leMinRightOfLe (s : q ≼ p) : q ≼ p ⊓ q := leMinOfle s (.refl q)
+def leMinRightOfLe {p q : Sequent L} (s : q ≼ p) : q ≼ p ⊓ q :=
+  leMinOfle s (.refl q s.val.traversal)
 
 end StrongerThan
 
@@ -143,9 +181,12 @@ def Forces (p : Sequent L) : Propositionᵢ L → Type u
   termination_by φ => φ.complexity
 
 
-abbrev allForces (φ : Propositionᵢ L) := (p : Sequent L) → Forces p φ
+abbrev allForces (φ : Propositionᵢ L) :=
+  (p : Sequent L) → (∼p).Traversal → Forces p φ
 
 namespace Forces
+
+variable {p q : Sequent L}
 
 scoped infix:45 " ⊩ " => Forces
 
@@ -209,26 +250,28 @@ def explosion {p : Sequent L} (b : p ⊩ ⊥) : (φ : Propositionᵢ L) → p �
   | ⊥ => b
   | .rel R v =>
     let ⟨d, hd⟩ := b.falsumEquiv
-    let h : ∼p ⊆ ∼p + ⦃.rel R v⦄ := by intro φ hφ; simp_all
-    relEquiv.symm ⟨.contraction d h, hd.contraction h⟩
+    relEquiv.symm ⟨d.weakening, hd.weakening⟩
   | φ ⋏ ψ => andEquiv.symm ⟨b.explosion φ, b.explosion ψ⟩
   | φ ⋎ ψ => orEquiv.symm <| .inl <| b.explosion φ
-  | φ 🡒 ψ => implyEquiv.symm fun q sqp dφ ↦ (b.monotone sqp).explosion ψ
+  | φ 🡒 ψ => implyEquiv.symm fun q sqp _ ↦ (b.monotone sqp).explosion ψ
   | ∀¹ φ => allEquiv.symm fun t ↦ b.explosion (φ/[t])
   | ∃¹ φ => exsEquiv.symm ⟨default, b.explosion (φ/[default])⟩
   termination_by φ => φ.complexity
 
-def efq (φ : Propositionᵢ L) : ⊩ ⊥ 🡒 φ := fun _ ↦ implyEquiv.symm fun _ _ d ↦ d.explosion φ
+def efq (φ : Propositionᵢ L) : ⊩ ⊥ 🡒 φ :=
+  fun _ _ ↦ implyEquiv.symm fun _ _ d ↦ d.explosion φ
 
-def implyOf {φ ψ : Propositionᵢ L} (b : (q : Sequent L) → q ⊩ φ → p ⊓ q ⊩ ψ) :
+def implyOf {φ ψ : Propositionᵢ L}
+    (b : (q : Sequent L) → (∼q).Traversal → q ⊩ φ → p ⊓ q ⊩ ψ) :
     p ⊩ φ 🡒 ψ := implyEquiv.symm fun q sqp fφ ↦
-  let fψ : p ⊓ q ⊩ ψ := b q fφ
+  let fψ : p ⊓ q ⊩ ψ := b q sqp.val.traversal fφ
   fψ.monotone (StrongerThan.leMinRightOfLe sqp)
 
 open LawfulSyntacticRewriting
 
-def modusPonens {φ ψ : Propositionᵢ L} (f : p ⊩ φ 🡒 ψ) (g : p ⊩ φ) : p ⊩ ψ :=
-  f.implyEquiv p (StrongerThan.refl p) g
+def modusPonens {φ ψ : Propositionᵢ L} (tp : (∼p).Traversal)
+    (f : p ⊩ φ 🡒 ψ) (g : p ⊩ φ) : p ⊩ ψ :=
+  f.implyEquiv p (StrongerThan.refl p tp) g
 
 abbrev ContextForces (p : Sequent L) (Γ : LJ.Sequent L) :=
   (φ : Propositionᵢ L) → φ ∈ Γ → p ⊩ φ
@@ -244,7 +287,7 @@ def monotone (b : ContextForces p Γ) (s : q ≼ p) : ContextForces q Γ :=
   fun φ hφ ↦ (b φ hφ).monotone s
 
 /-- Extend a forcing assignment by one formula (a routine semantic operation). -/
-def cons [L.DecidableEq] (b : ContextForces p Γ) (hφ : p ⊩ φ) :
+def cons (b : ContextForces p Γ) (hφ : p ⊩ φ) :
     ContextForces p (Γ + ⦃φ⦄) := fun ψ hψ ↦
   if h : φ = ψ then hφ.cast h else b ψ (by simp_all [eq_comm])
 
@@ -268,6 +311,7 @@ def HeadForces.ofSubset {Ξ Λ : LJ.Head L} (h : Ξ ⊆ Λ) :
         subst ψ
         exact b
 
+omit [L.DecidableEq] in
 private lemma rewrite_shift_eq (t : SyntacticTerm L) (φ : Propositionᵢ L) :
     Rew.rewrite (t :>ₙ fun x ↦ &x) ▹ Rewriting.shift φ = φ := by
   rw [← TransitiveRewriting.comp_app, Rew.rewrite_comp_shift_eq_id,
@@ -276,49 +320,52 @@ private lemma rewrite_shift_eq (t : SyntacticTerm L) (φ : Propositionᵢ L) :
 /-- Soundness of LJ for the canonical Type-valued forcing interpretation.
 - [Avi01, Section 3]
 -/
-def sound [L.DecidableEq] {Γ : LJ.Sequent L} {Ξ : LJ.Head L}
-    (d : Γ ⊢ᴸᴶ¹ Ξ) (p : Sequent L) (b : ContextForces p Γ) : HeadForces p Ξ :=
+def sound {Γ : LJ.Sequent L} {Ξ : LJ.Head L}
+    (d : Γ ⊢ᴸᴶ¹ Ξ) (p : Sequent L) (tp : (∼p).Traversal)
+    (b : ContextForces p Γ) : HeadForces p Ξ :=
   match d with
   | .identity R v => b (.rel R v) (by simp)
   | .cut (φ := φ) (Γ := Γ) (Δ := Δ) dφ d =>
       let bΓ := b.ofSubset (by intro ψ hψ; simp_all)
       let bΔ := b.ofSubset (by intro ψ hψ; simp_all)
-      sound d p <| bΔ.cons (sound dφ p bΓ)
-  | .contraction d hΓ hΞ =>
-      HeadForces.ofSubset hΞ <| sound d p (b.ofSubset hΓ)
+      sound d p tp <| bΔ.cons (sound dφ p tp bΓ)
+  | .contraction d => sound d p tp fun ψ hψ ↦ b ψ (by simp_all)
+  | .weakening d => sound d p tp (b.ofSubset Multiset.subset_add_left)
+  | .weakeningRight d => (sound d p tp b).explosion _
   | .verum => implyEquiv.symm fun _ _ h ↦ h
   | .falsum => b ⊥ (by simp)
   | .positiveImply d => implyEquiv.symm fun q sqp bφ ↦
-      sound d q <| (b.monotone sqp).cons bφ
+      sound d q sqp.val.traversal <| (b.monotone sqp).cons bφ
   | .negativeImply (φ := φ) (ψ := ψ) (Γ := Γ) (Δ := Δ) dφ d =>
       let bΓ := b.ofSubset (by intro θ hθ; simp_all)
       let bΔ := b.ofSubset (by intro θ hθ; simp_all)
       let bi : p ⊩ φ 🡒 ψ := b _ (by simp)
-      sound d p <| bΔ.cons (bi.modusPonens <| sound dφ p bΓ)
+      sound d p tp <| bΔ.cons (bi.modusPonens tp <| sound dφ p tp bΓ)
   | .positiveAnd dφ dψ =>
-      andEquiv.symm ⟨sound dφ p b, sound dψ p b⟩
+      andEquiv.symm ⟨sound dφ p tp b, sound dψ p tp b⟩
   | .negativeAnd (φ := φ) (ψ := ψ) (Γ := Γ) d =>
       let bΓ : ContextForces p Γ := b.ofSubset Multiset.subset_add_left
       let ⟨bφ, bψ⟩ := (b (φ ⋏ ψ) (by simp)).andEquiv
-      sound d p <| ((bΓ.cons bφ).cons bψ).ofSubset (by intro θ hθ; simpa [add_assoc] using hθ)
-  | .positiveOrLeft d => orEquiv.symm <| .inl <| sound d p b
-  | .positiveOrRight d => orEquiv.symm <| .inr <| sound d p b
+      sound d p tp <| ((bΓ.cons bφ).cons bψ).ofSubset
+        (by intro θ hθ; simpa [add_assoc] using hθ)
+  | .positiveOrLeft d => orEquiv.symm <| .inl <| sound d p tp b
+  | .positiveOrRight d => orEquiv.symm <| .inr <| sound d p tp b
   | .negativeOr (φ := φ) (ψ := ψ) (Γ := Γ) dφ dψ =>
       let bΓ := b.ofSubset (by intro θ hθ; simp_all)
       (b (φ ⋎ ψ) (by simp)).orEquiv.rec
-        (fun bφ ↦ sound dφ p <| bΓ.cons bφ)
-        (fun bψ ↦ sound dψ p <| bΓ.cons bψ)
+        (fun bφ ↦ sound dφ p tp <| bΓ.cons bφ)
+        (fun bψ ↦ sound dψ p tp <| bΓ.cons bψ)
   | .positiveForall (Γ := Γ) (φ := φ) d => allEquiv.symm fun t ↦
       let f : ℕ → SyntacticTerm L := t :>ₙ fun x ↦ &x
       let dt : Γ ⊢ᴸᴶ¹ some (φ/[t]) := (d.rewrite f).cast
         (by simp [f, Rewriting.shifts, Multiset.map_map, rewrite_shift_eq])
         (by simp [f, LJ.Head.rewrite, rewrite_free_eq_subst])
-      sound dt p b
+      sound dt p tp b
   | .negativeForall (φ := φ) (Γ := Γ) d =>
       let bΓ := b.ofSubset (by intro θ hθ; simp_all)
       let bAll := (b (∀¹ φ) (by simp)).allEquiv _
-      sound d p <| bΓ.cons bAll
-  | .positiveExists (t := t) d => exsEquiv.symm ⟨t, sound d p b⟩
+      sound d p tp <| bΓ.cons bAll
+  | .positiveExists (t := t) d => exsEquiv.symm ⟨t, sound d p tp b⟩
   | .negativeExists (Γ := Γ) (Ξ := Ξ) (φ := φ) d =>
       let ⟨t, bt⟩ := (b (∃¹ φ) (by simp)).exsEquiv
       let f : ℕ → SyntacticTerm L := t :>ₙ fun x ↦ &x
@@ -327,7 +374,7 @@ def sound [L.DecidableEq] {Γ : LJ.Sequent L} {Ξ : LJ.Head L}
           rewrite_free_eq_subst])
         (by cases Ξ <;> simp [f, LJ.Head.shift, LJ.Head.rewrite, rewrite_shift_eq])
       let bΓ := b.ofSubset (by intro θ hθ; simp_all)
-      sound dt p <| bΓ.cons bt
+      sound dt p tp <| bΓ.cons bt
   termination_by d.height
   decreasing_by
     all_goals simp [LJ.Derivation.height]
@@ -336,17 +383,22 @@ def sound [L.DecidableEq] {Γ : LJ.Sequent L} {Ξ : LJ.Head L}
       exact Nat.lt_succ_iff.mpr <| Nat.le_of_eq <|
         (LJ.Derivation.height_cast _ _ _).trans (LJ.Derivation.height_rewrite (t :>ₙ fun x ↦ &x) d)
 
-def ljSound [L.DecidableEq] {φ : Propositionᵢ L} (d : 𝐋𝐉¹ ⊢! φ) : ⊩ φ :=
-  fun p ↦ sound d p fun _ h ↦ by simp at h
+def ljSound {φ : Propositionᵢ L} (d : 𝐋𝐉¹ ⊢! φ) : ⊩ φ :=
+  fun p tp ↦ sound d p tp fun _ h ↦ by simp at h
 
 def relRefl {k} (R : L.Rel k) (v : Fin k → SyntacticTerm L) : ⦃.rel R v⦄ ⊩ rel R v :=
   relEquiv.symm ⟨Derivation.cast <| Derivation.identity _ _, by simp⟩
 
-protected def refl.or (ihφ : ⦃φ⦄ ⊩ φᴺ) (ihψ : ⦃ψ⦄ ⊩ ψᴺ) : ⦃φ ⋎ ψ⦄ ⊩ (φ ⋎ ψ)ᴺ :=
-  implyOf fun q dq ↦
+protected def refl.or {φ ψ : Proposition L}
+    (ihφ : ⦃φ⦄ ⊩ φᴺ) (ihψ : ⦃ψ⦄ ⊩ ψᴺ) : ⦃φ ⋎ ψ⦄ ⊩ (φ ⋎ ψ)ᴺ :=
+  implyOf fun q tq dq ↦
     let ⟨dφ, dψ⟩ : q ⊩ ∼φᴺ × q ⊩ ∼ψᴺ := dq.andEquiv
-    let bφ : ⦃φ⦄ ⊓ q ⊩ ⊥ := dφ.implyEquiv (⦃φ⦄ ⊓ q) (.minLeRight _ _) (ihφ.monotone (.minLeLeft _ _))
-    let bψ : ⦃ψ⦄ ⊓ q ⊩ ⊥ := dψ.implyEquiv (⦃ψ⦄ ⊓ q) (.minLeRight _ _) (ihψ.monotone (.minLeLeft _ _))
+    let tφ : (∼(⦃φ⦄ : Sequent L)).Traversal := .atom _
+    let tψ : (∼(⦃ψ⦄ : Sequent L)).Traversal := .atom _
+    let bφ : ⦃φ⦄ ⊓ q ⊩ ⊥ := dφ.implyEquiv (⦃φ⦄ ⊓ q)
+      (.minLeRight _ _ tφ tq) (ihφ.monotone (.minLeLeft _ _ tφ tq))
+    let bψ : ⦃ψ⦄ ⊓ q ⊩ ⊥ := dψ.implyEquiv (⦃ψ⦄ ⊓ q)
+      (.minLeRight _ _ tψ tq) (ihψ.monotone (.minLeLeft _ _ tψ tq))
     let ⟨bbφ, hbbφ⟩ := bφ.falsumEquiv
     let ⟨bbψ, hbbψ⟩ := bψ.falsumEquiv
     let bbφ' : ⊢ᴸᴷ¹ ∼q + ⦃∼φ⦄ := Derivation.cast bbφ (by simp [inf_def]; abel)
@@ -357,13 +409,16 @@ protected def refl.or (ihφ : ⦃φ⦄ ⊩ φᴺ) (ihψ : ⦃ψ⦄ ⊩ ψᴺ) : 
 
 -- Transparency is lowered so that rewriting under the recursive forcing definition remains stable.
 set_option backward.isDefEq.respectTransparency false in
-protected def refl.exs (d : ∀ x, ⦃φ/[&x]⦄ ⊩ (φ/[&x])ᴺ) : ⦃∃¹ φ⦄ ⊩ (∃¹ φ)ᴺ :=
-  implyOf fun q f ↦
+protected def refl.exs {φ : Semiproposition L 1}
+    (d : ∀ x, ⦃φ/[&x]⦄ ⊩ (φ/[&x])ᴺ) : ⦃∃¹ φ⦄ ⊩ (∃¹ φ)ᴺ :=
+  implyOf fun q tq f ↦
     let x := Sequent.newVar (∼q + ⦃∀¹ ∼φ⦄)
     let ih : ⦃φ/[&x]⦄ ⊩ φᴺ/[&x] := cast (d x) (by simp [Semiformula.subst_doubleNegation])
     let b : ⦃φ/[&x]⦄ ⊓ q ⊩ ⊥ :=
-      (f.allEquiv &x).implyEquiv (⦃φ/[&x]⦄ ⊓ q) (StrongerThan.minLeRight _ _)
-        (ih.monotone (StrongerThan.minLeLeft _ _))
+      let tφ : (∼(⦃φ/[&x]⦄ : Sequent L)).Traversal := .atom _
+      (f.allEquiv &x).implyEquiv (⦃φ/[&x]⦄ ⊓ q)
+        (StrongerThan.minLeRight _ _ tφ tq)
+        (ih.monotone (StrongerThan.minLeLeft _ _ tφ tq))
     let ⟨b, hb⟩ := b.falsumEquiv
     let hp : ¬(∼φ).FVar? x := by
       have : ¬(∀¹ ∼φ).FVar? x := Sequent.not_fvar?_newVar (by simp)
@@ -382,50 +437,44 @@ set_option backward.isDefEq.respectTransparency false in
 protected def refl : (φ : Proposition L) → ⦃φ⦄ ⊩ φᴺ
   |         ⊤ => implyEquiv.symm fun q sqp dφ ↦ dφ
   |         ⊥ => falsumEquiv.symm ⟨Derivation.verum, by simp⟩
-  |  .rel R v => implyOf fun q dq ↦
-    let b : ⦃.rel R v⦄ ⊓ q ⊩ rel R v := (relRefl R v).monotone (StrongerThan.minLeLeft _ _)
-    dq.implyEquiv (⦃.rel R v⦄ ⊓ q) (StrongerThan.minLeRight _ _) b
-  | .nrel R v => implyOf fun q dq ↦
+  |  .rel R v => implyOf fun q tq dq ↦
+    let tr : (∼(⦃.rel R v⦄ : Sequent L)).Traversal := .atom _
+    let b : ⦃.rel R v⦄ ⊓ q ⊩ rel R v :=
+      (relRefl R v).monotone (StrongerThan.minLeLeft _ _ tr tq)
+    dq.implyEquiv (⦃.rel R v⦄ ⊓ q) (StrongerThan.minLeRight _ _ tr tq) b
+  | .nrel R v => implyOf fun q _ dq ↦
     let ⟨d, hd⟩ := dq.relEquiv
     falsumEquiv.symm ⟨Derivation.cast d (by simp [inf_def]; abel), by simpa using hd⟩
   |     φ ⋏ ψ =>
     let ihφ : ⦃φ⦄ ⊩ φᴺ := Forces.refl φ
     let ihψ : ⦃ψ⦄ ⊩ ψᴺ := Forces.refl ψ
-    andEquiv.symm ⟨by simpa using ihφ.monotone (.K_left (p := 0) φ ψ),
-      by simpa using ihψ.monotone (.K_right (p := 0) φ ψ)⟩
+    andEquiv.symm ⟨by simpa using ihφ.monotone (.K_left (p := 0) .zero φ ψ),
+      by simpa using ihψ.monotone (.K_right (p := 0) .zero φ ψ)⟩
   |     φ ⋎ ψ => refl.or (Forces.refl φ) (Forces.refl ψ)
   |      ∀¹ φ => allEquiv.symm fun t ↦
     let b : ⦃φ/[t]⦄ ⊩ φᴺ/[t] := by simpa [Semiformula.rew_doubleNegation] using Forces.refl (φ/[t])
-    by simpa using b.monotone (StrongerThan.all (p := 0) φ t)
+    by simpa using b.monotone (StrongerThan.all (p := 0) .zero φ t)
   |      ∃¹ φ => refl.exs fun x ↦ Forces.refl (φ/[&x])
   termination_by φ => φ.complexity
 
 end Forces
 
-def constructiveHauptsatz [L.DecidableEq] [L.Encodable] {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
+def constructiveHauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
     {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := by
+  let tΓ : (∼(∼Γ)).Traversal := d.traversal.cast (by simp)
   have f : ((ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ) → Forces (∼Γ) ⊥ :=
-    Forces.sound d.gödelGentzen (∼Γ)
+    Forces.sound d.gödelGentzen (∼Γ) tΓ
   have g : (ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ := fun φ hφ ↦
-    have φ₀ := Multiset.getPreimage hφ
+    let t : (∼Γ).Traversal := d.traversal.map (∼·)
+    have φ₀ := t.getPreimage (f := fun θ : Proposition L ↦ θᴺ)
+      (by simpa [Sequent.doubleNegation] using hφ)
     have h : Forces (∼Γ) (φ₀.val)ᴺ := (Forces.refl φ₀.val).monotone <|
-      StrongerThan.ofSubset (by simpa using φ₀.property.1)
-    h.cast (by simpa using φ₀.property.2)
+      StrongerThan.ofSubset (.atom _) tΓ (by simpa using φ₀.property.1)
+    h.cast φ₀.property.2
   have ⟨b, hb⟩ := (f g).falsumEquiv
   exact ⟨Derivation.cast b (by simp), by simpa using hb⟩
 
-noncomputable def hauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
-    {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := by
-  classical
-  have f : ((ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ) → Forces (∼Γ) ⊥ :=
-    Forces.sound d.gödelGentzen (∼Γ)
-  have : ∀ ψ ∈ (∼Γ)ᴺ, Nonempty (Forces (∼Γ) ψ) := fun φ hφ ↦ by
-    have : ∃ φ₀ : Proposition L, ∼φ₀ ∈ Γ ∧ φ₀ᴺ = φ := by simpa [Sequent.doubleNegation] using hφ
-    rcases this with ⟨φ₀, hφ₀⟩
-    have h : Forces (∼Γ) φ₀ᴺ := (Forces.refl φ₀).monotone <|
-      StrongerThan.ofSubset (by simpa using hφ₀.1)
-    exact ⟨h.cast (by simpa using hφ₀.2)⟩
-  have ⟨b, hb⟩ := (f fun φ hφ ↦ Classical.choice (this φ hφ)).falsumEquiv
-  exact ⟨Derivation.cast b (by simp), by simpa using hb⟩
+def hauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
+    {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := constructiveHauptsatz d
 
 end Canonical

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -27,14 +27,13 @@ namespace Positive
 
 variable {Ξ Γ Δ : Sequent L}
 
-/-- Transports a traversal of the source to the target of a positive derivation. -/
-def traversal [L.DecidableEq] : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Ξ.Traversal → Γ.Traversal
-  | _, .refl, tΞ => tΞ
-  | _, .weakening (φ := φ) d, tΞ => (d.traversal tΞ).succ φ
-  | _, .contraction (φ := φ) d, tΞ => ((d.traversal tΞ).cast (by abel)).remove (a := φ)
-  | _, .or (φ := φ) (ψ := ψ) d, tΞ =>
+def traversal [L.DecidableEq] {Γ} : Ξ ⟶⁺ Γ → Ξ.Traversal → Γ.Traversal
+  | refl, tΞ => tΞ
+  | weakening (φ := φ) d, tΞ => (d.traversal tΞ).succ φ
+  | contraction (φ := φ) d, tΞ => ((d.traversal tΞ).cast (by abel)).remove (a := φ)
+  | or (φ := φ) (ψ := ψ) d, tΞ =>
       (((d.traversal tΞ).cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
-  | _, .exs (φ := φ) d, tΞ => (d.traversal tΞ).remove.succ (∃¹ φ)
+  | exs (φ := φ) d, tΞ => (d.traversal tΞ).remove.succ (∃¹ φ)
 
 instance : Structural (Positive Ξ) where
   weakening d := d.weakening
@@ -46,28 +45,28 @@ def ofSubset [L.DecidableEq] (tΞ : Ξ.Traversal) (tΓ : Γ.Traversal)
     (Γ := Ξ) (Δ := Γ) tΞ tΓ .refl ss
 
 def trans {Ξ Γ Δ : Sequent L} : Ξ ⟶⁺ Γ → Γ ⟶⁺ Δ → Ξ ⟶⁺ Δ
-  | b,    or d => or (b.trans d)
-  | b,   exs d => exs (b.trans d)
+  | b, or d => or (b.trans d)
+  | b, exs d => exs (b.trans d)
   | b, weakening d => weakening (b.trans d)
   | b, contraction d => contraction (b.trans d)
-  | b, .refl => b
+  | b, refl => b
 
 def cast {Ξ Γ Ξ' Γ' : Sequent L} (d : Ξ ⟶⁺ Γ)
     (hΞ : Ξ = Ξ' := by abel) (hΓ : Γ = Γ' := by abel) : Ξ' ⟶⁺ Γ' :=
   hΞ ▸ hΓ ▸ d
 
-def addLeft (Δ : Sequent L) : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
-  | _, or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
+def addLeft (Δ : Sequent L) {Γ} : Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
+  | or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
       cast (.or (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (ψ := ψ)
         (cast (addLeft Δ d)))
-  | _, exs (Γ := Γ) (φ := φ) (t := t) d =>
+  | exs (Γ := Γ) (φ := φ) (t := t) d =>
       cast (.exs (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (t := t)
         (cast (addLeft Δ d)))
-  | _, weakening (φ := φ) d => cast (.weakening (φ := φ) (addLeft Δ d))
-  | _, contraction (Γ := Γ) (φ := φ) d =>
+  | weakening (φ := φ) d => cast (.weakening (φ := φ) (addLeft Δ d))
+  | contraction (Γ := Γ) (φ := φ) d =>
       cast (.contraction (Γ := Δ + Γ) (φ := φ)
         (cast (addLeft Δ d) (hΞ := rfl) (hΓ := by abel)))
-  | _, .refl => .refl
+  | .refl => .refl
 
 def cons (φ) (d : Ξ ⟶⁺ Γ) : Ξ + ⦃φ⦄ ⟶⁺ Γ + ⦃φ⦄ :=
   cast (addLeft ⦃φ⦄ d)
@@ -77,11 +76,11 @@ def add {Γ Δ Ξ Θ : Sequent L} (d : Γ ⟶⁺ Δ) (b : Ξ ⟶⁺ Θ) :
   (addLeft Γ b).trans (cast (addLeft Θ d))
 
 def graft {Ξ Γ : Sequent L} (b : ⊢ᴸᴷ¹ Ξ) : Ξ ⟶⁺ Γ → ⊢ᴸᴷ¹ Γ
-  |    or d => .or (d.graft b)
-  |   exs d => .exs (d.graft b)
+  | or d => .or (d.graft b)
+  | exs d => .exs (d.graft b)
   | weakening d => .weakening (d.graft b)
   | contraction d => .contraction (d.graft b)
-  | .refl => b
+  | refl => b
 
 lemma graft_isCutFree_of_isCutFree {b : ⊢ᴸᴷ¹ Ξ} {d : Ξ ⟶⁺ Γ} (hb : Derivation.IsCutFree b) : Derivation.IsCutFree (d.graft b) := by
   induction d <;> simp [graft, *]
@@ -422,20 +421,19 @@ protected def refl : (φ : Proposition L) → ⦃φ⦄ ⊩ φᴺ
 
 end Forces
 
-def hauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
-    {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := by
+def hauptsatz {Γ : Sequent L} :
+    ⊢ᴸᴷ¹ Γ → {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := fun d ↦
   let t := d.traversal
-  let tΓ : (∼(∼Γ)).Traversal := t.cast (by simp)
   let tNegΓ : (∼Γ).Traversal := t.map (∼·)
   have f : ((ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ) → Forces (∼Γ) ⊥ :=
-    Forces.sound d.gödelGentzen (∼Γ) tΓ
+    Forces.sound d.gödelGentzen (∼Γ) (t.cast (by simp))
   have g : (ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ := fun φ hφ ↦
     have φ₀ := tNegΓ.getPreimage (f := fun θ : Proposition L ↦ θᴺ)
       (by simpa [Sequent.doubleNegation] using hφ)
     have h : Forces (∼Γ) (φ₀.val)ᴺ := (Forces.refl φ₀.val).monotone <|
-      StrongerThan.ofSubset (.atom _) tΓ (by simpa using φ₀.property.1)
+      StrongerThan.ofSubset (.atom _) (t.cast (by simp)) (by simpa using φ₀.property.1)
     h.cast φ₀.property.2
   have ⟨b, hb⟩ := (f g).falsumEquiv
-  exact ⟨Derivation.cast b (by simp), by simpa using hb⟩
+  ⟨Derivation.cast b (by simp), by simpa using hb⟩
 
 end Canonical

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -16,6 +16,14 @@ namespace FFL.FirstOrder.Derivation
 variable {L : Language}
 
 inductive Positive (Ξ : Sequent L) : Sequent L → Type _
+| refl : Ξ.Traversal → Positive Ξ Ξ
+| weakening : Positive Ξ Γ → Positive Ξ (Γ + ⦃φ⦄)
+| contraction : Positive Ξ (Γ + ⦃φ, φ⦄) → Positive Ξ (Γ + ⦃φ⦄)
+| or : Positive Ξ (Γ + ⦃φ, ψ⦄) → Positive Ξ (Γ + ⦃φ ⋎ ψ⦄)
+| exs : Positive Ξ (Γ + ⦃φ/[t]⦄) → Positive Ξ (Γ + ⦃∃¹ φ⦄)
+
+/--/
+inductive Positive (Ξ : Sequent L) : Sequent L → Type _
 | or : Positive Ξ (Γ + ⦃φ, ψ⦄) → Positive Ξ (Γ + ⦃φ ⋎ ψ⦄)
 | exs : Positive Ξ (Γ + ⦃φ/[t]⦄) → Positive Ξ (Γ + ⦃∃¹ φ⦄)
 | contraction : Positive Ξ Δ → Δ ⊆ Γ → Positive Ξ Γ

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -1,7 +1,6 @@
 module
 
 public import Foundation.FirstOrder.NegationTranslation.GoedelGentzen
-public import Foundation.FirstOrder.Basic.Coding
 
 /-!
 # Hauptsatz of classical first-order logic
@@ -16,7 +15,7 @@ namespace FFL.FirstOrder.Derivation
 variable {L : Language}
 
 inductive Positive (Ξ : Sequent L) : Sequent L → Type _
-| refl : Ξ.Traversal → Positive Ξ Ξ
+| refl : Positive Ξ Ξ
 | weakening : Positive Ξ Γ → Positive Ξ (Γ + ⦃φ⦄)
 | contraction : Positive Ξ (Γ + ⦃φ, φ⦄) → Positive Ξ (Γ + ⦃φ⦄)
 | or : Positive Ξ (Γ + ⦃φ, ψ⦄) → Positive Ξ (Γ + ⦃φ ⋎ ψ⦄)
@@ -28,19 +27,14 @@ namespace Positive
 
 variable {Ξ Γ Δ : Sequent L}
 
-/-- Recovers the traversal stored at the source of a positive derivation. -/
-def sourceTraversal : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Ξ.Traversal
-  | _, .refl t => t
-  | _, .weakening d | _, .contraction d | _, .or d | _, .exs d => d.sourceTraversal
-
-/-- Enumerates the target of a positive derivation. -/
-def traversal [L.DecidableEq] : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Γ.Traversal
-  | _, .refl t => t
-  | _, .weakening (φ := φ) d => d.traversal.succ φ
-  | _, .contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
-  | _, .or (φ := φ) (ψ := ψ) d =>
-      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
-  | _, .exs (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+/-- Transports a traversal of the source to the target of a positive derivation. -/
+def traversal [L.DecidableEq] : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Ξ.Traversal → Γ.Traversal
+  | _, .refl, tΞ => tΞ
+  | _, .weakening (φ := φ) d, tΞ => (d.traversal tΞ).succ φ
+  | _, .contraction (φ := φ) d, tΞ => ((d.traversal tΞ).cast (by abel)).remove (a := φ)
+  | _, .or (φ := φ) (ψ := ψ) d, tΞ =>
+      (((d.traversal tΞ).cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
+  | _, .exs (φ := φ) d, tΞ => (d.traversal tΞ).remove.succ (∃¹ φ)
 
 instance : Structural (Positive Ξ) where
   weakening d := d.weakening
@@ -49,45 +43,45 @@ instance : Structural (Positive Ξ) where
 def ofSubset [L.DecidableEq] (tΞ : Ξ.Traversal) (tΓ : Γ.Traversal)
     (ss : Ξ ⊆ Γ) : Ξ ⟶⁺ Γ :=
   Structural.ofSubset (F := Proposition L) (𝔇 := Positive Ξ)
-    (Γ := Ξ) (Δ := Γ) tΞ tΓ (.refl tΞ) ss
+    (Γ := Ξ) (Δ := Γ) tΞ tΓ .refl ss
 
 def trans {Ξ Γ Δ : Sequent L} : Ξ ⟶⁺ Γ → Γ ⟶⁺ Δ → Ξ ⟶⁺ Δ
   | b,    or d => or (b.trans d)
   | b,   exs d => exs (b.trans d)
   | b, weakening d => weakening (b.trans d)
   | b, contraction d => contraction (b.trans d)
-  | b, .refl _ => b
+  | b, .refl => b
 
 def cast {Ξ Γ Ξ' Γ' : Sequent L} (d : Ξ ⟶⁺ Γ)
     (hΞ : Ξ = Ξ' := by abel) (hΓ : Γ = Γ' := by abel) : Ξ' ⟶⁺ Γ' :=
   hΞ ▸ hΓ ▸ d
 
-def addLeft [L.DecidableEq] (tΔ : Δ.Traversal) : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
+def addLeft (Δ : Sequent L) : {Γ : Sequent L} → Ξ ⟶⁺ Γ → Δ + Ξ ⟶⁺ Δ + Γ
   | _, or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
       cast (.or (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (ψ := ψ)
-        (cast (addLeft tΔ d)))
+        (cast (addLeft Δ d)))
   | _, exs (Γ := Γ) (φ := φ) (t := t) d =>
       cast (.exs (Ξ := Δ + Ξ) (Γ := Δ + Γ) (φ := φ) (t := t)
-        (cast (addLeft tΔ d)))
-  | _, weakening (φ := φ) d => cast (.weakening (φ := φ) (addLeft tΔ d))
+        (cast (addLeft Δ d)))
+  | _, weakening (φ := φ) d => cast (.weakening (φ := φ) (addLeft Δ d))
   | _, contraction (Γ := Γ) (φ := φ) d =>
       cast (.contraction (Γ := Δ + Γ) (φ := φ)
-        (cast (addLeft tΔ d) (hΞ := rfl) (hΓ := by abel)))
-  | _, .refl t => .refl (tΔ.add t)
+        (cast (addLeft Δ d) (hΞ := rfl) (hΓ := by abel)))
+  | _, .refl => .refl
 
-def cons [L.DecidableEq] (φ) (d : Ξ ⟶⁺ Γ) : Ξ + ⦃φ⦄ ⟶⁺ Γ + ⦃φ⦄ :=
-  cast (addLeft (.atom φ) d)
+def cons (φ) (d : Ξ ⟶⁺ Γ) : Ξ + ⦃φ⦄ ⟶⁺ Γ + ⦃φ⦄ :=
+  cast (addLeft ⦃φ⦄ d)
 
-def add [L.DecidableEq] {Γ Δ Ξ Θ : Sequent L} (d : Γ ⟶⁺ Δ) (b : Ξ ⟶⁺ Θ) :
+def add {Γ Δ Ξ Θ : Sequent L} (d : Γ ⟶⁺ Δ) (b : Ξ ⟶⁺ Θ) :
     Γ + Ξ ⟶⁺ Δ + Θ :=
-  (addLeft d.sourceTraversal b).trans (cast (addLeft b.traversal d))
+  (addLeft Γ b).trans (cast (addLeft Θ d))
 
 def graft {Ξ Γ : Sequent L} (b : ⊢ᴸᴷ¹ Ξ) : Ξ ⟶⁺ Γ → ⊢ᴸᴷ¹ Γ
   |    or d => .or (d.graft b)
   |   exs d => .exs (d.graft b)
   | weakening d => .weakening (d.graft b)
   | contraction d => .contraction (d.graft b)
-  | .refl _ => b
+  | .refl => b
 
 lemma graft_isCutFree_of_isCutFree {b : ⊢ᴸᴷ¹ Ξ} {d : Ξ ⟶⁺ Γ} (hb : Derivation.IsCutFree b) : Derivation.IsCutFree (d.graft b) := by
   induction d <;> simp [graft, *]
@@ -115,7 +109,7 @@ omit [L.DecidableEq] in
 
 namespace StrongerThan
 
-protected def refl (p : Sequent L) (t : (∼p).Traversal) : p ≼ p := ⟨.refl t⟩
+protected def refl (p : Sequent L) : p ≼ p := ⟨.refl⟩
 
 def trans {r q p : Sequent L} (srq : r ≼ q) (sqp : q ≼ p) : r ≼ p := ⟨sqp.val.trans srq.val⟩
 
@@ -123,50 +117,35 @@ def ofSubset {q p : Sequent L} (tp : (∼p).Traversal) (tq : (∼q).Traversal)
     (h : q ⊇ p) : q ≼ p :=
   ⟨.ofSubset tp tq <| Multiset.map_subset_map h⟩
 
-def and {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
-    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ, ψ⦄ := by
-  let t := (tp.succ (∼φ)).succ (∼ψ)
-  let d : ∼p + ⦃∼φ, ∼ψ⦄ ⟶⁺ ∼p + ⦃∼φ ⋎ ∼ψ⦄ :=
-    .or (.refl (t.cast (by abel)))
-  exact ⟨d.cast (by simp) (by simp)⟩
+def K_left {p : Sequent L} (φ ψ : Proposition L) :
+    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ⦄ := by
+  let d : ∼p + ⦃∼φ⦄ ⟶⁺ ∼p + ⦃∼φ ⋎ ∼ψ⦄ :=
+    .or (.cast (.weakening (φ := ∼ψ) (.refl : ∼p + ⦃∼φ⦄ ⟶⁺ ∼p + ⦃∼φ⦄)) rfl);
+  exact ⟨d.cast (by simp) (by simp)⟩;
 
-def K_left {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
-    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃φ⦄ :=
-  trans (and tp φ ψ) (ofSubset ((tp.succ (∼φ)).cast (by simp))
-    (((tp.succ (∼φ)).succ (∼ψ)).cast (by simp; abel)) <| by
-    intro θ hθ
-    simp only [Multiset.mem_add] at *
-    tauto)
+def K_right {p : Sequent L} (φ ψ : Proposition L) :
+    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃ψ⦄ := by
+  let d : ∼p + ⦃∼ψ⦄ ⟶⁺ ∼p + ⦃∼φ ⋎ ∼ψ⦄ :=
+    .or (.cast (.weakening (φ := ∼φ) (.refl : ∼p + ⦃∼ψ⦄ ⟶⁺ ∼p + ⦃∼ψ⦄)) rfl);
+  exact ⟨d.cast (by simp) (by simp)⟩;
 
-def K_right {p : Sequent L} (tp : (∼p).Traversal) (φ ψ : Proposition L) :
-    p + ⦃φ ⋏ ψ⦄ ≼ p + ⦃ψ⦄ :=
-  trans (and tp φ ψ) (ofSubset ((tp.succ (∼ψ)).cast (by simp))
-    (((tp.succ (∼φ)).succ (∼ψ)).cast (by simp; abel)) <| by
-    intro θ hθ
-    simp only [Multiset.mem_add] at *
-    tauto)
-
-def all {p : Sequent L} (tp : (∼p).Traversal) (φ : Semiproposition L 1) (t) :
+def all {p : Sequent L} (φ : Semiproposition L 1) (t) :
     p + ⦃∀¹ φ⦄ ≼ p + ⦃φ/[t]⦄ := by
-  let d : ∼p + ⦃(∼φ)/[t]⦄ ⟶⁺ ∼p + ⦃∃¹ ∼φ⦄ := .exs (.refl (tp.succ _))
-  exact ⟨d.cast (by simp) (by simp)⟩
+  let d : ∼p + ⦃(∼φ)/[t]⦄ ⟶⁺ ∼p + ⦃∃¹ ∼φ⦄ := .exs .refl;
+  exact ⟨d.cast (by simp) (by simp)⟩;
 
-def minLeLeft (p q : Sequent L) (tp : (∼p).Traversal) (tq : (∼q).Traversal) :
-    p ⊓ q ≼ p :=
-  ofSubset tp (by simpa [inf_def] using tp.add tq) (by intro φ hφ; simp_all [inf_def])
+def minLeLeft (p q : Sequent L) (tq : (∼q).Traversal) : p ⊓ q ≼ p :=
+  ⟨Positive.cast (Structural.weakenMany tq (.refl : ∼p ⟶⁺ ∼p)) rfl (by simp [inf_def])⟩
 
-def minLeRight (p q : Sequent L) (tp : (∼p).Traversal) (tq : (∼q).Traversal) :
-    p ⊓ q ≼ q :=
-  ofSubset tq (by simpa [inf_def] using tp.add tq) (by intro φ hφ; simp_all [inf_def])
+def minLeRight (p q : Sequent L) (tp : (∼p).Traversal) : p ⊓ q ≼ q :=
+  ⟨Positive.cast (Structural.weakenMany tp (.refl : ∼q ⟶⁺ ∼q)) rfl
+    (by simp [inf_def, add_comm])⟩
 
-def leMinOfle {r p q : Sequent L} (srp : r ≼ p) (srq : r ≼ q) : r ≼ p ⊓ q := ⟨
-  let d : ∼p + ∼q ⟶⁺ ∼r := Positive.cast
-    (Structural.contractMany (F := Proposition L) (𝔇 := Positive (∼p + ∼q))
-      (Δ := 0) srp.val.traversal (Positive.cast (srp.val.add srq.val)))
-  neg_inf_p_eq _ _ ▸ d⟩
-
-def leMinRightOfLe {p q : Sequent L} (s : q ≼ p) : q ≼ p ⊓ q :=
-  leMinOfle s (.refl q s.val.traversal)
+def leMinRightOfLe {p q : Sequent L} (s : q ≼ p) (tq : (∼q).Traversal) : q ≼ p ⊓ q := by
+  let d : ∼p + ∼q ⟶⁺ ∼q + ∼q := (s.val.addLeft (∼q)).cast;
+  let d' : ∼p + ∼q ⟶⁺ ∼q :=
+    Positive.cast (Structural.contractMany (Δ := 0) tq (Positive.cast d rfl)) rfl;
+  exact ⟨d'.cast (by simp [inf_def]) rfl⟩;
 
 end StrongerThan
 
@@ -261,17 +240,18 @@ def explosion {p : Sequent L} (b : p ⊩ ⊥) : (φ : Propositionᵢ L) → p �
 def efq (φ : Propositionᵢ L) : ⊩ ⊥ 🡒 φ :=
   fun _ _ ↦ implyEquiv.symm fun _ _ d ↦ d.explosion φ
 
-def implyOf {φ ψ : Propositionᵢ L}
+def implyOf {φ ψ : Propositionᵢ L} (tp : (∼p).Traversal)
     (b : (q : Sequent L) → (∼q).Traversal → q ⊩ φ → p ⊓ q ⊩ ψ) :
     p ⊩ φ 🡒 ψ := implyEquiv.symm fun q sqp fφ ↦
-  let fψ : p ⊓ q ⊩ ψ := b q sqp.val.traversal fφ
-  fψ.monotone (StrongerThan.leMinRightOfLe sqp)
+  let tq := sqp.val.traversal tp
+  let fψ : p ⊓ q ⊩ ψ := b q tq fφ
+  fψ.monotone (StrongerThan.leMinRightOfLe sqp tq)
 
 open LawfulSyntacticRewriting
 
-def modusPonens {φ ψ : Propositionᵢ L} (tp : (∼p).Traversal)
+def modusPonens {φ ψ : Propositionᵢ L}
     (f : p ⊩ φ 🡒 ψ) (g : p ⊩ φ) : p ⊩ ψ :=
-  f.implyEquiv p (StrongerThan.refl p tp) g
+  f.implyEquiv p (StrongerThan.refl p) g
 
 abbrev ContextForces (p : Sequent L) (Γ : LJ.Sequent L) :=
   (φ : Propositionᵢ L) → φ ∈ Γ → p ⊩ φ
@@ -297,20 +277,6 @@ def HeadForces (p : Sequent L) : LJ.Head L → Type u
   | none => p ⊩ ⊥
   | some φ => p ⊩ φ
 
-def HeadForces.ofSubset {Ξ Λ : LJ.Head L} (h : Ξ ⊆ Λ) :
-    HeadForces p Ξ → HeadForces p Λ := by
-  intro b
-  cases Ξ with
-  | none => cases Λ with
-    | none => exact b
-    | some φ => exact b.explosion φ
-  | some φ => cases Λ with
-    | none => simp at h
-    | some ψ =>
-        have : φ = ψ := Option.some_subset_some.mp h
-        subst ψ
-        exact b
-
 omit [L.DecidableEq] in
 private lemma rewrite_shift_eq (t : SyntacticTerm L) (φ : Propositionᵢ L) :
     Rew.rewrite (t :>ₙ fun x ↦ &x) ▹ Rewriting.shift φ = φ := by
@@ -335,12 +301,12 @@ def sound {Γ : LJ.Sequent L} {Ξ : LJ.Head L}
   | .verum => implyEquiv.symm fun _ _ h ↦ h
   | .falsum => b ⊥ (by simp)
   | .positiveImply d => implyEquiv.symm fun q sqp bφ ↦
-      sound d q sqp.val.traversal <| (b.monotone sqp).cons bφ
+      sound d q (sqp.val.traversal tp) <| (b.monotone sqp).cons bφ
   | .negativeImply (φ := φ) (ψ := ψ) (Γ := Γ) (Δ := Δ) dφ d =>
       let bΓ := b.ofSubset (by intro θ hθ; simp_all)
       let bΔ := b.ofSubset (by intro θ hθ; simp_all)
       let bi : p ⊩ φ 🡒 ψ := b _ (by simp)
-      sound d p tp <| bΔ.cons (bi.modusPonens tp <| sound dφ p tp bΓ)
+      sound d p tp <| bΔ.cons (bi.modusPonens <| sound dφ p tp bΓ)
   | .positiveAnd dφ dψ =>
       andEquiv.symm ⟨sound dφ p tp b, sound dψ p tp b⟩
   | .negativeAnd (φ := φ) (ψ := ψ) (Γ := Γ) d =>
@@ -391,14 +357,14 @@ def relRefl {k} (R : L.Rel k) (v : Fin k → SyntacticTerm L) : ⦃.rel R v⦄ �
 
 protected def refl.or {φ ψ : Proposition L}
     (ihφ : ⦃φ⦄ ⊩ φᴺ) (ihψ : ⦃ψ⦄ ⊩ ψᴺ) : ⦃φ ⋎ ψ⦄ ⊩ (φ ⋎ ψ)ᴺ :=
-  implyOf fun q tq dq ↦
+  implyOf (.atom _) fun q tq dq ↦
     let ⟨dφ, dψ⟩ : q ⊩ ∼φᴺ × q ⊩ ∼ψᴺ := dq.andEquiv
     let tφ : (∼(⦃φ⦄ : Sequent L)).Traversal := .atom _
     let tψ : (∼(⦃ψ⦄ : Sequent L)).Traversal := .atom _
     let bφ : ⦃φ⦄ ⊓ q ⊩ ⊥ := dφ.implyEquiv (⦃φ⦄ ⊓ q)
-      (.minLeRight _ _ tφ tq) (ihφ.monotone (.minLeLeft _ _ tφ tq))
+      (.minLeRight _ _ tφ) (ihφ.monotone (.minLeLeft _ _ tq))
     let bψ : ⦃ψ⦄ ⊓ q ⊩ ⊥ := dψ.implyEquiv (⦃ψ⦄ ⊓ q)
-      (.minLeRight _ _ tψ tq) (ihψ.monotone (.minLeLeft _ _ tψ tq))
+      (.minLeRight _ _ tψ) (ihψ.monotone (.minLeLeft _ _ tq))
     let ⟨bbφ, hbbφ⟩ := bφ.falsumEquiv
     let ⟨bbψ, hbbψ⟩ := bψ.falsumEquiv
     let bbφ' : ⊢ᴸᴷ¹ ∼q + ⦃∼φ⦄ := Derivation.cast bbφ (by simp [inf_def]; abel)
@@ -411,14 +377,14 @@ protected def refl.or {φ ψ : Proposition L}
 set_option backward.isDefEq.respectTransparency false in
 protected def refl.exs {φ : Semiproposition L 1}
     (d : ∀ x, ⦃φ/[&x]⦄ ⊩ (φ/[&x])ᴺ) : ⦃∃¹ φ⦄ ⊩ (∃¹ φ)ᴺ :=
-  implyOf fun q tq f ↦
+  implyOf (.atom _) fun q tq f ↦
     let x := Sequent.newVar (∼q + ⦃∀¹ ∼φ⦄)
     let ih : ⦃φ/[&x]⦄ ⊩ φᴺ/[&x] := cast (d x) (by simp [Semiformula.subst_doubleNegation])
     let b : ⦃φ/[&x]⦄ ⊓ q ⊩ ⊥ :=
       let tφ : (∼(⦃φ/[&x]⦄ : Sequent L)).Traversal := .atom _
       (f.allEquiv &x).implyEquiv (⦃φ/[&x]⦄ ⊓ q)
-        (StrongerThan.minLeRight _ _ tφ tq)
-        (ih.monotone (StrongerThan.minLeLeft _ _ tφ tq))
+        (StrongerThan.minLeRight _ _ tφ)
+        (ih.monotone (StrongerThan.minLeLeft _ _ tq))
     let ⟨b, hb⟩ := b.falsumEquiv
     let hp : ¬(∼φ).FVar? x := by
       have : ¬(∀¹ ∼φ).FVar? x := Sequent.not_fvar?_newVar (by simp)
@@ -437,44 +403,42 @@ set_option backward.isDefEq.respectTransparency false in
 protected def refl : (φ : Proposition L) → ⦃φ⦄ ⊩ φᴺ
   |         ⊤ => implyEquiv.symm fun q sqp dφ ↦ dφ
   |         ⊥ => falsumEquiv.symm ⟨Derivation.verum, by simp⟩
-  |  .rel R v => implyOf fun q tq dq ↦
+  |  .rel R v => implyOf (.atom _) fun q tq dq ↦
     let tr : (∼(⦃.rel R v⦄ : Sequent L)).Traversal := .atom _
     let b : ⦃.rel R v⦄ ⊓ q ⊩ rel R v :=
-      (relRefl R v).monotone (StrongerThan.minLeLeft _ _ tr tq)
-    dq.implyEquiv (⦃.rel R v⦄ ⊓ q) (StrongerThan.minLeRight _ _ tr tq) b
-  | .nrel R v => implyOf fun q _ dq ↦
+      (relRefl R v).monotone (StrongerThan.minLeLeft _ _ tq)
+    dq.implyEquiv (⦃.rel R v⦄ ⊓ q) (StrongerThan.minLeRight _ _ tr) b
+  | .nrel R v => implyOf (.atom _) fun q _ dq ↦
     let ⟨d, hd⟩ := dq.relEquiv
     falsumEquiv.symm ⟨Derivation.cast d (by simp [inf_def]; abel), by simpa using hd⟩
   |     φ ⋏ ψ =>
     let ihφ : ⦃φ⦄ ⊩ φᴺ := Forces.refl φ
     let ihψ : ⦃ψ⦄ ⊩ ψᴺ := Forces.refl ψ
-    andEquiv.symm ⟨by simpa using ihφ.monotone (.K_left (p := 0) .zero φ ψ),
-      by simpa using ihψ.monotone (.K_right (p := 0) .zero φ ψ)⟩
+    andEquiv.symm ⟨by simpa using ihφ.monotone (.K_left (p := 0) φ ψ),
+      by simpa using ihψ.monotone (.K_right (p := 0) φ ψ)⟩
   |     φ ⋎ ψ => refl.or (Forces.refl φ) (Forces.refl ψ)
   |      ∀¹ φ => allEquiv.symm fun t ↦
     let b : ⦃φ/[t]⦄ ⊩ φᴺ/[t] := by simpa [Semiformula.rew_doubleNegation] using Forces.refl (φ/[t])
-    by simpa using b.monotone (StrongerThan.all (p := 0) .zero φ t)
+    by simpa using b.monotone (StrongerThan.all (p := 0) φ t)
   |      ∃¹ φ => refl.exs fun x ↦ Forces.refl (φ/[&x])
   termination_by φ => φ.complexity
 
 end Forces
 
-def constructiveHauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
+def hauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
     {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := by
-  let tΓ : (∼(∼Γ)).Traversal := d.traversal.cast (by simp)
+  let t := d.traversal
+  let tΓ : (∼(∼Γ)).Traversal := t.cast (by simp)
+  let tNegΓ : (∼Γ).Traversal := t.map (∼·)
   have f : ((ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ) → Forces (∼Γ) ⊥ :=
     Forces.sound d.gödelGentzen (∼Γ) tΓ
   have g : (ψ : Propositionᵢ L) → ψ ∈ (∼Γ)ᴺ → Forces (∼Γ) ψ := fun φ hφ ↦
-    let t : (∼Γ).Traversal := d.traversal.map (∼·)
-    have φ₀ := t.getPreimage (f := fun θ : Proposition L ↦ θᴺ)
+    have φ₀ := tNegΓ.getPreimage (f := fun θ : Proposition L ↦ θᴺ)
       (by simpa [Sequent.doubleNegation] using hφ)
     have h : Forces (∼Γ) (φ₀.val)ᴺ := (Forces.refl φ₀.val).monotone <|
       StrongerThan.ofSubset (.atom _) tΓ (by simpa using φ₀.property.1)
     h.cast φ₀.property.2
   have ⟨b, hb⟩ := (f g).falsumEquiv
   exact ⟨Derivation.cast b (by simp), by simpa using hb⟩
-
-def hauptsatz {Γ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) :
-    {d : ⊢ᴸᴷ¹ Γ // Derivation.IsCutFree d} := constructiveHauptsatz d
 
 end Canonical

--- a/Foundation/FirstOrder/Hauptsatz.lean
+++ b/Foundation/FirstOrder/Hauptsatz.lean
@@ -237,9 +237,6 @@ def explosion {p : Sequent L} (b : p ⊩ ⊥) : (φ : Propositionᵢ L) → p �
   | ∃¹ φ => exsEquiv.symm ⟨default, b.explosion (φ/[default])⟩
   termination_by φ => φ.complexity
 
-def efq (φ : Propositionᵢ L) : ⊩ ⊥ 🡒 φ :=
-  fun _ _ ↦ implyEquiv.symm fun _ _ d ↦ d.explosion φ
-
 def implyOf {φ ψ : Propositionᵢ L} (tp : (∼p).Traversal)
     (b : (q : Sequent L) → (∼q).Traversal → q ⊩ φ → p ⊓ q ⊩ ψ) :
     p ⊩ φ 🡒 ψ := implyEquiv.symm fun q sqp fφ ↦

--- a/Foundation/FirstOrder/Intuitionistic/LJ.lean
+++ b/Foundation/FirstOrder/Intuitionistic/LJ.lean
@@ -105,13 +105,6 @@ instance : Structural (fun Γ ↦ Γ ⊢ᴸᴶ¹ Ξ) where
   weakening d := d.weakening
   contraction d := d.contraction
 
-private lemma unshift_shift (φ : Propositionᵢ L) :
-    Rew.rewriteMap Nat.pred ▹ Rewriting.shift φ = φ := by
-  change Rew.rewriteMap Nat.pred ▹ (Rew.rewriteMap Nat.succ ▹ φ) = φ;
-  rw [← TransitiveRewriting.comp_app, Rew.rewriteMap_comp_rewriteMap];
-  change Rew.rewriteMap id ▹ φ = φ;
-  simp;
-
 /-- Enumerates the antecedent by recursion on the local rules.
 This is a routine syntactic construction. -/
 def traversal [L.DecidableEq] : {Γ : Sequent L} → {Ξ : Head L} →
@@ -134,12 +127,12 @@ def traversal [L.DecidableEq] : {Γ : Sequent L} → {Ξ : Head L} →
   | _, _, negativeOr (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋎ ψ)
   | _, _, positiveForall d =>
       (d.traversal.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
-        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])
+        simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])
   | _, _, negativeForall (φ := φ) d => d.traversal.remove.succ (∀¹ φ)
   | _, _, positiveExists d => d.traversal
   | _, _, negativeExists (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
-        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])).succ (∃¹ φ)
+        simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∃¹ φ)
 
 /-- Expands antecedent inclusion into local structural rules. -/
 def contra [L.DecidableEq] (d : Γ ⊢ᴸᴶ¹ Ξ) (t : Δ.Traversal)
@@ -328,54 +321,38 @@ def dni {φ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ φ) : Γ ⊢ᴸᴶ¹ (∼∼
   positiveNeg d.negativeNeg.weakeningRight
 
 /-- Contraposition for singleton derivations (standard intuitionistic reasoning). -/
-def contrapose [L.DecidableEq] {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
+def contrapose {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
     ⦃∼ψ⦄ ⊢ᴸᴶ¹ (∼φ : Propositionᵢ L) :=
-  positiveNeg <| negElim
-    (assumption ((Multiset.Traversal.atom (∼ψ)).succ φ) (by simp [Semiformulaᵢ.neg_def])) <|
-    cutOne (assumption ((Multiset.Traversal.atom (∼ψ)).succ φ) (by simp)) d
+  positiveNeg <| d.negativeNeg.weakeningRight.cast (heq := rfl)
 
 /-- Double negation preserves derivability, by twice applying contraposition (folklore). -/
-def doubleNegationMap [L.DecidableEq] {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
+def doubleNegationMap {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
     ⦃∼∼φ⦄ ⊢ᴸᴶ¹ (∼∼ψ : Propositionᵢ L) := d.contrapose.contrapose
 
-def dneOfNegative [L.DecidableEq] : {φ : Propositionᵢ L} → φ.IsNegative → ⦃∼∼φ⦄ ⊢ᴸᴶ¹ φ
-  | ⊥, _ => negElim (eta _) <|
-      ((positiveNeg (Γ := 0) (φ := ⊥) ((eta ⊥).cast (by simp))).weakening
-        (φ := ∼∼(⊥ : Propositionᵢ L))).cast (by simp)
+def dneOfNegative : {φ : Propositionᵢ L} → φ.IsNegative → ⦃∼∼φ⦄ ⊢ᴸᴶ¹ φ
+  | ⊥, _ =>
+      ((positiveNeg (Γ := 0) (φ := ⊥) ((eta ⊥).cast (by simp))).negativeNeg.weakeningRight).cast (heq := rfl)
   | φ ⋏ ψ, h =>
     have hn : φ.IsNegative ∧ ψ.IsNegative := by simpa using h
     positiveAnd
       (cutOne (doubleNegationMap (andLeft (eta _))) (dneOfNegative hn.1))
       (cutOne (doubleNegationMap (andRight (eta _))) (dneOfNegative hn.2))
   | φ 🡒 ψ, h => by
-    have hnψ : ψ.IsNegative := by simpa using h
-    have ihψ := dneOfNegative hnψ
-    let N : Sequent L := ⦃∼∼(φ 🡒 ψ)⦄
-    let tN : N.Traversal := .atom _
-    apply positiveImply (Γ := N) (φ := φ) (ψ := ψ)
-    let C : Sequent L := N + ⦃φ⦄
-    let tC := tN.succ φ
-    have dnnψ : C ⊢ᴸᴶ¹ ↑(∼∼ψ) := positiveNeg (Γ := C) <| by
-      let D : Sequent L := C + ⦃∼ψ⦄
-      let tD := tC.succ (∼ψ)
-      have dnImp : D ⊢ᴸᴶ¹ ∼(φ 🡒 ψ) := positiveNeg (Γ := D) <| by
-        let E : Sequent L := D + ⦃φ 🡒 ψ⦄
-        let tE := tD.succ (φ 🡒 ψ)
-        have dψ : E ⊢ᴸᴶ¹ ψ := modusPonens
-          (assumption (φ := φ 🡒 ψ) tE (by simp [E]))
-          (assumption (φ := φ) tE (by simp [E, D, C]))
-        exact negElim
-          (assumption (φ := ∼ψ) tE (by simp [D, Semiformulaᵢ.neg_def])) dψ
-      exact negElim
-        (assumption (φ := ∼∼(φ 🡒 ψ)) tD (by simp [C, N, Semiformulaᵢ.neg_def])) dnImp
-    exact cutOne dnnψ ihψ
+    have ihψ := dneOfNegative (φ := ψ) (by simpa using h);
+    let d₁ : ⦃φ⦄ + ⦃φ 🡒 ψ⦄ ⊢ᴸᴶ¹ ψ :=
+      negativeImply (Δ := 0) (eta φ) ((eta ψ).cast (by simp) rfl) |>.cast (heq := rfl);
+    let d₂ : ⦃φ, ∼ψ⦄ ⊢ᴸᴶ¹ (∼(φ 🡒 ψ) : Propositionᵢ L) :=
+      positiveNeg <| d₁.negativeNeg.weakeningRight.cast (heq := rfl);
+    let d₃ : ⦃∼∼(φ 🡒 ψ), φ⦄ ⊢ᴸᴶ¹ (∼∼ψ : Propositionᵢ L) :=
+      positiveNeg <| d₂.negativeNeg.weakeningRight.cast (heq := rfl);
+    exact positiveImply (cutOne d₃ ihψ);
   | ∀¹ φ, h => positiveForall <| cutOne
       (cast (doubleNegationMap (specialize (eta (∀¹ Rewriting.shift φ)) &0))
         (by simp [Semiformulaᵢ.neg_def]) (by simp))
       (dneOfNegative (by simpa using h))
   termination_by φ _ => φ.complexity
 
-def ofDNOfNegative [L.DecidableEq] {φ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ (∼∼φ : Propositionᵢ L))
+def ofDNOfNegative {φ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ (∼∼φ : Propositionᵢ L))
     (h : φ.IsNegative) : Γ ⊢ᴸᴶ¹ φ := cutOne d (dneOfNegative h)
 
 /-- Mutual LJ derivability from singleton antecedents. -/
@@ -392,7 +369,7 @@ def symm (d : InterDerivation L φ ψ) : InterDerivation L ψ φ := ⟨d.2, d.1�
 
 def trans (d₁ : InterDerivation L φ ψ) (d₂ : InterDerivation L ψ χ) :
     InterDerivation L φ χ := ⟨cutOne d₁.1 d₂.1, cutOne d₂.2 d₁.2⟩
-def neg [L.DecidableEq] (d : InterDerivation L φ ψ) : InterDerivation L (∼φ) (∼ψ) :=
+def neg (d : InterDerivation L φ ψ) : InterDerivation L (∼φ) (∼ψ) :=
   ⟨contrapose d.2, contrapose d.1⟩
 
 def and (dφ : InterDerivation L φ₁ φ₂) (dψ : InterDerivation L ψ₁ ψ₂) :
@@ -410,10 +387,10 @@ def all {φ ψ : Semipropositionᵢ L 1}
       (cast (specialize (eta (∀¹ Rewriting.shift φ)) &0) (by simp) (by simp)) d
   exact ⟨lift d.1, lift d.2⟩
 
-def dne [L.DecidableEq] (h : φ.IsNegative) : InterDerivation L (∼∼φ) φ :=
+def dne (h : φ.IsNegative) : InterDerivation L (∼∼φ) φ :=
   ⟨dneOfNegative h, dni (eta φ)⟩
 
-def iffnegOfNegIff [L.DecidableEq] (h : φ.IsNegative)
+def iffnegOfNegIff (h : φ.IsNegative)
     (d : InterDerivation L (∼φ) ψ) : InterDerivation L φ (∼ψ) :=
   (dne h).symm.trans d.neg
 

--- a/Foundation/FirstOrder/Intuitionistic/LJ.lean
+++ b/Foundation/FirstOrder/Intuitionistic/LJ.lean
@@ -46,9 +46,12 @@ inductive Derivation : Sequent L → Head L → Type _
 /-- Cut rule -/
 | cut {φ : Propositionᵢ L} {Γ Δ Ξ} :
   Derivation Γ φ → Derivation (Δ + ⦃φ⦄) Ξ → Derivation (Γ + Δ) Ξ
-/-- Structural rule -/
-| contraction {Γ Γ' : Multiset (Propositionᵢ L)} {Ξ Ξ' : Option (Propositionᵢ L)} :
-  Derivation Γ Ξ → Γ ⊆ Γ' → Ξ ⊆ Ξ' → Derivation Γ' Ξ'
+/-- Left contraction -/
+| contraction : Derivation (Γ + ⦃φ, φ⦄) Ξ → Derivation (Γ + ⦃φ⦄) Ξ
+/-- Left weakening -/
+| weakening : Derivation Γ Ξ → Derivation (Γ + ⦃φ⦄) Ξ
+/-- Right weakening -/
+| weakeningRight : Derivation Γ none → Derivation Γ (some φ)
 /-- Positive introduction of verum -/
 | verum : Derivation 0 (some ⊤)
 /-- Negative introduction of falsum -/
@@ -98,14 +101,60 @@ open Rewriting LawfulSyntacticRewriting
 def cast (d : Γ ⊢ᴸᴶ¹ Ξ) (seq : Γ = Δ := by abel) (heq : Ξ = Λ := by simp) :
     Δ ⊢ᴸᴶ¹ Λ := seq ▸ heq ▸ d
 
+instance : Structural (fun Γ ↦ Γ ⊢ᴸᴶ¹ Ξ) where
+  weakening d := d.weakening
+  contraction d := d.contraction
+
+private lemma unshift_shift (φ : Propositionᵢ L) :
+    Rew.rewriteMap Nat.pred ▹ Rewriting.shift φ = φ := by
+  change Rew.rewriteMap Nat.pred ▹ (Rew.rewriteMap Nat.succ ▹ φ) = φ;
+  rw [← TransitiveRewriting.comp_app, Rew.rewriteMap_comp_rewriteMap];
+  change Rew.rewriteMap id ▹ φ = φ;
+  simp;
+
+/-- Enumerates the antecedent by recursion on the local rules.
+This is a routine syntactic construction. -/
+def traversal [L.DecidableEq] : {Γ : Sequent L} → {Ξ : Head L} →
+    (Γ ⊢ᴸᴶ¹ Ξ) → Γ.Traversal
+  | _, _, identity R v => .atom (Semiformulaᵢ.rel R v)
+  | _, _, cut d e => d.traversal.add e.traversal.remove
+  | _, _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | _, _, weakening (φ := φ) d => d.traversal.succ φ
+  | _, _, weakeningRight d => d.traversal
+  | _, _, verum => .zero
+  | _, _, falsum => .atom ⊥
+  | _, _, positiveImply d => d.traversal.remove
+  | _, _, negativeImply (φ := φ) (ψ := ψ) d e =>
+      (d.traversal.add e.traversal.remove).succ (φ 🡒 ψ)
+  | _, _, positiveAnd d _ => d.traversal
+  | _, _, negativeAnd (φ := φ) (ψ := ψ) d =>
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋏ ψ)
+  | _, _, positiveOrLeft d => d.traversal
+  | _, _, positiveOrRight d => d.traversal
+  | _, _, negativeOr (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋎ ψ)
+  | _, _, positiveForall d =>
+      (d.traversal.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
+        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])
+  | _, _, negativeForall (φ := φ) d => d.traversal.remove.succ (∀¹ φ)
+  | _, _, positiveExists d => d.traversal
+  | _, _, negativeExists (φ := φ) d =>
+      ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
+        simp [Rewriting.shifts, Multiset.map_map, unshift_shift])).succ (∃¹ φ)
+
+/-- Expands antecedent inclusion into local structural rules. -/
+def contra [L.DecidableEq] (d : Γ ⊢ᴸᴶ¹ Ξ) (t : Δ.Traversal)
+    (h : Γ ⊆ Δ := by simp) : Δ ⊢ᴸᴶ¹ Ξ :=
+  Structural.ofSubset (F := Propositionᵢ L)
+    (𝔇 := fun Γ ↦ Γ ⊢ᴸᴶ¹ Ξ) (Γ := Γ) (Δ := Δ) d.traversal t d h
+
 def eta : (φ : Propositionᵢ L) → ⦃φ⦄ ⊢ᴸᴶ¹ φ
   | .rel R v => identity R v
-  |        ⊥ => contraction falsum (by simp) (by simp)
+  |        ⊥ => falsum.weakeningRight
   |    φ ⋏ ψ => positiveAnd
       (cast (negativeAnd (Γ := 0) (φ := φ) (ψ := ψ) (Ξ := φ) <|
-        contraction (eta φ) (by simp) (by simp)))
+        ((eta φ).weakening (φ := ψ)).cast (by simp)))
       (cast (negativeAnd (Γ := 0) (φ := φ) (ψ := ψ) (Ξ := ψ) <|
-        contraction (eta ψ) (by simp) (by simp)))
+        ((eta ψ).weakening (φ := φ)).cast (by simp [add_comm])))
   |    φ ⋎ ψ => negativeOr (Γ := 0) (φ := φ) (ψ := ψ) (Ξ := φ ⋎ ψ)
       (cast (positiveOrLeft (ψ := ψ) (eta φ)))
       (cast (positiveOrRight (φ := φ) (eta ψ)))
@@ -121,8 +170,8 @@ def eta : (φ : Propositionᵢ L) → ⦃φ⦄ ⊢ᴸᴶ¹ φ
         cast (eta (Rewriting.free φ)) (by simp) (by simp))
   termination_by φ => φ.complexity
 
-def assumption {φ : Propositionᵢ L} (h : φ ∈ Γ) : Γ ⊢ᴸᴶ¹ φ :=
-  contraction (eta φ) (by simpa using h) (by simp)
+def assumption [L.DecidableEq] {φ : Propositionᵢ L} (t : Γ.Traversal)
+    (h : φ ∈ Γ) : Γ ⊢ᴸᴶ¹ φ := (eta φ).contra t (by simpa using h)
 
 def positiveNeg {φ : Propositionᵢ L} (d : Γ + ⦃φ⦄ ⊢ᴸᴶ¹ (⊥ : Propositionᵢ L)) :
     Γ ⊢ᴸᴶ¹ (∼φ : Propositionᵢ L) :=
@@ -133,15 +182,17 @@ def negativeNeg {φ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ φ) :
   cast (seq := by rw [add_zero]; rfl) <| negativeImply (φ := φ) (ψ := ⊥) (Γ := Γ) (Δ := 0) (Ξ := none) d <|
     cast falsum (by simp) (by rfl)
 
-def modusPonens {φ ψ : Propositionᵢ L} (di : Γ ⊢ᴸᴶ¹ φ 🡒 ψ) (dφ : Γ ⊢ᴸᴶ¹ φ) :
+def modusPonens [L.DecidableEq] {φ ψ : Propositionᵢ L} (di : Γ ⊢ᴸᴶ¹ φ 🡒 ψ) (dφ : Γ ⊢ᴸᴶ¹ φ) :
     Γ ⊢ᴸᴶ¹ ψ :=
-  contraction
-    (cut (φ := φ 🡒 ψ) (Γ := Γ) (Δ := Γ) (Ξ := ψ) di <| cast (seq := by simp) <|
+  have d : Γ + Γ ⊢ᴸᴶ¹ ψ :=
+    cut (φ := φ 🡒 ψ) (Γ := Γ) (Δ := Γ) (Ξ := ψ) di <| cast (seq := by simp) <|
       negativeImply (φ := φ) (ψ := ψ) (Γ := Γ) (Δ := 0) (Ξ := ψ)
-        dφ (cast (eta ψ) (by simp) (by simp)))
-    (by intro θ hθ; simp_all) (by simp)
+        dφ (cast (eta ψ) (by simp) (by simp))
+  cast (Structural.contractMany (F := Propositionᵢ L)
+    (𝔇 := fun Δ ↦ Δ ⊢ᴸᴶ¹ (some ψ)) (Δ := 0) di.traversal
+    (cast d (by simp) (by rfl))) (by simp)
 
-def negElim {φ : Propositionᵢ L} (dn : Γ ⊢ᴸᴶ¹ (∼φ : Propositionᵢ L))
+def negElim [L.DecidableEq] {φ : Propositionᵢ L} (dn : Γ ⊢ᴸᴶ¹ (∼φ : Propositionᵢ L))
     (dφ : Γ ⊢ᴸᴶ¹ φ) : Γ ⊢ᴸᴶ¹ (⊥ : Propositionᵢ L) :=
   modusPonens dn dφ
 
@@ -150,15 +201,15 @@ def cutOne {φ : Propositionᵢ L} (dφ : Γ ⊢ᴸᴶ¹ φ) (d : ⦃φ⦄ ⊢�
 
 def andLeft {φ ψ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ φ ⋏ ψ) : Γ ⊢ᴸᴶ¹ φ :=
   cutOne d <| cast <| negativeAnd (Γ := 0) (φ := φ) (ψ := ψ) (Ξ := φ) <|
-    assumption (by simp)
+    ((eta φ).weakening (φ := ψ)).cast (by simp)
 
 def andRight {φ ψ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ φ ⋏ ψ) : Γ ⊢ᴸᴶ¹ ψ :=
   cutOne d <| cast <| negativeAnd (Γ := 0) (φ := φ) (ψ := ψ) (Ξ := ψ) <|
-    assumption (by simp)
+    ((eta ψ).weakening (φ := φ)).cast (by simp [add_comm])
 
 def specialize {φ : Semipropositionᵢ L 1} (d : Γ ⊢ᴸᴶ¹ ∀¹ φ) (t : Term L ℕ) : Γ ⊢ᴸᴶ¹ φ/[t] :=
   cutOne d <| cast <| negativeForall (Γ := 0) (Ξ := φ/[t]) (φ := φ) (t := t) <|
-    assumption (by simp)
+    (eta (φ/[t])).cast (by simp)
 
 def rewrite (f : ℕ → SyntacticTerm L) {Γ : Sequent L} {Ξ : Head L} : Γ ⊢ᴸᴶ¹ Ξ →
     Γ.map (Rew.rewrite f ▹ ·) ⊢ᴸᴶ¹ Head.rewrite f Ξ
@@ -168,9 +219,17 @@ def rewrite (f : ℕ → SyntacticTerm L) {Γ : Sequent L} {Ξ : Head L} : Γ �
       (Γ := Γ.map (Rew.rewrite f ▹ ·)) (Δ := Δ.map (Rew.rewrite f ▹ ·))
       (Ξ := Head.rewrite f Ξ)
       ((rewrite f dφ).cast) ((rewrite f d).cast (by simp))).cast (by simp)
-  | contraction d hΓ hΞ =>
-    (rewrite f d).contraction (Multiset.map_subset_map hΓ) (by
-      cases hΞ <;> simp [Head.rewrite])
+  | contraction (Γ := Γ) (φ := φ) (Ξ := Ξ) d =>
+      (contraction (Γ := Γ.map (Rew.rewrite f ▹ ·)) (φ := Rew.rewrite f ▹ φ)
+        (Ξ := Head.rewrite f Ξ)
+        ((rewrite f d).cast (by simp) (by cases Ξ <;> rfl))).cast
+        (by simp) (by cases Ξ <;> rfl)
+  | weakening (Γ := Γ) (φ := φ) (Ξ := Ξ) d =>
+      (weakening (Γ := Γ.map (Rew.rewrite f ▹ ·)) (φ := Rew.rewrite f ▹ φ)
+        (Ξ := Head.rewrite f Ξ) (rewrite f d)).cast
+        (by simp) (by cases Ξ <;> rfl)
+  | weakeningRight (φ := φ) d =>
+      ((rewrite f d).weakeningRight (φ := Rew.rewrite f ▹ φ)).cast (by simp)
   | verum => verum
   | falsum => falsum
   | positiveImply (Γ := Γ) (φ := φ) (ψ := ψ) d =>
@@ -224,7 +283,9 @@ def rewrite (f : ℕ → SyntacticTerm L) {Γ : Sequent L} {Ξ : Head L} : Γ �
 def height : {Γ : Sequent L} → {Ξ : Head L} → Γ ⊢ᴸᴶ¹ Ξ → ℕ
   | _, _, .identity _ _ => 0
   | _, _, .cut d₁ d₂ => max (height d₁) (height d₂) + 1
-  | _, _, .contraction d _ _ => height d + 1
+  | _, _, .contraction d => height d + 1
+  | _, _, .weakening d => height d + 1
+  | _, _, .weakeningRight d => height d + 1
   | _, _, .verum => 0
   | _, _, .falsum => 0
   | _, _, .positiveImply d => height d + 1
@@ -263,25 +324,24 @@ protected def map (d : Γ ⊢ᴸᴶ¹ Ξ) (f : ℕ → ℕ) :
 protected def shift (d : Γ ⊢ᴸᴶ¹ Ξ) : Γ⁺ ⊢ᴸᴶ¹ Ξ.shift :=
   cast (d.map Nat.succ) (by rfl) (by cases Ξ <;> rfl)
 
-def weakening (d : Γ ⊢ᴸᴶ¹ Ξ) (hΓ : Γ ⊆ Δ) : Δ ⊢ᴸᴶ¹ Ξ :=
-  contraction d hΓ (by cases Ξ <;> simp)
-
 def dni {φ : Propositionᵢ L} (d : Γ ⊢ᴸᴶ¹ φ) : Γ ⊢ᴸᴶ¹ (∼∼φ : Propositionᵢ L) :=
-  positiveNeg <| contraction d.negativeNeg (by simp) (by simp)
+  positiveNeg d.negativeNeg.weakeningRight
 
 /-- Contraposition for singleton derivations (standard intuitionistic reasoning). -/
-def contrapose {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
+def contrapose [L.DecidableEq] {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
     ⦃∼ψ⦄ ⊢ᴸᴶ¹ (∼φ : Propositionᵢ L) :=
-  positiveNeg <| negElim (assumption (by simp [Semiformulaᵢ.neg_def])) <|
-    cutOne (assumption (by simp)) d
+  positiveNeg <| negElim
+    (assumption ((Multiset.Traversal.atom (∼ψ)).succ φ) (by simp [Semiformulaᵢ.neg_def])) <|
+    cutOne (assumption ((Multiset.Traversal.atom (∼ψ)).succ φ) (by simp)) d
 
 /-- Double negation preserves derivability, by twice applying contraposition (folklore). -/
-def doubleNegationMap {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
+def doubleNegationMap [L.DecidableEq] {φ ψ : Propositionᵢ L} (d : ⦃φ⦄ ⊢ᴸᴶ¹ ψ) :
     ⦃∼∼φ⦄ ⊢ᴸᴶ¹ (∼∼ψ : Propositionᵢ L) := d.contrapose.contrapose
 
 def dneOfNegative [L.DecidableEq] : {φ : Propositionᵢ L} → φ.IsNegative → ⦃∼∼φ⦄ ⊢ᴸᴶ¹ φ
-  | ⊥, _ => negElim (eta _) <| contraction
-      (positiveNeg (Γ := 0) (φ := ⊥) (assumption (by simp))) (by simp) (by simp)
+  | ⊥, _ => negElim (eta _) <|
+      ((positiveNeg (Γ := 0) (φ := ⊥) ((eta ⊥).cast (by simp))).weakening
+        (φ := ∼∼(⊥ : Propositionᵢ L))).cast (by simp)
   | φ ⋏ ψ, h =>
     have hn : φ.IsNegative ∧ ψ.IsNegative := by simpa using h
     positiveAnd
@@ -291,19 +351,23 @@ def dneOfNegative [L.DecidableEq] : {φ : Propositionᵢ L} → φ.IsNegative �
     have hnψ : ψ.IsNegative := by simpa using h
     have ihψ := dneOfNegative hnψ
     let N : Sequent L := ⦃∼∼(φ 🡒 ψ)⦄
+    let tN : N.Traversal := .atom _
     apply positiveImply (Γ := N) (φ := φ) (ψ := ψ)
     let C : Sequent L := N + ⦃φ⦄
+    let tC := tN.succ φ
     have dnnψ : C ⊢ᴸᴶ¹ ↑(∼∼ψ) := positiveNeg (Γ := C) <| by
       let D : Sequent L := C + ⦃∼ψ⦄
+      let tD := tC.succ (∼ψ)
       have dnImp : D ⊢ᴸᴶ¹ ∼(φ 🡒 ψ) := positiveNeg (Γ := D) <| by
         let E : Sequent L := D + ⦃φ 🡒 ψ⦄
+        let tE := tD.succ (φ 🡒 ψ)
         have dψ : E ⊢ᴸᴶ¹ ψ := modusPonens
-          (assumption (φ := φ 🡒 ψ) (by simp [E]))
-          (assumption (φ := φ) (by simp [E, D, C]))
+          (assumption (φ := φ 🡒 ψ) tE (by simp [E]))
+          (assumption (φ := φ) tE (by simp [E, D, C]))
         exact negElim
-          (assumption (φ := ∼ψ) (by simp [D, Semiformulaᵢ.neg_def])) dψ
+          (assumption (φ := ∼ψ) tE (by simp [D, Semiformulaᵢ.neg_def])) dψ
       exact negElim
-        (assumption (φ := ∼∼(φ 🡒 ψ)) (by simp [C, N, Semiformulaᵢ.neg_def])) dnImp
+        (assumption (φ := ∼∼(φ 🡒 ψ)) tD (by simp [C, N, Semiformulaᵢ.neg_def])) dnImp
     exact cutOne dnnψ ihψ
   | ∀¹ φ, h => positiveForall <| cutOne
       (cast (doubleNegationMap (specialize (eta (∀¹ Rewriting.shift φ)) &0))
@@ -328,7 +392,7 @@ def symm (d : InterDerivation L φ ψ) : InterDerivation L ψ φ := ⟨d.2, d.1�
 
 def trans (d₁ : InterDerivation L φ ψ) (d₂ : InterDerivation L ψ χ) :
     InterDerivation L φ χ := ⟨cutOne d₁.1 d₂.1, cutOne d₂.2 d₁.2⟩
-def neg (d : InterDerivation L φ ψ) : InterDerivation L (∼φ) (∼ψ) :=
+def neg [L.DecidableEq] (d : InterDerivation L φ ψ) : InterDerivation L (∼φ) (∼ψ) :=
   ⟨contrapose d.2, contrapose d.1⟩
 
 def and (dφ : InterDerivation L φ₁ φ₂) (dψ : InterDerivation L ψ₁ ψ₂) :
@@ -409,14 +473,17 @@ def deduct : adjoin φ T ⊢! ψ → T ⊢! φ 🡒 ψ
       simpa [hθφ] using hΓ θ hθΓ,
     LJ.Derivation.cast (heq := by rfl) <|
       LJ.Derivation.positiveImply (φ := (φ : Propositionᵢ L)) (ψ := (ψ : Propositionᵢ L)) <|
-      LJ.Derivation.contraction (Ξ' := (ψ : Propositionᵢ L)) d (by
+      LJ.Derivation.contra d
+        (((d.traversal.filter (· ≠ (φ : Propositionᵢ L))).cast (by
+          simp [Multiset.filter_map, Rewriting.emb_injective.eq_iff])).succ
+          (φ : Propositionᵢ L)) (by
         intro θ hθ
         rcases Multiset.mem_map.mp hθ with ⟨χ, hχ, rfl⟩
         by_cases h : χ = φ
         · subst χ
           simp
         · exact Multiset.mem_add.mpr <| Or.inl <|
-            Multiset.mem_map_of_mem Rewriting.emb <| Multiset.mem_filter_of_mem hχ h) (by simp)⟩
+            Multiset.mem_map_of_mem Rewriting.emb <| Multiset.mem_filter_of_mem hχ h)⟩
 
 def deductInv : T ⊢! φ 🡒 ψ → adjoin φ T ⊢! ψ
   | ⟨Γ, hΓ, d⟩ =>

--- a/Foundation/FirstOrder/Intuitionistic/LJ.lean
+++ b/Foundation/FirstOrder/Intuitionistic/LJ.lean
@@ -105,36 +105,33 @@ instance : Structural (fun Γ ↦ Γ ⊢ᴸᴶ¹ Ξ) where
   weakening d := d.weakening
   contraction d := d.contraction
 
-/-- Enumerates the antecedent by recursion on the local rules.
-This is a routine syntactic construction. -/
-def traversal [L.DecidableEq] : {Γ : Sequent L} → {Ξ : Head L} →
-    (Γ ⊢ᴸᴶ¹ Ξ) → Γ.Traversal
-  | _, _, identity R v => .atom (Semiformulaᵢ.rel R v)
-  | _, _, cut d e => d.traversal.add e.traversal.remove
-  | _, _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
-  | _, _, weakening (φ := φ) d => d.traversal.succ φ
-  | _, _, weakeningRight d => d.traversal
-  | _, _, verum => .zero
-  | _, _, falsum => .atom ⊥
-  | _, _, positiveImply d => d.traversal.remove
-  | _, _, negativeImply (φ := φ) (ψ := ψ) d e =>
+def traversal [L.DecidableEq] {Γ : Sequent L} {Ξ : Head L} :
+    Γ ⊢ᴸᴶ¹ Ξ → Γ.Traversal
+  | identity R v => .atom (Semiformulaᵢ.rel R v)
+  | cut d e => d.traversal.add e.traversal.remove
+  | contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | weakening (φ := φ) d => d.traversal.succ φ
+  | weakeningRight d => d.traversal
+  | verum => .zero
+  | falsum => .atom ⊥
+  | positiveImply d => d.traversal.remove
+  | negativeImply (φ := φ) (ψ := ψ) d e =>
       (d.traversal.add e.traversal.remove).succ (φ 🡒 ψ)
-  | _, _, positiveAnd d _ => d.traversal
-  | _, _, negativeAnd (φ := φ) (ψ := ψ) d =>
+  | positiveAnd d _ => d.traversal
+  | negativeAnd (φ := φ) (ψ := ψ) d =>
       ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋏ ψ)
-  | _, _, positiveOrLeft d => d.traversal
-  | _, _, positiveOrRight d => d.traversal
-  | _, _, negativeOr (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋎ ψ)
-  | _, _, positiveForall d =>
+  | positiveOrLeft d => d.traversal
+  | positiveOrRight d => d.traversal
+  | negativeOr (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋎ ψ)
+  | positiveForall d =>
       (d.traversal.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
         simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])
-  | _, _, negativeForall (φ := φ) d => d.traversal.remove.succ (∀¹ φ)
-  | _, _, positiveExists d => d.traversal
-  | _, _, negativeExists (φ := φ) d =>
+  | negativeForall (φ := φ) d => d.traversal.remove.succ (∀¹ φ)
+  | positiveExists d => d.traversal
+  | negativeExists (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewriteMap Nat.pred ▹ ·)).cast (by
         simp [Rewriting.shifts, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∃¹ φ)
 
-/-- Expands antecedent inclusion into local structural rules. -/
 def contra [L.DecidableEq] (d : Γ ⊢ᴸᴶ¹ Ξ) (t : Δ.Traversal)
     (h : Γ ⊆ Δ := by simp) : Δ ⊢ᴸᴶ¹ Ξ :=
   Structural.ofSubset (F := Propositionᵢ L)
@@ -273,25 +270,25 @@ def rewrite (f : ℕ → SyntacticTerm L) {Γ : Sequent L} {Ξ : Head L} : Γ �
       |>.cast (by simp [Rew.q_rewrite])
 
 /-- Height of an LJ derivation, with initial rules at height zero (standard definition). -/
-def height : {Γ : Sequent L} → {Ξ : Head L} → Γ ⊢ᴸᴶ¹ Ξ → ℕ
-  | _, _, .identity _ _ => 0
-  | _, _, .cut d₁ d₂ => max (height d₁) (height d₂) + 1
-  | _, _, .contraction d => height d + 1
-  | _, _, .weakening d => height d + 1
-  | _, _, .weakeningRight d => height d + 1
-  | _, _, .verum => 0
-  | _, _, .falsum => 0
-  | _, _, .positiveImply d => height d + 1
-  | _, _, .negativeImply d₁ d₂ => max (height d₁) (height d₂) + 1
-  | _, _, .positiveAnd d₁ d₂ => max (height d₁) (height d₂) + 1
-  | _, _, .negativeAnd d => height d + 1
-  | _, _, .positiveOrLeft d => height d + 1
-  | _, _, .positiveOrRight d => height d + 1
-  | _, _, .negativeOr d₁ d₂ => max (height d₁) (height d₂) + 1
-  | _, _, .positiveForall d => height d + 1
-  | _, _, .negativeForall d => height d + 1
-  | _, _, .positiveExists d => height d + 1
-  | _, _, .negativeExists d => height d + 1
+def height {Γ : Sequent L} {Ξ : Head L} : Γ ⊢ᴸᴶ¹ Ξ → ℕ
+  | identity _ _ => 0
+  | cut d₁ d₂ => max (height d₁) (height d₂) + 1
+  | contraction d => height d + 1
+  | weakening d => height d + 1
+  | weakeningRight d => height d + 1
+  | verum => 0
+  | falsum => 0
+  | positiveImply d => height d + 1
+  | negativeImply d₁ d₂ => max (height d₁) (height d₂) + 1
+  | positiveAnd d₁ d₂ => max (height d₁) (height d₂) + 1
+  | negativeAnd d => height d + 1
+  | positiveOrLeft d => height d + 1
+  | positiveOrRight d => height d + 1
+  | negativeOr d₁ d₂ => max (height d₁) (height d₂) + 1
+  | positiveForall d => height d + 1
+  | negativeForall d => height d + 1
+  | positiveExists d => height d + 1
+  | negativeExists d => height d + 1
 
 /-- Transport along sequent equalities preserves height (routine). -/
 @[simp] lemma height_cast {Γ Δ : Sequent L} {Ξ Λ : Head L}

--- a/Foundation/FirstOrder/Kripke/Intuitionistic.lean
+++ b/Foundation/FirstOrder/Kripke/Intuitionistic.lean
@@ -179,9 +179,12 @@ theorem sound {Γ : LJ.Sequent L} {Ξ : LJ.Head L} :
       obtain ⟨hΓ, hΔ⟩ := Multiset.forall_mem_add.mp hΓ
       exact sound d w fv hfv <| Multiset.forall_mem_add.mpr
         ⟨hΔ, by simpa using sound dφ w fv hfv hΓ⟩
-  | .contraction (Ξ := Ξ) d hΔ hΞ, w, fv, hfv, hΓ => by
-      have hd := sound d w fv hfv fun φ hφ ↦ hΓ φ (hΔ hφ)
-      cases Ξ <;> cases hΞ <;> simp_all [ForcesHead]
+  | .contraction d, w, fv, hfv, hΓ =>
+      sound d w fv hfv (by simpa only [Multiset.forall_mem_add,
+        Multiset.forall_mem_atom, and_self] using hΓ)
+  | .weakening d, w, fv, hfv, hΓ =>
+      sound d w fv hfv fun φ hφ ↦ hΓ φ (Multiset.mem_add.mpr (Or.inl hφ))
+  | .weakeningRight d, w, fv, hfv, hΓ => (sound d w fv hfv hΓ).elim
   | .verum, _, _, _, _ => by simp [ForcesHead]
   | .falsum, _, _, _, hΓ => hΓ (⊥ : Propositionᵢ L) (by simp)
   | .positiveImply d, w, fv, hfv, hΓ => by

--- a/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
+++ b/Foundation/FirstOrder/NegationTranslation/GoedelGentzen.lean
@@ -97,9 +97,9 @@ def negDoubleNegation : (φ : Proposition L) →
   | ⊤ => by
       constructor
       · exact negElim (eta (∼(⊤ : Propositionᵢ L))) <|
-          weakening verum (by simp)
+          verum.weakening (φ := ∼∼(⊥ : Propositionᵢ L))
       · apply positiveNeg
-        exact assumption (by simp)
+        exact assumption ((Multiset.Traversal.atom _).succ _) (by simp)
   | ⊥ => InterDerivation.refl _
   | φ ⋏ ψ => by
       have eφ := (negDoubleNegation φ).iffnegOfNegIff (by simp)
@@ -143,9 +143,8 @@ def deductNeg {Γ : Sequent L} {φ : Proposition L}
 
 def gödelGentzen {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → (∼Γ)ᴺ ⊢ᴸᴶ¹ (⊥ : Propositionᵢ L)
   | identity R v => by
-      exact LJ.Derivation.contraction
-        (LJ.Derivation.eta (∼(.rel R v) : Propositionᵢ L)).negativeNeg
-        (by simp [Sequent.doubleNegation]) (by simp)
+      exact ((LJ.Derivation.eta (∼(.rel R v) : Propositionᵢ L)).negativeNeg.cast
+        (by simp [Sequent.doubleNegation]) (by rfl)).weakeningRight
   | verum => by
       simpa [Sequent.doubleNegation] using LJ.Derivation.eta (⊥ : Propositionᵢ L)
   | and (Γ := Γ) (φ := φ) (ψ := ψ) dφ dψ => by
@@ -154,8 +153,7 @@ def gödelGentzen {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → (∼Γ)ᴺ ⊢ᴸᴶ¹ (
       have dψ : (∼Γ)ᴺ ⊢ᴸᴶ¹ (∼(∼ψ)ᴺ : Propositionᵢ L) :=
         deductNeg (gödelGentzen dψ)
       have dAnd := LJ.Derivation.positiveAnd dφ dψ
-      exact LJ.Derivation.contraction dAnd.negativeNeg
-        (by simp [Sequent.doubleNegation]) (by simp)
+      exact (dAnd.negativeNeg.cast (by simp [Sequent.doubleNegation]) (by rfl)).weakeningRight
   | or (Γ := Γ) (φ := φ) (ψ := ψ) d =>
       (LJ.Derivation.negativeAnd (Γ := (∼Γ)ᴺ) (φ := (∼φ)ᴺ)
         (ψ := (∼ψ)ᴺ) (Ξ := (⊥ : Propositionᵢ L)) <|
@@ -170,8 +168,7 @@ def gödelGentzen {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → (∼Γ)ᴺ ⊢ᴸᴶ¹ (
       have dAll := LJ.Derivation.positiveForall (Γ := (∼Γ)ᴺ)
         (φ := ∼(∼φ)ᴺ) <|
         dFree.cast (heq := by simp [Semiformula.rew_doubleNegation])
-      exact LJ.Derivation.contraction dAll.negativeNeg
-        (by simp [Sequent.doubleNegation]) (by simp)
+      exact (dAll.negativeNeg.cast (by simp [Sequent.doubleNegation]) (by rfl)).weakeningRight
   | exs (Γ := Γ) (φ := φ) (t := t) d =>
       (LJ.Derivation.negativeForall (Γ := (∼Γ)ᴺ) (φ := (∼φ)ᴺ)
         (t := t) (Ξ := (⊥ : Propositionᵢ L)) <|
@@ -186,9 +183,15 @@ def gödelGentzen {Γ : Sequent L} : ⊢ᴸᴷ¹ Γ → (∼Γ)ᴺ ⊢ᴸᴶ¹ (
       exact (LJ.Derivation.cut (Γ := (∼Γ)ᴺ) (Δ := (∼Δ)ᴺ)
         (φ := φᴺ) (Ξ := (⊥ : Propositionᵢ L)) dφ <|
         ihn.cast (by simp)).cast (by simp [Sequent.doubleNegation])
-  | contraction d h =>
-      LJ.Derivation.weakening (gödelGentzen d) <|
-        Multiset.map_subset_map <| Multiset.map_subset_map h
+  | contraction (Γ := Γ) (φ := φ) d =>
+      have e : (∼Γ)ᴺ + ⦃(∼φ)ᴺ, (∼φ)ᴺ⦄ ⊢ᴸᴶ¹ (⊥ : Propositionᵢ L) :=
+        (gödelGentzen d).cast (by simp [Sequent.doubleNegation]) (by rfl)
+      (LJ.Derivation.contraction (Γ := (∼Γ)ᴺ) (φ := (∼φ)ᴺ)
+        (Ξ := (⊥ : Propositionᵢ L)) e).cast
+        (by simp [Sequent.doubleNegation]) (by rfl)
+  | weakening (Γ := Γ) (φ := φ) d =>
+      ((gödelGentzen d).weakening (φ := (∼φ)ᴺ)).cast
+        (by simp [Sequent.doubleNegation])
 
 end Derivation
 

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -89,8 +89,6 @@ variable {F : Type*} [LogicalConnective F] [LogicalNeutral F]
 
 alias cast := Structural.cast
 alias weakenMany := Structural.weakenMany
-alias contractMany := Structural.contractMany
-alias absorb := Structural.absorb
 alias ofSubset := Structural.ofSubset
 
 def contra [OneSidedLK 𝔇] [DecidableEq F] (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -39,66 +39,79 @@ class OneSidedLK.Cut
     (𝔇 : Multiset F → Type*) extends OneSidedLK 𝔇 where
   cut : 𝔇 (Γ + ⦃φ⦄) → 𝔇 (Δ + ⦃∼φ⦄) → 𝔇 (Γ + Δ)
 
+namespace Structural
+
+variable {F : Type*} {𝔇 : Multiset F → Type*} {Γ Δ : Multiset F} {φ : F}
+
+def cast (d : 𝔇 Γ) (h : Γ = Δ := by abel) : 𝔇 Δ := h ▸ d
+
+/-- Repeated weakening along a traversal (a routine structural derivation). -/
+def weakenMany [Structural 𝔇] {Γ Δ : Multiset F} (t : Δ.Traversal) (d : 𝔇 Γ) : 𝔇 (Γ + Δ) :=
+  match t with
+  | .zero => cast d
+  | .succ φ t => cast (weakening (φ := φ) (weakenMany t d))
+
+/-- Repeated contraction along a traversal (a routine structural derivation). -/
+def contractMany [Structural 𝔇] {Γ Δ : Multiset F} (t : Γ.Traversal) (d : 𝔇 (Δ + Γ + Γ)) : 𝔇 (Δ + Γ) :=
+  match t with
+  | .zero => cast d
+  | @Multiset.Traversal.succ _ Γ φ t =>
+      have d₁ : 𝔇 ((Δ + Γ + Γ) + ⦃φ, φ⦄) := cast d
+      have d₂ : 𝔇 ((Δ + ⦃φ⦄) + Γ + Γ) := cast (contraction d₁)
+      cast (contractMany t d₂)
+
+/-- Absorbs a formula already in the context (a routine structural derivation). -/
+def absorb [Structural 𝔇] [DecidableEq F] (d : 𝔇 (Γ + ⦃φ⦄)) (h : φ ∈ Γ) : 𝔇 Γ :=
+  have he : Γ.erase φ + ⦃φ⦄ = Γ := by
+    simpa [Multiset.add_atom_eq_cons] using Multiset.cons_erase h
+  have d' : 𝔇 (Γ.erase φ + ⦃φ, φ⦄) :=
+    cast d (by simpa [add_assoc] using congrArg (· + ⦃φ⦄) he.symm)
+  cast (contraction d') he
+
+/-- Expands multiset inclusion into local structural rules using traversals. -/
+def ofSubset [Structural 𝔇] [DecidableEq F]
+    (tΓ : Γ.Traversal) (tΔ : Δ.Traversal) (d : 𝔇 Γ) (h : Γ ⊆ Δ) : 𝔇 Δ :=
+  let rec go {Γ : Multiset F} (t : Γ.Traversal) (h : Γ ⊆ Δ) (d : 𝔇 (Δ + Γ)) : 𝔇 Δ :=
+    match t with
+    | .zero => cast d
+    | @Multiset.Traversal.succ _ Γ φ t =>
+        have d' : 𝔇 ((Δ + Γ) + ⦃φ⦄) := cast d
+        have hp : φ ∈ Δ := h (by simp)
+        go t (fun ψ hψ ↦ h (by simp [hψ])) (absorb d' (by simp [hp]))
+  go tΓ h (cast (weakenMany tΔ d))
+
+end Structural
+
 namespace OneSidedLK
 
 variable {F : Type*} [LogicalConnective F] [LogicalNeutral F]
   [TildeInvolutive F] [LogicalConnective.DeMorgan F] [LogicalNeutral.DeMorgan F] {𝔇 : Multiset F → Type*}
 
-def cast (b : 𝔇 Γ) (h : Γ = Δ := by abel) : 𝔇 Δ := h ▸ b
+alias cast := Structural.cast
+alias weakenMany := Structural.weakenMany
+alias contractMany := Structural.contractMany
+alias absorb := Structural.absorb
+alias ofSubset := Structural.ofSubset
 
-def weakenMany [Structural 𝔇] (tΔ : Δ.Traversal) (d : 𝔇 Γ) : 𝔇 (Γ + Δ) :=
-  match tΔ with
-  | .zero => cast d
-  | .succ φ t => Structural.weakening (weakenMany t d)
+def contra [OneSidedLK 𝔇] [DecidableEq F] (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
+    (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ := ofSubset tΓ tΔ d h
 
-def contractMany [Structural 𝔇] (tΓ : Γ.Traversal) (d : 𝔇 (Δ + Γ + Γ)) : 𝔇 (Δ + Γ) :=
-  match tΓ with
-  | .zero => cast d
-  | .succ φ t =>
-    let d' : 𝔇 ((Δ + (t.toList : Multiset F) + (t.toList : Multiset F)) + ⦃φ, φ⦄) :=
-      cast d (by simp [t.coe_toList]; abel)
-    contractMany t (Structural.contraction d')
-
-def absorb [Structural 𝔇] [DecidableEq F] (d : 𝔇 (Γ + ⦃φ⦄)) (h : φ ∈ Γ) : 𝔇 Γ := by
-  let e := Γ.erase φ
-  have he : Γ = e + ⦃φ⦄ := by
-    exact (Multiset.add_singleton_eq_iff.mpr ⟨h, rfl⟩).symm
-  have d' : 𝔇 (e + ⦃φ, φ⦄) := cast d (by rw [he]; abel)
-  exact cast (Structural.contraction d') (by rw [← he]; simp [he, e])
-
-def ofSubset [Structural 𝔇] [DecidableEq F]
-    (tΓ : Γ.Traversal) (tΔ : Δ.Traversal) (d : 𝔇 Γ) (h : Γ ⊆ Δ) : 𝔇 Δ := by
-  let rec go {Γ : Multiset F} (tΓ : Γ.Traversal) (d : 𝔇 (Δ + Γ))
-      (hΓ : Γ ⊆ Δ) : 𝔇 Δ :=
-    match tΓ with
-    | .zero => cast d (by simp)
-    | .succ φ t =>
-      let d₁ : 𝔇 (Δ + (t.toList : Multiset F) + ⦃φ⦄) :=
-        cast d (by simp [t.coe_toList]; abel)
-      let d₂ : 𝔇 (Δ + (t.toList : Multiset F)) :=
-        absorb d₁ (by exact mem_of_mem_add_left (hΓ (by simp)))
-      go t d₂ (by
-        intro ψ hψ
-        exact hΓ (by simp [hψ]))
-  go tΓ (cast (weakenMany tΔ d) (by abel)) h
-
-def contra [OneSidedLK 𝔇] (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ :=
-  ofSubset (default : Γ.Traversal) (default : Δ.Traversal) d h
-
-def close [OneSidedLK 𝔇] (φ : F) (hp : φ ∈ Γ := by simp) (hn : ∼φ ∈ Γ := by simp) : 𝔇 Γ :=
-  contra (identity φ) (by
+def close [OneSidedLK 𝔇] [DecidableEq F] (φ : F) (t : Γ.Traversal)
+    (hp : φ ∈ Γ := by simp) (hn : ∼φ ∈ Γ := by simp) : 𝔇 Γ :=
+  contra ((Multiset.Traversal.atom φ).succ (∼φ)) t (identity φ) (by
     intro ψ hψ
     rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all)
 
-def top [OneSidedLK 𝔇] (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ := contra verum (by simpa using h)
+def top [OneSidedLK 𝔇] [DecidableEq F] (t : Γ.Traversal) (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ :=
+  contra (.atom ⊤) t verum (by simpa using h)
 
-def tensor [OneSidedLK 𝔇] {φ ψ : F} (tΓ : Γ.Traversal := by exact default)
-    (tΔ : Δ.Traversal := by exact default)
+def tensor [OneSidedLK 𝔇] {φ ψ : F} (tΓ : Γ.Traversal)
+    (tΔ : Δ.Traversal)
     (dφ : 𝔇 (Γ + ⦃φ⦄)) (dψ : 𝔇 (Δ + ⦃ψ⦄)) :
     𝔇 (Γ + Δ + ⦃φ ⋏ ψ⦄) :=
   and
-    (cast (weakenMany tΔ dφ) (by simp; abel))
-    (cast (weakenMany tΓ dψ) (by simp; abel))
+    (cast (weakenMany tΔ dφ) (by abel))
+    (cast (weakenMany tΓ dψ) (by abel))
 
 alias cut := OneSidedLK.Cut.cut
 
@@ -116,6 +129,7 @@ def modusPonens [Cut 𝔇] (di : 𝔇 (Γ + ⦃φ 🡒 ψ⦄)) (dp : 𝔇 (Δ + 
     𝔇 (Γ + Δ + ⦃ψ⦄) :=
   have h₁ : 𝔇 ⦃∼(φ 🡒 ψ), ∼φ, ψ⦄ := cast
     (tensor (𝔇 := 𝔇) (Γ := ⦃∼φ⦄) (Δ := ⦃ψ⦄) (φ := φ) (ψ := ∼ψ)
+      (.atom _) (.atom _)
       (cast (identity φ) (by abel)) (cast (identity (∼ψ)) (by simp; abel)))
     (by simp [LogicalConnective.DeMorgan.imply]; abel)
   have h₂ : 𝔇 (Γ + ⦃∼φ, ψ⦄) := cast <|
@@ -125,7 +139,7 @@ def modusPonens [Cut 𝔇] (di : 𝔇 (Γ + ⦃φ 🡒 ψ⦄)) (dp : 𝔇 (Δ + 
 def disj₂ {Γ : List F} {Δ : Multiset F} [OneSidedLK 𝔇] :
     𝔇 ((Γ : Multiset F) + Δ) → 𝔇 (Δ + ⦃⋁Γ⦄) := fun d ↦
   match Γ with
-  | [] => contra d (by intro φ hφ; simp_all)
+  | [] => cast (Structural.weakening (φ := ⊥) (cast d (by simp) : 𝔇 Δ)) (by simp)
   | [φ] => cast d (by
     change φ ::ₘ Δ = Δ + ⦃φ⦄
     exact (Multiset.add_atom_eq_cons φ Δ).symm)
@@ -139,17 +153,21 @@ def disj₂ {Γ : List F} {Δ : Multiset F} [OneSidedLK 𝔇] :
   termination_by _ => Γ.length
 
 def conj₂ [OneSidedLK 𝔇] {Γ : List F} {Δ : Multiset F}
+    (tΔ : Δ.Traversal)
     (d : (φ : F) → φ ∈ Γ → 𝔇 (Δ + ⦃φ⦄)) : 𝔇 (Δ + ⦃⋀Γ⦄) :=
   match Γ with
-  |          [] => contra verum (by intro φ hφ; simp_all)
+  |          [] => cast (weakenMany tΔ verum) (by simp; abel)
   |         [φ] => d φ (by simp)
   | φ :: ψ :: Γ =>
-    have : 𝔇 (Δ + ⦃⋀(ψ :: Γ)⦄) := conj₂ (Γ := ψ :: Γ) (fun χ h ↦ d χ (by simp_all))
+    have : 𝔇 (Δ + ⦃⋀(ψ :: Γ)⦄) := conj₂ (Γ := ψ :: Γ) tΔ (fun χ h ↦ d χ (by simp_all))
     and (Γ := Δ) (φ := φ) (ψ := ⋀(ψ :: Γ)) (d φ (by simp)) this
 
 namespace AxiomDerivation
 
 variable [OneSidedLK 𝔇]
+
+def identityWith (φ : F) (t : Γ.Traversal) : 𝔇 (Γ + ⦃φ, ∼φ⦄) :=
+  cast (Structural.weakenMany t (identity φ))
 
 def introOr (d : 𝔇 ⦃φ, ψ⦄) : 𝔇 ⦃φ ⋎ ψ⦄ :=
   cast (or (Γ := 0) (φ := φ) (ψ := ψ) (cast d (by abel))) (by simp)
@@ -159,16 +177,16 @@ def introDisj {Γ : List F} (d : 𝔇 (Γ : Multiset F)) : 𝔇 ⦃⋁Γ⦄ :=
 
 /-- The rule expansion of the classical negation equivalence axiom. This is a routine syntactic derivation. -/
 def negEquiv (φ : F) : 𝔇 ⦃(φ ⋎ ∼φ ⋎ ⊥) ⋏ (φ ⋏ ⊤ ⋎ ∼φ)⦄ :=
-  have d₁ : 𝔇 ⦃φ ⋎ ∼φ ⋎ ⊥⦄ := introDisj <| close φ (Γ := ⦃φ, ∼φ, ⊥⦄)
-  have dp : 𝔇 ⦃∼φ, φ⦄ := close φ (Γ := ⦃∼φ, φ⦄)
-  have dt : 𝔇 ⦃∼φ, ⊤⦄ := top (Γ := ⦃∼φ, ⊤⦄)
+  have d₁ : 𝔇 ⦃φ ⋎ ∼φ ⋎ ⊥⦄ := introDisj (Γ := [φ, ∼φ, ⊥]) <| cast (identityWith φ (.atom ⊥)) (by change ⦃⊥⦄ + ⦃φ, ∼φ⦄ = ⦃φ, ∼φ, ⊥⦄; abel)
+  have dp : 𝔇 ⦃∼φ, φ⦄ := cast (identity φ)
+  have dt : 𝔇 ⦃∼φ, ⊤⦄ := cast (Structural.weakening (φ := ∼φ) verum)
   have dc : 𝔇 ⦃∼φ, φ ⋏ ⊤⦄ := cast <| and (Γ := ⦃∼φ⦄) (φ := φ) (ψ := ⊤) (cast dp) (cast dt)
   cast <| and (Γ := 0) (φ := φ ⋎ ∼φ ⋎ ⊥) (ψ := φ ⋏ ⊤ ⋎ ∼φ)
     (cast d₁) (cast <| introOr (φ := φ ⋏ ⊤) (ψ := ∼φ) <| cast dc (by abel))
 
 /-- The rule expansion of the K axiom. This is a routine syntactic derivation. -/
 def implyK (φ ψ : F) : 𝔇 ⦃∼φ ⋎ ∼ψ ⋎ φ⦄ :=
-  introDisj <| close φ (Γ := ⦃∼φ, ∼ψ, φ⦄)
+  introDisj (Γ := [∼φ, ∼ψ, φ]) <| cast (identityWith φ (.atom (∼ψ))) (by change ⦃∼ψ⦄ + ⦃φ, ∼φ⦄ = ⦃∼φ, ∼ψ, φ⦄; abel)
 
 /-- The rule expansion of the S axiom. This is a routine syntactic derivation. -/
 def implyS (φ ψ χ : F) : 𝔇 ⦃φ ⋏ ψ ⋏ ∼χ ⋎ φ ⋏ ∼ψ ⋎ ∼φ ⋎ χ⦄ :=
@@ -176,15 +194,12 @@ def implyS (φ ψ χ : F) : 𝔇 ⦃φ ⋏ ψ ⋏ ∼χ ⋎ φ ⋏ ∼ψ ⋎ ∼
   let B := φ ⋏ ∼ψ
   let C := ∼φ
   let D := χ
-  have dφ : 𝔇 (⦃B, C, D⦄ + ⦃φ⦄) := close φ (Γ := ⦃B, C, D⦄ + ⦃φ⦄)
-    (by simp) (by simp [C])
-  have dbp : 𝔇 (⦃C, D, ψ⦄ + ⦃φ⦄) := close φ (Γ := ⦃C, D, ψ⦄ + ⦃φ⦄)
-    (by simp) (by simp [C])
-  have dbn : 𝔇 (⦃C, D, ψ⦄ + ⦃∼ψ⦄) := close ψ (Γ := ⦃C, D, ψ⦄ + ⦃∼ψ⦄)
+  have dφ : 𝔇 (⦃B, C, D⦄ + ⦃φ⦄) := cast (identityWith φ ((Multiset.Traversal.atom B).succ D)) (by dsimp [C]; abel)
+  have dbp : 𝔇 (⦃C, D, ψ⦄ + ⦃φ⦄) := cast (identityWith φ ((Multiset.Traversal.atom D).succ ψ)) (by dsimp [C]; abel)
+  have dbn : 𝔇 (⦃C, D, ψ⦄ + ⦃∼ψ⦄) := cast (identityWith ψ ((Multiset.Traversal.atom C).succ D))
   have dψ : 𝔇 (⦃B, C, D⦄ + ⦃ψ⦄) := cast <|
     and (Γ := ⦃C, D, ψ⦄) (φ := φ) (ψ := ∼ψ) dbp dbn
-  have dnχ : 𝔇 (⦃B, C, D⦄ + ⦃∼χ⦄) := close χ (Γ := ⦃B, C, D⦄ + ⦃∼χ⦄)
-    (by simp [D]) (by simp)
+  have dnχ : 𝔇 (⦃B, C, D⦄ + ⦃∼χ⦄) := cast (identityWith χ ((Multiset.Traversal.atom B).succ C)) (by dsimp [D]; abel)
   have dr : 𝔇 (⦃B, C, D⦄ + ⦃ψ ⋏ ∼χ⦄) := and (φ := ψ) (ψ := ∼χ) dψ dnχ
   have da : 𝔇 ⦃A, B, C, D⦄ := cast <| and (φ := φ) (ψ := ψ ⋏ ∼χ) dφ dr
   introDisj da
@@ -192,28 +207,28 @@ def implyS (φ ψ χ : F) : 𝔇 ⦃φ ⋏ ψ ⋏ ∼χ ⋎ φ ⋏ ∼ψ ⋎ ∼
 /-- The rule expansion of the first conjunction axiom. This is a routine syntactic derivation. -/
 def and₁ (φ ψ : F) : 𝔇 ⦃(∼φ ⋎ ∼ψ) ⋎ φ⦄ :=
   introOr <| cast <| or (Γ := ⦃φ⦄) (φ := ∼φ) (ψ := ∼ψ)
-    (cast <| close φ (Γ := ⦃φ, ∼φ, ∼ψ⦄))
+    (cast <| identityWith φ (.atom (∼ψ)))
 
 /-- The rule expansion of the second conjunction axiom. This is a routine syntactic derivation. -/
 def and₂ (φ ψ : F) : 𝔇 ⦃(∼φ ⋎ ∼ψ) ⋎ ψ⦄ :=
   introOr <| cast <| or (Γ := ⦃ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
-    (cast <| close ψ (Γ := ⦃ψ, ∼φ, ∼ψ⦄))
+    (cast <| identityWith ψ (.atom (∼φ)))
 
 /-- The rule expansion of conjunction introduction. This is a routine syntactic derivation. -/
 def and₃ (φ ψ : F) : 𝔇 ⦃∼φ ⋎ ∼ψ ⋎ φ ⋏ ψ⦄ :=
-  have dp : 𝔇 ⦃∼φ, ∼ψ, φ⦄ := close φ (Γ := ⦃∼φ, ∼ψ, φ⦄)
-  have dq : 𝔇 ⦃∼φ, ∼ψ, ψ⦄ := close ψ (Γ := ⦃∼φ, ∼ψ, ψ⦄)
+  have dp : 𝔇 ⦃∼φ, ∼ψ, φ⦄ := cast (identityWith φ (.atom (∼ψ)))
+  have dq : 𝔇 ⦃∼φ, ∼ψ, ψ⦄ := cast (identityWith ψ (.atom (∼φ)))
   introDisj (Γ := [∼φ, ∼ψ, φ ⋏ ψ]) <| cast <|
     and (Γ := ⦃∼φ, ∼ψ⦄) (φ := φ) (ψ := ψ)
     (cast dp (by abel)) (cast dq (by abel))
 
 /-- The rule expansion of the first disjunction axiom. This is a routine syntactic derivation. -/
 def or₁ (φ ψ : F) : 𝔇 ⦃∼φ ⋎ φ ⋎ ψ⦄ :=
-  introDisj <| close φ (Γ := ⦃∼φ, φ, ψ⦄)
+  introDisj (Γ := [∼φ, φ, ψ]) <| cast (identityWith φ (.atom ψ)) (by change ⦃ψ⦄ + ⦃φ, ∼φ⦄ = ⦃∼φ, φ, ψ⦄; abel)
 
 /-- The rule expansion of the second disjunction axiom. This is a routine syntactic derivation. -/
 def or₂ (φ ψ : F) : 𝔇 ⦃∼ψ ⋎ φ ⋎ ψ⦄ :=
-  introDisj <| close ψ (Γ := ⦃∼ψ, φ, ψ⦄)
+  introDisj (Γ := [∼ψ, φ, ψ]) <| cast (identityWith ψ (.atom φ)) (by change ⦃φ⦄ + ⦃ψ, ∼ψ⦄ = ⦃∼ψ, φ, ψ⦄; abel)
 
 /-- The rule expansion of disjunction elimination. This is a routine syntactic derivation. -/
 def or₃ (φ ψ χ : F) : 𝔇 ⦃φ ⋏ ∼χ ⋎ ψ ⋏ ∼χ ⋎ ∼φ ⋏ ∼ψ ⋎ χ⦄ :=
@@ -221,20 +236,18 @@ def or₃ (φ ψ χ : F) : 𝔇 ⦃φ ⋏ ∼χ ⋎ ψ ⋏ ∼χ ⋎ ∼φ ⋏ �
   let B := ψ ⋏ ∼χ
   let C := ∼φ ⋏ ∼ψ
   let D := χ
-  have dap : 𝔇 (⦃B, D, ∼φ⦄ + ⦃φ⦄) := close φ (Γ := ⦃B, D, ∼φ⦄ + ⦃φ⦄)
-  have dan : 𝔇 (⦃B, D, ∼φ⦄ + ⦃∼χ⦄) := close χ (Γ := ⦃B, D, ∼φ⦄ + ⦃∼χ⦄)
-    (by simp [D]) (by simp)
+  have dap : 𝔇 (⦃B, D, ∼φ⦄ + ⦃φ⦄) := cast (identityWith φ ((Multiset.Traversal.atom B).succ D))
+  have dan : 𝔇 (⦃B, D, ∼φ⦄ + ⦃∼χ⦄) := cast (identityWith χ ((Multiset.Traversal.atom B).succ (∼φ))) (by dsimp [D]; abel)
   have dnp : 𝔇 (⦃A, B, D⦄ + ⦃∼φ⦄) := cast <| and (φ := φ) (ψ := ∼χ) dap dan
-  have dbp : 𝔇 (⦃A, D, ∼ψ⦄ + ⦃ψ⦄) := close ψ (Γ := ⦃A, D, ∼ψ⦄ + ⦃ψ⦄)
-  have dbn : 𝔇 (⦃A, D, ∼ψ⦄ + ⦃∼χ⦄) := close χ (Γ := ⦃A, D, ∼ψ⦄ + ⦃∼χ⦄)
-    (by simp [D]) (by simp)
+  have dbp : 𝔇 (⦃A, D, ∼ψ⦄ + ⦃ψ⦄) := cast (identityWith ψ ((Multiset.Traversal.atom A).succ D))
+  have dbn : 𝔇 (⦃A, D, ∼ψ⦄ + ⦃∼χ⦄) := cast (identityWith χ ((Multiset.Traversal.atom A).succ (∼ψ))) (by dsimp [D]; abel)
   have dnn : 𝔇 (⦃A, B, D⦄ + ⦃∼ψ⦄) := cast <| and (φ := ψ) (ψ := ∼χ) dbp dbn
   have dc : 𝔇 ⦃A, B, C, D⦄ := cast <| and (φ := ∼φ) (ψ := ∼ψ) dnp dnn
   introDisj dc
 
 /-- The rule expansion of double-negation elimination. This is a routine syntactic derivation. -/
 def dne (φ : F) : 𝔇 ⦃∼φ ⋎ φ⦄ :=
-  introOr <| close φ (Γ := ⦃∼φ, φ⦄)
+  introOr <| cast (identity φ)
 
 end AxiomDerivation
 
@@ -295,13 +308,15 @@ instance : Entailment.Cl 𝓟 := AxiomDerivation.cl 𝓟 PrincipalEntailment.equ
 variable {𝓟}
 
 lemma derivable_iff_provable_disj {Γ : List F} : Nonempty (𝔇 (Γ : Multiset F)) ↔ 𝓟 ⊢ ⋁Γ := by
+  classical
   constructor
   · rintro ⟨d⟩
     have : 𝔇 ((Γ : Multiset F) + 0) := cast d
     exact provable_iff.mpr ⟨disj₂ this⟩
   · rintro h
     have d₁ : 𝔇 ⦃⋁Γ⦄ := (provable_iff.mp h).some
-    have d₂ : 𝔇 ((Γ : Multiset F) + ⦃⋀(∼Γ)⦄) := conj₂ fun φ h ↦ close φ (by simp) (by simp_all)
+    have d₂ : 𝔇 ((Γ : Multiset F) + ⦃⋀(∼Γ)⦄) :=
+      conj₂ (.ofList Γ) fun φ h ↦ close φ ((Multiset.Traversal.ofList Γ).succ φ) (by simp) (by simp_all)
     exact ⟨cast (eCut (Γ := 0) (Δ := (Γ : Multiset F)) d₁ d₂)⟩
 
 end PrincipalEntailment
@@ -321,8 +336,8 @@ def cast (d : 𝔇 Δ) (h : Δ = Γ.map f := by simp) : Pullback 𝔇 f Γ := by
 def uncast (d : Pullback 𝔇 f Γ) (h : Δ = Γ.map f := by simp) : 𝔇 Δ := h ▸ d
 
 instance oneSidedLK [OneSidedLK 𝔇] : OneSidedLK (Pullback 𝔇 f) where
-  weakening d := cast <| Structural.weakening (uncast d (by simp))
-  contraction d := cast <| Structural.contraction (uncast d (by simp))
+  weakening {Γ φ} d := cast <| Structural.weakening (Γ := Γ.map f) (φ := f φ) (uncast d (by simp))
+  contraction {Γ φ} d := cast <| Structural.contraction (Γ := Γ.map f) (φ := f φ) (uncast d (by simp))
   identity φ := cast <| identity (𝔇 := 𝔇) (f φ)
   verum := cast verum
   and {Γ φ ψ} d₁ d₂ := cast <| and (Γ := Γ.map f) (φ := f φ) (ψ := f ψ)
@@ -351,15 +366,7 @@ end Pullback
 
 end OneSidedLK
 
-namespace Structural
 
-alias cast := OneSidedLK.cast
-alias weakenMany := OneSidedLK.weakenMany
-alias contractMany := OneSidedLK.contractMany
-alias absorb := OneSidedLK.absorb
-alias ofSubset := OneSidedLK.ofSubset
-
-end Structural
 
 end FFL
 

--- a/Foundation/Logic/Calculus.lean
+++ b/Foundation/Logic/Calculus.lean
@@ -17,12 +17,18 @@ public section
 
 namespace FFL
 
+/-! ## Structural rules -/
+
+class Structural {F : Type*} (𝔇 : Multiset F → Type*) where
+  weakening : 𝔇 Γ → 𝔇 (Γ + ⦃φ⦄)
+  contraction : 𝔇 (Γ + ⦃φ, φ⦄) → 𝔇 (Γ + ⦃φ⦄)
+
 /-! ## One-sided $\mathbf{LK}$ -/
 
 class OneSidedLK {F : Type*} [LogicalConnective F] [LogicalNeutral F]
-    [TildeInvolutive F] [LogicalConnective.DeMorgan F] [LogicalNeutral.DeMorgan F] (𝔇 : Multiset F → Type*) where
+    [TildeInvolutive F] [LogicalConnective.DeMorgan F] [LogicalNeutral.DeMorgan F]
+    (𝔇 : Multiset F → Type*) extends Structural 𝔇 where
   identity (φ) : 𝔇 ⦃φ, ∼φ⦄
-  contraction : 𝔇 Δ → Δ ⊆ Γ → 𝔇 Γ
   verum : 𝔇 ⦃⊤⦄
   and : 𝔇 (Γ + ⦃φ⦄) → 𝔇 (Γ + ⦃ψ⦄) → 𝔇 (Γ + ⦃φ ⋏ ψ⦄)
   or : 𝔇 (Γ + ⦃φ, ψ⦄) → 𝔇 (Γ + ⦃φ ⋎ ψ⦄)
@@ -40,20 +46,59 @@ variable {F : Type*} [LogicalConnective F] [LogicalNeutral F]
 
 def cast (b : 𝔇 Γ) (h : Γ = Δ := by abel) : 𝔇 Δ := h ▸ b
 
-def contra [OneSidedLK 𝔇] (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ := contraction d h
+def weakenMany [Structural 𝔇] (tΔ : Δ.Traversal) (d : 𝔇 Γ) : 𝔇 (Γ + Δ) :=
+  match tΔ with
+  | .zero => cast d
+  | .succ φ t => Structural.weakening (weakenMany t d)
+
+def contractMany [Structural 𝔇] (tΓ : Γ.Traversal) (d : 𝔇 (Δ + Γ + Γ)) : 𝔇 (Δ + Γ) :=
+  match tΓ with
+  | .zero => cast d
+  | .succ φ t =>
+    let d' : 𝔇 ((Δ + (t.toList : Multiset F) + (t.toList : Multiset F)) + ⦃φ, φ⦄) :=
+      cast d (by simp [t.coe_toList]; abel)
+    contractMany t (Structural.contraction d')
+
+def absorb [Structural 𝔇] [DecidableEq F] (d : 𝔇 (Γ + ⦃φ⦄)) (h : φ ∈ Γ) : 𝔇 Γ := by
+  let e := Γ.erase φ
+  have he : Γ = e + ⦃φ⦄ := by
+    exact (Multiset.add_singleton_eq_iff.mpr ⟨h, rfl⟩).symm
+  have d' : 𝔇 (e + ⦃φ, φ⦄) := cast d (by rw [he]; abel)
+  exact cast (Structural.contraction d') (by rw [← he]; simp [he, e])
+
+def ofSubset [Structural 𝔇] [DecidableEq F]
+    (tΓ : Γ.Traversal) (tΔ : Δ.Traversal) (d : 𝔇 Γ) (h : Γ ⊆ Δ) : 𝔇 Δ := by
+  let rec go {Γ : Multiset F} (tΓ : Γ.Traversal) (d : 𝔇 (Δ + Γ))
+      (hΓ : Γ ⊆ Δ) : 𝔇 Δ :=
+    match tΓ with
+    | .zero => cast d (by simp)
+    | .succ φ t =>
+      let d₁ : 𝔇 (Δ + (t.toList : Multiset F) + ⦃φ⦄) :=
+        cast d (by simp [t.coe_toList]; abel)
+      let d₂ : 𝔇 (Δ + (t.toList : Multiset F)) :=
+        absorb d₁ (by exact mem_of_mem_add_left (hΓ (by simp)))
+      go t d₂ (by
+        intro ψ hψ
+        exact hΓ (by simp [hψ]))
+  go tΓ (cast (weakenMany tΔ d) (by abel)) h
+
+def contra [OneSidedLK 𝔇] (d : 𝔇 Γ) (h : Γ ⊆ Δ := by simp) : 𝔇 Δ :=
+  ofSubset (default : Γ.Traversal) (default : Δ.Traversal) d h
 
 def close [OneSidedLK 𝔇] (φ : F) (hp : φ ∈ Γ := by simp) (hn : ∼φ ∈ Γ := by simp) : 𝔇 Γ :=
-  contraction (identity φ) (by
+  contra (identity φ) (by
     intro ψ hψ
     rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all)
 
-def top [OneSidedLK 𝔇] (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ := contraction verum (by simpa using h)
+def top [OneSidedLK 𝔇] (h : ⊤ ∈ Γ := by simp) : 𝔇 Γ := contra verum (by simpa using h)
 
-def tensor [OneSidedLK 𝔇] {φ ψ : F} (dφ : 𝔇 (Γ + ⦃φ⦄)) (dψ : 𝔇 (Δ + ⦃ψ⦄)) :
+def tensor [OneSidedLK 𝔇] {φ ψ : F} (tΓ : Γ.Traversal := by exact default)
+    (tΔ : Δ.Traversal := by exact default)
+    (dφ : 𝔇 (Γ + ⦃φ⦄)) (dψ : 𝔇 (Δ + ⦃ψ⦄)) :
     𝔇 (Γ + Δ + ⦃φ ⋏ ψ⦄) :=
   and
-    (contraction dφ (by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all))
-    (contraction dψ (by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all))
+    (cast (weakenMany tΔ dφ) (by simp; abel))
+    (cast (weakenMany tΓ dψ) (by simp; abel))
 
 alias cut := OneSidedLK.Cut.cut
 
@@ -276,8 +321,9 @@ def cast (d : 𝔇 Δ) (h : Δ = Γ.map f := by simp) : Pullback 𝔇 f Γ := by
 def uncast (d : Pullback 𝔇 f Γ) (h : Δ = Γ.map f := by simp) : 𝔇 Δ := h ▸ d
 
 instance oneSidedLK [OneSidedLK 𝔇] : OneSidedLK (Pullback 𝔇 f) where
+  weakening d := cast <| Structural.weakening (uncast d (by simp))
+  contraction d := cast <| Structural.contraction (uncast d (by simp))
   identity φ := cast <| identity (𝔇 := 𝔇) (f φ)
-  contraction {Δ Γ} d h := cast (contraction d (Multiset.map_subset_map h) : 𝔇 (Γ.map f)) (by simp)
   verum := cast verum
   and {Γ φ ψ} d₁ d₂ := cast <| and (Γ := Γ.map f) (φ := f φ) (ψ := f ψ)
     (uncast d₁ (by simp)) (uncast d₂ (by simp))
@@ -304,6 +350,16 @@ omit [TildeInvolutive F] [LogicalConnective.DeMorgan F] [LogicalNeutral.DeMorgan
 end Pullback
 
 end OneSidedLK
+
+namespace Structural
+
+alias cast := OneSidedLK.cast
+alias weakenMany := OneSidedLK.weakenMany
+alias contractMany := OneSidedLK.contractMany
+alias absorb := OneSidedLK.absorb
+alias ofSubset := OneSidedLK.ofSubset
+
+end Structural
 
 end FFL
 

--- a/Foundation/Propositional/Tait/Calculus.lean
+++ b/Foundation/Propositional/Tait/Calculus.lean
@@ -66,10 +66,11 @@ def close (φ : NNFormula α) (hp : φ ∈ Δ := by simp) (hn : ∼φ ∈ Δ := 
   eta φ |>.weakening (by intro ψ hψ; rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all)
 
 instance : OneSidedLK (Derivation (α := α)) where
+  weakening d := d.wk (by simp)
+  contraction d := d.wk (by simp)
   verum := verum
   and d₁ d₂ := d₁.and d₂
   or d := d.or
-  contraction d ss := d.wk ss
   identity φ := eta φ
 
 instance : OneSidedLK.Cut (Derivation (α := α)) where

--- a/Foundation/Propositional/Tait/Calculus.lean
+++ b/Foundation/Propositional/Tait/Calculus.lean
@@ -43,15 +43,15 @@ instance : Structural (Derivation (α := α)) where
 
 /-- Enumerates the end sequent by recursion on the local inference rules.
 This is a routine syntactic construction. -/
-def traversal [DecidableEq α] : {Γ : Sequent α} → (⊢ᴸᴷ⁰ Γ) → Γ.Traversal
-  | _, identity a => (Multiset.Traversal.atom (NNFormula.atom a)).succ (NNFormula.natom a)
-  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
-  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
-  | _, weakening (φ := φ) d => d.traversal.succ φ
-  | _, verum => .atom ⊤
-  | _, or (φ := φ) (ψ := ψ) d =>
+def traversal [DecidableEq α] {Γ : Sequent α} : ⊢ᴸᴷ⁰ Γ → Γ.Traversal
+  | identity a => (Multiset.Traversal.atom (NNFormula.atom a)).succ (NNFormula.natom a)
+  | cut d dn => d.traversal.remove.add dn.traversal.remove
+  | contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | weakening (φ := φ) d => d.traversal.succ φ
+  | verum => .atom ⊤
+  | or (φ := φ) (ψ := ψ) d =>
       ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
-  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
+  | and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
 
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
 def contra [DecidableEq α] (d : ⊢ᴸᴷ⁰ Δ) (t : Γ.Traversal)

--- a/Foundation/Propositional/Tait/Calculus.lean
+++ b/Foundation/Propositional/Tait/Calculus.lean
@@ -66,8 +66,12 @@ def close (φ : NNFormula α) (hp : φ ∈ Δ := by simp) (hn : ∼φ ∈ Δ := 
   eta φ |>.weakening (by intro ψ hψ; rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all)
 
 instance : OneSidedLK (Derivation (α := α)) where
-  weakening d := d.wk (by simp)
-  contraction d := d.wk (by simp)
+  weakening {Γ φ} d := d.wk (by
+    intro ψ hψ;
+    exact Multiset.mem_add.mpr (Or.inl hψ))
+  contraction {Γ φ} d := d.wk (by
+    intro ψ hψ;
+    simp_all)
   verum := verum
   and d₁ d₂ := d₁.and d₂
   or d := d.or

--- a/Foundation/Propositional/Tait/Calculus.lean
+++ b/Foundation/Propositional/Tait/Calculus.lean
@@ -12,7 +12,8 @@ abbrev Sequent (α : Type*) := Multiset (NNFormula α)
 inductive Derivation : Sequent α → Type _
 | identity (a : α) : Derivation ⦃NNFormula.atom a, NNFormula.natom a⦄
 | cut : Derivation (Γ + ⦃φ⦄) → Derivation (Δ + ⦃∼φ⦄) → Derivation (Γ + Δ)
-| wk : Derivation Δ → Δ ⊆ Γ → Derivation Γ
+| contraction : Derivation (Γ + ⦃φ, φ⦄) → Derivation (Γ + ⦃φ⦄)
+| weakening : Derivation Γ → Derivation (Γ + ⦃φ⦄)
 | verum : Derivation ⦃⊤⦄
 | or : Derivation (Γ + ⦃φ, ψ⦄) → Derivation (Γ + ⦃φ ⋎ ψ⦄)
 | and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) → Derivation (Γ + ⦃φ ⋏ ψ⦄)
@@ -26,7 +27,7 @@ variable {T U : Theory α} {Δ Δ₁ Δ₂ Γ : Sequent α}
 def height {Δ : Sequent α} : ⊢ᴸᴷ⁰ Δ → ℕ
   |identity _ => 0
   | cut dp dn => max dp.height dn.height + 1
-  |    wk d _ => d.height + 1
+  | contraction d | weakening d => d.height + 1
   |     verum => 0
   |      or d => d.height + 1
   | and dp dq => max (height dp) (height dq) + 1
@@ -36,42 +37,50 @@ protected abbrev cast (d : ⊢ᴸᴷ⁰ Δ) (e : Δ = Γ := by abel) : ⊢ᴸᴷ
 @[simp] lemma height_cast (d : ⊢ᴸᴷ⁰ Δ) (e : Δ = Γ) : height (Derivation.cast d e) = height d := by
   rcases e with rfl; simp [Derivation.cast]
 
-def weakening (d : ⊢ᴸᴷ⁰ Δ) (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ⁰ Γ := wk d h
+instance : Structural (Derivation (α := α)) where
+  weakening d := d.weakening
+  contraction d := d.contraction
 
-def top (h : ⊤ ∈ Δ := by simp) : ⊢ᴸᴷ⁰ Δ := verum.wk (by simp [h])
+/-- Enumerates the end sequent by recursion on the local inference rules.
+This is a routine syntactic construction. -/
+def traversal [DecidableEq α] : {Γ : Sequent α} → (⊢ᴸᴷ⁰ Γ) → Γ.Traversal
+  | _, identity a => (Multiset.Traversal.atom (NNFormula.atom a)).succ (NNFormula.natom a)
+  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
+  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | _, weakening (φ := φ) d => d.traversal.succ φ
+  | _, verum => .atom ⊤
+  | _, or (φ := φ) (ψ := ψ) d =>
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
+  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
 
-def identity' (a : α) (hpos : .atom a ∈ Δ := by simp) (hneg : .natom a ∈ Δ := by simp) : ⊢ᴸᴷ⁰ Δ :=
-  (identity a).wk (by intro φ hφ; rcases Multiset.mem_add.mp hφ with hφ | hφ <;> simp_all)
+/-- Applies structural rules along supplied traversals (a routine derived rule). -/
+def contra [DecidableEq α] (d : ⊢ᴸᴷ⁰ Δ) (t : Γ.Traversal)
+    (h : Δ ⊆ Γ := by simp) : ⊢ᴸᴷ⁰ Γ :=
+  Structural.ofSubset d.traversal t d h
 
-def tensor {φ ψ} (dφ : ⊢ᴸᴷ⁰ Γ + ⦃φ⦄) (dψ : ⊢ᴸᴷ⁰ Δ + ⦃ψ⦄) :
-    ⊢ᴸᴷ⁰ Γ + Δ + ⦃φ ⋏ ψ⦄ :=
-  and
-    (dφ.weakening (by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all))
-    (dψ.weakening (by intro χ hχ; rcases Multiset.mem_add.mp hχ with hχ | hχ <;> simp_all))
+/-- Combines two derivations by weakening and conjunction (a standard derived rule). -/
+def tensor {φ ψ} (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
+    (dφ : ⊢ᴸᴷ⁰ Γ + ⦃φ⦄) (dψ : ⊢ᴸᴷ⁰ Δ + ⦃ψ⦄) : ⊢ᴸᴷ⁰ Γ + Δ + ⦃φ ⋏ ψ⦄ :=
+  and (Structural.weakenMany tΔ dφ |>.cast) (Structural.weakenMany tΓ dψ |>.cast)
 
 /-- Identity expansion; the standard structural induction on propositional formulas (folklore). -/
 def eta : (φ : NNFormula α) → ⊢ᴸᴷ⁰ ⦃φ, ∼φ⦄
-  | .atom a | .natom a => identity' a
-  | ⊤ | ⊥ => top
+  | .atom a => identity a
+  | .natom a => (identity a).cast (by simp [add_comm])
+  | ⊤ => verum.weakening
+  | ⊥ => (verum.weakening (φ := ⊥)).cast (by simp [add_comm])
   | φ ⋏ ψ =>
     (or (Γ := ⦃φ ⋏ ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
       (tensor (Γ := ⦃∼φ⦄) (Δ := ⦃∼ψ⦄) (φ := φ) (ψ := ψ)
-        (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
+        (.atom _) (.atom _) (eta φ).cast (eta ψ).cast).cast).cast (by simp [add_comm])
   | φ ⋎ ψ =>
     (or (Γ := ⦃∼φ ⋏ ∼ψ⦄) (φ := φ) (ψ := ψ)
       (tensor (Γ := ⦃φ⦄) (Δ := ⦃ψ⦄) (φ := ∼φ) (ψ := ∼ψ)
-        (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
-
-def close (φ : NNFormula α) (hp : φ ∈ Δ := by simp) (hn : ∼φ ∈ Δ := by simp) : ⊢ᴸᴷ⁰ Δ :=
-  eta φ |>.weakening (by intro ψ hψ; rcases Multiset.mem_add.mp hψ with hψ | hψ <;> simp_all)
+        (.atom _) (.atom _) (eta φ) (eta ψ)).cast).cast (by simp [add_comm])
 
 instance : OneSidedLK (Derivation (α := α)) where
-  weakening {Γ φ} d := d.wk (by
-    intro ψ hψ;
-    exact Multiset.mem_add.mpr (Or.inl hψ))
-  contraction {Γ φ} d := d.wk (by
-    intro ψ hψ;
-    simp_all)
+  weakening d := d.weakening
+  contraction d := d.contraction
   verum := verum
   and d₁ d₂ := d₁.and d₂
   or d := d.or

--- a/Foundation/SecondOrder/Derivation.lean
+++ b/Foundation/SecondOrder/Derivation.lean
@@ -2,11 +2,13 @@ module
 
 public import Foundation.SecondOrder.Syntax.Rew
 
-@[expose] public section
-
 /-!
 # Second-order one-sided $\mathbf{LK}$
+
+The structural rules are the standard local weakening and contraction rules.
 -/
+
+@[expose] public section
 
 namespace FFL.SecondOrder
 
@@ -14,55 +16,78 @@ open FirstOrder
 
 variable {L : Language}
 
-abbrev Sequent (L : Language) := List (Proposition L)
+abbrev Sequent (L : Language) := Multiset (Proposition L)
 
 namespace Sequent
 
 def shift₀ (Γ : Sequent L) : Sequent L := Γ.map Semiproposition.shift₀
 
-@[simp] lemma shift₀_nil : shift₀ ([] : Sequent L) = [] := rfl
+@[simp] lemma shift₀_zero : shift₀ (0 : Sequent L) = 0 := rfl
 
-@[simp] lemma shift₀_cons (φ : Proposition L) (Γ : Sequent L) :
-    shift₀ (φ :: Γ) = Semiproposition.shift₀ φ :: shift₀ Γ := rfl
+@[simp] lemma shift₀_add (Γ Δ : Sequent L) :
+    shift₀ (Γ + Δ) = shift₀ Γ + shift₀ Δ := Multiset.map_add _ _ _
+
+@[simp] lemma shift₀_atom (φ : Proposition L) : shift₀ ⦃φ⦄ = ⦃Semiproposition.shift₀ φ⦄ := Multiset.map_atom _ _
 
 def shift₁ (Γ : Sequent L) : Sequent L := Γ.map Semiproposition.shift₁
 
-@[simp] lemma shift₁_nil : shift₁ ([] : Sequent L) = [] := rfl
+@[simp] lemma shift₁_zero : shift₁ (0 : Sequent L) = 0 := rfl
 
-@[simp] lemma shift₁_cons (φ : Proposition L) (Γ : Sequent L) :
-    shift₁ (φ :: Γ) = Semiproposition.shift₁ φ :: shift₁ Γ := rfl
+@[simp] lemma shift₁_add (Γ Δ : Sequent L) :
+    shift₁ (Γ + Δ) = shift₁ Γ + shift₁ Δ := Multiset.map_add _ _ _
 
-instance : Tilde (Sequent L) := ⟨List.map (∼·)⟩
+@[simp] lemma shift₁_atom (φ : Proposition L) : shift₁ ⦃φ⦄ = ⦃Semiproposition.shift₁ φ⦄ := Multiset.map_atom _ _
 
-@[simp] lemma tilde_nil : ∼([] : Sequent L) = [] := rfl
+instance : Tilde (Sequent L) := ⟨Multiset.map (∼·)⟩
 
-@[simp] lemma tilde_cons (φ : Proposition L) (Γ : Sequent L) :
-    ∼(φ :: Γ) = ∼φ :: ∼Γ := rfl
+@[simp] lemma tilde_zero : ∼(0 : Sequent L) = 0 := rfl
+
+@[simp] lemma tilde_add (Γ Δ : Sequent L) : ∼(Γ + Δ) = ∼Γ + ∼Δ := Multiset.map_add _ _ _
+
+@[simp] lemma tilde_atom (φ : Proposition L) : ∼⦃φ⦄ = ⦃∼φ⦄ := Multiset.map_atom _ _
 
 end Sequent
 
 /-- Second-order one-sided $\mathbf{LK}$-derivation -/
 inductive Derivation : Sequent L → Type _
-| identity : Derivation [φ, ∼φ]
-| cut : Derivation (φ :: Γ) → Derivation (∼φ :: Γ) → Derivation Γ
-| wk : Derivation Γ → Γ ⊆ Δ → Derivation Δ
-| verum : Derivation [⊤]
-| and : Derivation (φ :: Γ) → Derivation (ψ :: Γ) → Derivation (φ ⋏ ψ :: Γ)
-| or : Derivation (φ :: ψ :: Γ) → Derivation (φ ⋎ ψ :: Γ)
-| all₁ {φ : Semiproposition L 0 1} : Derivation (φ.free₀ :: Sequent.shift₀ Γ) → Derivation ((∀¹ φ) :: Γ)
-| exs₁ {φ : Semiproposition L 0 1} : Derivation (φ/[t] :: Γ) → Derivation ((∃¹ φ) :: Γ)
-| all₂ {φ : Semiproposition L 1 0} : Derivation (φ.free₁ :: Sequent.shift₁ Γ) → Derivation ((∀² φ) :: Γ)
-| exs₂ {φ : Semiproposition L 1 0} : Derivation (φ/⟦ψ⟧ :: Γ) → Derivation ((∃² φ) :: Γ)
+| identity : Derivation ⦃φ, ∼φ⦄
+| cut : Derivation (Γ + ⦃φ⦄) → Derivation (Δ + ⦃∼φ⦄) → Derivation (Γ + Δ)
+| contraction : Derivation (Γ + ⦃φ, φ⦄) → Derivation (Γ + ⦃φ⦄)
+| weakening : Derivation Γ → Derivation (Γ + ⦃φ⦄)
+| verum : Derivation ⦃⊤⦄
+| and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) → Derivation (Γ + ⦃φ ⋏ ψ⦄)
+| or : Derivation (Γ + ⦃φ, ψ⦄) → Derivation (Γ + ⦃φ ⋎ ψ⦄)
+| all₁ {φ : Semiproposition L 0 1} : Derivation (Sequent.shift₀ Γ + ⦃φ.free₀⦄) → Derivation (Γ + ⦃∀¹ φ⦄)
+| exs₁ {φ : Semiproposition L 0 1} : Derivation (Γ + ⦃φ/[t]⦄) → Derivation (Γ + ⦃∃¹ φ⦄)
+| all₂ {φ : Semiproposition L 1 0} : Derivation (Sequent.shift₁ Γ + ⦃φ.free₁⦄) → Derivation (Γ + ⦃∀² φ⦄)
+| exs₂ {φ : Semiproposition L 1 0} : Derivation (Γ + ⦃φ/⟦ψ⟧⦄) → Derivation (Γ + ⦃∃² φ⦄)
 
 scoped prefix:45 "⊢ᴸᴷ¹ " => Derivation
 
 namespace Derivation
 
-def cast {Γ Δ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) (h : Γ = Δ) : ⊢ᴸᴷ¹ Δ := h ▸ d
+def cast {Γ Δ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) (h : Γ = Δ := by abel) : ⊢ᴸᴷ¹ Δ := h ▸ d
+
+instance : OneSidedLK (Derivation (L := L)) where
+  weakening d := d.weakening
+  contraction d := d.contraction
+  identity _ := .identity
+  verum := .verum
+  and d₁ d₂ := d₁.and d₂
+  or d := d.or
+
+instance : OneSidedLK.Cut (Derivation (L := L)) where
+  cut d₁ d₂ := d₁.cut d₂
+
+/-- Applies structural rules along supplied traversals (a routine derived rule). -/
+def contra [DecidableEq (Proposition L)] {Γ Δ : Sequent L}
+    (d : ⊢ᴸᴷ¹ Γ) (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
+    (h : Γ ⊆ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
+  Structural.ofSubset tΓ tΔ d h
 
 end Derivation
 
-abbrev Proof (φ : Sentence L) := ⊢ᴸᴷ¹ [(φ : Proposition L)]
+abbrev Proof (φ : Sentence L) := ⊢ᴸᴷ¹ ⦃(φ : Proposition L)⦄
 
 inductive Proof.Symbol (L : Language) : Type
 | symbol
@@ -77,7 +102,7 @@ abbrev Schema (L : Language) := Set (Proposition L)
 
 protected structure Schema.Derivation (𝓢 : Schema L) (φ : Proposition L) where
   axioms : Sequent L
-  derivation : Derivation (φ :: ∼axioms)
+  derivation : Derivation (∼axioms + ⦃φ⦄)
   isInstance : ∀ φ ∈ axioms, φ ∈ 𝓢
 
 instance : Entailment (Schema L) (Proposition L) := ⟨Schema.Derivation⟩

--- a/Foundation/SecondOrder/Derivation.lean
+++ b/Foundation/SecondOrder/Derivation.lean
@@ -62,11 +62,11 @@ inductive Derivation : Sequent L → Type _
 | all₂ {φ : Semiproposition L 1 0} : Derivation (Sequent.shift₁ Γ + ⦃φ.free₁⦄) → Derivation (Γ + ⦃∀² φ⦄)
 | exs₂ {φ : Semiproposition L 1 0} : Derivation (Γ + ⦃φ/⟦ψ⟧⦄) → Derivation (Γ + ⦃∃² φ⦄)
 
-scoped prefix:45 "⊢ᴸᴷ¹ " => Derivation
+scoped prefix:45 "⊢ᴸᴷ² " => Derivation
 
 namespace Derivation
 
-def cast {Γ Δ : Sequent L} (d : ⊢ᴸᴷ¹ Γ) (h : Γ = Δ := by abel) : ⊢ᴸᴷ¹ Δ := h ▸ d
+def cast {Γ Δ : Sequent L} (d : ⊢ᴸᴷ² Γ) (h : Γ = Δ := by abel) : ⊢ᴸᴷ² Δ := h ▸ d
 
 instance : OneSidedLK (Derivation (L := L)) where
   weakening d := d.weakening
@@ -79,15 +79,40 @@ instance : OneSidedLK (Derivation (L := L)) where
 instance : OneSidedLK.Cut (Derivation (L := L)) where
   cut d₁ d₂ := d₁.cut d₂
 
+private lemma unshift₁_shift₁ {N n : ℕ} (φ : Semiproposition L N n) :
+    (Rew.rewrite Nat.pred).app (Semiproposition.shift₁ φ) = φ := by
+  induction φ using Semiformula.rec' <;>
+    simp_all [Semiproposition.shift₁, Rew.shift];
+
+/-- Enumerates the end sequent by recursion on the local inference rules.
+This is a routine syntactic construction. -/
+def traversal [DecidableEq (Proposition L)] : {Γ : Sequent L} → (⊢ᴸᴷ² Γ) → Γ.Traversal
+  | _, identity (φ := φ) => (Multiset.Traversal.atom φ).succ (∼φ)
+  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
+  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | _, weakening (φ := φ) d => d.traversal.succ φ
+  | _, verum => .atom ⊤
+  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
+  | _, or (φ := φ) (ψ := ψ) d =>
+      ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
+  | _, all₁ (φ := φ) d =>
+      ((d.traversal.remove.map (FirstOrder.Rew.rewriteMap Nat.pred ▹ ·)).cast (by
+        simp [Sequent.shift₀, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∀¹ φ)
+  | _, exs₁ (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+  | _, all₂ (φ := φ) d =>
+      ((d.traversal.remove.map (Rew.rewrite Nat.pred).app).cast (by
+        simp [Sequent.shift₁, Multiset.map_map, unshift₁_shift₁])).succ (∀² φ)
+  | _, exs₂ (φ := φ) d => d.traversal.remove.succ (∃² φ)
+
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
 def contra [DecidableEq (Proposition L)] {Γ Δ : Sequent L}
-    (d : ⊢ᴸᴷ¹ Γ) (tΓ : Γ.Traversal) (tΔ : Δ.Traversal)
-    (h : Γ ⊆ Δ := by simp) : ⊢ᴸᴷ¹ Δ :=
-  Structural.ofSubset tΓ tΔ d h
+    (d : ⊢ᴸᴷ² Γ) (tΔ : Δ.Traversal)
+    (h : Γ ⊆ Δ := by simp) : ⊢ᴸᴷ² Δ :=
+  Structural.ofSubset d.traversal tΔ d h
 
 end Derivation
 
-abbrev Proof (φ : Sentence L) := ⊢ᴸᴷ¹ ⦃(φ : Proposition L)⦄
+abbrev Proof (φ : Sentence L) := ⊢ᴸᴷ² ⦃(φ : Proposition L)⦄
 
 inductive Proof.Symbol (L : Language) : Type
 | symbol

--- a/Foundation/SecondOrder/Derivation.lean
+++ b/Foundation/SecondOrder/Derivation.lean
@@ -84,30 +84,27 @@ private lemma unshift₁_shift₁ {N n : ℕ} (φ : Semiproposition L N n) :
   induction φ using Semiformula.rec' <;>
     simp_all [Semiproposition.shift₁, Rew.shift];
 
-/-- Enumerates the end sequent by recursion on the local inference rules.
-This is a routine syntactic construction. -/
-def traversal [DecidableEq (Proposition L)] : {Γ : Sequent L} → (⊢ᴸᴷ² Γ) → Γ.Traversal
-  | _, identity (φ := φ) => (Multiset.Traversal.atom φ).succ (∼φ)
-  | _, cut d dn => d.traversal.remove.add dn.traversal.remove
-  | _, contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
-  | _, weakening (φ := φ) d => d.traversal.succ φ
-  | _, verum => .atom ⊤
-  | _, and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
-  | _, or (φ := φ) (ψ := ψ) d =>
+def traversal [L.DecidableEq] {Γ : Sequent L} : ⊢ᴸᴷ² Γ → Γ.Traversal
+  | identity (φ := φ) => (Multiset.Traversal.atom φ).succ (∼φ)
+  | cut d dn => d.traversal.remove.add dn.traversal.remove
+  | contraction (φ := φ) d => (d.traversal.cast (by abel)).remove (a := φ)
+  | weakening (φ := φ) d => d.traversal.succ φ
+  | verum => .atom ⊤
+  | and (φ := φ) (ψ := ψ) d _ => d.traversal.remove.succ (φ ⋏ ψ)
+  | or (φ := φ) (ψ := ψ) d =>
       ((d.traversal.cast (by abel)).remove (a := ψ)).remove (a := φ) |>.succ (φ ⋎ ψ)
-  | _, all₁ (φ := φ) d =>
+  | all₁ (φ := φ) d =>
       ((d.traversal.remove.map (FirstOrder.Rew.rewriteMap Nat.pred ▹ ·)).cast (by
         simp [Sequent.shift₀, Multiset.map_map, Rewriting.rewriteMap_pred_shift])).succ (∀¹ φ)
-  | _, exs₁ (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
-  | _, all₂ (φ := φ) d =>
+  | exs₁ (φ := φ) d => d.traversal.remove.succ (∃¹ φ)
+  | all₂ (φ := φ) d =>
       ((d.traversal.remove.map (Rew.rewrite Nat.pred).app).cast (by
         simp [Sequent.shift₁, Multiset.map_map, unshift₁_shift₁])).succ (∀² φ)
-  | _, exs₂ (φ := φ) d => d.traversal.remove.succ (∃² φ)
+  | exs₂ (φ := φ) d => d.traversal.remove.succ (∃² φ)
 
 /-- Applies structural rules along supplied traversals (a routine derived rule). -/
-def contra [DecidableEq (Proposition L)] {Γ Δ : Sequent L}
-    (d : ⊢ᴸᴷ² Γ) (tΔ : Δ.Traversal)
-    (h : Γ ⊆ Δ := by simp) : ⊢ᴸᴷ² Δ :=
+def contra [L.DecidableEq] {Γ Δ : Sequent L}
+    (d : ⊢ᴸᴷ² Γ) (tΔ : Δ.Traversal) (h : Γ ⊆ Δ := by simp) : ⊢ᴸᴷ² Δ :=
   Structural.ofSubset d.traversal tΔ d h
 
 end Derivation

--- a/Foundation/SecondOrder/Syntax/Formula.lean
+++ b/Foundation/SecondOrder/Syntax/Formula.lean
@@ -42,6 +42,38 @@ namespace Semiformula
 
 variable {L : Language} {Ξ ξ : Type*}
 
+section Decidable
+
+variable [L.DecidableEq] [DecidableEq Ξ] [DecidableEq ξ]
+
+/-- Decides formula equality by structural recursion (a routine syntactic construction). -/
+def hasDecEq : {N n : ℕ} → (φ ψ : Semiformula L Ξ ξ N n) → Decidable (φ = ψ)
+  | _, _, φ, ψ => by
+    cases φ <;> cases ψ <;> try { apply isFalse; intro h; cases h; done };
+    case verum.verum => exact isTrue rfl;
+    case falsum.falsum => exact isTrue rfl;
+    case rel.rel k r v k' r' v' | nrel.nrel k r v k' r' v' =>
+      by_cases h : k = k';
+      . subst k';
+        simpa only [rel.injEq, nrel.injEq, heq_eq_eq, true_and] using
+          (inferInstance : Decidable (r = r' ∧ v = v'));
+      . exact isFalse (by intro e; cases e; exact h rfl);
+    case bvar.bvar X t Y u | nbvar.nbvar X t Y u |
+        fvar.fvar X t Y u | nfvar.nfvar X t Y u =>
+      simpa only [bvar.injEq, nbvar.injEq, fvar.injEq, nfvar.injEq] using
+        (inferInstance : Decidable (X = Y ∧ t = u));
+    case and.and φ ψ φ' ψ' | or.or φ ψ φ' ψ' =>
+      letI := hasDecEq φ φ';
+      letI := hasDecEq ψ ψ';
+      simpa only [and.injEq, or.injEq] using
+        (inferInstance : Decidable (φ = φ' ∧ ψ = ψ'));
+    case all₁.all₁ φ ψ | exs₁.exs₁ φ ψ | all₂.all₂ φ ψ | exs₂.exs₂ φ ψ =>
+      simpa only [all₁.injEq, exs₁.injEq, all₂.injEq, exs₂.injEq] using hasDecEq φ ψ;
+termination_by _ _ φ _ => sizeOf φ
+instance : DecidableEq (Semiformula L Ξ ξ N n) := hasDecEq
+
+end Decidable
+
 instance : Top (Semiformula L Ξ ξ N n) := ⟨verum⟩
 
 instance : Bot (Semiformula L Ξ ξ N n) := ⟨falsum⟩

--- a/Foundation/Syntax/Predicate/Rew.lean
+++ b/Foundation/Syntax/Predicate/Rew.lean
@@ -941,6 +941,20 @@ lemma quantItr_succ_smul_castLE {φ : F ((n + 1) + s)} :
 
 end Rewriting
 
+namespace Rewriting
+
+variable {S : ℕ → Type*} [LCWQ S] [SyntacticRewriting L S S]
+  [ReflectiveRewriting L ℕ S] [TransitiveRewriting L ℕ S ℕ S ℕ S]
+
+/-- Renaming free variables by predecessor undoes shift (a routine substitution law). -/
+lemma rewriteMap_pred_shift (φ : S n) : Rew.rewriteMap Nat.pred ▹ shift φ = φ := by
+  change Rew.rewriteMap Nat.pred ▹ (Rew.rewriteMap Nat.succ ▹ φ) = φ;
+  rw [← TransitiveRewriting.comp_app, Rew.rewriteMap_comp_rewriteMap];
+  change Rew.rewriteMap id ▹ φ = φ;
+  simp;
+
+end Rewriting
+
 namespace LawfulSyntacticRewriting
 
 variable {S : ℕ → Type*} [LCWQ S] [SyntacticRewriting L S S]

--- a/Foundation/Vorspiel/Multiset.lean
+++ b/Foundation/Vorspiel/Multiset.lean
@@ -2,7 +2,6 @@ module
 
 public import Mathlib.Data.Multiset.AddSub
 public import Mathlib.Data.Multiset.Basic
-public import Mathlib.Logic.Encodable.Basic
 public import Mathlib.Tactic.Abel
 public import Mathlib.Algebra.Order.Group.Multiset
 
@@ -65,12 +64,6 @@ lemma add_map_subset_map_filter_add_atom [DecidableEq α]
       exact mem_add.mpr <| Or.inl <| mem_add.mpr <| Or.inr <| by simp
     · exact mem_add.mpr <| Or.inl <| mem_add.mpr <| Or.inl <|
         mem_map.mpr ⟨c, mem_filter.mpr ⟨hc, h⟩, rfl⟩
-
-/-- Constructively extract a preimage from a mapped multiset over an encodable type. -/
-def getPreimage [Encodable α] [DecidableEq β] {f : α → β} {s : Multiset α}
-    (h : b ∈ s.map f) : {a : α // a ∈ s ∧ f a = b} := by
-  letI := Encodable.decidableEqOfEncodable α
-  exact Encodable.chooseX (mem_map.mp h)
 
 lemma map_subset_iff {s₁ s₂ : Multiset α} (f : α → β) (hf : Function.Injective f) :
     map f s₁ ⊆ map f s₂ ↔ s₁ ⊆ s₂ := by

--- a/Foundation/Vorspiel/Multiset.lean
+++ b/Foundation/Vorspiel/Multiset.lean
@@ -125,14 +125,27 @@ lemma toList_ofList (l : List α) : (ofList l).toList = l := by
     rw [toList_cast]
     exact congrArg (List.cons a) ih
 
+private lemma cast_cast {s t u : Multiset α} (d : Traversal s) (h : s = t) (h' : t = u) :
+    (d.cast h).cast h' = d.cast (h.trans h') := by
+  cases h;
+  cases h';
+  rfl;
+
+private lemma cast_succ {s t : Multiset α} (d : Traversal s) (a : α) (h : s = t) :
+    (d.succ a).cast (congrArg (· + ⦃a⦄) h) = (d.cast h).succ a := by
+  cases h;
+  rfl;
+
+-- Unfold traversal indices when transporting the list reconstruction.
+set_option backward.isDefEq.respectTransparency false in
 lemma ofList_toList {s : Multiset α} (t : Traversal s) :
     (ofList t.toList).cast (by simp) = t := by
   induction t with
   | zero => rfl
   | succ a t ih =>
-    dsimp [toList, ofList]
-    have h₁ := congrArg (succ a) ih
-    convert h₁ using 1 <;> apply proof_irrelheq
+    simp only [toList, ofList];
+    rw [cast_cast];
+    exact (cast_succ (ofList t.toList) a t.coe_toList).trans (congrArg (succ a) ih);
 
 def equiv {s : Multiset α} : Traversal s ≃ {l : List α // (l : Multiset α) = s} where
   toFun t := ⟨t.toList, by simp⟩
@@ -146,6 +159,12 @@ def equiv {s : Multiset α} : Traversal s ≃ {l : List α // (l : Multiset α) 
 def map (f : α → β) {s : Multiset α} (t : Traversal s) : Traversal (s.map f) :=
   (ofList (t.toList.map f)).cast (by
     simpa only [Multiset.map_coe] using congrArg (Multiset.map f) t.coe_toList)
+
+/-- Construct a traversal of the elements satisfying a decidable predicate. -/
+def filter (p : α → Prop) [DecidablePred p] {s : Multiset α} (t : Traversal s) :
+    Traversal (s.filter p) :=
+  (ofList (t.toList.filter p)).cast (by
+    simpa only [Multiset.filter_coe] using congrArg (Multiset.filter p) t.coe_toList)
 
 /-- Construct a traversal after removing one occurrence of an element. -/
 def erase [DecidableEq α] (a : α) {s : Multiset α} (t : Traversal s) :

--- a/Foundation/Vorspiel/Multiset.lean
+++ b/Foundation/Vorspiel/Multiset.lean
@@ -1,6 +1,7 @@
 module
 
 public import Mathlib.Data.Multiset.AddSub
+public import Mathlib.Data.Multiset.Basic
 public import Mathlib.Logic.Encodable.Basic
 public import Mathlib.Tactic.Abel
 public import Mathlib.Algebra.Order.Group.Multiset
@@ -81,5 +82,105 @@ lemma map_subset_iff {s₁ s₂ : Multiset α} (f : α → β) (hf : Function.In
     rcases hf heq
     assumption
   · exact map_subset_map
+
+inductive Traversal {α : Type*} : Multiset α → Type _ where
+  | zero : Traversal 0
+  | succ (a : α) : Traversal s → Traversal (s + ⦃a⦄)
+
+namespace Traversal
+
+def cast {s t : Multiset α} (h : s = t) : Traversal s → Traversal t := fun t ↦ h ▸ t
+
+def atom (a : α) : Traversal ⦃a⦄ := zero.succ a
+
+def add (t₁ : Traversal s₁) (t₂ : Traversal s₂) : Traversal (s₁ + s₂) :=
+  match t₂ with
+  |     zero => t₁.cast (by simp)
+  | succ a t => (add t₁ t).succ a |>.cast (by abel)
+
+def toList {s : Multiset α} : Traversal s → List α
+  |     zero => []
+  | succ a t => a :: t.toList
+
+lemma toList_cast {s t : Multiset α} (h : s = t) (u : Traversal s) :
+    (u.cast h).toList = u.toList := by
+  cases h
+  rfl
+
+@[simp] lemma coe_toList {s : Multiset α} (t : Traversal s) : (t.toList : Multiset α) = s :=
+  match t with
+  |     zero => rfl
+  | succ a t => by
+    simp [toList, coe_toList t, add_atom_eq_cons, ←Multiset.cons_coe]
+
+def ofList : (l : List α) → Traversal (l : Multiset α)
+  |     [] => zero
+  | a :: t => (ofList t).succ a |>.cast (by simp [add_atom_eq_cons, ←Multiset.cons_coe])
+
+lemma toList_ofList (l : List α) : (ofList l).toList = l := by
+  induction l with
+  | nil => rfl
+  | cons a l ih =>
+    change (cast _ (succ a (ofList l))).toList = _
+    rw [toList_cast]
+    exact congrArg (List.cons a) ih
+
+lemma ofList_toList {s : Multiset α} (t : Traversal s) :
+    (ofList t.toList).cast (by simp) = t := by
+  induction t with
+  | zero => rfl
+  | succ a t ih =>
+    dsimp [toList, ofList]
+    have h₁ := congrArg (succ a) ih
+    convert h₁ using 1 <;> apply proof_irrelheq
+
+def equiv {s : Multiset α} : Traversal s ≃ {l : List α // (l : Multiset α) = s} where
+  toFun t := ⟨t.toList, by simp⟩
+  invFun l := ofList l.1 |>.cast (by simp [l.2])
+  left_inv t := ofList_toList t
+  right_inv s := by
+    apply Subtype.ext
+    simp [toList_cast, toList_ofList]
+
+/-- Construct a traversal after applying a function to every element. -/
+def map (f : α → β) {s : Multiset α} (t : Traversal s) : Traversal (s.map f) :=
+  (ofList (t.toList.map f)).cast (by
+    simpa only [Multiset.map_coe] using congrArg (Multiset.map f) t.coe_toList)
+
+/-- Construct a traversal after removing one occurrence of an element. -/
+def erase [DecidableEq α] (a : α) {s : Multiset α} (t : Traversal s) :
+    Traversal (s.erase a) :=
+  (ofList (t.toList.erase a)).cast (by
+    simpa only [Multiset.coe_erase] using congrArg (fun u ↦ u.erase a) t.coe_toList)
+
+/-- Remove the distinguished occurrence from a traversal of an adjoined atom. -/
+def remove [DecidableEq α] {a : α} {s : Multiset α}
+    (t : Traversal (s + ⦃a⦄)) : Traversal s :=
+  (erase a t).cast (by
+    rw [atom_eq_singleton, erase_add_right_pos s (mem_singleton_self a)]
+    rw [erase_singleton, add_zero]
+    )
+
+/-- Constructively extract a preimage from a mapped traversal. -/
+def getPreimage [DecidableEq β] {f : α → β} {s : Multiset α}
+    (t : Traversal s) {b : β} (h : b ∈ s.map f) :
+    {a : α // a ∈ s ∧ f a = b} := by
+  have hex : ∃ a ∈ t.toList, f a = b := by
+    have h' : b ∈ Multiset.map f (t.toList : Multiset α) := by
+      rw [t.coe_toList]
+      exact h
+    obtain ⟨a, ha, hab⟩ := mem_map.mp h'
+    exact ⟨a, ha, hab⟩
+  let w : {a : α // a ∈ t.toList ∧ f a = b} :=
+    List.chooseX (fun a ↦ f a = b) t.toList hex
+  have hs : w.1 ∈ s := by
+    have hc := t.coe_toList
+    exact Eq.mp (congrArg (fun m : Multiset α => w.1 ∈ m) hc) w.2.1
+  exact ⟨w.1, hs, w.2.2⟩
+
+noncomputable instance inhabited {s : Multiset α} : Inhabited (Traversal s) :=
+  ⟨ofList (s.toList) |>.cast (by simp)⟩
+
+end Traversal
 
 end Multiset


### PR DESCRIPTION
Make contraction and weakening explicit rules.
```lean
inductive Derivation : Sequent L → Type _
| identity (r : L.Rel k) (v) : Derivation ⦃.rel r v, .nrel r v⦄
| cut : Derivation (Γ + ⦃φ⦄) → Derivation (Δ + ⦃∼φ⦄) → Derivation (Γ + Δ)
| contraction : Derivation (Γ + ⦃φ, φ⦄) → Derivation (Γ + ⦃φ⦄)
| weakening : Derivation Γ → Derivation (Γ + ⦃φ⦄)
| verum : Derivation ⦃⊤⦄
| or : Derivation (Γ + ⦃φ, ψ⦄) → Derivation (Γ + ⦃φ ⋎ ψ⦄)
| and : Derivation (Γ + ⦃φ⦄) → Derivation (Γ + ⦃ψ⦄) → Derivation (Γ + ⦃φ ⋏ ψ⦄)
| all : Derivation (Γ⁺ + ⦃φ.free⦄) → Derivation (Γ + ⦃∀¹ φ⦄)
| exs : Derivation (Γ + ⦃φ/[t]⦄) → Derivation (Γ + ⦃∃¹ φ⦄)
```